### PR TITLE
Fix MySQL constraints when table names are in lower case

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -70,7 +70,7 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
 
         val constraints = HashMap<Pair<String, String>, MutableList<ForeignKeyConstraint>>()
 
-        val tableNames = tables.map { it.tableName }
+        val tableNames = tables.map { it.nameInDatabaseCase() }
 
         fun inTableList(): String {
             if (tables.isNotEmpty()) {


### PR DESCRIPTION
This is an additional fix for #394 Foreign Key Constraints being recreated