### PR TITLE
map autoincremented LONG type correctly to PostgreSQL type "BIGSERIAL"

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -4,7 +4,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
 
     override fun shortAutoincType(): String = "SERIAL"
 
-    override fun longAutoincType(): String = "SERIAL"
+    override fun longAutoincType(): String = "BIGSERIAL"
 
     override fun dateTimeType(): String = "TIMESTAMP"
 


### PR DESCRIPTION
currenlty SERIAL is used which will yield a INT (= integer) and not a BIGINT (=long) as desired