### PR TITLE
#280 Fix batchInsert generated result type consistent with column type

### DIFF
--- a/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -68,7 +68,7 @@ fun <T:Table, E:Any> T.batchInsert(data: Iterable<E>, ignore: Boolean = false, b
     }
     var statement = newBatchStatement()
 
-    val result = ArrayList<Map<Column<*>, Any>>()
+    val result = mutableListOf<Map<Column<*>, Any>>()
     fun BatchInsertStatement.handleBatchException(body: BatchInsertStatement.() -> Unit) {
         try {
             body()
@@ -90,7 +90,10 @@ fun <T:Table, E:Any> T.batchInsert(data: Iterable<E>, ignore: Boolean = false, b
         statement.execute(TransactionManager.current())
         result += statement.generatedKey.orEmpty()
     }
-    return result
+
+    val columnTypedResult = result.map { it.mapValues { it.key.columnType.valueFromDB(it.value) } }
+
+    return columnTypedResult
 }
 
 fun <T:Table> T.insertIgnore(body: T.(UpdateBuilder<*>)->Unit): InsertStatement<Long> = InsertStatement<Long>(this, isIgnore = true).apply {


### PR DESCRIPTION
Use `columnType.valueFromDB()` in `Column` to convert raw type value from `ResultSet` to specific type corresponding to column.