### PR TITLE
Improve log message (Contain id information).

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -459,9 +459,9 @@ abstract class EntityClass<ID : Any, out T: Entity<ID>>(val table: IdTable<ID>, 
     internal val klass: Class<*> = entityType ?: javaClass.enclosingClass as Class<T>
     private val ctor = klass.constructors[0]
 
-    operator fun get(id: EntityID<ID>): T = findById(id) ?: error("Entity not found in database")
+    operator fun get(id: EntityID<ID>): T = findById(id) ?: error("Entity id $id not found in database")
 
-    operator fun get(id: ID): T = findById(id) ?: error("Entity not found in database")
+    operator fun get(id: ID): T = findById(id) ?: error("Entity id $id not found in database")
 
     open protected fun warmCache(): EntityCache = TransactionManager.current().entityCache
 


### PR DESCRIPTION
Hi, This is very trivial improvement.
I improve message of exception thrown when Entity id not found on calling entity.

Exception message changes as described below.

Before:
```
java.lang.IllegalStateException: Entity not found in database

	at org.jetbrains.exposed.dao.EntityClass.get(Entity.kt:462)
	at org.jetbrains.exposed.sql.tests.shared.EntityTests$testDefaults01$1.invoke(EntityTests.kt:116)
	at 
	.........
```
After:
```
java.lang.IllegalStateException: Entity id 999999999 not found in database

	at org.jetbrains.exposed.dao.EntityClass.get(Entity.kt:462)
	at org.jetbrains.exposed.sql.tests.shared.EntityTests$testDefaults01$1.invoke(EntityTests.kt:116)
	at
 	.........
```

I think id information in log message is useful, specifically in this case (entity id not found case).