### PR TITLE
[BugFix] Prevent defining duplicated colum name in a table

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Exceptions.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Exceptions.kt
@@ -37,4 +37,14 @@ class ExposedSQLException(cause: Throwable?, val contexts: List<StatementContext
 
 class UnsupportedByDialectException(baseMessage: String, val dialect: DatabaseDialect) : UnsupportedOperationException(baseMessage + ", dialect: ${dialect.name}.")
 
+/**
+ * DuplicateColumnException is thrown :
+ *
+ * When you attempt to create a table with multiple columns having the same name.
+ * When you replace a column of a table so that you define multiple columns having the same name.
+ *
+ * @param columnName the duplicated column name
+ */
+class DuplicateColumnException(columnName: String) : ExceptionInInitializerError("Duplicate column name : $columnName")
+
 internal fun Transaction.throwUnsupportedException(message: String): Nothing = throw UnsupportedByDialectException(message, db.dialect)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Exceptions.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Exceptions.kt
@@ -45,6 +45,6 @@ class UnsupportedByDialectException(baseMessage: String, val dialect: DatabaseDi
  *
  * @param columnName the duplicated column name
  */
-class DuplicateColumnException(columnName: String) : ExceptionInInitializerError("Duplicate column name : $columnName")
+class DuplicateColumnException(columnName: String, tableName: String) : ExceptionInInitializerError("Duplicate column name \"$columnName\" in table \"$tableName\"")
 
 internal fun Transaction.throwUnsupportedException(message: String): Nothing = throw UnsupportedByDialectException(message, db.dialect)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -681,11 +681,10 @@ fun ColumnSet.targetTables(): List<Table> = when (this) {
     else -> error("No target provided for update")
 }
 
-private fun <T> ArrayList<Column<*>>.addColumn(column: Column<T>) {
+private fun <T> MutableList<Column<*>>.addColumn(column: Column<T>) {
     if (this.any { it.name == column.name }) {
         throw DuplicateColumnException(column.name)
     } else {
         this.add(column)
     }
 }
-

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -665,6 +665,14 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
     }
 
     override fun hashCode(): Int = tableName.hashCode()
+
+    private fun <T> MutableList<Column<*>>.addColumn(column: Column<T>) {
+        if (this.any { it.name == column.name }) {
+            throw DuplicateColumnException(column.name, tableName)
+        } else {
+            this.add(column)
+        }
+    }
 }
 
 data class Seq(private val name: String) {
@@ -681,10 +689,3 @@ fun ColumnSet.targetTables(): List<Table> = when (this) {
     else -> error("No target provided for update")
 }
 
-private fun <T> MutableList<Column<*>>.addColumn(column: Column<T>) {
-    if (this.any { it.name == column.name }) {
-        throw DuplicateColumnException(column.name)
-    } else {
-        this.add(column)
-    }
-}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.exceptions.DuplicateColumnException
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
@@ -222,7 +223,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
      * Adds a new column to a table.
      */
     fun <T> registerColumn(name: String, type: IColumnType): Column<T> = Column<T>(this, name, type).apply {
-        _columns.add(this)
+        _columns.addColumn(this)
     }
 
     /**
@@ -231,7 +232,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
      */
     fun<TColumn: Column<*>> replaceColumn(oldColumn: Column<*>, newColumn: TColumn) : TColumn {
         _columns.remove(oldColumn)
-        _columns.add(newColumn)
+        _columns.addColumn(newColumn)
         return newColumn
     }
 
@@ -260,7 +261,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
         val originalColumn = (table.id.columnType as EntityIDColumnType<*>).idColumn
         val columnTypeCopy = originalColumn.columnType.cloneAsBaseType()
         val answer = Column<EntityID<ID>>(this, name, EntityIDColumnType(Column<ID>(table, name, columnTypeCopy)))
-        _columns.add(answer)
+        _columns.addColumn(answer)
         return answer
     }
 
@@ -482,7 +483,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
                                     onDelete: ReferenceOption? = null, onUpdate: ReferenceOption? = null): Column<T> {
         val originalType = (refColumn.columnType as? EntityIDColumnType<*>)?.idColumn?.columnType ?: refColumn.columnType
         val column = Column<T>(this, name, originalType.cloneAsBaseType()).references(refColumn, onDelete, onUpdate)
-        this._columns.add(column)
+        this._columns.addColumn(column)
         return column
     }
 
@@ -679,3 +680,12 @@ fun ColumnSet.targetTables(): List<Table> = when (this) {
     is Join -> this.table.targetTables() + this.joinParts.flatMap { it.joinPart.targetTables() }
     else -> error("No target provided for update")
 }
