### PR TITLE
ADBA project terminated

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Exposed Roadmap
 
 * Refactor test to cover different jdbc-drivers/database versions (with docker-compose or test containers)
-* Move from jdbc drivers to something more asynchronous ([R2DBC](https://r2dbc.io/)\/[ADBA](https://github.com/oracle/oracle-db-examples/tree/master/java/AoJ))
+* Move from jdbc drivers to something more asynchronous ([R2DBC](https://r2dbc.io/))
 * Support Kotlin Native
 * Support Kotlin JS


### PR DESCRIPTION
Oracle announced that they have stopped work on ADBA. https://mail.openjdk.java.net/pipermail/jdbc-spec-discuss/2019-September/000529.html