### PR TITLE
Removed unnecessary special treatment for SQLite

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
@@ -16,7 +16,6 @@ import java.util.Locale
 
 private val DEFAULT_DATE_STRING_FORMATTER by lazy { DateTimeFormatter.ISO_LOCAL_DATE.withLocale(Locale.ROOT).withZone(ZoneId.systemDefault()) }
 private val DEFAULT_DATE_TIME_STRING_FORMATTER by lazy { DateTimeFormatter.ISO_LOCAL_DATE_TIME.withLocale(Locale.ROOT).withZone(ZoneId.systemDefault()) }
-private val SQLITE_DATE_TIME_STRING_FORMATTER by lazy { DateTimeFormatter.ofPattern("yyyy-MM-d HH:mm:ss").withZone(ZoneId.systemDefault()) }
 
 private fun formatterForDateString(date: String) = dateTimeWithFractionFormat(date.substringAfterLast('.', "").length)
 private fun dateTimeWithFractionFormat(fraction: Int) : DateTimeFormatter {

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
@@ -88,10 +88,7 @@ class JavaLocalDateTimeColumnType : ColumnType(), IDateColumnType {
         is java.sql.Timestamp -> value.toLocalDateTime()
         is Int -> LocalDateTime.ofInstant(Instant.ofEpochMilli(value.toLong()), ZoneId.systemDefault())
         is Long -> LocalDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneId.systemDefault())
-        is String -> when (currentDialect) {
-            is SQLiteDialect -> LocalDateTime.parse(value, SQLITE_DATE_TIME_STRING_FORMATTER)
-            else -> LocalDateTime.parse(value, formatterForDateString(value))
-        }
+        is String -> LocalDateTime.parse(value, formatterForDateString(value))
         else -> valueFromDB(value.toString())
     }
 


### PR DESCRIPTION
Reason for change
===========================
Currently the `JavaLocalDateTimeColumnType` using a sqlite backend expects datetime strings to be in the following format: `yyyy-MM-d HH:mm:ss`. 

However, according to the manual[1] SQLite allows the following string formats for datetimes: 
 * YYYY-MM-DD
 * YYYY-MM-DD HH:MM
 * YYYY-MM-DD HH:MM:SS
 * **YYYY-MM-DD HH:MM:SS.SSS  <--- This format is currently broken**


Thus, some of the datetime strings written by other clients can't be parsed by exposed. I observed this limitation when reading datetimes written by python + SQLAlchemy. 

I implemented a fix by removing special treatment (only) for SQLite Datetimes. Now the normal datetime parsing machinery is used which auto-detects if there is a fraction part and of how many digits the fraction part consists. 

Limitations of this pull request
=========================

SQLite would also allow Datetimes where the Date and the time part are separated by a `T` char. I did not implement special treatment for those cases



[1] https://www.sqlite.org/lang_datefunc.html