### PR TITLE
Added UpdateBuilder.update expression builder version.

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.sql.statements
 
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.SqlExpressionBuilder
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.VarCharColumnType
 import java.util.*
@@ -31,5 +32,12 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>): 
             error("$column is already initialized")
         }
         values[column] = value
+    }
+
+    open fun <T, S:T?> update(column: Column<T>, value: SqlExpressionBuilder.() -> Expression<S>) {
+        if (values.containsKey(column)) {
+            error("$column is already initialized")
+        }
+        values[column] = SqlExpressionBuilder.value()
     }
 }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/MiscTableTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/MiscTableTest.kt
@@ -326,7 +326,7 @@ class MiscTableTest : DatabaseTestsBase() {
 
             tbl.update({ tbl.n.eq(101) }) {
                 it.update(s, tbl.s.substring(2, 255))
-                it.update(sn, tbl.s.substring(3, 255))
+                it.update(sn) { tbl.s.substring(3, 255) }
             }
 
             val row = tbl.select { tbl.n eq 101 }.single()


### PR DESCRIPTION
We would like to have access to niceties from SqlExpressionBuilder here like `plus(t: T)`
```
update(c) { c + 1 }
```