### PR TITLE
[Custom PK constraint name] adding the feature of defining a custom n…

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -39,6 +39,7 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
         val alterTablePrefix = "ALTER TABLE ${TransactionManager.current().identity(table)} ADD"
         val isLastColumnInPK = indexInPK != null && indexInPK == table.columns.mapNotNull { it.indexInPK }.max()
         val columnDefinition = when {
+            isOneColumnPK() && table.isCustomPKNameDefined && isLastColumnInPK && currentDialect !is H2Dialect -> descriptionDdl() + ", ADD ${table.primaryKeyConstraint()}"
             isOneColumnPK() && (currentDialect is H2Dialect || currentDialect is SQLiteDialect) -> descriptionDdl().removeSuffix(" PRIMARY KEY")
             !isOneColumnPK() && isLastColumnInPK && currentDialect !is H2Dialect -> descriptionDdl() + ", ADD ${table.primaryKeyConstraint()}"
             else -> descriptionDdl()
@@ -91,7 +92,7 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
             append(" NOT NULL")
         }
 
-        if (isOneColumnPK() && !isSQLiteAutoIncColumn) {
+        if (!table.isCustomPKNameDefined && isOneColumnPK() && !isSQLiteAutoIncColumn) {
             append(" PRIMARY KEY")
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -325,7 +325,7 @@ class DDLTests : DatabaseTestsBase() {
         }
 
         /**
-         * We are excluding H2 because it is covered by the test {@link #testAddCompositePrimaryKeyToTableH2()}
+         * We are excluding H2 because it is covered by the test [testAddCompositePrimaryKeyToTableH2]
          */
         withTables(listOf(TestDB.H2, TestDB.H2_MYSQL), table) {
             val tableProperName = tableName.inProperCase()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -40,6 +40,14 @@ object EntityTestsData {
         val y1 = optReference("y1", YTable)
     }
 
+    /*
+    Entity with the default name of the primary key constraint.
+    */
+    object Book : IntIdTable("Article") {
+        val title = varchar("name", 50).primaryKey()
+        override val primaryKey = "Custom_PK_Article"
+    }
+
     class XEntity(id: EntityID<Int>): Entity<Int>(id) {
         var b1 by XTable.b1
         var b2 by XTable.b2
@@ -91,7 +99,14 @@ object EntityTestsData {
 }
 
 class EntityTests: DatabaseTestsBase() {
-    @Test fun testDefaults01() {
+
+    @Test fun testCustomPKContraintName() {
+        withTables(EntityTestsData.Book) {
+            assertEquals(EntityTestsData.Book.primaryKey, "Custom_PK_Article")
+        }
+    }
+
+        @Test fun testDefaults01() {
         withTables(EntityTestsData.YTable, EntityTestsData.XTable) {
             val x = EntityTestsData.XEntity.new {  }
             assertEquals (x.b1, true, "b1 mismatched")


### PR DESCRIPTION
This PR is related to the issue [470](https://github.com/JetBrains/Exposed/issues/470) .
- This PR is to allow the user to define his proper primarykey constraint name. Here is an example :

```
object Table : Table("table") {
        val id1 = integer("id1").primaryKey()
        val id2 = integer("id2").primaryKey()
        override val primaryKey = "CustomPK"
}
```

=> generated SQL:
`CREATE TABLE table (id1 INT,id2 INT, CONSTRAINT CustomPK PRIMARY KEY (id1,id2))`

- If the PK constraint name is defined and even when the primary key contains only one single column, then the constraint name must be generated rather than generating : [id1 INT PRIMARY KEY]. Exemple:
```
object Table : Table("table") {
        val id1 = integer("id1").primaryKey()
        val id2 = integer("id2")
        override val primaryKey = "CustomPK"
}
```

=> generated SQL : 
`CREATE TABLE table (id1 INT, CONSTRAINT CustomPK PRIMARY KEY (id1))`

- When the primaryKey is not overridden, then the default name of the constraint is : pk_<Table-name>_<listOf(keys) seperated by '\_'> ( pk_Table_id1_id2...)

- Tests are added to DDLTests and EntityTests.

@Tapac thanks to review this, if all is OK, so that i can add the feature documentation to the wiki.