### PR TITLE
Make `notInList` function symmetrical with `inList` function

### DIFF
--- a/exposed/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -170,6 +170,13 @@ object SqlExpressionBuilder {
 
     infix fun<T> ExpressionWithColumnType<T>.notInList(list: Iterable<T>): Op<Boolean> = InListOrNotInListOp(this, list, isInList = false)
 
+    @Suppress("UNCHECKED_CAST")
+    @JvmName("notInListIds")
+    infix fun<T:Comparable<T>> Column<EntityID<T>>.notInList(list: Iterable<T>): Op<Boolean> {
+        val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
+        return notInList(list.map { EntityID(it, idTable) })
+    }
+
     infix fun<T> ExpressionWithColumnType<T>.inSubQuery(query: Query): Op<Boolean> = InSubQueryOp(this, query)
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
I think a `Column<EntityID<T>>.notInList` method is also convenient as `Column<EntityID<T>>.inList` method is.
And it makes symmetry between `inList` and `notInList` method.

If this PR does not follow the project's direction, feel free to close this.