### PR TITLE
Adding the feature of defining the primarykey constraint name

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -37,7 +37,7 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
 
     override fun createStatement(): List<String> {
         val alterTablePrefix = "ALTER TABLE ${TransactionManager.current().identity(table)} ADD"
-        val isLastColumnInPK = indexInPK != null && indexInPK == table.columns.mapNotNull { it.indexInPK }.max()
+        val isLastColumnInPK = table.primaryKey.columns.lastOrNull() == this
         val columnDefinition = when {
             isOneColumnPK() && table.isCustomPKNameDefined && isLastColumnInPK && currentDialect !is H2Dialect -> descriptionDdl() + ", ADD ${table.primaryKeyConstraint()}"
             isOneColumnPK() && (currentDialect is H2Dialect || currentDialect is SQLiteDialect) -> descriptionDdl().removeSuffix(" PRIMARY KEY")
@@ -55,19 +55,19 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
 
     override fun dropStatement() = listOf(TransactionManager.current().let {"ALTER TABLE ${it.identity(table)} DROP COLUMN ${it.identity(this)}" })
 
-    internal fun isOneColumnPK() = table.columns.singleOrNull { it.indexInPK != null } == this
+    internal fun isOneColumnPK() = table.primaryKey.columns.singleOrNull() == this
 
     fun descriptionDdl(): String = buildString {
         val tr = TransactionManager.current()
         append(tr.identity(this@Column))
         append(" ")
-        val isPKColumn = indexInPK != null
+        val isPKColumn = table.primaryKey.columns.contains(this@Column)
         val colType = columnType
         val isSQLiteAutoIncColumn = currentDialect is SQLiteDialect && colType.isAutoInc
 
         when {
             !isPKColumn && isSQLiteAutoIncColumn -> tr.throwUnsupportedException("Auto-increment could be applied only to primary key column")
-            isSQLiteAutoIncColumn && !isOneColumnPK() && table.columns.any{ it.indexInPK != null} -> append(currentDialect.dataTypeProvider.integerType())
+            isSQLiteAutoIncColumn && !isOneColumnPK() && table.primaryKey.columns.isNotEmpty() -> append(currentDialect.dataTypeProvider.integerType())
             else -> append(colType.sqlType())
         }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -39,6 +39,7 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
         val alterTablePrefix = "ALTER TABLE ${TransactionManager.current().identity(table)} ADD"
         val isLastColumnInPK = indexInPK != null && indexInPK == table.columns.mapNotNull { it.indexInPK }.max()
         val columnDefinition = when {
+            isOneColumnPK() && table.isCustomPKNameDefined && isLastColumnInPK && currentDialect !is H2Dialect -> descriptionDdl() + ", ADD ${table.primaryKeyConstraint()}"
             isOneColumnPK() && (currentDialect is H2Dialect || currentDialect is SQLiteDialect) -> descriptionDdl().removeSuffix(" PRIMARY KEY")
             !isOneColumnPK() && isLastColumnInPK && currentDialect !is H2Dialect -> descriptionDdl() + ", ADD ${table.primaryKeyConstraint()}"
             else -> descriptionDdl()
@@ -91,7 +92,7 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
             append(" NOT NULL")
         }
 
-        if (isOneColumnPK() && !isSQLiteAutoIncColumn) {
+        if (!table.isCustomPKNameDefined && isOneColumnPK() && !isSQLiteAutoIncColumn) {
             append(" PRIMARY KEY")
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -259,7 +259,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
     /**
      * Represents the primary key of the table. It is initialized with existing keys.
      */
-    open val primaryKey = PrimaryKey(getPrimaryKeyColumns(), "")
+    open val primaryKey by lazy { PrimaryKey(getPrimaryKeyColumns(), "") }
 
     /**
      * Returns the list of columns in the primary key.
@@ -652,7 +652,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
     }
 
     internal fun primaryKeyConstraint(): String? {
-        val pkey = columns.filter { it.indexInPK != null }.sortedWith(compareBy({ !it.columnType.isAutoInc }, { it.indexInPK }))
+        val pkey = primaryKey.columns
 
         if (pkey.isNotEmpty()) {
             val tr = TransactionManager.current()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -239,42 +239,69 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
 
     /**
      * The primary key class.
-     *
-     * @param columns list of columns in the primarykey
-     * @param name the primary key constraint name, by default it will be resolved from the table name with "pk_" prefix
      */
-    inner class PrimaryKey(vararg columns: Column<*>, var name: String = "") {
-        val columns = columns
-        init {
+    inner class PrimaryKey {
+        val columns: List<Column<*>>
+        val name: String
+
+        /**
+         * Define the columns in the primary key of the current table. You can also provide the name of primary key constraint
+         * by passing the "name" argument. Example : PrimaryKey(id1, id2, id3..., name = "CustomPKName")
+         *
+         * @param columns list of columns in the primary key
+         * @param name the primary key constraint name, by default it will be resolved from the table name with "pk_" prefix
+         */
+        constructor(vararg columns: Column<*>, name: String = "") {
+            this.columns = columns.toList()
+
             checkMultipleDeclaration()
 
             for (column in columns) {
-                column.primaryKey()
+                column.markPrimaryKey()
             }
 
             if (name.isEmpty()) {
-                name = "pk_${tableName}"
+                this.name = "pk_${tableName}"
             } else {
+                this.name = name
                 isCustomPKNameDefined = true
             }
         }
 
+        /**
+         * Initialize PrimaryKey class with columns defined using [primaryKey] method
+         *
+        * This constructor must be removed when [primaryKey] method is no longer supported.
+        */
+        internal constructor(columns: List<Column<*>>) {
+            this.columns = columns
+            this.name = "pk_${tableName}"
+        }
+
+        /**
+         * Mark @receiver column as an element of primary key.
+         */
+        private fun <T> Column<T>.markPrimaryKey() {
+            indexInPK = table.columns.count { it.indexInPK != null } + 1
+        }
+
         /** Check if both old and new declarations of primary key are defined.
          *
-         * Workaround : unregister old primary keys and log error.
-         * This workaround must be removed when old [primaryKey] method is no longer supported.
+         * Remove columns from primary key to take columns declared in PrimaryKey class instead.
+         * Log an error.
+         * This function must be removed when [primaryKey] method is no longer supported.
          */
         private fun checkMultipleDeclaration() {
-            if (columns.isNotEmpty()) {
-                unregisterPrimaryKey()
+            if (this@Table.columns.any { it.indexInPK != null }) {
+                removeOldPrimaryKey()
                 exposedLogger.error("Confusion between multiple declarations of primary key. " +
                                     "Use only override val primaryKey=PrimaryKey() declaration.")
             }
         }
 
-        // This workaround must be removed when old primaryKey(indx) method is no longer supported.
-        private fun unregisterPrimaryKey() {
-            for(column in columns) {
+        /** This function must be removed when [primaryKey] method is no longer supported. */
+        private fun removeOldPrimaryKey() {
+            for (column in columns.filter { it.indexInPK != null }) {
                 column.indexInPK = null
             }
         }
@@ -283,7 +310,7 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
     /**
      * Represents the primary key of the table. It is initialized with existing keys.
      */
-    open val primaryKey by lazy { PrimaryKey(*getPrimaryKeyColumns().toTypedArray()) }
+    open val primaryKey by lazy { PrimaryKey(getPrimaryKeyColumns()) }
 
     /**
      * Returns the list of columns in the primary key.
@@ -299,6 +326,9 @@ open class Table(name: String = ""): ColumnSet(), DdlAware {
      *
      * @param indx An optional column index in a primary key
      */
+    @Deprecated("This function will be no longer supported. Please use the new declarations of primary key by " +
+                "overriding the primaryKey property in the current table. " +
+                "Example : object TableName : Table() { override val primaryKey = PrimaryKey(columns, name = \"CustomPKConstraintName\") }")
     fun <T> Column<T>.primaryKey(indx: Int? = null): Column<T> {
         if (indx != null && table.columns.any { it.indexInPK == indx } ) throw IllegalArgumentException("Table $tableName already contains PK at $indx")
         indexInPK = indx ?: table.columns.count { it.indexInPK != null } + 1


### PR DESCRIPTION
This PR is related to the issue #470 .
- This PR is to allow the user to define his proper primarykey constraint name. Here is an example :

```Kotlin
object table : Table("table") {
        val id1 = integer("id1")
        val id2 = integer("id2")
        override val primaryKey = PrimaryKey(listOf(id1, id2), "CustomPk")
}
```

=> generated SQL:
`CREATE TABLE table (id1 INT,id2 INT, CONSTRAINT CustomPK PRIMARY KEY (id1,id2))`

- When the PK constraint name is defined and the primary key contains only one single column, then the constraint name must be defined in the generated SQL query.

@Tapac if the design and the code are ok i'm thinking also to add the functions : 
- table.primaryKey.rename("newPkname") => rename the constraint.
- table.primaryKey.drop() => drop the constraint.