### PR TITLE
[SQLite] fixing a bug in creating table with autoInc column and custom primarykey

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -67,7 +67,7 @@ class Column<T>(val table: Table, val name: String, override val columnType: ICo
 
         when {
             !isPKColumn && isSQLiteAutoIncColumn -> tr.throwUnsupportedException("Auto-increment could be applied only to primary key column")
-            isSQLiteAutoIncColumn && !isOneColumnPK() && table.primaryKey != null -> append(currentDialect.dataTypeProvider.integerType())
+            isSQLiteAutoIncColumn && (!isOneColumnPK() || table.isCustomPKNameDefined()) && table.primaryKey != null -> append(currentDialect.dataTypeProvider.integerType())
             else -> append(colType.sqlType())
         }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -130,6 +130,24 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun addOneColumnPrimaryKeyToTableNotH2Test() {
+        withTables(excludeSettings = listOf(TestDB.H2, TestDB.H2_MYSQL), tables = *arrayOf(Book)) {
+            val tableProperName = Book.tableName.inProperCase()
+            val pkConstraintName = Book.primaryKey.name
+            val id1ProperName = Book.id.name.inProperCase()
+            val ddlId1 = Book.id.ddl
+
+            assertEquals("ALTER TABLE $tableProperName ADD ${Book.id.descriptionDdl()}, ADD CONSTRAINT $pkConstraintName PRIMARY KEY ($id1ProperName)", ddlId1.first())
+        }
+    }
+
+    object Book : Table("Book") {
+        val id = integer("id").autoIncrement()
+
+        override val primaryKey = PrimaryKey(id, name = "PKConstraintName")
+    }
+
     object Person : Table("Person") {
         val id1 = integer("id1")
         val id2 = integer("id2")


### PR DESCRIPTION
Creating a table that has an autoIncrement column and a custom primarykey (that contains single column) causes an error in SQLite dialect. Here is an example :
```Kotlin
object Test : Table("Test") {
        val id = integer("id").autoIncrement()

        // Rest of columns

        override val primaryKey = PrimaryKey(id, name = "PKConstraintName")
    }
```

SQL generated : 
```SQL
CREATE TABLE IF NOT EXISTS Test(id INTEGER PRIMARY KEY AUTOINCREMENT, CONSTRAINT PKConstraintName PRIMARY KEY (id))
```

Error :  `SQL error or missing database (table "Test" has more than one primary key)`

.

=> **So in this PR I did a little change to consider this case.**