### PR TITLE
Allow IntIdTable's id column to be renamed.

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/dao/IntEntity.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/dao/IntEntity.kt
@@ -2,8 +2,8 @@ package org.jetbrains.exposed.dao
 
 import org.jetbrains.exposed.sql.Column
 
-open class IntIdTable(name: String = "") : IdTable<Int>(name) {
-    override val id: Column<EntityID<Int>> = integer("id").autoIncrement().primaryKey().entityId()
+open class IntIdTable(name: String = "", columnName: String = "id") : IdTable<Int>(name) {
+    override val id: Column<EntityID<Int>> = integer(columnName).autoIncrement().primaryKey().entityId()
 }
 
 abstract class IntEntity(id: EntityID<Int>) : Entity<Int>(id)


### PR DESCRIPTION
This PR adds a `columnName` parameter to the `IntIdTable` class.

# Problem
When creating SQL tables, I personally like to be specific about id column names to remove any ambiguity when reading data. `IntIdTable` provides the `id` column but forces the column name as `id`. To get around this I have to directly extend `IdTable` and redefine the same id column in `IntIdTable` just to name the column.

# Solution
This PR solves that problem by simply adding a `columnName` String parameter to the `IntIdTable` class. `columnName` is optional and defaults to `"id"`, the current value to provide backwards compatibility.