### PR TITLE
Add open initializer function to Entity

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -584,8 +584,8 @@ abstract class EntityClass<ID : Any, out T: Entity<ID>>(val table: IdTable<ID>, 
         }
         prototype.beforeInit()
         prototype.init()
-        prototype.afterInit()
         warmCache().scheduleInsert(this, prototype)
+        prototype.afterInit()
         return prototype
     }
 

--- a/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -256,8 +256,8 @@ open class Entity<ID:Any>(val id: EntityID<ID>) {
     open fun beforeInit(){}
     
     open fun afterInit(){}
-	
-	open fun flush(batch: EntityBatchUpdate<ID>? = null): Boolean {
+    
+    open fun flush(batch: EntityBatchUpdate<ID>? = null): Boolean {
         if (!writeValues.isEmpty()) {
             if (batch == null) {
                 val table = klass.table

--- a/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -253,9 +253,11 @@ open class Entity<ID:Any>(val id: EntityID<ID>) {
         EntityHook.registerChange(EntityChange(klass, id, EntityChangeType.Removed))
     }
     
-    open fun initialize() {}
-
-    open fun flush(batch: EntityBatchUpdate<ID>? = null): Boolean {
+    open fun beforeInit(){}
+    
+    open fun afterInit(){}
+	
+	open fun flush(batch: EntityBatchUpdate<ID>? = null): Boolean {
         if (!writeValues.isEmpty()) {
             if (batch == null) {
                 val table = klass.table
@@ -580,8 +582,9 @@ abstract class EntityClass<ID : Any, out T: Entity<ID>>(val table: IdTable<ID>, 
         if (id != null) {
             prototype.writeValues.put(table.id as Column<Any?>, entityId)
         }
-        prototype.initialize()
+        prototype.beforeInit()
         prototype.init()
+        prototype.afterInit()
         warmCache().scheduleInsert(this, prototype)
         return prototype
     }

--- a/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -252,6 +252,8 @@ open class Entity<ID:Any>(val id: EntityID<ID>) {
         table.deleteWhere{table.id eq id}
         EntityHook.registerChange(EntityChange(klass, id, EntityChangeType.Removed))
     }
+    
+    open fun initialize() {}
 
     open fun flush(batch: EntityBatchUpdate<ID>? = null): Boolean {
         if (!writeValues.isEmpty()) {
@@ -578,6 +580,7 @@ abstract class EntityClass<ID : Any, out T: Entity<ID>>(val table: IdTable<ID>, 
         if (id != null) {
             prototype.writeValues.put(table.id as Column<Any?>, entityId)
         }
+        prototype.initialize()
         prototype.init()
         warmCache().scheduleInsert(this, prototype)
         return prototype


### PR DESCRIPTION
This would allow any subclass of Entity to detect whether it is being initialized (by new{}) or just created from previously existing database values. Custom entities could overwrite this method to do certain initializing stuff because the default init block is called every time (also on loading from the database).