### PR TITLE
Add generic custom sql function support

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -23,6 +23,10 @@ class CurrentDateTime : Function<DateTime>(DateColumnType(false)) {
     }
 }
 
+class CustomFunction1<T: Any?>(val expr: Expression<T>, _columnType: IColumnType, val functionName : String) : Function<T?>(_columnType) {
+    override fun toSQL(queryBuilder: QueryBuilder): String = "$functionName(${expr.toSQL(queryBuilder)})"
+}
+
 class Month<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
     override fun toSQL(queryBuilder: QueryBuilder): String = "MONTH(${expr.toSQL(queryBuilder)})"
 }

--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -41,6 +41,7 @@ fun<T:String?> Expression<T>.trim() : Function<T> = Trim(this)
 
 fun<T:String?> Expression<T>.lowerCase() : Function<T> = LowerCase(this)
 fun<T:String?> Expression<T>.upperCase() : Function<T> = UpperCase(this)
+fun<T:Any?> ExpressionWithColumnType<T>.function(functionName: String) : Function<T?> = CustomFunction1(this, this.columnType, functionName)
 
 fun <T : String?> Expression<T>.groupConcat(separator: String? = null, distinct: Boolean = false, orderBy: Pair<Expression<*>,SortOrder>): GroupConcat<T> =
         GroupConcat(this, separator, distinct, orderBy)

--- a/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
+++ b/exposed/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
@@ -1507,6 +1507,30 @@ class DMLTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testCustomStringFunctions() {
+        withCitiesAndUsers { cities, users, userData ->
+            val customLower = DMLTestsData.Cities.name.function("lower")
+            assert(cities.slice(customLower).selectAll().any { it[customLower] == "prague" })
+
+            val customUpper = DMLTestsData.Cities.name.function("UPPER")
+            assert(cities.slice(customUpper).selectAll().any { it[customUpper] == "PRAGUE" })
+        }
+    }
+
+    @Test
+    fun testCustomIntegerFunctions() {
+        withCitiesAndUsers { cities, users, userData ->
+            val ids = cities.selectAll().map { it[DMLTestsData.Cities.id] }.toList()
+            kotlin.assert(ids == listOf(1,2,3)) { ids }
+
+            val sqrt = DMLTestsData.Cities.id.function("SQRT")
+            val sqrtIds = cities.slice(sqrt).selectAll().map { it[sqrt] }.toList()
+            val res= sqrtIds == listOf(1,1,1)
+            assert(res) {sqrtIds}
+        }
+    }
+
+    @Test
     fun testJoinWithAdditionalConstraint() {
         withCitiesAndUsers { cities, users, userData ->
             val usersAlias = users.alias("name")


### PR DESCRIPTION
I ran into a use case, where I wanted to call some SQL functions exposed by PostGIS. 
But looking at the code I wondered why there is no support for generic functions, so I added that instead.

Existing functions like upper, lower etc could be redefined as function("UPPER") if you want to reduce the amount of code for some added complexity.

I think it is best if functions are defined in a type safe matter, but it is also nice for users to have a "rabbit hole" to be able to just call any function in the database.