### PR TITLE
Also accept Ints when parsing a DATE from SQL

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -226,6 +226,7 @@ class DateColumnType(val time: Boolean): ColumnType() {
     override fun valueFromDB(value: Any): Any = when(value) {
         is java.sql.Date ->  DateTime(value.time)
         is java.sql.Timestamp -> DateTime(value.time)
+        is Int -> DateTime(value.toLong())
         is Long -> DateTime(value)
         is String -> when {
             currentDialect == SQLiteDialect && time -> SQLITE_DATE_TIME_STRING_FORMATTER.parseDateTime(value)


### PR DESCRIPTION
Some very early dates (at least 1970-01-02) get stored in SQLite as integers, therefore the `when` in `DateColumnType.valueFromDB` fails since it does not count Ints.

Ints need to be cast to a Long in order to play well with the DateTime constructor.