### PR TITLE
Postgres ignore + replace

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -19,7 +19,7 @@ internal class H2Dialect: VendorDialect(dialectName, H2DataTypeProvider) {
     override val supportsMultipleGeneratedKeys: Boolean = false
 
     override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
-        if (!isMySQLMode) throw UnsupportedOperationException("REPLACE is only supported in MySQL compatibility more for H2")
+        if (!isMySQLMode) throw UnsupportedOperationException("REPLACE is only supported in MySQL compatibility mode for H2")
 
         val builder = QueryBuilder(true)
         val values = data.map { builder.registerArgument(it.first.columnType, it.second) }

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -40,24 +40,24 @@ internal class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataType
         }
     }
 
-    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
-
-        val builder = QueryBuilder(true)
-        val sql = if (data.isEmpty()) ""
-        else data.joinToString(prefix = "VALUES (", postfix = ")") { (col, value) ->
-            builder.registerArgument(col, value)
-        }
-
-        val columns = data.map { it.first }
-
-        val def = super.insert(false, table,columns, sql, transaction)
-
-        val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
-        val uniqueCols = columns.filter { it.indexInPK != null || it in uniqueIdxCols}
-        
-        val conflictKey = uniqueCols.joinToString { transaction.identity(it) }
-        return def + "ON CONFLICT ($conflictKey) DO UPDATE SET " + columns.joinToString { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}"}
-    }
+//    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
+//
+//        val builder = QueryBuilder(true)
+//        val sql = if (data.isEmpty()) ""
+//        else data.joinToString(prefix = "VALUES (", postfix = ")") { (col, value) ->
+//            builder.registerArgument(col, value)
+//        }
+//
+//        val columns = data.map { it.first }
+//
+//        val def = super.insert(false, table,columns, sql, transaction)
+//
+//        val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
+//        val uniqueCols = columns.filter { it.indexInPK != null || it in uniqueIdxCols}
+//
+//        val conflictKey = uniqueCols.joinToString { transaction.identity(it) }
+//        return def + "ON CONFLICT ($conflictKey) DO UPDATE SET " + columns.joinToString { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}"}
+//    }
 
     override fun insert(ignore: Boolean, table: Table, columns: List<Column<*>>, expr: String, transaction: Transaction): String {
         val def = super.insert(false, table, columns, expr, transaction)
@@ -66,6 +66,6 @@ internal class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataType
 
     companion object {
         const val dialectName = "postgresql"
-        private const val onConflictIgnore = "ON_CONFLICT_IGNORE"
+        private const val onConflictIgnore = "ON CONFLICT DO NOTHING"
     }
 }

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.sql.vendors
 
-import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.util.*
 
@@ -41,7 +40,32 @@ internal class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataType
         }
     }
 
+    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
+
+        val builder = QueryBuilder(true)
+        val sql = if (data.isEmpty()) ""
+        else data.joinToString(prefix = "VALUES (", postfix = ")") { (col, value) ->
+            builder.registerArgument(col, value)
+        }
+
+        val columns = data.map { it.first }
+
+        val def = super.insert(false, table,columns, sql, transaction)
+
+        val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
+        val uniqueCols = columns.filter { it.indexInPK != null || it in uniqueIdxCols}
+        
+        val conflictKey = uniqueCols.joinToString { transaction.identity(it) }
+        return def + "ON CONFLICT ($conflictKey) DO UPDATE SET " + columns.joinToString { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}"}
+    }
+
+    override fun insert(ignore: Boolean, table: Table, columns: List<Column<*>>, expr: String, transaction: Transaction): String {
+        val def = super.insert(false, table, columns, expr, transaction)
+        return if (ignore) "$def $onConflictIgnore" else onConflictIgnore
+    }
+
     companion object {
         const val dialectName = "postgresql"
+        private const val onConflictIgnore = "ON_CONFLICT_IGNORE"
     }
 }

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -40,28 +40,28 @@ internal class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataType
         }
     }
 
-//    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
-//
-//        val builder = QueryBuilder(true)
-//        val sql = if (data.isEmpty()) ""
-//        else data.joinToString(prefix = "VALUES (", postfix = ")") { (col, value) ->
-//            builder.registerArgument(col, value)
-//        }
-//
-//        val columns = data.map { it.first }
-//
-//        val def = super.insert(false, table,columns, sql, transaction)
-//
-//        val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
-//        val uniqueCols = columns.filter { it.indexInPK != null || it in uniqueIdxCols}
-//
-//        val conflictKey = uniqueCols.joinToString { transaction.identity(it) }
-//        return def + "ON CONFLICT ($conflictKey) DO UPDATE SET " + columns.joinToString { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}"}
-//    }
+    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
+
+        val builder = QueryBuilder(true)
+        val sql = if (data.isEmpty()) ""
+        else data.joinToString(prefix = "VALUES (", postfix = ")") { (col, value) ->
+            builder.registerArgument(col, value)
+        }
+
+        val columns = data.map { it.first }
+
+        val def = super.insert(false, table, columns, sql, transaction)
+
+        val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
+        val uniqueCols = columns.filter { it.indexInPK != null || it in uniqueIdxCols }
+
+        val conflictKey = uniqueCols.joinToString { transaction.identity(it) }
+        return def + "ON CONFLICT ($conflictKey) DO UPDATE SET " + columns.joinToString { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}" }
+    }
 
     override fun insert(ignore: Boolean, table: Table, columns: List<Column<*>>, expr: String, transaction: Transaction): String {
         val def = super.insert(false, table, columns, expr, transaction)
-        return if (ignore) "$def $onConflictIgnore" else onConflictIgnore
+        return if (ignore) "$def $onConflictIgnore" else def
     }
 
     companion object {

--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -52,9 +52,9 @@ internal class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataType
 
         val def = super.insert(false, table, columns, sql, transaction)
 
-        val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
-        val uniqueCols = columns.filter { it.indexInPK != null || it in uniqueIdxCols }
-
+        val uniqueCols = columns.filter { it.indexInPK != null }.sortedBy { it.indexInPK }
+        if (uniqueCols.isEmpty())
+            throw IllegalStateException("Postgres replace table must supply at least one primary key")
         val conflictKey = uniqueCols.joinToString { transaction.identity(it) }
         return def + "ON CONFLICT ($conflictKey) DO UPDATE SET " + columns.joinToString { "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}" }
     }


### PR DESCRIPTION
Resolves #290

This PR attempts to add support for ignore and replace

From what I've looked up, ignore involves simply adding `ON CONFLICT DO NOTHING`.

Replace is a bit different for postgres, as it goes through ignore and calls update on conflicts. It also needs to specify which keys to look out for conflicts, which is why I've made it default to the unique keys (snippet taken from the H2 code).

This was tested against [this code](https://github.com/AllanWang/McGill-Data/blob/91e47b96eca3f9f6734aac4e66b13976cd6fb3c7/database/src/test/kotlin/ca/allanwang/mcgill/db/DbTest.kt)

The dependency is passed through jitpack, so it's easy to tweak something and update the import

------------------

On top of this, I have one question:

The replace method for PG looks similar to ignore from H2. Isn't ignore not supposed to update rows and just stop on conflict?

Once I have a better idea of what's going on I can document the arguments so it's clearer for people like me who are new to sql