### PR TITLE
Add support for check constraints.

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -15,7 +15,6 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
     internal var indexInPK: Int? = null
     internal var defaultValueFun: (() -> T)? = null
     internal var dbDefaultValue: Expression<T>? = null
-    internal var checkConstraint: Pair<String, Op<Boolean>>? = null
 
     override fun equals(other: Any?): Boolean {
         return (other as? Column<*>)?.let {
@@ -86,14 +85,8 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
             append(" NOT NULL")
         }
 
-
         if (isOneColumnPK()) {
             append(" PRIMARY KEY")
-        }
-
-        if (checkConstraint != null) {
-            if (currentDialect is H2Dialect) append(",")
-            append(CheckConstraint.from(this@Column).checkPart)
         }
     }
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -15,6 +15,7 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
     internal var indexInPK: Int? = null
     internal var defaultValueFun: (() -> T)? = null
     internal var dbDefaultValue: Expression<T>? = null
+    internal var checkConstraint: Pair<String, Op<Boolean>>? = null
 
     override fun equals(other: Any?): Boolean {
         return (other as? Column<*>)?.let {
@@ -88,6 +89,11 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
 
         if (isOneColumnPK()) {
             append(" PRIMARY KEY")
+        }
+
+        if (checkConstraint != null) {
+            if (currentDialect is H2Dialect) append(",")
+            append(CheckConstraint.from(this@Column).checkPart)
         }
     }
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -64,11 +64,9 @@ data class ForeignKeyConstraint(val fkName: String, val refereeTable: String, va
 data class CheckConstraint(val tableName: String, val checkName: String, val checkOp: String) : DdlAware {
 
     companion object {
-        fun from(column: Column<*>): CheckConstraint {
-            assert(column.checkConstraint != null) { "$column does not have any check constraint" }
+        fun from(table: Table, name: String, op: Op<Boolean>): CheckConstraint {
             val tr = TransactionManager.current()
-            val name = column.checkConstraint!!.first.let { if (it.isBlank()) "" else tr.quoteIfNecessary(it) }
-            return CheckConstraint(tr.identity(column.table), name, column.checkConstraint!!.second.toString())
+            return CheckConstraint(tr.identity(table), if (name.isBlank()) "" else tr.quoteIfNecessary(name), op.toString())
         }
     }
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -76,19 +76,20 @@ data class CheckConstraint(val tableName: String, val checkName: String, val che
     }
 
     override fun createStatement(): List<String> {
-        if (currentDialect is MysqlDialect) exposedLogger.warn("CHECK constraints are not currently supported by MySQL")
-        return listOf("ALTER TABLE $tableName ADD$checkPart")
+        return if (currentDialect is MysqlDialect) {
+            exposedLogger.warn("Creation of CHECK constraints is not currently supported by MySQL")
+            listOf()
+        } else listOf("ALTER TABLE $tableName ADD$checkPart")
     }
 
     override fun dropStatement(): List<String> {
-        if (currentDialect is MysqlDialect) throw UnsupportedOperationException("CHECK constraints are not currently supported by MySQL")
-        return listOf("ALTER TABLE $tableName DROP CONSTRAINT $checkName")
+        return if (currentDialect is MysqlDialect) {
+            exposedLogger.warn("Deletion of CHECK constraints is not currently supported by MySQL")
+            listOf()
+        } else listOf("ALTER TABLE $tableName DROP CONSTRAINT $checkName")
     }
 
-    override fun modifyStatement(): List<String> {
-        if (currentDialect is MysqlDialect) throw UnsupportedOperationException("CHECK constraints are not currently supported by MySQL")
-        return dropStatement() + createStatement()
-    }
+    override fun modifyStatement() = dropStatement() + createStatement()
 }
 
 data class Index(val indexName: String, val table: Table, val columns: List<Column<*>>, val unique: Boolean) : DdlAware {

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -76,17 +76,17 @@ data class CheckConstraint(val tableName: String, val checkName: String, val che
     }
 
     override fun createStatement(): List<String> {
-        if (currentDialect is MysqlDialect) throw UnsupportedOperationException("Check constraints are not currently supported by MySQL")
+        if (currentDialect is MysqlDialect) exposedLogger.warn("CHECK constraints are not currently supported by MySQL")
         return listOf("ALTER TABLE $tableName ADD$checkPart")
     }
 
     override fun dropStatement(): List<String> {
-        if (currentDialect is MysqlDialect) throw UnsupportedOperationException("Check constraints are not currently supported by MySQL")
+        if (currentDialect is MysqlDialect) throw UnsupportedOperationException("CHECK constraints are not currently supported by MySQL")
         return listOf("ALTER TABLE $tableName DROP CONSTRAINT $checkName")
     }
 
     override fun modifyStatement(): List<String> {
-        if (currentDialect is MysqlDialect) throw UnsupportedOperationException("Check constraints are not currently supported by MySQL")
+        if (currentDialect is MysqlDialect) throw UnsupportedOperationException("CHECK constraints are not currently supported by MySQL")
         return dropStatement() + createStatement()
     }
 }

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -404,21 +404,25 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
     }
 
     /**
-     * Creates a check constraint in this column
-     * @param name The name to identify the constraint, optional.
-     * @param op The expression that the value of this column must satisfy
+     * Creates a check constraint in this column.
+     * @param name The name to identify the constraint, optional. Must be **unique** (case-insensitive) to this table, otherwise, the constraint will
+     * not be created. All names are [trimmed][String.trim], blank names are ignored and the database engine decides the default name.
+     * @param op The expression against which the newly inserted values will be compared.
      */
     fun <T> Column<T>.check(name: String = "", op: SqlExpressionBuilder.(Column<T>) -> Op<Boolean>) = apply {
-        table.checkConstraints.add(name to SqlExpressionBuilder.op(this))
+        table.checkConstraints.takeIf { name.isEmpty() || it.none { it.first.equals(name, true) } }?.add(name to SqlExpressionBuilder.op(this))
+                ?: exposedLogger.warn("A CHECK constraint with name '$name' was ignored because there is already one with that name")
     }
 
     /**
-     * Creates a check constraint in this table
-     * @param name The name to identify the constraint, optional.
-     * @param op The expression that the values in certain columns must satisfy
+     * Creates a check constraint in this table.
+     * @param name The name to identify the constraint, optional. Must be **unique** (case-insensitive) to this table, otherwise, the constraint will
+     * not be created. All names are [trimmed][String.trim], blank names are ignored and the database engine decides the default name.
+     * @param op The expression against which the newly inserted values will be compared.
      */
     fun check(name: String = "", op: SqlExpressionBuilder.() -> Op<Boolean>) {
-        checkConstraints.add(name to SqlExpressionBuilder.op())
+        checkConstraints.takeIf { name.isEmpty() || it.none { it.first.equals(name, true) } }?.add(name to SqlExpressionBuilder.op())
+                ?: exposedLogger.warn("A CHECK constraint with name '$name' was ignored because there is already one with that name")
     }
 
     val ddl: List<String>

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -402,6 +402,16 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
         index(true, *columns)
     }
 
+    /**
+     * Creates a check constraint in this column
+     * @param name The name to identify the constraint, optional.
+     * @param op The expression that the value of this column must satisfy
+     */
+    fun <T> Column<T>.check(name: String = "", op: SqlExpressionBuilder.(Column<T>) -> Op<Boolean>): Column<T> {
+        this.checkConstraint = name to SqlExpressionBuilder.op(this)
+        return this
+    }
+
     val ddl: List<String>
         get() = createStatement()
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -447,7 +447,9 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
                         append(references.joinToString(prefix = ", ", separator = ", ") { ForeignKeyConstraint.from(it).foreignKeyPart })
                     }
                 }
