### PR TITLE
fix bug where DateTime should be converted to DateTime

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -224,6 +224,7 @@ class DateColumnType(val time: Boolean): ColumnType() {
     }
 
     override fun valueFromDB(value: Any): Any = when(value) {
+        is DateTime -> value
         is java.sql.Date ->  DateTime(value.time)
         is java.sql.Timestamp -> DateTime(value.time)
         is Int -> DateTime(value.toLong())


### PR DESCRIPTION
This happened when updating a date column with postgresql driver. The `value`-argument was already a `DateTime` and you were trying to convert it to `DateTime` via `String` but with different formats, leading to an exception. My pull request fixes this.