### PR TITLE
Sum can now return null. This change was missed in the fixes for #41.

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -69,7 +69,7 @@ class Avg<out T>(val expr: Expression<T>, scale: Int): Function<BigDecimal?>() {
     override val columnType: ColumnType = DecimalColumnType(Int.MAX_VALUE, scale)
 }
 
-class Sum<T>(val expr: Expression<T>, _columnType: ColumnType): Function<T>() {
+class Sum<T>(val expr: Expression<T>, _columnType: ColumnType): Function<T?>() {
     override fun toSQL(queryBuilder: QueryBuilder): String {
         return "SUM(${expr.toSQL(queryBuilder)})"
     }


### PR DESCRIPTION
As per http://dev.mysql.com/doc/refman/5.7/en/group-by-functions.html#function_sum "SUM() returns NULL if there were no matching rows."