### PR TITLE
Add batch select

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DMLTests.kt
@@ -989,6 +989,71 @@ class DMLTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun `selectBatched should respect 'where' expression and the provided batch size`() {
+        val Cities = DMLTestsData.Cities
+        withTables(Cities) {
+            val names = List(100) { UUID.randomUUID().toString() }
+            Cities.batchInsert(names) { name -> this[Cities.name] = name }
+
+            val batches = Cities.selectBatched(batchSize = 25) { Cities.id less 51 }
+                    .toList().map { it.toCityNameList() }
+
+            val expectedNames = names.take(50)
+            assertEqualLists(listOf(
+                    expectedNames.take(25),
+                    expectedNames.takeLast(25)
+            ), batches)
+        }
+    }
+
+    @Test
+    fun `when batch size is greater than the amount of available items, selectAllBatched should return 1 batch`() {
+        val Cities = DMLTestsData.Cities
+        withTables(Cities) {
+            val names = List(25) { UUID.randomUUID().toString() }
+            Cities.batchInsert(names) { name -> this[Cities.name] = name }
+
+            val batches = Cities.selectAllBatched(batchSize = 100).toList().map { it.toCityNameList() }
+
+            assertEqualLists(listOf(names), batches)
+        }
+    }
+
+    @Test
+    fun `when there are no items, selectAllBatched should return an empty iterable`() {
+        val Cities = DMLTestsData.Cities
+        withTables(Cities) {
+            val batches = Cities.selectAllBatched().toList()
+
+            assertEqualLists(batches, emptyList())
+        }
+    }
+
+    @Test
+    fun `when there are no items of the given condition, should return an empty iterable`() {
+        val Cities = DMLTestsData.Cities
+        withTables(Cities) {
+            val names = List(25) { UUID.randomUUID().toString() }
+            Cities.batchInsert(names) { name -> this[Cities.name] = name }
+
+            val batches = Cities.selectBatched(batchSize = 100) { Cities.id greater 50 }
+                    .toList().map { it.toCityNameList() }
+
+            assertEqualLists(emptyList(), batches)
+        }
+    }
+
+    @Test(expected = java.lang.UnsupportedOperationException::class)
+    fun `when the table doesn't have an autoinc column, selectAllBatched should throw an exception`() {
+        DMLTestsData.UserData.selectAllBatched()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `when batch size is 0 or less, should throw an exception`() {
+        DMLTestsData.Cities.selectAllBatched(batchSize = -1)
+    }
+
+    @Test
     fun testJoinWithAlias01() {
         withCitiesAndUsers { cities, users, userData ->
             val usersAlias = users.alias("u2")
@@ -1242,7 +1307,7 @@ class DMLTests : DatabaseTestsBase() {
 
     @Test fun testTRUEandFALSEOps() {
         withCitiesAndUsers { cities, _, _ ->
-            val allSities = cities.selectAll().map { it[cities.name] }
+            val allSities = cities.selectAll().toCityNameList()
             assertEquals(0, cities.select { Op.FALSE }.count())
             assertEquals(allSities.size, cities.select { Op.TRUE }.count())
         }
@@ -1310,6 +1375,7 @@ class DMLTests : DatabaseTestsBase() {
         }
     }
 
+    private fun Iterable<ResultRow>.toCityNameList(): List<String> = map { it[DMLTestsData.Cities.name] }
 }
 
 object OrgMemberships : IntIdTable() {


### PR DESCRIPTION
Follow up on https://github.com/JetBrains/Exposed/issues/641.

This functionality is inspired by Rails' [find_in_batches](https://apidock.com/rails/v5.2.3/ActiveRecord/Batches/find_in_batches) and is an alternative to using 'fetchSize' that does not rely on server-side cursors. It's also a much more efficient approach than using [limit+offset](https://www.eversql.com/faster-pagination-in-mysql-why-order-by-with-limit-and-offset-is-slow/).

The requirement for this to work is that the source table has an auto-increment column.

@Tapac I used a different naming style for the tests as I felt I needed more words, but if you prefer I can try to use the same format as the other tests.