### PR TITLE
Add CONCAT function support ( #509 )

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -129,3 +129,7 @@ class GroupConcat<T : String?>(
     override fun toSQL(queryBuilder: QueryBuilder): String
             = currentDialect.functionProvider.groupConcat(this, queryBuilder)
 }
+
+class Concat<T>(val expr: Expression<*>, vararg val items: String) : Function<T?>(VarCharColumnType()) {
+    override fun toSQL(queryBuilder: QueryBuilder): String = currentDialect.functionProvider.concat(expr, queryBuilder, *items)
+}

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -53,6 +53,8 @@ fun <T : String?> Expression<T>.groupConcat(separator: String? = null, distinct:
 fun <T : String?> Expression<T>.groupConcat(separator: String? = null, distinct: Boolean = false, orderBy: Array<Pair<Expression<*>,SortOrder>> = emptyArray()): GroupConcat<T> =
         GroupConcat(this, separator, distinct, *orderBy)
 
+fun <T : String?> Column<T>.concat(vararg items: String): Concat<T> =
+        Concat(this, *items)
 
 object SqlExpressionBuilder {
     fun <T, S:T?, E:ExpressionWithColumnType<S>, R:T> coalesce(expr: E, alternate: ExpressionWithColumnType<out T>) : ExpressionWithColumnType<R> =

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -125,6 +125,9 @@ abstract class FunctionProvider {
         append(")")
     }
 
+    open fun concat(expr: Expression<*>, builder: QueryBuilder, vararg items: String) =
+            "CONCAT(${expr.toSQL(builder)} , '${items.joinToString(" ,")}')"
+
     interface MatchMode {
         fun mode() : String
     }


### PR DESCRIPTION
Add SQL's `CONCAT` function support.

Here is the PostgreSQL documentation about this function:
[](https://www.postgresql.org/docs/9.1/functions-string.html#FUNCTIONS-STRING-OTHER)