-                append(checkConstraints.joinToString(prefix = ",", separator = ",") { (name, op) -> CheckConstraint.from(this@Table, name, op).checkPart })
+                if (checkConstraints.isNotEmpty()) {
+                    append(checkConstraints.joinToString(prefix = ",", separator = ",") { (name, op) -> CheckConstraint.from(this@Table, name, op).checkPart })
+                }
 
                 append(")")
             }

--- a/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -219,7 +219,7 @@ class DDLTests : DatabaseTestsBase() {
             else -> "NULL"
         }
 
-        
+
         withTables(TestTable) {
             val dtType = currentDialect.dataTypeProvider.dateTimeType()
             assertEquals("CREATE TABLE " + if (currentDialect.supportsIfNotExists) { "IF NOT EXISTS " } else { "" } +
@@ -384,11 +384,11 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
-    
+
     private abstract class EntityTable(name: String = "") : IdTable<String>(name) {
         override val id: Column<EntityID<String>> = varchar("id", 64).clientDefault { UUID.randomUUID().toString() }.primaryKey().entityId()
     }
-    
+
     @Test fun complexTest01() {
         val User = object : EntityTable() {
             val name = varchar("name", 255)
@@ -482,10 +482,17 @@ class DDLTests : DatabaseTestsBase() {
 
             assertEquals(1, checkTable.selectAll().count())
 
-            assertFailAndRollback("Check constraint") {
+            assertFailAndRollback("Check constraint 1") {
                 checkTable.insert {
                     it[positive] = -472
-                    it[negative] = 354
+                    it[negative] = -354
+                }
+            }
+
+            assertFailAndRollback("Check constraint 2") {
+                checkTable.insert {
+                    it[positive] = 538
+                    it[negative] = 915
                 }
             }
         }
@@ -509,10 +516,17 @@ class DDLTests : DatabaseTestsBase() {
 
             assertEquals(1, checkTable.selectAll().count())
 
-            assertFailAndRollback("Check constraint") {
+            assertFailAndRollback("Check constraint 1") {
                 checkTable.insert {
-                    it[positive] = -14
-                    it[negative] = 42
+                    it[positive] = -47
+                    it[negative] = -35
+                }
+            }
+
+            assertFailAndRollback("Check constraint 2") {
+                checkTable.insert {
+                    it[positive] = 53
+                    it[negative] = 91
                 }
             }
         }

--- a/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -468,7 +468,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testCheckConstraint() {
+    @Test fun testCheckConstraint01() {
         val checkTable = object : Table("checkTable") {
             val positive = integer("positive").check { it greaterEq 0 }
             val negative = integer("negative").check("subZero") { it less 0 }
@@ -478,6 +478,33 @@ class DDLTests : DatabaseTestsBase() {
             checkTable.insert {
                 it[positive] = 42
                 it[negative] = -14
+            }
+
+            assertEquals(1, checkTable.selectAll().count())
+
+            assertFailAndRollback("Check constraint") {
+                checkTable.insert {
+                    it[positive] = -472
+                    it[negative] = 354
+                }
+            }
+        }
+    }
+
+    @Test fun testCheckConstraint02() {
+        val checkTable = object : Table("multiCheckTable") {
+            val positive = integer("positive")
+            val negative = integer("negative")
+
+            init {
+                check("multi") { (negative less 0) and (positive greaterEq 0) }
+            }
+        }
+
+        withTables(listOf(TestDB.MYSQL), checkTable) {
+            checkTable.insert {
+                it[positive] = 57
+                it[negative] = -32
             }
 
             assertEquals(1, checkTable.selectAll().count())


### PR DESCRIPTION
This is a first implementation of the support for check constraints, based on the Issue #268 

A test has been created to test this new functionality: `DDLTests.testCheckConstraint()`. It has been tested to work with PostgreSQL, SQLite and H2.