### PR TITLE
Added uuid value autogeneration

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -371,6 +371,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
         replaceColumn(this@autoIncrement, this)
     }
 
+    fun Column<UUID>.autoGenerate(): Column<UUID> = this.clientDefault { UUID.randomUUID() }
 
     fun <N:Comparable<N>> Column<EntityID<N>>.autoinc(idSeqName: String? = null): Column<EntityID<N>> = cloneWithAutoInc(idSeqName).apply {
         replaceColumn(this@autoinc, this)


### PR DESCRIPTION
New method Column<UUID>.autoGenerate() allows to automatically generate random UUID value to columns where explicit passing of a value is not mandatory (for id's for example)

Example of usage:
```
object TestTable : Table("test_table") {
    val id = uuid("id").autoGenerate().primaryKey()
    val val1 = text("val1")
}
```