### PR TITLE
Split InsertStatement.get into get, tryGet to simplify get use.

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -52,7 +52,7 @@ fun <Key:Comparable<Key>, T: IdTable<Key>> T.insertAndGetId(body: T.(InsertState
     InsertStatement<EntityID<Key>>(this, false).run {
         body(this)
         execute(TransactionManager.current())
-        get(id)!!
+        get(id)
     }
 
 /**
@@ -102,7 +102,7 @@ fun <T:Table> T.insertIgnore(body: T.(UpdateBuilder<*>)->Unit): InsertStatement<
 fun <Key:Comparable<Key>, T: IdTable<Key>> T.insertIgnoreAndGetId(body: T.(UpdateBuilder<*>)->Unit) = InsertStatement<EntityID<Key>>(this, isIgnore = true).run {
     body(this)
     execute(TransactionManager.current())
-    get(id)
+    tryGet(id)
 }
 
 /**

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -16,11 +16,15 @@ open class InsertStatement<Key:Any>(val table: Table, val isIgnore: Boolean = fa
         private set
 
     @Deprecated("Will be made internal on the next releases")
-    open val generatedKey: Key? get() = autoIncColumns.firstOrNull()?.let { get(it) } as Key?
+    open val generatedKey: Key? get() = autoIncColumns.firstOrNull()?.let { tryGet(it) } as Key?
 
-    infix operator fun <T> get(column: Column<T>): T? {
-        val row = resultedValues?.get(0)
-        if (row == null && !isIgnore)  error("No key generated")
+    infix operator fun <T> get(column: Column<T>): T {
+        val row = resultedValues?.firstOrNull() ?: error("No key generated")
+        return row[column]
+    }
+
+    fun <T> tryGet(column: Column<T>): T? {
+        val row = resultedValues?.firstOrNull()
         return row?.tryGet(column)
     }
 

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/sql/SamplesSQL.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/sql/SamplesSQL.kt
@@ -33,7 +33,7 @@ fun main(args: Array<String>) {
 
         val pragueId = Cities.insert {
             it.update(name, stringLiteral("   Prague   ").trim().substring(1, 2))
-        }[Cities.id]!!
+        }[Cities.id]
 
         val pragueName = Cities.select { Cities.id eq pragueId }.single()[Cities.name]
         assertEquals(pragueName, "Pr")

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -470,7 +470,7 @@ class DDLTests : DatabaseTestsBase() {
             } get (t.id)
 
 
-            val readOn = t.select{t.id eq id!!}.first()[t.b]
+            val readOn = t.select { t.id eq id }.first()[t.b]
             val text = readOn.binaryStream.reader().readText()
 
             assertEquals("Hello there!", text)

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.Random
 import org.jetbrains.exposed.sql.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.sql.statements.BatchInsertStatement
+import org.jetbrains.exposed.sql.statements.InsertStatement
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.transactions.TransactionManager
@@ -970,6 +971,27 @@ class DMLTests : DatabaseTestsBase() {
         assertEquals(row[this.fcn], fcn)
         assertEquals(row[this.dblcn], dblcn)
     }
+    private fun DMLTestsData.Misc.checkInsert(row: InsertStatement<Number>, n: Int, nn: Int?, d: DateTime, dn: DateTime?,
+                                           t: DateTime, tn: DateTime?, e: DMLTestsData.E, en: DMLTestsData.E?,
+                                           es: DMLTestsData.E, esn: DMLTestsData.E?, s: String, sn: String?,
+                                           dc: BigDecimal, dcn: BigDecimal?, fcn: Float?, dblcn: Double?) {
+        assertEquals(row[this.n], n)
+        assertEquals(row[this.nn], nn)
+        assertEqualDateTime(row[this.d], d)
+        assertEqualDateTime(row[this.dn], dn)
+        assertEqualDateTime(row[this.t], t)
+        assertEqualDateTime(row[this.tn], tn)
+        assertEquals(row[this.e], e)
+        assertEquals(row[this.en], en)
+        assertEquals(row[this.es], es)
+        assertEquals(row[this.esn], esn)
+        assertEquals(row[this.s], s)
+        assertEquals(row[this.sn], sn)
+        assertEquals(row[this.dc], dc)
+        assertEquals(row[this.dcn], dcn)
+        assertEquals(row[this.fcn], fcn)
+        assertEquals(row[this.dblcn], dblcn)
+    }
 
     @Test
     fun testInsert01() {
@@ -1079,6 +1101,30 @@ class DMLTests : DatabaseTestsBase() {
             val row = tbl.selectAll().single()
             tbl.checkRow(row, 42, null, date, null, time, null, DMLTestsData.E.ONE, null, DMLTestsData.E.ONE, null, stringThatNeedsEscaping, null,
                     BigDecimal("239.42"), null, null, null)
+        }
+    }
+
+    @Test
+    fun testInsertGet01() {
+        val tbl = DMLTestsData.Misc
+        val date = today
+        val time = DateTime.now()
+
+        withTables(tbl) {
+            val row = tbl.insert {
+                it[n] = 42
+                it[d] = date
+                it[t] = time
+                it[e] = DMLTestsData.E.ONE
+                it[es] = DMLTestsData.E.ONE
+                it[s] = "test"
+                it[dc] = BigDecimal("239.42")
+                it[char] = '('
+            }
+
+            tbl.checkInsert(row, 42, null, date, null, time, null, DMLTestsData.E.ONE, null, DMLTestsData.E.ONE,
+                    null, "test", null, BigDecimal("239.42"), null, null, null)
+            assertEquals('(', row[tbl.char])
         }
     }
 


### PR DESCRIPTION
Related discussion on Slack:
Johannes Jensen   [Mar 14th at 10:51 AM]
Another thread: What is the use case for having `InsertStatement.get` return `T?` ? The only use in the project that ought to use this functionality at all is `fun <Key:Comparable<Key>, T: IdTable<Key>> T.insertIgnoreAndGetId`.

It seems to me that it ought to be changed to `T` and instead define a `InsertStatement.tryGet` for the much rarer use so can avoid having !! just to retrieve a generated key.
2 replies

Andrey Tarashevskiy   [2 hours ago]
Nullable columns could produce `null` on insert and that's not the 'null == value was absent from insert'

Johannes Jensen   [< 1 minute ago]
But since `T` isnt contrained to `Any` it would just be ie. `Int?` which would work. Or I am not understanding you correctly. I have submitted a pull request with the change and a test that shows retrieval of null values.