### PR TITLE
[Improved solution] Adding sql datetime functions year, day, hour, minute, second

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -139,7 +139,7 @@ class IntegerColumnType : ColumnType() {
     override fun valueFromDB(value: Any): Any = when(value) {
         is Int -> value
         is Number -> value.toInt()
-        is String -> value.toIntOrNull() ?: value
+        is String -> value.toInt()
         else -> error("Unexpected value of type Int: $value of ${value::class.qualifiedName}")
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -139,6 +139,7 @@ class IntegerColumnType : ColumnType() {
     override fun valueFromDB(value: Any): Any = when(value) {
         is Int -> value
         is Number -> value.toInt()
+        is String -> value.toIntOrNull() ?: value
         else -> error("Unexpected value of type Int: $value of ${value::class.qualifiedName}")
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -175,6 +175,42 @@ abstract class FunctionProvider {
         expr.toList().appendTo { +it }
         append(")")
     }
+
+    open fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("YEAR(")
+        append(expr)
+        append(")")
+    }
+
+    open fun <T> month(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("MONTH(")
+        append(expr)
+        append(")")
+    }
+
+    open fun <T> day(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("DAY(")
+        append(expr)
+        append(")")
+    }
+
+    open fun <T> hour(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("HOUR(")
+        append(expr)
+        append(")")
+    }
+
+    open fun <T> minute(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("MINUTE(")
+        append(expr)
+        append(")")
+    }
+
+    open fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("SECOND(")
+        append(expr)
+        append(")")
+    }
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -98,6 +98,42 @@ internal object OracleFunctionProvider : FunctionProvider() {
         else
             expr.toList().appendTo(separator = " || '$separator' || ") { +it }
     }
+
+    override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(YEAR FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> month(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(MONTH FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> day(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(DAY FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> hour(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(HOUR FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> minute(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(MINUTE FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(SECOND FROM")
+        append(expr)
+        append(")")
+    }
 }
 
 open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, OracleFunctionProvider) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -100,37 +100,37 @@ internal object OracleFunctionProvider : FunctionProvider() {
     }
 
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(YEAR FROM")
+        append("Extract(YEAR FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> month(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(MONTH FROM")
+        append("Extract(MONTH FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> day(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(DAY FROM")
+        append("Extract(DAY FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> hour(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(HOUR FROM")
+        append("Extract(HOUR FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> minute(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(MINUTE FROM")
+        append("Extract(MINUTE FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(SECOND FROM")
+        append("Extract(SECOND FROM ")
         append(expr)
         append(")")
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -78,6 +78,42 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
             append(" ~* ")
         append(pattern)
     }
+
+    override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(YEAR FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> month(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(MONTH FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> day(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(DAY FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> hour(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(HOUR FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> minute(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(MINUTE FROM")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("Extract(SECOND FROM")
+        append(expr)
+        append(")")
+    }
 }
 
 open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProvider, PostgreSQLFunctionProvider) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -80,37 +80,37 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
     }
 
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(YEAR FROM")
+        append("Extract(YEAR FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> month(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(MONTH FROM")
+        append("Extract(MONTH FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> day(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(DAY FROM")
+        append("Extract(DAY FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> hour(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(HOUR FROM")
+        append("Extract(HOUR FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> minute(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(MINUTE FROM")
+        append("Extract(MINUTE FROM ")
         append(expr)
         append(")")
     }
 
     override fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("Extract(SECOND FROM")
+        append("Extract(SECOND FROM ")
         append(expr)
         append(")")
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -53,6 +53,42 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         else
             expr.toList().appendTo(this, separator = " || '$separator' || ") { +it }
     }
+
+    override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("STRFTIME('%Y',")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> month(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("STRFTIME('%m',")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> day(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("STRFTIME('%d',")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> hour(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("STRFTIME('%H',")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> minute(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("STRFTIME('%M',")
+        append(expr)
+        append(")")
+    }
+
+    override fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("STRFTIME('%S',")
+        append(expr)
+        append(")")
+    }
 }
 
 open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQLiteFunctionProvider) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -57,37 +57,37 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("STRFTIME('%Y',")
         append(expr)
-        append(")")
+        append(" / 1000, 'unixepoch')")
     }
 
     override fun <T> month(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("STRFTIME('%m',")
         append(expr)
-        append(")")
+        append(" / 1000, 'unixepoch')")
     }
 
     override fun <T> day(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("STRFTIME('%d',")
         append(expr)
-        append(")")
+        append(" / 1000, 'unixepoch')")
     }
 
     override fun <T> hour(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("STRFTIME('%H',")
         append(expr)
-        append(")")
+        append(" / 1000, 'unixepoch')")
     }
 
     override fun <T> minute(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("STRFTIME('%M',")
         append(expr)
-        append(")")
+        append(" / 1000, 'unixepoch')")
     }
 
     override fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("STRFTIME('%S',")
         append(expr)
-        append(")")
+        append(" / 1000, 'unixepoch')")
     }
 }
 

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateFunctions.kt
@@ -20,24 +20,50 @@ class CurrentDateTime : Function<LocalDateTime>(JavaLocalDateTimeColumnType.INST
     }
 }
 
+class Year<T:Temporal?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.year(expr, queryBuilder)
+    }
+}
+
 class Month<T:Temporal?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        when (currentDialect) {
-            is PostgreSQLDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
-            is OracleDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
-            is OracleDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
-            is SQLServerDialect -> append("MONTH(", expr, ")")
-            is MariaDBDialect -> append("MONTH(", expr, ")")
-            is SQLiteDialect -> append("STRFTIME('%m',", expr, ")")
-            is H2Dialect -> append("MONTH(", expr, ")")
-            else -> append("MONTH(", expr, ")")
-        }
+        currentDialect.functionProvider.month(expr, queryBuilder)
+    }
+}
+
+class Day<T:Temporal?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.day(expr, queryBuilder)
+    }
+}
+
+class Hour<T:Temporal?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.hour(expr, queryBuilder)
+    }
+}
+
+class Minute<T:Temporal?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.minute(expr, queryBuilder)
+    }
+}
+
+class Second<T:Temporal?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.second(expr, queryBuilder)
     }
 }
 
 fun <T: Temporal?> Expression<T>.date() = Date(this)
 
