### PR TITLE
Build LIMIT only if size is strictly positive

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -107,7 +107,14 @@ abstract class FunctionProvider {
     open fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String
         = transaction.throwUnsupportedException("There's no generic SQL for replace. There must be vendor specific implementation")
 
-    open fun queryLimit(size: Int, offset: Int, alreadyOrdered: Boolean) = "LIMIT $size" + if (offset > 0) " OFFSET $offset" else ""
+    open fun queryLimit(size: Int, offset: Int, alreadyOrdered: Boolean) = buildString {
+        if (size > 0) {
+            append("LIMIT $size")
+            if (offset > 0) {
+                append(" OFFSET $offset")
+            }
+        }
+    }
 
     open fun <T : String?> groupConcat(expr: GroupConcat<T>, queryBuilder: QueryBuilder) = buildString {
         append("GROUP_CONCAT(")


### PR DESCRIPTION
AFAIK it doesn't make sense to pass a non-positive value to the `LIMIT` clause, so this PR prevents it from ever happening. Unfortunately I wasn't able to figure out how to write a test for this change : (