### PR TITLE
Column count does not match in InsertSelectStatement

### DIFF
--- a/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
+++ b/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
@@ -543,6 +543,17 @@ class DMLTests() : DatabaseTestsBase() {
         }
     }
 
+    @Test fun testInsertSelect03() {
+        withCitiesAndUsers(exclude = listOf(TestDB.MYSQL, TestDB.POSTGRESQL)) { cities, users, userData ->
+            val userCount = users.slice().selectAll().apply { count = true }.count()
+
+            users.insert(users.slice(stringParam("Foo"), stringParam("Foo"), intParam(1)).selectAll())
+
+            val r = users.select {users.id eq "Foo"}.orderBy(users.id).toList()
+            assertEquals(userCount + 1, r.size)
+        }
+    }
+
     @Test fun testSelectCase01() {
         withCitiesAndUsers { cities, users, userData ->
             val field = Expression.build { case().When(users.id eq "alex", stringLiteral("11")).Else (stringLiteral("22"))}


### PR DESCRIPTION
I tried fixing it in Query by removing the Set that is removing duplicates.. but another error surfaces that I cannot make any sense of.