### PR TITLE
Implemented nested transactions support

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -15,9 +15,9 @@ class Database private constructor(val connector: () -> Connection) {
     internal val metadata: DatabaseMetaData get() = this.transactionManager.currentOrNull()?.connection?.metaData ?: with(connector()) {
         try {
             metaData
-        }
-        finally {
+        } catch (e: Throwable) {
             close()
+            throw e
         }
     }
 

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.exposed.sql
 
-import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
-import org.jetbrains.exposed.sql.transactions.DEFAULT_REPETITION_ATTEMPTS
-import org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManager
-import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.*
 import org.jetbrains.exposed.sql.vendors.*
 import java.math.BigDecimal
 import java.sql.Connection
@@ -15,7 +12,7 @@ import javax.sql.DataSource
 
 class Database private constructor(val connector: () -> Connection) {
 
-    internal val metadata: DatabaseMetaData get() = TransactionManager.currentOrNull()?.connection?.metaData ?: with(connector()) {
+    internal val metadata: DatabaseMetaData get() = this.transactionManager.currentOrNull()?.connection?.metaData ?: with(connector()) {
         try {
             metaData
         }

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.exposedLogger
 import java.sql.Connection
 import java.sql.SQLException
+import java.sql.Savepoint
 
 class ThreadLocalTransactionManager(private val db: Database,
                                     @Volatile override var defaultIsolationLevel: Int,
@@ -14,133 +15,214 @@ class ThreadLocalTransactionManager(private val db: Database,
 
     val threadLocal = ThreadLocal<Transaction>()
 
-    override fun newTransaction(isolation: Int): Transaction = Transaction(ThreadLocalTransaction(db, isolation, threadLocal)).apply {
+    override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction = Transaction(
+        ThreadLocalTransaction(
+            db = db,
+            transactionIsolation = if (outerTransaction != null) outerTransaction.transactionIsolation else isolation,
+            threadLocal = threadLocal,
+            outerTransaction = outerTransaction,
+            connectionProvider = {
+                if (outerTransaction == null) {
+                    db.connector().apply {
+                        autoCommit = false
+                        this.transactionIsolation = isolation
+                    }
+                } else {
+                    outerTransaction.connection
+                }
+            }
+        )
+    ).apply {
         threadLocal.set(this)
     }
 
     override fun currentOrNull(): Transaction? = threadLocal.get()
 
-    private class ThreadLocalTransaction(override val db: Database, isolation: Int, val threadLocal: ThreadLocal<Transaction>) : TransactionInterface {
+    private class ThreadLocalTransaction(
+        override val db: Database,
+        override val transactionIsolation: Int,
+        val threadLocal: ThreadLocal<Transaction>,
+        override val outerTransaction: Transaction?,
+        private val connectionProvider: () -> Connection = { db.connector() }
+    ) : TransactionInterface {
 
-        private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) {
-            db.connector().apply {
-                autoCommit = false
-                transactionIsolation = isolation
-            }
-        }
+        private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) { connectionProvider() }
         override val connection: Connection
             get() = connectionLazy.value
 
-        override val outerTransaction: Transaction? = threadLocal.get()
+        private val topLevelTransaction = outerTransaction == null
+        private var savepoint: Savepoint? = if (!topLevelTransaction) {
+            connection.setSavepoint("POINT_$name")
+        } else null
+
 
         override fun commit() {
-            if (connectionLazy.isInitialized())
-                connection.commit()
+            if (connectionLazy.isInitialized()) {
+                if (topLevelTransaction) {
+                    connection.commit()
+                } else {
+                    // do nothing in nested. close() will commit everything and release savepoint.
+                }
+            }
         }
 
         override fun rollback() {
             if (connectionLazy.isInitialized() && !connection.isClosed) {
-                connection.rollback()
+                if (topLevelTransaction) {
+                    connection.rollback()
+                } else {
+                    connection.rollback(savepoint)
+                    savepoint = connection.setSavepoint("POINT_$name")
+                }
             }
         }
 
         override fun close() {
             try {
-                if (connectionLazy.isInitialized()) connection.close()
+                if (topLevelTransaction) {
+                    if (connectionLazy.isInitialized()) connection.close()
+                } else {
+                    savepoint.let {
+                        connection.releaseSavepoint(it)
+                        savepoint = null
+                    }
+                }
             } finally {
                 threadLocal.set(outerTransaction)
             }
         }
 
+        private val name: String
+            get() {
+                var p: Transaction? = outerTransaction
+                var value: String = ""
+
+                while (p != null) {
+                    value = p.hashCode().toString(16) + "_" + value
+                    p = p.outerTransaction
+                }
+                return value + this.hashCode().toString(16)
+            }
     }
 }
 
 fun <T> transaction(db: Database? = null, statement: Transaction.() -> T): T =
     transaction(db.transactionManager.defaultIsolationLevel, db.transactionManager.defaultRepetitionAttempts, db, statement)
 
-fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Database? = null, statement: Transaction.() -> T): T {
+fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Database? = null, statement: Transaction.() -> T): T = keepAndRestoreTransactionRefAfterRun(db) {
     val outer = TransactionManager.currentOrNull()
 
-    return if (outer != null && (db == null || outer.db == db)) {
-        outer.statement()
+    if (outer != null && (db == null || outer.db == db)) {
+        val outerManager = outer.db.transactionManager
+
+        db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
+        val transaction = db.transactionManager.newTransaction(transactionIsolation, outer)
+        try {
+            transaction.statement().also {
+                transaction.commit()
+            }
+        } finally {
+            TransactionManager.resetCurrent(outerManager)
+        }
     } else {
         val existingForDb = db?.let { db.transactionManager }
-        existingForDb?.currentOrNull()?.let {
+        existingForDb?.currentOrNull()?.let { transaction ->
             val currentManager = outer?.db.transactionManager
             try {
                 TransactionManager.resetCurrent(existingForDb)
-                it.statement()
+                transaction.statement().also {
+                    transaction.commit()
+                }
             } finally {
                 TransactionManager.resetCurrent(currentManager)
             }
-        } ?: inTopLevelTransaction(transactionIsolation, repetitionAttempts, db, outer, statement)
+        } ?: inTopLevelTransaction(transactionIsolation, repetitionAttempts, db, null, statement)
     }
 }
 
-private fun TransactionInterface.rollbackLoggingException(log: (Exception) -> Unit){
+private fun TransactionInterface.rollbackLoggingException(log: (Exception) -> Unit) {
     try {
         rollback()
-    } catch (e: Exception){
+    } catch (e: Exception) {
         log(e)
     }
 }
 
-private inline fun TransactionInterface.closeLoggingException(log: (Exception) -> Unit){
+private inline fun TransactionInterface.closeLoggingException(log: (Exception) -> Unit) {
     try {
         close()
-    } catch (e: Exception){
+    } catch (e: Exception) {
         log(e)
     }
 }
 
-fun <T> inTopLevelTransaction(transactionIsolation: Int, repetitionAttempts: Int, db: Database? = null, outerTransaction: Transaction? = null, statement: Transaction.() -> T): T {
-    var repetitions = 0
+fun <T> inTopLevelTransaction(
+    transactionIsolation: Int,
+    repetitionAttempts: Int,
+    db: Database? = null,
+    outerTransaction: Transaction? = null,
+    statement: Transaction.() -> T
+): T {
 
-    val outerManager = outerTransaction?.db.transactionManager.takeIf { it.currentOrNull() != null }
+    fun run():T {
+        var repetitions = 0
 
-    while (true) {
-        db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
-        val transaction = db.transactionManager.newTransaction(transactionIsolation)
+        val outerManager = outerTransaction?.db.transactionManager.takeIf { it.currentOrNull() != null }
 
-        try {
-            val answer = transaction.statement()
-            transaction.commit()
-            return answer
-        }
-        catch (e: SQLException) {
-            val exposedSQLException = e as? ExposedSQLException
-            val queriesToLog = exposedSQLException?.causedByQueries()?.joinToString(";\n") ?: "${transaction.currentStatement}"
-            val message = "Transaction attempt #$repetitions failed: ${e.message}. Statement(s): $queriesToLog"
-            exposedSQLException?.contexts?.forEach {
-                transaction.interceptors.filterIsInstance<SqlLogger>().forEach { logger ->
-                    logger.log(it, transaction)
-                }
-            }
-            exposedLogger.warn(message, e)
-            transaction.rollbackLoggingException { exposedLogger.warn("Transaction rollback failed: ${it.message}. See previous log line for statement", it) }
-            repetitions++
-            if (repetitions >= repetitionAttempts) {
-                throw e
-            }
-        }
-        catch (e: Throwable) {
-            val currentStatement = transaction.currentStatement
-            transaction.rollbackLoggingException { exposedLogger.warn("Transaction rollback failed: ${it.message}. Statement: $currentStatement", it) }
-            throw e
-        }
-        finally {
-            TransactionManager.resetCurrent(outerManager)
-            val currentStatement = transaction.currentStatement
+        while (true) {
+            db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
+            val transaction = db.transactionManager.newTransaction(transactionIsolation, outerTransaction)
+
             try {
-                currentStatement?.let {
-                    if(!it.isClosed) it.close()
-                    transaction.currentStatement = null
+                val answer = transaction.statement()
+                transaction.commit()
+                return answer
+            } catch (e: SQLException) {
+                val exposedSQLException = e as? ExposedSQLException
+                val queriesToLog = exposedSQLException?.causedByQueries()?.joinToString(";\n")
+                    ?: "${transaction.currentStatement}"
+                val message = "Transaction attempt #$repetitions failed: ${e.message}. Statement(s): $queriesToLog"
+                exposedSQLException?.contexts?.forEach {
+                    transaction.interceptors.filterIsInstance<SqlLogger>().forEach { logger ->
+                        logger.log(it, transaction)
+                    }
                 }
-                transaction.closeExecutedStatements()
-            } catch (e: Exception) {
-                exposedLogger.warn("Statements close failed", e)
+                exposedLogger.warn(message, e)
+                transaction.rollbackLoggingException { exposedLogger.warn("Transaction rollback failed: ${it.message}. See previous log line for statement", it) }
+                repetitions++
+                if (repetitions >= repetitionAttempts) {
+                    throw e
+                }
+            } catch (e: Throwable) {
+                val currentStatement = transaction.currentStatement
+                transaction.rollbackLoggingException { exposedLogger.warn("Transaction rollback failed: ${it.message}. Statement: $currentStatement", it) }
+                throw e
+            } finally {
+                TransactionManager.resetCurrent(outerManager)
+                val currentStatement = transaction.currentStatement
+                try {
+                    currentStatement?.let {
+                        if (!it.isClosed) it.close()
+                        transaction.currentStatement = null
+                    }
+                    transaction.closeExecutedStatements()
+                } catch (e: Exception) {
+                    exposedLogger.warn("Statements close failed", e)
+                }
+                transaction.closeLoggingException { exposedLogger.warn("Transaction close failed: ${it.message}. Statement: $currentStatement", it) }
             }
-            transaction.closeLoggingException { exposedLogger.warn("Transaction close failed: ${it.message}. Statement: $currentStatement", it) }
         }
+    }
+
+    return keepAndRestoreTransactionRefAfterRun(db) {
+        run()
+    }
+}
+
+internal fun <T> keepAndRestoreTransactionRefAfterRun(db: Database? = null, block: () -> T): T {
+    val manager = db.transactionManager as? ThreadLocalTransactionManager
+    val currentTransaction = manager?.threadLocal?.get()
+    return block().also {
+        manager?.threadLocal?.set(currentTransaction)
     }
 }

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -12,6 +12,8 @@ interface TransactionInterface {
 
     val connection: Connection
 
+    val transactionIsolation: Int
+
     val outerTransaction: Transaction?
 
     fun commit()
@@ -30,7 +32,7 @@ private object NotInitializedManager : TransactionManager {
 
     override var defaultRepetitionAttempts: Int = -1
 
-    override fun newTransaction(isolation: Int): Transaction = error("Please call Database.connect() before using this code")
+    override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction = error("Please call Database.connect() before using this code")
 
     override fun currentOrNull(): Transaction? = error("Please call Database.connect() before using this code")
 }
@@ -41,7 +43,7 @@ interface TransactionManager {
 
     var defaultRepetitionAttempts: Int
 
-    fun newTransaction(isolation: Int = defaultIsolationLevel) : Transaction
+    fun newTransaction(isolation: Int = defaultIsolationLevel, outerTransaction: Transaction? = null) : Transaction
 
     fun currentOrNull(): Transaction?
 

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -68,13 +68,13 @@ interface TransactionManager {
             }
         }
 
-        internal fun managerFor(database: Database) = registeredDatabases[database]
+        internal fun managerFor(database: Database?) = if (database != null) registeredDatabases[database] else manager
 
         private val currentThreadManager = object : ThreadLocal<TransactionManager>() {
             override fun initialValue(): TransactionManager = managers.first
         }
 
-        val manager: TransactionManager
+        private val manager: TransactionManager
             get() = currentThreadManager.get()
 
 
@@ -91,3 +91,5 @@ interface TransactionManager {
         fun isInitialized() = managers.first != NotInitializedManager
     }
 }
+
+val Database?.transactionManager: TransactionManager get() = TransactionManager.managerFor(this) ?: throw RuntimeException("database ${this} don't have any transaction manager")

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
@@ -3,10 +3,12 @@ package org.jetbrains.exposed.sql.transactions.experimental
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transactionManager
 
 suspend fun <T> transaction(db: Database? = null, statement: suspend Transaction.() -> T): T =
-        transaction(TransactionManager.manager.defaultIsolationLevel, TransactionManager.manager.defaultRepetitionAttempts, db, statement)
+    db.transactionManager.let { manager ->
+        transaction(manager.defaultIsolationLevel, manager.defaultRepetitionAttempts, db, statement)
+    }
 
 suspend fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Database? = null, statement: suspend Transaction.() -> T): T =
     org.jetbrains.exposed.sql.transactions.transaction(transactionIsolation, repetitionAttempts, db) {

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
@@ -8,6 +8,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -38,7 +39,7 @@ class MultiDatabaseEntityTest {
 
     @After
     fun after() {
-        TransactionManager.resetCurrent(currentDB?.let { TransactionManager.managerFor(it) })
+        TransactionManager.resetCurrent(currentDB?.transactionManager)
         transaction(db1) {
             SchemaUtils.drop(EntityTestsData.XTable, EntityTestsData.YTable)
         }

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseTest.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.sql.tests.shared.DMLTestsData
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -27,7 +28,7 @@ class MultiDatabaseTest {
 
     @After
     fun after() {
-        TransactionManager.resetCurrent(currentDB?.let { TransactionManager.managerFor(it) })
+        TransactionManager.resetCurrent(currentDB?.transactionManager)
     }
 
     @Test

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/EntityTests.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/EntityTests.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
+import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.joda.time.DateTime
 import org.junit.Test
 import java.sql.Connection
@@ -479,7 +480,7 @@ class EntityTests: DatabaseTestsBase() {
     }
 
     private fun <T> newTransaction(statement: Transaction.() -> T) =
-            inTopLevelTransaction(TransactionManager.current().db.metadata.defaultTransactionIsolation, 1, null, statement)
+            inTopLevelTransaction(TransactionManager.current().db.metadata.defaultTransactionIsolation, 1, null, null, statement)
 
     @Test fun sharingEntityBetweenTransactions() {
         withTables(Humans) {

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.exposed.sql.tests.shared
+
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class NestedTransactionsTest : DatabaseTestsBase() {
+
+    @Test
+    fun testNestedTransactions() {
+        withTables(DMLTestsData.Cities) {
+
+            assertTrue(DMLTestsData.Cities.selectAll().empty())
+
+            DMLTestsData.Cities.insert {
+                it[DMLTestsData.Cities.name] = "city1"
+            }
+
+            kotlin.test.assertEquals(1, DMLTestsData.Cities.selectAll().count())
+
+            assertEqualLists(listOf("city1"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+
+            transaction {
+                DMLTestsData.Cities.insert {
+                    it[DMLTestsData.Cities.name] = "city2"
+                }
+                assertEqualLists(listOf("city1", "city2"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+
+                transaction {
+                    DMLTestsData.Cities.insert {
+                        it[DMLTestsData.Cities.name] = "city3"
+                    }
+                    assertEqualLists(listOf("city1", "city2", "city3"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+                }
+
+                assertEqualLists(listOf("city1", "city2", "city3"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+
+                rollback()
+            }
+
+            assertEqualLists(listOf("city1"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+        }
+    }
+}

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -10,6 +10,7 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -57,7 +58,7 @@ class ConnectionTimeoutTest : DatabaseTestsBase(){
         val db = Database.connect(datasource = datasource)
 
         try {
-            transaction(TransactionManager.manager.defaultIsolationLevel, 42, db) {
+            transaction(db.transactionManager.defaultIsolationLevel, 42, db) {
                 exec("SELECT 1;")
                 // NO OP
             }
@@ -119,7 +120,7 @@ class ConnectionExceptions {
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(TransactionManager.manager.defaultIsolationLevel, 5, db) {
+            transaction(db.transactionManager.defaultIsolationLevel, 5, db) {
                 this.exec("BROKEN_SQL_THAT_CAUSES_EXCEPTION()")
             }
             fail("Should have thrown an exception")
@@ -152,7 +153,7 @@ class ConnectionExceptions {
         val wrappingDataSource = WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(TransactionManager.manager.defaultIsolationLevel, 5, db) {
+            transaction(db.transactionManager.defaultIsolationLevel, 5, db) {
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")
@@ -175,7 +176,7 @@ class ConnectionExceptions {
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(TransactionManager.manager.defaultIsolationLevel, 5, db) {
+            transaction(db.transactionManager.defaultIsolationLevel, 5, db) {
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")
@@ -237,22 +238,24 @@ class ThreadLocalManagerTest : DatabaseTestsBase() {
         if (TestDB.MYSQL !in TestDB.enabledInTests()) return
 
         var secondThreadTm: TransactionManager? = null
-        TestDB.MYSQL.connect()
+        val db1 = TestDB.MYSQL.connect()
+        lateinit var db2: Database
+
         transaction {
-            val firstThreadTm = TransactionManager.manager
+            val firstThreadTm = db1.transactionManager
             SchemaUtils.create(DMLTestsData.Cities)
             thread {
-                TestDB.MYSQL.connect()
+                db2 = TestDB.MYSQL.connect()
                 transaction {
                     DMLTestsData.Cities.selectAll().toList()
-                    secondThreadTm = TransactionManager.manager
+                    secondThreadTm = db2.transactionManager
                     assertNotEquals(firstThreadTm, secondThreadTm)
                 }
             }.join()
-            assertEquals(firstThreadTm, TransactionManager.manager)
+            assertEquals(firstThreadTm, db1.transactionManager)
             SchemaUtils.drop(DMLTestsData.Cities)
         }
-        assertEquals(secondThreadTm, TransactionManager.manager)
+        assertEquals(secondThreadTm, db2.transactionManager)
     }
 }
 
@@ -285,7 +288,7 @@ class MultipleDatabaseBugTest {
         db = Database.connect(ds)
 
         // SQLite supports only TRANSACTION_SERIALIZABLE and TRANSACTION_READ_UNCOMMITTED
-        TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
+        db.transactionManager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
     }
 
     @Test
@@ -309,7 +312,7 @@ class MultipleDatabaseBugTest {
 
     private fun initDb() {
         transaction {
-            println("TransactionManager: ${TransactionManager.manager}")
+            println("TransactionManager: ${this.db.transactionManager}")
             println("Transaction connection url: ${connection.metaData?.url}")
         }
     }

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
@@ -48,7 +48,7 @@ class SpringTransactionManager(dataSource: DataSource,
         currentOrNull()?.commit()
     }
 
-    override fun newTransaction(isolation: Int): Transaction {
+    override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction {
         val tDefinition = dataSource?.connection?.transactionIsolation?.takeIf { it != isolation }?.let {
                 DefaultTransactionDefinition().apply { isolationLevel = isolation }
         }
@@ -60,7 +60,7 @@ class SpringTransactionManager(dataSource: DataSource,
 
     private fun initTransaction(): Transaction {
         val connection = (TransactionSynchronizationManager.getResource(dataSource) as ConnectionHolder).connection
-        val transactionImpl = SpringTransaction(connection, db, currentOrNull())
+        val transactionImpl = SpringTransaction(connection, db, defaultIsolationLevel, currentOrNull())
         TransactionManager.resetCurrent(this)
         return Transaction(transactionImpl).apply {
             TransactionSynchronizationManager.bindResource(this@SpringTransactionManager, this)
@@ -69,7 +69,7 @@ class SpringTransactionManager(dataSource: DataSource,
 
     override fun currentOrNull(): Transaction? = TransactionSynchronizationManager.getResource(this) as Transaction?
 
-    private class SpringTransaction(override val connection: Connection, override val db: Database, override val outerTransaction: Transaction?) : TransactionInterface {
+    private class SpringTransaction(override val connection: Connection, override val db: Database, override val transactionIsolation: Int, override val outerTransaction: Transaction?) : TransactionInterface {
 
         override fun commit() {
             connection.run {


### PR DESCRIPTION
Hi, I've implemented nested transaction support using JDBC savepoints.

now you can use pattern  
```kotlin
transaction { 
  transaction {
      transaction {
      }
      rollback()
  }
}
```
Also made a little bit refactoring towards removing singletons.