### PR TITLE
fix: getOrPut throws UOE for ConcurrentMap's.

### DIFF
--- a/src/kotlin/sql/vendors/Default.kt
+++ b/src/kotlin/sql/vendors/Default.kt
@@ -103,7 +103,7 @@ internal abstract class VendorDialect : DatabaseMetadataDialect, DialectSpecific
         return constraints
     }
 
-    private val existingIndicesCache = ConcurrentHashMap<String, List<Index>>()
+    private val existingIndicesCache = HashMap<String, List<Index>>()
 
     override @Synchronized fun existingIndices(vararg tables: Table): Map<String, List<Index>> {
         for(table in tables.map {it.tableName}) {


### PR DESCRIPTION
Replace ConcurrentHashMap with simple HashMap.
CHM is unnecessary in this place, as in columnConstraintsCache property -
both methods existingIndices and columnConstraints are synchronized on singletones.