### PR TITLE
Add timezone to DateTime column type

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -19,12 +19,12 @@ class Date(val expr: Expression<DateTime?>): Function<DateTime>() {
         return "DATE(${expr.toSQL(queryBuilder)})"
     }
 
-    override val columnType: IColumnType = DateColumnType(false)
+    override val columnType: IColumnType = DateColumnType(time = false, withTimezone = false)
 }
 
 class CurrentDateTime : Function<DateTime>() {
     override fun toSQL(queryBuilder: QueryBuilder) = "CURRENT_TIMESTAMP"
-    override val columnType: IColumnType = DateColumnType(false)
+    override val columnType: IColumnType = DateColumnType(time = true, withTimezone = false)
 }
 
 class Month(val expr: Expression<DateTime?>): Function<DateTime>() {
@@ -32,7 +32,7 @@ class Month(val expr: Expression<DateTime?>): Function<DateTime>() {
         return "MONTH(${expr.toSQL(queryBuilder)})"
     }
 
-    override val columnType: IColumnType = DateColumnType(false)
+    override val columnType: IColumnType = DateColumnType(time = false, withTimezone = false)
 }
 
 class LowerCase<out T: String?>(val expr: Expression<T>) : Function<T>() {

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -88,15 +88,15 @@ fun booleanParam(value: Boolean): Expression<Boolean> = QueryParameter(value, Bo
 fun intParam(value: Int): Expression<Int> = QueryParameter(value, IntegerColumnType())
 fun longParam(value: Long): Expression<Long> = QueryParameter(value, LongColumnType())
 fun stringParam(value: String): Expression<String> = QueryParameter(value, StringColumnType())
-fun dateParam(value: DateTime): Expression<DateTime> = QueryParameter(value, DateColumnType(false))
-fun dateTimeParam(value: DateTime): Expression<DateTime> = QueryParameter(value, DateColumnType(true))
+fun dateParam(value: DateTime, withTimezone: Boolean): Expression<DateTime> = QueryParameter(value, DateColumnType(false, withTimezone))
+fun dateTimeParam(value: DateTime, withTimezone: Boolean): Expression<DateTime> = QueryParameter(value, DateColumnType(true, withTimezone))
 
 fun booleanLiteral(value: Boolean) : LiteralOp<Boolean> = LiteralOp (BooleanColumnType(), value)
 fun intLiteral(value: Int) : LiteralOp<Int> = LiteralOp (IntegerColumnType(), value)
 fun longLiteral(value: Long) : LiteralOp<Long> = LiteralOp(LongColumnType(), value)
 fun stringLiteral(value: String) : LiteralOp<String> = LiteralOp(StringColumnType(), value)
-fun dateLiteral(value: DateTime) : LiteralOp<DateTime> = LiteralOp(DateColumnType(false), value)
-fun dateTimeLiteral(value: DateTime) : LiteralOp<DateTime> = LiteralOp(DateColumnType(true), value)
+fun dateLiteral(value: DateTime, withTimezone: Boolean) : LiteralOp<DateTime> = LiteralOp(DateColumnType(false, withTimezone), value)
+fun dateTimeLiteral(value: DateTime, withTimezone: Boolean) : LiteralOp<DateTime> = LiteralOp(DateColumnType(true, withTimezone), value)
 
 abstract class ComparisonOp(val expr1: Expression<*>, val expr2: Expression<*>, val opSign: String): Op<Boolean>() {
     override fun toSQL(queryBuilder: QueryBuilder):String {

--- a/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -128,7 +128,10 @@ object SqlExpressionBuilder {
             is Int -> intLiteral(value)
             is Long -> longLiteral(value)
             is String -> stringLiteral(value)
-            is DateTime -> if ((columnType as DateColumnType).time) dateTimeLiteral(value) else dateLiteral(value)
+            is DateTime -> {
+                val dateColumnType = columnType as DateColumnType
+                if (dateColumnType.time) dateTimeLiteral(value, dateColumnType.withTimezone) else dateLiteral(value, dateColumnType.withTimezone)
+            }
             else -> LiteralOp<T>(columnType, value)
         }
     }

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -212,11 +212,11 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
 
     fun long(name: String): Column<Long> = registerColumn(name, LongColumnType())
 
-    fun date(name: String): Column<DateTime> = registerColumn(name, DateColumnType(false))
+    fun date(name: String, withTimezone: Boolean = false): Column<DateTime> = registerColumn(name, DateColumnType(false, withTimezone))
 
     fun bool(name: String): Column<Boolean> = registerColumn(name, BooleanColumnType())
 
-    fun datetime(name: String): Column<DateTime> = registerColumn(name, DateColumnType(true))
+    fun datetime(name: String, withTimezone: Boolean = false): Column<DateTime> = registerColumn(name, DateColumnType(true, withTimezone))
 
     fun blob(name: String): Column<Blob> = registerColumn(name, BlobColumnType())
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -17,7 +17,7 @@ open class DataTypeProvider {
 
     open fun uuidType() = "BINARY(16)"
 
-    open fun dateTimeType() = "DATETIME"
+    open fun dateTimeType(withTimezone: Boolean) = "DATETIME"
 
     open fun blobType(): String = "BLOB"
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -7,6 +7,8 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 
 internal object H2DataTypeProvider : DataTypeProvider() {
     override fun uuidType(): String = "UUID"
+
+    override fun dateTimeType(withTimezone: Boolean): String = if (withTimezone) "TIMESTAMP WITH TIME ZONE" else "TIMESTAMP"
 }
 
 internal object H2Dialect: VendorDialect("h2", H2DataTypeProvider) {

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 
 internal object MysqlDataTypeProvider : DataTypeProvider() {
-    override fun dateTimeType(): String = if (MysqlDialect.isFractionDateTimeSupported()) "DATETIME(6)" else "DATETIME"
+    override fun dateTimeType(withTimezone: Boolean): String = if (MysqlDialect.isFractionDateTimeSupported()) "DATETIME(6)" else "DATETIME"
 }
 
 internal object MysqlFunctionProvider : FunctionProvider() {

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -14,7 +14,7 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
 
     override fun longType() = "NUMBER(19)"
 
-    override fun dateTimeType() = "TIMESTAMP"
+    override fun dateTimeType(withTimezone: Boolean) = if (withTimezone) "TIMESTAMP WITH TIME ZONE" else "TIMESTAMP"
 
     override fun uuidType() = "RAW(16)"
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -8,7 +8,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
 
     override fun longAutoincType(): String = "BIGSERIAL"
 
-    override fun dateTimeType(): String = "TIMESTAMP"
+    override fun dateTimeType(withTimezone: Boolean): String = if (withTimezone) "TIMESTAMP WITH TIME ZONE" else "TIMESTAMP"
 
     override fun uuidType(): String = "uuid"
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -8,7 +8,7 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun shortAutoincType(): String = "INTEGER AUTO_INCREMENT"
     override fun longAutoincType(): String = "INTEGER AUTO_INCREMENT"
     override fun booleanToStatementString(bool: Boolean) = if (bool) "1" else "0"
-    override fun dateTimeType(): String  = "NUMERIC"
+    override fun dateTimeType(withTimezone: Boolean): String  = "NUMERIC"
     override val blobAsStream: Boolean = true
 }
 


### PR DESCRIPTION
This PR basically adds timezone for the `DATETIME` type on all supported DBs. It also fixes at least a bug when retrieving a DateTime type from the DB (it tries to convert a `DateTime` to a `DateTime` by parsing it through the formatter, but it fails when doing so. Also, this is obviously not necessary)