+fun <T: Temporal?> Expression<T>.year() = Year(this)
 fun <T: Temporal?> Expression<T>.month() = Month(this)
+fun <T: Temporal?> Expression<T>.day() = Day(this)
+fun <T: Temporal?> Expression<T>.hour() = Hour(this)
+fun <T: Temporal?> Expression<T>.minute() = Minute(this)
+fun <T: Temporal?> Expression<T>.second() = Second(this)
 
 
 fun dateParam(value: LocalDate): Expression<LocalDate> = QueryParameter(value, JavaLocalDateColumnType.INSTANCE)

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -1,13 +1,52 @@
 package org.jetbrains.exposed
 
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.`java-time`.*
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
+import org.junit.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.temporal.Temporal
 import kotlin.test.assertEquals
 
+open class JavaTimeBaseTest : DatabaseTestsBase() {
+
+    @Test
+    fun javaTimeFunctions() {
+        withTables(listOf(TestDB.SQLITE), Cities) {
+            SchemaUtils.create(Cities)
+
+            val now = LocalDateTime.now()
+
+            val cityID = Cities.insert {
+                it[name] = "Tunisia"
+                it[local_time] = now
+            } get Cities.id
+
+            val insertedYear = Cities.slice(Cities.local_time.year()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.year()]
+            val insertedMonth = Cities.slice(Cities.local_time.month()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.month()]
+            val insertedDay = Cities.slice(Cities.local_time.day()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.day()]
+            val insertedHour = Cities.slice(Cities.local_time.hour()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.hour()]
+            val insertedMinute = Cities.slice(Cities.local_time.minute()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.minute()]
+            val insertedSecond = Cities.slice(Cities.local_time.second()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.second()]
+
+            assertEquals(now.year, insertedYear)
+            assertEquals(now.month.value, insertedMonth)
+            assertEquals(now.dayOfMonth, insertedDay)
+            assertEquals(now.hour, insertedHour)
+            assertEquals(now.minute, insertedMinute)
+            assertEquals(now.second, insertedSecond)
+        }
+    }
+}
 
 fun <T:Temporal> assertEqualDateTime(d1: T?, d2: T?) {
     when{
@@ -29,3 +68,9 @@ fun equalDateTime(d1: Temporal?, d2: Temporal?) = try {
 }
 
 val today: LocalDate = LocalDate.now()
+
+object Cities : Table() {
+    val id = integer("cityId").autoIncrement("cities_seq").primaryKey() // PKColumn<Int>
+    val name = varchar("name", 50) // Column<String>
+    val local_time = datetime("local_time").nullable() // Column<datetime>
+}

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -1,12 +1,9 @@
 package org.jetbrains.exposed
 
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.`java-time`.*
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
-import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
@@ -21,22 +18,20 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
 
     @Test
     fun javaTimeFunctions() {
-        withTables(listOf(TestDB.SQLITE), Cities) {
-            SchemaUtils.create(Cities)
-
+        withTables(CitiesTime) {
             val now = LocalDateTime.now()
 
-            val cityID = Cities.insert {
+            val cityID = CitiesTime.insertAndGetId {
                 it[name] = "Tunisia"
                 it[local_time] = now
-            } get Cities.id
+            }
 
-            val insertedYear = Cities.slice(Cities.local_time.year()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.year()]
-            val insertedMonth = Cities.slice(Cities.local_time.month()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.month()]
-            val insertedDay = Cities.slice(Cities.local_time.day()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.day()]
-            val insertedHour = Cities.slice(Cities.local_time.hour()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.hour()]
-            val insertedMinute = Cities.slice(Cities.local_time.minute()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.minute()]
-            val insertedSecond = Cities.slice(Cities.local_time.second()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.second()]
+            val insertedYear = CitiesTime.slice(CitiesTime.local_time.year()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.year()]
+            val insertedMonth = CitiesTime.slice(CitiesTime.local_time.month()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.month()]
+            val insertedDay = CitiesTime.slice(CitiesTime.local_time.day()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.day()]
+            val insertedHour = CitiesTime.slice(CitiesTime.local_time.hour()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.hour()]
+            val insertedMinute = CitiesTime.slice(CitiesTime.local_time.minute()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.minute()]
+            val insertedSecond = CitiesTime.slice(CitiesTime.local_time.second()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.second()]
 
             assertEquals(now.year, insertedYear)
             assertEquals(now.month.value, insertedMonth)
@@ -69,8 +64,7 @@ fun equalDateTime(d1: Temporal?, d2: Temporal?) = try {
 
 val today: LocalDate = LocalDate.now()
 
-object Cities : Table() {
-    val id = integer("cityId").autoIncrement("cities_seq").primaryKey() // PKColumn<Int>
+object CitiesTime : IntIdTable("CitiesTime") {
     val name = varchar("name", 50) // Column<String>
     val local_time = datetime("local_time").nullable() // Column<datetime>
 }

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
@@ -18,23 +18,50 @@ class CurrentDateTime : Function<DateTime>(DateColumnType(false)) {
     }
 }
 
+class Year<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.year(expr, queryBuilder)
+    }
+}
+
 class Month<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        when (currentDialect) {
-            is PostgreSQLDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
-            is OracleDialect -> append("EXTRACT(MONTH FROM ", expr, ")")
-            is SQLServerDialect -> append("MONTH(", expr, ")")
-            is MariaDBDialect -> append("MONTH(", expr, ")")
-            is SQLiteDialect -> append("STRFTIME('%m',", expr, ")")
-            is H2Dialect -> append("MONTH(", expr, ")")
-            else -> append("MONTH(", expr, ")")
-        }
+        currentDialect.functionProvider.month(expr, queryBuilder)
+    }
+}
+
+class Day<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.day(expr, queryBuilder)
+    }
+}
+
+class Hour<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.hour(expr, queryBuilder)
+    }
+}
+
+class Minute<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.minute(expr, queryBuilder)
+    }
+}
+
+class Second<T:DateTime?>(val expr: Expression<T>): Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        currentDialect.functionProvider.second(expr, queryBuilder)
     }
 }
 
 fun <T: DateTime?> Expression<T>.date() = Date(this)
 
