### PR TITLE
Wrapper method for multi-column unique indices and multi-column index test

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -310,6 +310,10 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
 
     fun<T> Column<T>.uniqueIndex() : Column<T> = index(true)
 
+    fun uniqueIndex(vararg columns: Column<*>) {
+        index(true, *columns)
+    }
+
     val ddl: List<String>
         get() = createStatement()
 

--- a/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -184,18 +184,21 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testUniqueMultiColumnIndex() {
+    @Test fun testMultiColumnIndex() {
         val t = object : Table("t1") {
             val type = varchar("type", 255)
             val name = varchar("name", 255)
             init {
+                index(false, name, type)
                 uniqueIndex(type, name)
             }
         }
 
         withTables(t) {
-            val alter = SchemaUtils.createIndex(t.indices[0].first, t.indices[0].second)
-            assertEquals("CREATE UNIQUE INDEX ${"t1_type_name_unique".inProperCase()} ON ${"t1".inProperCase()} (${"type".inProperCase()}, ${"name".inProperCase()})", alter)
+            val indexAlter = SchemaUtils.createIndex(t.indices[0].first, t.indices[0].second)
+            val uniqueAlter = SchemaUtils.createIndex(t.indices[1].first, t.indices[1].second)
+            assertEquals("CREATE INDEX ${"t1_name_type".inProperCase()} ON ${"t1".inProperCase()} (${"name".inProperCase()}, ${"type".inProperCase()})", indexAlter)
+            assertEquals("CREATE UNIQUE INDEX ${"t1_type_name_unique".inProperCase()} ON ${"t1".inProperCase()} (${"type".inProperCase()}, ${"name".inProperCase()})", uniqueAlter)
         }
     }
 

--- a/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -184,6 +184,21 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @Test fun testUniqueMultiColumnIndex() {
+        val t = object : Table("t1") {
+            val type = varchar("type", 255)
+            val name = varchar("name", 255)
+            init {
+                uniqueIndex(type, name)
+            }
+        }
+
+        withTables(t) {
+            val alter = SchemaUtils.createIndex(t.indices[0].first, t.indices[0].second)
+            assertEquals("CREATE UNIQUE INDEX ${"t1_type_name_unique".inProperCase()} ON ${"t1".inProperCase()} (${"type".inProperCase()}, ${"name".inProperCase()})", alter)
+        }
+    }
+
     @Test fun testBlob() {
         val t = object: Table("t1") {
             val id = integer("id").autoIncrement("t1_seq").primaryKey()


### PR DESCRIPTION
I wanted a way to specify a multi-column unique index in a Table that was more readable than

```
init {
    index(true, columnA, columnB)
}
```

so I added a wrapper method for uniqueIndex that takes multiple columns

```
init {
    uniqueIndex(columnA, columnB)
}
```

Also added a test that checks the SQL generated for multi-column indices. I only ran this test on h2 though. 