### PR TITLE
Fixing the month built-in function in case of all database dialects

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/JavaDateFunctions.kt
@@ -1,6 +1,13 @@
 package org.jetbrains.exposed.sql
 
-import org.jetbrains.exposed.sql.vendors.*
+import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MariaDBDialect
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
+import org.jetbrains.exposed.sql.vendors.OracleDialect
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.sql.vendors.SQLiteDialect
+import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.Temporal

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/JavaDateFunctions.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.sql
 
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
-import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.jetbrains.exposed.sql.vendors.*
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.Temporal
@@ -20,7 +19,18 @@ class CurrentDateTime : Function<LocalDateTime>(JavaLocalDateTimeColumnType.INST
 }
 
 class Month<T:Temporal?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("MONTH(", expr,")") }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        when (currentDialect) {
+            is PostgreSQLDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
+            is OracleDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
+            is OracleDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
+            is SQLServerDialect -> append("MONTH(", expr, ")")
+            is MariaDBDialect -> append("MONTH(", expr, ")")
+            is SQLiteDialect -> append("STRFTIME('%m',", expr, ")")
+            is H2Dialect -> append("MONTH(", expr, ")")
+            else -> append("MONTH(", expr, ")")
+        }
+    }
 }
 
 fun <T: Temporal?> Expression<T>.date() = Date(this)

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/DateFunctions.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/DateFunctions.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.sql
 
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
-import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.jetbrains.exposed.sql.vendors.*
 import org.joda.time.DateTime
 
 class Date<T:DateTime?>(val expr: Expression<T>): Function<DateTime>(DateColumnType(false)) {
@@ -18,7 +17,18 @@ class CurrentDateTime : Function<DateTime>(DateColumnType(false)) {
 }
 
 class Month<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("MONTH(", expr,")") }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        when (currentDialect) {
+            is PostgreSQLDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
+            is OracleDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
+            is OracleDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
+            is SQLServerDialect -> append("MONTH(", expr, ")")
+            is MariaDBDialect -> append("MONTH(", expr, ")")
+            is SQLiteDialect -> append("STRFTIME('%m',", expr, ")")
+            is H2Dialect -> append("MONTH(", expr, ")")
+            else -> append("MONTH(", expr, ")")
+        }
+    }
 }
 
 fun <T: DateTime?> Expression<T>.date() = Date(this)

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/DateFunctions.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/DateFunctions.kt
@@ -1,6 +1,13 @@
 package org.jetbrains.exposed.sql
 
-import org.jetbrains.exposed.sql.vendors.*
+import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MariaDBDialect
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
+import org.jetbrains.exposed.sql.vendors.OracleDialect
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.sql.vendors.SQLiteDialect
+import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.joda.time.DateTime
 
 class Date<T:DateTime?>(val expr: Expression<T>): Function<DateTime>(DateColumnType(false)) {


### PR DESCRIPTION
To select only the month on a datetime column we use Table.datetime-column.month(). 
This causes an error when using, for example, PostgreSQL database.
That's is because syntax of the month function is not the same for all database dialects. 

For example:
- For H2 database it will work because the syntax of month function is MONTH(<datetime-column>).
- For PostgreSQL it will cause an error because the syntax is EXTRACT(MONTH FROM <datetime-column>).