### PR TITLE
Fix spring-transaction test

### DIFF
--- a/spring-transaction/src/test/kotlin/org.jetbrains.exposed.spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org.jetbrains.exposed.spring/ExposedTransactionManagerTest.kt
@@ -6,8 +6,10 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Assert
+import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.MethodSorters
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
@@ -38,8 +40,8 @@ open class TestConfig : TransactionManagementConfigurer {
 }
 
 @RunWith(SpringJUnit4ClassRunner::class)
-@ContextConfiguration(classes = arrayOf(TestConfig::class))
-@Transactional
+@ContextConfiguration(classes = [TestConfig::class])
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 open class ExposedTransactionManagerTest {
 
     @Autowired
@@ -50,6 +52,7 @@ open class ExposedTransactionManagerTest {
     }
 
     @Test
+    @Transactional
     @Repeat(5)
     fun testConnection() {
         val pm = ctx.getBean(PlatformTransactionManager::class.java)
@@ -65,6 +68,7 @@ open class ExposedTransactionManagerTest {
     }
 
     @Test
+    @Transactional
     @Repeat(5)
     fun testConnection2() {
         SchemaUtils.create(t1)


### PR DESCRIPTION
`testConnectionWithoutAnnotation()` will succeed without `transaction {}`.
`testConnection2()` will succeed without `@transactional`.