### PR TITLE
Add size property on ColumnMetadata class

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -219,7 +219,7 @@ abstract class FunctionProvider {
  * type:
  * @see java.sql.Types
  */
-data class ColumnMetadata(val name: String, val type: Int, val nullable: Boolean)
+data class ColumnMetadata(val name: String, val type: Int, val nullable: Boolean, val size: Int?)
 
 interface DatabaseDialect {
     val name: String

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -42,7 +42,9 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
     override fun columns(vararg tables: Table): Map<Table, List<ColumnMetadata>> {
         val rs =  metadata.getColumns(databaseName, oracleSchema, "%", "%")
         val result = rs.extractColumns(tables) {
-            it.getString("TABLE_NAME") to ColumnMetadata(it.getString("COLUMN_NAME")/*.quoteIdentifierWhenWrongCaseOrNecessary(tr)*/, it.getInt("DATA_TYPE"), it.getBoolean("NULLABLE"))
+            //@see java.sql.DatabaseMetaData.getColumns
+            val columnMetadata = ColumnMetadata(it.getString("COLUMN_NAME")/*.quoteIdentifierWhenWrongCaseOrNecessary(tr)*/, it.getInt("DATA_TYPE"), it.getBoolean("NULLABLE"), it.getInt("COLUMN_SIZE").takeIf { it != 0 })
+            it.getString("TABLE_NAME") to columnMetadata
         }
         rs.close()
         return result

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -23,8 +23,8 @@ class ConnectionTests : DatabaseTestsBase() {
                 requireNotNull(columns(People)[People])
             }.toSet()
             val expected = setOf(
-                    ColumnMetadata("ID", Types.BIGINT, false),
-                    ColumnMetadata("NAME", Types.VARCHAR, true)
+                    ColumnMetadata("ID", Types.BIGINT, false, 19),
+                    ColumnMetadata("NAME", Types.VARCHAR, true, 80)
             )
             assertEquals(expected, columnMetadata)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.exposed.sql.tests.shared
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.vendors.ColumnMetadata
+import org.junit.Test
+import java.sql.Types
+
+class ConnectionTests : DatabaseTestsBase() {
+
+    object People : LongIdTable() {
+        val name = varchar("name", 80).nullable()
+    }
+
+    @Test
+    fun testGettingColumnMetadata() {
+        withDb (TestDB.H2){
+            SchemaUtils.create(People)
+
+            val columnMetadata = connection.metadata {
+                requireNotNull(columns(People)[People])
+            }.toSet()
+            val expected = setOf(
+                    ColumnMetadata("ID", Types.BIGINT, false),
+                    ColumnMetadata("NAME", Types.VARCHAR, true)
+            )
+            assertEquals(expected, columnMetadata)
+        }
+    }
+}


### PR DESCRIPTION
fixes #495

I referenced this java doc.
https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getColumns-java.lang.String-java.lang.String-java.lang.String-java.lang.String-