### PR TITLE
Adding create and drop database methods

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -180,6 +180,32 @@ object SchemaUtils {
     }
 
     /**
+     * Creates databases
+     *
+     * @param databases the names of the databases
+     * @param inBatch flag to perform database creation in a single batch
+     */
+    fun createDatabase(vararg databases: String, inBatch: Boolean = false) {
+        with(TransactionManager.current()) {
+            val createStatements = databases.flatMap { listOf(currentDialect.createDatabase(it)) }
+            execStatements(inBatch, createStatements)
+        }
+    }
+
+    /**
+     * Drops databases
+     *
+     * @param databases the names of the databases
+     * @param inBatch flag to perform database creation in a single batch
+     */
+    fun dropDatabase(vararg databases: String, inBatch: Boolean = false) {
+        with(TransactionManager.current()) {
+            val createStatements = databases.flatMap { listOf(currentDialect.dropDatabase(it)) }
+            execStatements(inBatch, createStatements)
+        }
+    }
+
+    /**
      * This function should be used in cases when you want an easy-to-use auto-actualization of database scheme.
      * It will create all absent tables, add missing columns for existing tables if it's possible (columns are nullable or have default values).
      *

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -576,10 +576,7 @@ interface DatabaseDialect {
         }
     }
 
-    fun createDatabase(name: String) = if (currentDialect.supportsIfNotExists)
-        "CREATE DATABASE IF NOT EXISTS ${name.inProperCase()}"
-    else
-        "CREATE DATABASE ${name.inProperCase()}"
+    fun createDatabase(name: String) = "CREATE DATABASE IF NOT EXISTS ${name.inProperCase()}"
 
     fun dropDatabase(name: String) = "DROP DATABASE IF EXISTS ${name.inProperCase()}"
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -575,6 +575,13 @@ interface DatabaseDialect {
             this.append("$str1 $str2")
         }
     }
+
+    fun createDatabase(name: String) = if (currentDialect.supportsIfNotExists)
+        "CREATE DATABASE IF NOT EXISTS ${name.inProperCase()}"
+    else
+        "CREATE DATABASE ${name.inProperCase()}"
+
+    fun dropDatabase(name: String) = "DROP DATABASE IF EXISTS ${name.inProperCase()}"
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -103,6 +103,10 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         return super.createIndex(index)
     }
 
+    override fun createDatabase(name: String) = "CREATE SCHEMA IF NOT EXISTS ${name.inProperCase()}"
+
+    override fun dropDatabase(name: String) = "DROP SCHEMA IF EXISTS ${name.inProperCase()}"
+
     companion object {
         /** H2 dialect name */
         const val dialectName: String = "h2"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -182,6 +182,10 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
 
     override fun modifyColumn(column: Column<*>): String = super.modifyColumn(column).replace("MODIFY COLUMN", "MODIFY")
 
+    override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
+
+    override fun dropDatabase(name: String): String = "DROP DATABASE ${name.inProperCase()}"
+
     companion object {
         /** Oracle dialect name */
         const val dialectName: String = "oracle"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -172,6 +172,10 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
         }
     }
 
+    override fun createDatabase(name: String): String = "END; CREATE DATABASE ${name.inProperCase()}"
+
+    override fun dropDatabase(name: String): String = "END; DROP DATABASE ${name.inProperCase()}"
+
     companion object {
         /** PostgreSQL dialect name */
         const val dialectName: String = "postgresql"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -172,9 +172,9 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
         }
     }
 
-    override fun createDatabase(name: String): String = "END; CREATE DATABASE ${name.inProperCase()}"
+    override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
 
-    override fun dropDatabase(name: String): String = "END; DROP DATABASE ${name.inProperCase()}"
+    override fun dropDatabase(name: String): String = "DROP DATABASE ${name.inProperCase()}"
 
     companion object {
         /** PostgreSQL dialect name */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -106,6 +106,8 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     override fun modifyColumn(column: Column<*>): String =
         super.modifyColumn(column).replace("MODIFY COLUMN", "ALTER COLUMN")
 
+    override fun dropDatabase(name: String) = "DROP DATABASE ${name.inProperCase()}"
+
     companion object {
         /** SQLServer dialect name */
         const val dialectName: String = "sqlserver"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -106,6 +106,8 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     override fun modifyColumn(column: Column<*>): String =
         super.modifyColumn(column).replace("MODIFY COLUMN", "ALTER COLUMN")
 
+    override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
+
     override fun dropDatabase(name: String) = "DROP DATABASE ${name.inProperCase()}"
 
     companion object {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -144,6 +144,10 @@ open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQ
         }
     }
 
+    override fun createDatabase(name: String) = "ATTACH DATABASE '${name.toLowerCase()}.db' AS ${name.inProperCase()}"
+
+    override fun dropDatabase(name: String) = "DETACH DATABASE ${name.inProperCase()}"
+
     companion object {
         /** SQLite dialect name */
         const val dialectName: String = "sqlite"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
@@ -1,0 +1,20 @@
+package org.jetbrains.exposed.sql.tests.shared.ddl
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class DatabaseTests : DatabaseTestsBase() {
+
+    @Test
+    fun `create database test`() {
+        withDb() {
+            val dbName = "jetbrains"
+            SchemaUtils.createDatabase(dbName)
+            SchemaUtils.dropDatabase(dbName)
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
@@ -3,18 +3,29 @@ package org.jetbrains.exposed.sql.tests.shared.ddl
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
-import org.jetbrains.exposed.sql.tests.currentDialectTest
-import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.junit.Test
 
 class DatabaseTests : DatabaseTestsBase() {
 
     @Test
     fun `create database test`() {
-        withDb() {
+        // PostgreSQL will be tested in the next test function
+        withDb(excludeSettings = listOf(TestDB.POSTGRESQL)) {
             val dbName = "jetbrains"
             SchemaUtils.createDatabase(dbName)
             SchemaUtils.dropDatabase(dbName)
+        }
+    }
+
+    @Test
+    fun `create database test in postgreSQL`() {
+        // PostgreSQL needs auto commit to be "ON" to allow create database statement
+        withDb(TestDB.POSTGRESQL) {
+            connection.autoCommit = true
+            val dbName = "jetbrains"
+            SchemaUtils.createDatabase(dbName)
+            SchemaUtils.dropDatabase(dbName)
+            connection.autoCommit = false
         }
     }
 }


### PR DESCRIPTION
This PR is to add requested feature #757 .

Create database and drop database methods are implemented differently in each dialect :

- H2 : `CREATE/DROP SCHEMA IF NOT EXISTS dbname`
- SQLite : `ATTACH/DETACH  DATABASE dbname.db' AS dbname`
- Others : `CREATE/DROP DATABASE [IF NOT EXISTS] dbname` 