### PR TITLE
existing index creation fix

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -318,11 +318,13 @@ abstract class VendorDialect(override val name: String,
                     }
                 }
                 rs.close()
-                val tColumns = table.columns.associateBy { transaction.identity(it) }
+                val tColumns = table.columns.associateBy { transaction.identity(it).trim('"') }
+
                 tmpIndices.filterNot { it.key.first in pkNames }
                         .mapNotNull { (index, columns) ->
                             columns.mapNotNull { cn -> tColumns[cn] }.takeIf { c -> c.size == columns.size }?.let { c -> Index(c, index.second, index.first) }
                         }
+
             }
         }
         return HashMap(existingIndicesCache)


### PR DESCRIPTION
some columns was stored in the map with quotes and columns.mapNotNull { cn -> tColumns[cn] } failed to find them