### PR TITLE
Update readme examples to use SchemaUtils

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fun main(args: Array<String>) {
     Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
     transaction {
-        create (Cities, Users)
+        SchemaUtils.create (Cities, Users)
 
         val saintPetersburgId = Cities.insert {
             it[name] = "St. Petersburg"
@@ -210,7 +210,7 @@ fun main(args: Array<String>) {
     transaction {
         addLogger(StdOutSqlLogger)
 
-        create (Cities, Users)
+        SchemaUtils.create (Cities, Users)
 
         val stPete = City.new {
             name = "St. Petersburg"


### PR DESCRIPTION
I'm new here so maybe this isnt necessary at all, but I just started a project with Ktor and Exposed and was really struggling to figure out where `create` was coming from. After poking around, I found that `SchemaUtils.create` is probably what this readme should say instead.

If I am wrong, please let me know.

Thanks!