### PR TITLE
Set RepetitionAttempts in TransactionManager (to set globally)

### DIFF
--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.spring
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
+import org.jetbrains.exposed.sql.transactions.DEFAULT_REPETITION_ATTEMPTS
 import org.jetbrains.exposed.sql.transactions.TransactionInterface
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.springframework.jdbc.datasource.ConnectionHolder
@@ -16,7 +17,8 @@ import javax.sql.DataSource
 
 
 class SpringTransactionManager(dataSource: DataSource,
-                               @Volatile override var defaultIsolationLevel: Int = DEFAULT_ISOLATION_LEVEL
+                               @Volatile override var defaultIsolationLevel: Int = DEFAULT_ISOLATION_LEVEL,
+                               @Volatile override var defaultRepetitionAttempts: Int = DEFAULT_REPETITION_ATTEMPTS
 ) : DataSourceTransactionManager(dataSource), TransactionManager {
 
     private val db = Database.connect(dataSource) { this }

--- a/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
+import org.jetbrains.exposed.sql.transactions.DEFAULT_REPETITION_ATTEMPTS
 import org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManager
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
@@ -85,7 +86,7 @@ class Database private constructor(val connector: () -> Connection) {
         }
 
         private fun doConnect(getNewConnection: () -> Connection, setupConnection: (Connection) -> Unit = {},
-                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL) }
+                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return Database {
                 getNewConnection().apply { setupConnection(this) }
@@ -95,18 +96,18 @@ class Database private constructor(val connector: () -> Connection) {
         }
 
         fun connect(datasource: DataSource, setupConnection: (Connection) -> Unit = {},
-                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL) }
+                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return doConnect( { datasource.connection!! }, setupConnection, manager )
         }
 
         fun connect(getNewConnection: () -> Connection,
-                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL) }
+                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return doConnect( getNewConnection, manager = manager )
         }
         fun connect(url: String, driver: String, user: String = "", password: String = "", setupConnection: (Connection) -> Unit = {},
-                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL) }): Database {
+                    manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_ISOLATION_LEVEL, DEFAULT_REPETITION_ATTEMPTS) }): Database {
             Class.forName(driver).newInstance()
 
             return doConnect( { DriverManager.getConnection(url, user, password) }, setupConnection, manager )

--- a/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -9,7 +9,8 @@ import java.sql.Connection
 import java.sql.SQLException
 
 class ThreadLocalTransactionManager(private val db: Database,
-                                    @Volatile override var defaultIsolationLevel: Int) : TransactionManager {
+                                    @Volatile override var defaultIsolationLevel: Int,
+                                    @Volatile override var defaultRepetitionAttempts: Int) : TransactionManager {
 
     val threadLocal = ThreadLocal<Transaction>()
 
@@ -54,7 +55,7 @@ class ThreadLocalTransactionManager(private val db: Database,
     }
 }
 
-fun <T> transaction(db: Database? = null, statement: Transaction.() -> T): T = transaction(TransactionManager.manager.defaultIsolationLevel, 3, db, statement)
+fun <T> transaction(db: Database? = null, statement: Transaction.() -> T): T = transaction(TransactionManager.manager.defaultIsolationLevel, TransactionManager.manager.defaultRepetitionAttempts, db, statement)
 
 fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Database? = null, statement: Transaction.() -> T): T {
     val outer = TransactionManager.currentOrNull()

--- a/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -22,8 +22,12 @@ interface TransactionInterface {
 
 const val DEFAULT_ISOLATION_LEVEL = Connection.TRANSACTION_REPEATABLE_READ
 
+const val DEFAULT_REPETITION_ATTEMPTS = 3
+
 private object NotInitializedManager : TransactionManager {
     override var defaultIsolationLevel: Int = -1
+
+    override var defaultRepetitionAttempts: Int = -1
 
     override fun newTransaction(isolation: Int): Transaction = error("Please call Database.connect() before using this code")
 
@@ -33,6 +37,8 @@ private object NotInitializedManager : TransactionManager {
 interface TransactionManager {
 
     var defaultIsolationLevel: Int
+
+    var defaultRepetitionAttempts: Int
 
     fun newTransaction(isolation: Int = defaultIsolationLevel) : Transaction
 


### PR DESCRIPTION
The default repetitionAttempts value is 3 in transaction!
We need to set (change) it every time we use a transaction, and It's better to config that in expose settings globally... in Database.connect(..., manager = {...})
So, I wrote some code to do that.
Thanks