### PR TITLE
Enable the use of binary type without length in oracle and postgresql…

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -271,8 +271,11 @@ open class TextColumnType(collate: String? = null) : StringColumnType(collate) {
     }
 }
 
-class BinaryColumnType(val length: Int) : ColumnType() {
-    override fun sqlType(): String  = currentDialect.dataTypeProvider.binaryType(length)
+/**
+ * Implements the binary column type.
+ */
+open class BasicBinaryColumnType : ColumnType() {
+    override fun sqlType(): String  = currentDialect.dataTypeProvider.binaryType()
 
     override fun valueFromDB(value: Any): Any {
         if (value is Blob) {
@@ -285,6 +288,15 @@ class BinaryColumnType(val length: Int) : ColumnType() {
         is ByteArray -> value.toString(Charsets.UTF_8)
         else -> "$value"
     }
+}
+
+/**
+ * Implements the binary column type.
+ *
+ * @param length The maximum amount of bytes to store
+ */
+class BinaryColumnType(val length: Int) : BasicBinaryColumnType() {
+    override fun sqlType(): String  = currentDialect.dataTypeProvider.binaryType(length)
 }
 
 class BlobColumnType : ColumnType() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -386,6 +386,13 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
     fun binary(name: String, length: Int): Column<ByteArray> = registerColumn(name, BinaryColumnType(length))
 
     /**
+     * A binary column to store an array of bytes.
+     *
+     * @param name The column name
+     */
+    fun binary(name: String): Column<ByteArray> = registerColumn(name, BasicBinaryColumnType())
+
+    /**
      * A uuid column to store a UUID.
      *
      * @param name The column name

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -380,13 +380,19 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
     /**
      * A binary column to store an array of bytes.
      *
+     * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.testBinary
+     *
      * @param name The column name
-     * @param length The maximum amount of bytes to store
+     * @param length The maximum amount of bytes to store, this parameter is necessary only in H2, SQLite, MySQL,
+     *               MariaDB, and SQL Server dialects.
      */
     fun binary(name: String, length: Int): Column<ByteArray> = registerColumn(name, BinaryColumnType(length))
 
     /**
-     * A binary column to store an array of bytes.
+     * A binary column to store an array of bytes. This function is supported only by Oracle and PostgeSQL dialects.
+     * If you are using another dialect, please use instead the [binary] function by adding the length parameter.
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.testBinaryWithoutLength
      *
      * @param name The column name
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 internal typealias TableAndColumnName = Pair<String, String>
 
-open class DataTypeProvider {
+abstract class DataTypeProvider {
     open fun integerAutoincType() = "INT AUTO_INCREMENT"
 
     open fun integerType() = "INT"
@@ -29,6 +29,8 @@ open class DataTypeProvider {
     open fun blobType(): String = "BLOB"
 
     open fun binaryType(length: Int): String = "VARBINARY($length)"
+
+    open abstract fun binaryType(): String
 
     open fun booleanType(): String = "BOOLEAN"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -10,6 +10,11 @@ import java.util.*
 
 internal object H2DataTypeProvider : DataTypeProvider() {
     override fun uuidType(): String = "UUID"
+
+    override fun binaryType(): String {
+        exposedLogger.error("The length of the Binary column is missing.")
+        error("The length of the Binary column is missing.")
+    }
 }
 
 private val Transaction.isMySQLMode: Boolean

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -7,6 +7,11 @@ import java.math.BigDecimal
 
 internal object MysqlDataTypeProvider : DataTypeProvider() {
     override fun dateTimeType(): String = if ((currentDialect as MysqlDialect).isFractionDateTimeSupported()) "DATETIME(6)" else "DATETIME"
+
+    override fun binaryType(): String {
+        exposedLogger.error("The length of the Binary column is missing.")
+        error("The length of the Binary column is missing.")
+    }
 }
 
 internal open class MysqlFunctionProvider : FunctionProvider() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -22,7 +22,12 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
 
     override fun blobType() = "BLOB"
 
-    override fun binaryType(length: Int): String = "BLOB"
+    override fun binaryType(length: Int): String {
+        exposedLogger.warn("The length of the binary column is not required.")
+        return binaryType()
+    }
+
+    override fun binaryType(): String = "BLOB"
 
     override fun booleanType() = "CHAR(1)"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -17,7 +17,12 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
 
     override fun blobType(): String = "bytea"
 
-    override fun binaryType(length: Int): String = "bytea"
+    override fun binaryType(length: Int): String {
+        exposedLogger.warn("The length of the binary column is not required.")
+        return binaryType()
+    }
+
+    override fun binaryType(): String = "bytea"
 
     override fun uuidToDB(value: UUID): Any = value
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -23,6 +23,11 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
     override fun uuidType() = "uniqueidentifier"
 
     override fun uuidToDB(value: UUID) = value.toString()
+
+    override fun binaryType(): String {
+        exposedLogger.error("The length of the Binary column is missing.")
+        error("The length of the Binary column is missing.")
+    }
 }
 
 internal object SQLServerFunctionProvider : FunctionProvider() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -11,6 +11,11 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun booleanToStatementString(bool: Boolean) = if (bool) "1" else "0"
     override fun dateTimeType(): String  = "NUMERIC"
     override val blobAsStream: Boolean = true
+
+    override fun binaryType(): String {
+        exposedLogger.error("The length of the Binary column is missing.")
+        error("The length of the Binary column is missing.")
+    }
 }
 
 internal object SQLiteFunctionProvider : FunctionProvider() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -433,8 +433,42 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testBinaryWithoutLength() {
+        val tableWithBinary = object : Table("TableWithBinary") {
+            val binaryColumn = binary("binaryColumn")
+        }
+
+        fun SizedIterable<ResultRow>.readAsString() = map { String(it[tableWithBinary.binaryColumn]) }
+
+        withDb(listOf(TestDB.ORACLE,TestDB.POSTGRESQL)) {
+            val exposedBytes = "Exposed".toByteArray()
+            val kotlinBytes = "Kotlin".toByteArray()
+
+            SchemaUtils.create(tableWithBinary)
+
+            tableWithBinary.insert {
+                it[tableWithBinary.binaryColumn] = exposedBytes
+            }
+            val insertedExposed = tableWithBinary.selectAll().readAsString().single()
+
+            assertEquals("Exposed", insertedExposed)
+
+            tableWithBinary.insert {
+                it[tableWithBinary.binaryColumn] = kotlinBytes
+            }
+
+            assertEqualCollections(tableWithBinary.selectAll().readAsString(), "Exposed", "Kotlin")
+
+            val insertedKotlin = tableWithBinary.select { tableWithBinary.binaryColumn eq kotlinBytes }.readAsString()
+            assertEqualCollections(insertedKotlin, "Kotlin")
+
+            SchemaUtils.drop(tableWithBinary)
+        }
+    }
+
     @Test fun testBinary() {
-        val t = object : Table() {
+        val t = object : Table("t") {
             val binary = binary("bytes", 10)
             val byteCol = binary("byteCol", 1).clientDefault { byteArrayOf(0) }
         }


### PR DESCRIPTION
This pull request is related to the issue [#618](https://github.com/JetBrains/Exposed/issues/618).
In oracle and postgresql, the binary column type doesn't require a length property. So this PR aims to allow declaring a binary column with/without specifying the length.
There are two scenarios : 
- using oracle or postgresql and specifying a length => warning is logged indicating that the length is not required and the program continues without error.
- using other DB without specifying a length => error is logged indicating that the length is missing and the program fails with exception.