### PR TITLE
Support auto increment for own ColumnType implementation

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -64,7 +64,13 @@ class AutoIncColumnType(val delegate: ColumnType, private val _autoincSeq: Strin
         is EntityIDColumnType<*> -> resolveAutIncType(columnType.idColumn.columnType)
         is IntegerColumnType -> currentDialect.dataTypeProvider.integerAutoincType()
         is LongColumnType -> currentDialect.dataTypeProvider.longAutoincType()
-        else -> error("Unsupported type $delegate for auto-increment")
+        else -> guessAutIncTypeBy(columnType.sqlType())
+    } ?: error("Unsupported type $delegate for auto-increment")
+
+    private fun guessAutIncTypeBy(sqlType: String) : String? = when (sqlType) {
+        currentDialect.dataTypeProvider.longType() -> currentDialect.dataTypeProvider.longAutoincType()
+        currentDialect.dataTypeProvider.integerType() -> currentDialect.dataTypeProvider.integerAutoincType()
+        else -> null
     }
 
     override fun sqlType(): String = resolveAutIncType(delegate)


### PR DESCRIPTION
Hi,

In our project we use [own `ColumnType` implementation](https://github.com/TouK/kotlin-exposed-realworld/blob/d3f9f90fe0f4cbec4fc6b2ec0207a99b218a9dc9/src/main/kotlin/io/realworld/shared/infrastructure/WrapperColumn.kt#L43) to wrap [id columns types](https://github.com/TouK/kotlin-exposed-realworld/blob/d3f9f90fe0f4cbec4fc6b2ec0207a99b218a9dc9/src/main/kotlin/io/realworld/comment/infrastructure/SqlCommentRepositories.kt#L25). When we use `SchemaUtils` to create schema, `resolveAutIncType` function raises exception because our `ColumnType` is not `LongColumnType` or `IntegerColumnType`, so we reworked this method to find auto increment type basing on `sqlType`.