### PR TITLE
Allowed user to set default isolation level

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -45,7 +45,7 @@ class ThreadLocalTransactionManager(private val db: Database) : TransactionManag
     }
 }
 
-fun <T> transaction(statement: Transaction.() -> T): T = transaction(Connection.TRANSACTION_REPEATABLE_READ, 3, statement)
+fun <T> transaction(statement: Transaction.() -> T): T = transaction(TransactionManager.defaultIsolationLevel, 3, statement)
 
 fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, statement: Transaction.() -> T): T {
     val outer = TransactionManager.currentOrNull()

--- a/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -21,11 +21,12 @@ interface TransactionInterface {
 
 interface TransactionManager {
 
-    fun newTransaction(isolation: Int = Connection.TRANSACTION_REPEATABLE_READ) : Transaction
+    fun newTransaction(isolation: Int = defaultIsolationLevel) : Transaction
 
     fun currentOrNull(): Transaction?
 
     companion object {
+        var defaultIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ
 
         @Volatile lateinit internal var _manager: TransactionManager
 


### PR DESCRIPTION
### Why?
- Something is wrong with the way the DAO interacts with H2 Clobs (I'm looking into this a bit but it seemed easier to use SQLite as a reference DB instead.  On H2 the connection is closed before the data has been read/cached).
- SQLite doesn't support `Connection.TRANSACTION_REPEATABLE_READ`.
- The `transaction {}` syntax is so sexy I can't let it go.
### What changed?
- You can now set the default transaction level used with `transaction {}` via the `TransactionManager` companion object:

`TransactionManager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE`
