### PR TITLE
Explicitly specify constraint name in create table statement

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -51,7 +51,10 @@ data class ForeignKeyConstraint(val fkName: String,
     }
 
     internal val foreignKeyPart = buildString {
-        append(" FOREIGN KEY ($fromColumn) REFERENCES $targetTable($targetColumn)")
+        if (fkName.isNotBlank()) {
+            append("CONSTRAINT $fkName ")
+        }
+        append("FOREIGN KEY ($fromColumn) REFERENCES $targetTable($targetColumn)")
         if (deleteRule != ReferenceOption.NO_ACTION) {
             append(" ON DELETE $deleteRule")
         }
@@ -60,7 +63,7 @@ data class ForeignKeyConstraint(val fkName: String,
         }
     }
 
-    override fun createStatement() = listOf("ALTER TABLE $fromTable ADD" + (if (fkName.isNotBlank()) " CONSTRAINT $fkName" else "") + foreignKeyPart)
+    override fun createStatement() = listOf("ALTER TABLE $fromTable ADD $foreignKeyPart")
 
     override fun dropStatement() = listOf("ALTER TABLE $fromTable DROP " +
             when (currentDialect) {

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -59,6 +59,8 @@ internal object MysqlFunctionProvider : FunctionProvider() {
 
 open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, MysqlFunctionProvider) {
 
+    override val identifierLengthLimit = 64
+
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean {
         val expression = e.toSQL(QueryBuilder(false)).trim()
         return super.isAllowedAsColumnDefault(e) ||


### PR DESCRIPTION
Exposed uses `ALTER TABLE` statements to create constraints in case when there are cycles in table structure. In this case it explicitly sets constraint name to `fk_${fromCol.table.tableName}_${fromCol.name}_${targetColumn.name}`. However, if there are no cycles, constraints are defined in `CREATE TABLE` statements without name specification: thus, their names are generated by database engine that uses different naming convention (ie `Table_ibfk_1` in innodb).

This patch makes Exposed to explicitly specify constraint names in `CREATE TABLE` statements.

It also sets `identifierLengthLimit` for MySQL to 64 (as specified [here](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html)) to fix test that fails otherwise.