### PR TITLE
Add the same ON UPDATE constraint as ON DELETE

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -46,6 +46,7 @@ data class ForeignKeyConstraint(val fkName: String, val refereeTable: String, va
         append(" FOREIGN KEY ($referencedColumn) REFERENCES $refereeTable($refereeColumn)")
         if (deleteRule != ReferenceOption.NO_ACTION) {
             append(" ON DELETE $deleteRule")
+            append(" ON UPDATE $deleteRule")
         }
     }
 


### PR DESCRIPTION
A quick hack for enabling some ON UPDATE support. Most users probably need either both ON UPDATE and ON DELETE, or none. See also #321 