+
+private fun <T> ArrayList<Column<*>>.addColumn(column: Column<T>) {
+    if (this.any { it.name == column.name }) {
+        throw DuplicateColumnException(column.name)
+    } else {
+        this.add(column)
+    }
+}
+

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -840,61 +840,10 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
-    // https://github.com/JetBrains/Exposed/issues/709
-    @Test
-    fun createTableWithDuplicateColumn() {
-        val assertionFailureMessage = "Can't create a table with multiple columns having the same name"
-
-        withDb() {
-            assertFails(assertionFailureMessage) {
-                SchemaUtils.create(TableWithDuplicatedColumn)
-            }
-            assertFails(assertionFailureMessage) {
-                SchemaUtils.create(TableDuplicatedColumnRefereToIntIdTable)
-            }
-            assertFails(assertionFailureMessage) {
-                SchemaUtils.create(TableDuplicatedColumnRefereToTable)
-            }
-        }
-    }
-
-    // https://github.com/JetBrains/Exposed/issues/709
-    @Test
-    fun replaceColumnToDuplicateColumn() {
-        val assertionFailureMessage = "Can't replace a column with another one that has the same name as an existing column"
-
-        withTables(IDTable) {
-            assertFailsWith(exceptionClass =    DuplicateColumnException::class,
-                            message =           assertionFailureMessage
-            ) {
-                //Duplicate the id column by replacing the IDTable.code by a column with the name "id"
-                val id = Column<Int>(IDTable, IDTable.id.name, IDTable.id.columnType)
-                IDTable.replaceColumn(IDTable.code, id)
-            }
-        }
-    }
-
     object TableFromSchemeOne : IntIdTable("one.test")
 
     object TableFromSchemeTwo : IntIdTable("two.test") {
         val reference = reference("testOne", TableFromSchemeOne)
-    }
-
-    object TableWithDuplicatedColumn : Table("myTable") {
-        val id1 = integer("id")
-        val id2 = integer("id")
-    }
-
-    object IDTable : IntIdTable("myTable") {
-        val code = integer("code")
-    }
-
-    object TableDuplicatedColumnRefereToIntIdTable : IntIdTable("myTable") {
-        val reference = reference("id", IDTable)
-    }
-
-    object TableDuplicatedColumnRefereToTable : Table("myTable") {
-        val reference = reference("id", TableWithDuplicatedColumn.id1)
     }
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.exposed.sql.tests.shared.ddl
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.junit.Test
+
+import kotlin.test.assertFails
+
+class CreateTableTests : DatabaseTestsBase() {
+    // https://github.com/JetBrains/Exposed/issues/709
+    @Test
+    fun createTableWithDuplicateColumn() {
+        val assertionFailureMessage = "Can't create a table with multiple columns having the same name"
+
+        withDb() {
+            assertFails(assertionFailureMessage) {
+                SchemaUtils.create(TableWithDuplicatedColumn)
+            }
+            assertFails(assertionFailureMessage) {
+                SchemaUtils.create(TableDuplicatedColumnRefereToIntIdTable)
+            }
+            assertFails(assertionFailureMessage) {
+                SchemaUtils.create(TableDuplicatedColumnRefereToTable)
+            }
+        }
+    }
+
+    object TableWithDuplicatedColumn : Table("myTable") {
+        val id1 = integer("id")
+        val id2 = integer("id")
+    }
+
+    object IDTable : IntIdTable("IntIdTable")
+
+    object TableDuplicatedColumnRefereToIntIdTable : IntIdTable("myTable") {
+        val reference = reference("id", IDTable)
+    }
+
+    object TableDuplicatedColumnRefereToTable : Table("myTable") {
+        val reference = reference("id", TableWithDuplicatedColumn.id1)
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ReplaceColumnTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ReplaceColumnTests.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.exposed.sql.tests.shared.ddl
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.exceptions.DuplicateColumnException
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.junit.Test
+
+import kotlin.test.assertFailsWith
+
+class ReplaceColumnTests : DatabaseTestsBase() {
+    // https://github.com/JetBrains/Exposed/issues/709
+    @Test
+    fun replaceColumnToDuplicateColumn() {
+        val assertionFailureMessage = "Can't replace a column with another one that has the same name as an existing column"
+
+        withTables(IDTable) {
+            assertFailsWith(exceptionClass =    DuplicateColumnException::class,
+                            message =           assertionFailureMessage
+            ) {
+                //Duplicate the id column by replacing the IDTable.code by a column with the name "id"
+                val id = Column<Int>(IDTable, IDTable.id.name, IDTable.id.columnType)
+                IDTable.replaceColumn(IDTable.code, id)
+            }
+        }
+    }
+
+    object IDTable : IntIdTable("myTable") {
+        val code = integer("code")
+    }
+}


### PR DESCRIPTION
This PR is to resolve the bug #709 .
In Fact, there are two scenarios where Exposed allow to create a table with multiple columns that have the same name (which fails later when executing the query in the database) : 
- First exemple : 
```Kotlin
object TableWithDuplicatedColumn : Table("myTable") {
        val id1 = integer("id")
        val id2 = integer("id")
}
```
- Second exemple : 
```Kotlin
object IDTable : IntIdTable("myTable") 
object TableDuplicatedColumnRefereToIntIdTable : IntIdTable("myTable") {
        val reference = reference("id", IDTable)
}
```

So this PR is to introduce a new Exception that is thrown when user attempt to produce a table with duplicate column name (when creating the table or when replacing column of an existing table)