### PR TITLE
remove groupBy-aliasing in count query 

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -277,20 +277,17 @@ open class Query(val transaction: Transaction, set: FieldSet, where: Op<Boolean>
             fun Column<*>.makeAlias() = alias(transaction.quoteIfNecessary("${table.tableName}_$name"))
 
             val originalSet = set
-            val originalGroupBy = groupedByColumns
             try {
                 var expInx = 0
                 adjustSlice {
-                    slice(originalSet.fields.map { (it as? Column<*>)?.makeAlias() ?: it.alias("exp${expInx++}") })
-                }
-                groupedByColumns = originalGroupBy.map {
-                    (it as? Column<*>)?.takeIf { it in originalSet.fields }?.makeAlias()?.aliasOnlyExpression() ?: it
+                    slice(originalSet.fields.map {
+                        it as? ExpressionAlias<*> ?: ((it as? Column<*>)?.makeAlias() ?: it.alias("exp${expInx++}"))
+                    })
                 }
 
                 alias("subquery").selectAll().count()
             } finally {
                 set = originalSet
-                groupedByColumns = originalGroupBy
             }
         } else {
             try {

--- a/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
+++ b/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
@@ -1230,6 +1230,12 @@ class DMLTests : DatabaseTestsBase() {
         }
     }
 
+    @Test fun `test that count() works with Query that contains distinct and columns with same name from different tables and already defined alias`() {
+        withCitiesAndUsers { cities, users, _ ->
+            assertEquals(3, cities.innerJoin(users).slice(users.id.alias("usersId"), cities.id).selectAll().withDistinct().count())
+        }
+    }
+
     @Test fun  `test that count() returns right value for Query with group by` () {
         withCitiesAndUsers { _, user, userData ->
             val uniqueUsersInData = userData.slice(userData.user_id).selectAll().withDistinct().count()


### PR DESCRIPTION
I removed the groupBy-aliasing within the count() function of `Query` because you cannot use aliases in a group-by clause in Oracle (and as far as i know also MSSQL) and it also doesn't make any sense to me. Is there any real use-case someone would need this?

I also fixed the duplicate aliasing (which also causes a `SqlException`)  when the column is already an `ExpressionAlias`. Now if the expression is an `ExpressionAlias` it won't automatiically create an alias for it anymore. 
  