+fun <T: DateTime?> Expression<T>.year() = Year(this)
 fun <T: DateTime?> Expression<T>.month() = Month(this)
+fun <T: DateTime?> Expression<T>.day() = Day(this)
+fun <T: DateTime?> Expression<T>.hour() = Hour(this)
+fun <T: DateTime?> Expression<T>.minute() = Minute(this)
+fun <T: DateTime?> Expression<T>.second() = Second(this)
 
 
 fun dateParam(value: DateTime): Expression<DateTime> = QueryParameter(value, DateColumnType(false))

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -1,18 +1,14 @@
 package org.jetbrains.exposed
 
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.jodatime.*
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
-import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-import org.joda.time.LocalDateTime
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -23,22 +19,20 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
 
     @Test
     fun jodaTimeFunctions() {
-        withTables(listOf(TestDB.SQLITE), Cities) {
-            SchemaUtils.create(Cities)
+        withTables(CitiesTime) {
+            val now = DateTime.now()
 
-            val now = LocalDateTime.now()
-
-            val cityID = Cities.insert {
+            val cityID = CitiesTime.insertAndGetId {
                 it[name] = "St. Petersburg"
                 it[local_time] = now.toDateTime()
-            } get Cities.id
+            }
 
-            val insertedYear = Cities.slice(Cities.local_time.year()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.year()]
-            val insertedMonth = Cities.slice(Cities.local_time.month()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.month()]
-            val insertedDay = Cities.slice(Cities.local_time.day()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.day()]
-            val insertedHour = Cities.slice(Cities.local_time.hour()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.hour()]
-            val insertedMinute = Cities.slice(Cities.local_time.minute()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.minute()]
-            val insertedSecond = Cities.slice(Cities.local_time.second()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.second()]
+            val insertedYear = CitiesTime.slice(CitiesTime.local_time.year()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.year()]
+            val insertedMonth = CitiesTime.slice(CitiesTime.local_time.month()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.month()]
+            val insertedDay = CitiesTime.slice(CitiesTime.local_time.day()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.day()]
+            val insertedHour = CitiesTime.slice(CitiesTime.local_time.hour()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.hour()]
+            val insertedMinute = CitiesTime.slice(CitiesTime.local_time.minute()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.minute()]
+            val insertedSecond = CitiesTime.slice(CitiesTime.local_time.second()).select { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.second()]
 
             assertEquals(now.year, insertedYear)
             assertEquals(now.monthOfYear, insertedMonth)
@@ -72,8 +66,7 @@ fun equalDateTime(d1: DateTime?, d2: DateTime?) = try {
 
 val today: DateTime = DateTime.now().withTimeAtStartOfDay()
 
-object Cities : Table() {
-    val id = integer("cityId").autoIncrement("cities_seq").primaryKey() // PKColumn<Int>
+object CitiesTime : IntIdTable("CitiesTime") {
     val name = varchar("name", 50) // Column<String>
     val local_time = datetime("local_time").nullable() // Column<datetime>
 }

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -1,15 +1,52 @@
 package org.jetbrains.exposed
 
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.jodatime.*
+import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
+import org.joda.time.LocalDateTime
+import org.junit.Test
 import kotlin.test.assertEquals
 
 open class JodaTimeBaseTest : DatabaseTestsBase() {
     init {
         DateTimeZone.setDefault(DateTimeZone.UTC)
+    }
+
+    @Test
+    fun jodaTimeFunctions() {
+        withTables(listOf(TestDB.SQLITE), Cities) {
+            SchemaUtils.create(Cities)
+
+            val now = LocalDateTime.now()
+
+            val cityID = Cities.insert {
+                it[name] = "St. Petersburg"
+                it[local_time] = now.toDateTime()
+            } get Cities.id
+
+            val insertedYear = Cities.slice(Cities.local_time.year()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.year()]
+            val insertedMonth = Cities.slice(Cities.local_time.month()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.month()]
+            val insertedDay = Cities.slice(Cities.local_time.day()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.day()]
+            val insertedHour = Cities.slice(Cities.local_time.hour()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.hour()]
+            val insertedMinute = Cities.slice(Cities.local_time.minute()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.minute()]
+            val insertedSecond = Cities.slice(Cities.local_time.second()).select { Cities.id.eq(cityID) }.single()[Cities.local_time.second()]
+
+            assertEquals(now.year, insertedYear)
+            assertEquals(now.monthOfYear, insertedMonth)
+            assertEquals(now.dayOfMonth, insertedDay)
+            assertEquals(now.hourOfDay, insertedHour)
+            assertEquals(now.minuteOfHour, insertedMinute)
+            assertEquals(now.secondOfMinute, insertedSecond)
+        }
     }
 }
 
@@ -34,3 +71,9 @@ fun equalDateTime(d1: DateTime?, d2: DateTime?) = try {
 }
 
 val today: DateTime = DateTime.now().withTimeAtStartOfDay()
+
+object Cities : Table() {
+    val id = integer("cityId").autoIncrement("cities_seq").primaryKey() // PKColumn<Int>
+    val name = varchar("name", 50) // Column<String>
+    val local_time = datetime("local_time").nullable() // Column<datetime>
+}

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.3.0-M1")
     implementation(project(":exposed-core"))
     implementation(project(":exposed-jdbc"))
+    implementation(project(":exposed-jodatime"))
     implementation(project(":exposed-dao"))
     implementation(kotlin("test-junit"))
     implementation("org.slf4j", "slf4j-log4j12", "1.7.26")

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.3.0-M1")
     implementation(project(":exposed-core"))
     implementation(project(":exposed-jdbc"))
-    implementation(project(":exposed-jodatime"))
     implementation(project(":exposed-dao"))
     implementation(kotlin("test-junit"))
     implementation("org.slf4j", "slf4j-log4j12", "1.7.26")


### PR DESCRIPTION
This PR is similar to a previous PR that i did to add sql datetime functions.
But in his PR, i'm using the currentDialect.functionProvider to access the function. So that the convenient function is selected during runtime(via polymorphism) rather than using when statement.
=> better design and performance.
@Tapac are you agree? so that i close the previous PR