### PR TITLE
Add support for 'insertIgnore' and 'deleteIgnore' in SQLite

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -1,8 +1,6 @@
 package org.jetbrains.exposed.sql.vendors
 
-import org.jetbrains.exposed.sql.Expression
-import org.jetbrains.exposed.sql.Index
-import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.*
 
 internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun shortAutoincType(): String = "INTEGER AUTO_INCREMENT"
@@ -22,6 +20,16 @@ internal class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
     override fun getDatabase(): String = ""
+
+    override fun insert(ignore: Boolean, table: Table, columns: List<Column<*>>, expr: String, transaction: Transaction): String {
+        val def = super.insert(false, table, columns, expr, transaction)
+        return if (ignore) def.replaceFirst("INSERT", "INSERT OR IGNORE") else def
+    }
+
+    override fun delete(ignore: Boolean, table: Table, where: String?, transaction: Transaction): String {
+        val def = super.delete(false, table, where, transaction)
+        return if (ignore) def.replaceFirst("DELETE", "DELETE OR IGNORE") else def
+    }
 
     override fun createIndex(index: Index): String {
         val originalCreateIndex = super.createIndex(index.copy(unique = false))

--- a/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
+++ b/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
@@ -941,7 +941,7 @@ class DMLTests : DatabaseTestsBase() {
             val name = varchar("foo", 10).uniqueIndex()
         }
 
-        withTables(TestDB.values().toList() - listOf(TestDB.MYSQL), idTable) {
+        withTables(TestDB.values().toList() - listOf(TestDB.SQLITE, TestDB.MYSQL), idTable) {
             idTable.insertIgnoreAndGetId {
                 it[idTable.name] = "1"
             }


### PR DESCRIPTION
Added support for 'insertIgnore' and 'deleteIgnore' in SQLite based on the [official documentation](https://sqlite.org/lang_conflict.html)