### PR TITLE
DecimalColumnType - wrong handling with precision and scale

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -118,9 +118,9 @@ class LongColumnType(autoinc: Boolean = false): ColumnType(autoinc = autoinc) {
     }
 }
 
-class DecimalColumnType(val scale: Int, val precision: Int): ColumnType() {
-    override fun sqlType(): String  = "DECIMAL($scale, $precision)"
-    override fun valueFromDB(value: Any): Any = super.valueFromDB(value).let { (it as? BigDecimal)?.setScale(precision, RoundingMode.HALF_EVEN) ?: it }
+class DecimalColumnType(val precision: Int, val scale: Int): ColumnType() {
+    override fun sqlType(): String  = "DECIMAL($precision, $scale)"
+    override fun valueFromDB(value: Any): Any = super.valueFromDB(value).let { (it as? BigDecimal)?.setScale(scale, RoundingMode.HALF_EVEN) ?: it }
 }
 
 class EnumerationColumnType<T:Enum<T>>(val klass: Class<T>): ColumnType() {

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -192,7 +192,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
 
     fun char(name: String): Column<Char> = registerColumn(name, CharacterColumnType())
 
-    fun decimal(name: String, scale: Int, precision: Int): Column<BigDecimal> = registerColumn(name, DecimalColumnType(scale, precision))
+    fun decimal(name: String, precision: Int, scale: Int): Column<BigDecimal> = registerColumn(name, DecimalColumnType(precision, scale))
 
     fun long(name: String): Column<Long> = registerColumn(name, LongColumnType())
 


### PR DESCRIPTION
This PR fix a wrong SQL syntax to create DECIMAL data type
## Problem
When creating a decimal column type => precision and scale are wrong. In current implementation if you want to create a column of type DECIMAL(16,5) so you will do it by using the Exposed
```kotlin
val price = decimal("PRICE", 5, 16) // exposed  decimal(name, scale, precision)
```
but this will create a column PRICE(5,16) so insert of value 123456,5 fail.

## Solution of this PR
I changed order of arguments in the DecimalColumnType and also in the Table.kt.

All tests are passed