### PR TITLE
Avoid expensive String expansion when logger is disabled

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/SQLLog.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/SQLLog.kt
@@ -20,22 +20,24 @@ inline fun <R> logTimeSpent(message: String, block: ()->R) : R {
     return answer
 }
 
-class StdOutSqlLogger : SqlLogger {
+object StdOutSqlLogger : SqlLogger {
 
     override fun log (context: StatementContext, transaction: Transaction) {
         System.out.println("SQL: ${context.expandArgs(transaction)}")
     }
 }
 
-class Slf4jSqlLogger : SqlLogger {
+object Slf4jSqlLogger : SqlLogger {
 
     override fun log (context: StatementContext, transaction: Transaction) {
-        exposedLogger.debug(context.expandArgs(TransactionManager.current()))
+        if (exposedLogger.isDebugEnabled) {
+            exposedLogger.debug(context.expandArgs(TransactionManager.current()))
+        }
     }
 }
 
 class CompositeSqlLogger : SqlLogger, StatementInterceptor {
-    private val loggers: ArrayList<SqlLogger> = ArrayList()
+    private val loggers: ArrayList<SqlLogger> = ArrayList(2)
 
     fun addLogger (logger: SqlLogger) {
         loggers.add(logger)

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -53,7 +53,7 @@ open class Transaction(private val transactionImpl: TransactionInterface): UserD
     val statementStats = hashMapOf<String, Pair<Int,Long>>()
 
     init {
-        logger.addLogger(Slf4jSqlLogger())
+        logger.addLogger(Slf4jSqlLogger)
     }
 
     override fun commit() {

--- a/src/test/kotlin/demo/SamplesDao.kt
+++ b/src/test/kotlin/demo/SamplesDao.kt
@@ -38,7 +38,7 @@ fun main(args: Array<String>) {
     Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
     transaction {
-        logger.addLogger(StdOutSqlLogger())
+        logger.addLogger(StdOutSqlLogger)
 
         SchemaUtils.create (Cities, Users)
 

--- a/src/test/kotlin/demo/SamplesSQL.kt
+++ b/src/test/kotlin/demo/SamplesSQL.kt
@@ -19,7 +19,7 @@ fun main(args: Array<String>) {
     Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
     transaction {
-        logger.addLogger(StdOutSqlLogger())
+        logger.addLogger(StdOutSqlLogger)
 
         SchemaUtils.create (Cities, Users)
 


### PR DESCRIPTION
I had OutOfMemory issues when performing benchmarks using Exposed, due to expensive logging operations, even when logger is disabled.