### PR TITLE
Make ids on IN SQL condition distinct on eager loading

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
@@ -109,14 +109,14 @@ private fun <ID: Comparable<ID>> List<Entity<ID>>.preloadRelations(vararg relati
             is Reference<*, *, *> -> {
                 (refObject as Reference<Comparable<Comparable<*>>, *, Entity<*>>).reference.let { refColumn ->
                     this.map { it.run { refColumn.lookup() } }.takeIf { it.isNotEmpty() }?.let { refIds ->
-                        refObject.factory.find { refColumn.referee<Comparable<Comparable<*>>>()!! inList refIds }.toList()
+                        refObject.factory.find { refColumn.referee<Comparable<Comparable<*>>>()!! inList refIds.distinct() }.toList()
                     }.orEmpty()
                 }
             }
             is OptionalReference<*, *, *> -> {
                 (refObject as OptionalReference<Comparable<Comparable<*>>, *, Entity<*>>).reference.let { refColumn ->
                     this.mapNotNull { it.run { refColumn.lookup() } }.takeIf { it.isNotEmpty() }?.let { refIds ->
-                        refObject.factory.find { refColumn.referee<Comparable<Comparable<*>>>()!! inList refIds }.toList()
+                        refObject.factory.find { refColumn.referee<Comparable<Comparable<*>>>()!! inList refIds.distinct() }.toList()
                     }.orEmpty()
                 }
             }


### PR DESCRIPTION
# Abstract

When I use [`with` clause of eager-loading feature](https://github.com/JetBrains/Exposed/wiki/DAO#eager-loading), a SQL selecting referenced tables with `IN` query is executed. But ids in `IN` query are not distinct, so make them distinct by this PR.

# Example

For example, in below code,

```kotlin
val region1 = Region.new {
    name = "United States"
}
School.new {
    name = "Eton"
    region = region1
}
School.new {
    name = "Harrow"
    region = region1
}
commit()
School.all().with(School::region)
```

Below SQL is executed.

```sql
SQL: SELECT SCHOOL.ID, SCHOOL."NAME", SCHOOL.REGION_ID, SCHOOL.SECONDARY_REGION_ID FROM SCHOOL
SQL: SELECT REGION.ID, REGION."NAME" FROM REGION WHERE REGION.ID IN (1, 1)
```

But, duplicated ids exist (`IN (1, 1)`), so make them distinct by this PR fix.

After applying this PR fix, you can get below SQL.

```sql
SQL: SELECT SCHOOL.ID, SCHOOL."NAME", SCHOOL.REGION_ID, SCHOOL.SECONDARY_REGION_ID FROM SCHOOL
SQL: SELECT REGION.ID, REGION."NAME" FROM REGION WHERE REGION.ID = 1
```