### PR TITLE
bugfix for camel cased column in uniqueIndex

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -316,7 +316,7 @@ abstract class VendorDialect(override val name: String,
                     }
                 }
                 rs.close()
-                val tColumns = table.columns.associateBy { transaction.identity(it) }
+                val tColumns = table.columns.associateBy { transaction.identity(it).replace("\"", "") }
                 tmpIndices.filterNot { it.key.first in pkNames }
                         .mapNotNull {
                             it.value.mapNotNull { cn -> tColumns[cn] }.takeIf { c -> c.size == it.value.size }?.let { c -> Index(c, it.key.second) }


### PR DESCRIPTION
While creating unique indexes I've come across a bug which is trying to create the unique constraint even though the constraint has already been created (in postgresql). It can be replicated by the following code:
```kotlin
object ProductTable : LongIdTable() {
    val userId: Column<Long> = long("userId").uniqueIndex()
}
transaction() {
    SchemaUtils.createMissingTablesAndColumns(ProductTable)
}
```

The problem appears because of the camel cased `long("userId")`. When I write the column name without casing the bug is not manifesting. I traced the bug to `transaction.identity(it)` which will quote the column so the column name will be `""userId""` instead of `"userId"`. Thus I believe if we remove all the quotes the problem is solved. I don't know if this bug is replicated on other dialects other than postgres.