### PR TITLE
Allow overriding the fetch size for a Query

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -57,6 +57,14 @@ class Database private constructor(val connector: () -> Connection) {
         }
     }
 
+    var defaultFetchSize: Int? = null
+        private set
+
+    fun defaultFetchSize(size: Int): Database {
+        defaultFetchSize = size
+        return this
+    }
+
     private fun String.isIdentifier() = !isEmpty() && first().isIdentifierStart() && all { it.isIdentifierStart() || it in '0'..'9' }
     private fun Char.isIdentifierStart(): Boolean = this in 'a'..'z' || this in 'A'..'Z' || this == '_' || this in extraNameCharacters
 

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -124,7 +124,7 @@ open class Query(set: FieldSet, where: Op<Boolean>?): SizedIterable<ResultRow>, 
     fun isForUpdate() = (forUpdate ?: false) && currentDialect.supportsSelectForUpdate()
 
     override fun PreparedStatement.executeInternal(transaction: Transaction): ResultSet? {
-        val fetchSize = this@Query.fetchSize
+        val fetchSize = this@Query.fetchSize ?: transaction.db.defaultFetchSize
         if (fetchSize != null) {
             this.fetchSize = fetchSize
         }

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -93,6 +93,8 @@ open class Query(set: FieldSet, where: Op<Boolean>?): SizedIterable<ResultRow>, 
         private set
     var offset: Int = 0
         private set
+    var fetchSize: Int? = null
+        private set
 
     /**
      * Changes [set.fields] field of a Query, [set.source] will be preserved
@@ -121,7 +123,13 @@ open class Query(set: FieldSet, where: Op<Boolean>?): SizedIterable<ResultRow>, 
     fun hasCustomForUpdateState() = forUpdate != null
     fun isForUpdate() = (forUpdate ?: false) && currentDialect.supportsSelectForUpdate()
 
-    override fun PreparedStatement.executeInternal(transaction: Transaction): ResultSet? = executeQuery()
+    override fun PreparedStatement.executeInternal(transaction: Transaction): ResultSet? {
+        val fetchSize = this@Query.fetchSize
+        if (fetchSize != null) {
+            this.fetchSize = fetchSize
+        }
+        return executeQuery()
+    }
 
     override fun arguments() = QueryBuilder(true).let {
         prepareSQL(it)
@@ -229,6 +237,11 @@ open class Query(set: FieldSet, where: Op<Boolean>?): SizedIterable<ResultRow>, 
     override fun limit(n: Int, offset: Int): Query {
         this.limit = n
         this.offset = offset
+        return this
+    }
+
+    fun fetchSize(n: Int): Query {
+        this.fetchSize = n
         return this
     }
 


### PR DESCRIPTION
At lest in PostgreSQL, the result set from a select() does not appear to be fetched lazily, and PostgreSQL seems to be caching the entire ResultSet.

```kotlin
MyTable.select { ... }.forEach { ... }
```

![image](https://user-images.githubusercontent.com/503910/41879311-5198e9ec-7896-11e8-9bf9-0793a9399ac8.png)

After this change,
```kotlin
MyTable.select { ... }.fetchSize(1000).forEach { ... }
```

<img width="417" alt="screen shot 2018-06-25 at 5 47 59 pm" src="https://user-images.githubusercontent.com/503910/41881346-50dfd916-78a0-11e8-8e33-cd5319a7d014.png">

In this test case case, it reduces memory usage by approximately 1.3gb.