### PR TITLE
[KDoc & Format] SQL Expressions, Operators and Functions

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
@@ -31,32 +31,32 @@ class QueryBuilder(
         internalBuilder.append(postfix)
     }
 
-    /** Appends all arguments to this [QueryBuilder]. */
-    fun append(vararg expr: Any): QueryBuilder = apply {
-        for (item in expr) {
-            when (item) {
-                is Expression<*> -> +item
-                is String -> +item
-                is Char -> +item
-                else -> throw IllegalArgumentException("Can't append $item as it has unknown type")
-            }
-        }
-    }
+
+    /** Appends the specified [value] to this [QueryBuilder]. */
+    fun append(value: Char): QueryBuilder = apply { internalBuilder.append(value) }
+
+    /** Appends the specified [value] to this [QueryBuilder]. */
+    fun append(value: String): QueryBuilder = apply { internalBuilder.append(value) }
+
+    /** Appends the specified [value] to this [QueryBuilder]. */
+    fun append(value: Expression<*>): QueryBuilder = apply(value::toQueryBuilder)
+
 
     /** Appends the receiver [Char] to this [QueryBuilder]. */
-    operator fun Char.unaryPlus(): QueryBuilder = this@QueryBuilder.also { internalBuilder.append(this) }
+    operator fun Char.unaryPlus(): QueryBuilder = append(this)
 
     /** Appends the receiver [String] to this [QueryBuilder]. */
-    operator fun String.unaryPlus(): QueryBuilder = this@QueryBuilder.also { internalBuilder.append(this) }
+    operator fun String.unaryPlus(): QueryBuilder = append(this)
 
     /** Appends the receiver [Expression] to this [QueryBuilder]. */
-    operator fun Expression<*>.unaryPlus(): QueryBuilder = this@QueryBuilder.also(this::toQueryBuilder)
+    operator fun Expression<*>.unaryPlus(): QueryBuilder = append(this)
+
 
     /** Adds the specified [argument] as a value of the specified [column]. */
     fun <T> registerArgument(column: Column<*>, argument: T) {
         when (argument) {
-            is Expression<*> -> +argument
-            DefaultValueMarker -> +column.dbDefaultValue!!
+            is Expression<*> -> append(argument)
+            DefaultValueMarker -> append(column.dbDefaultValue!!)
             else -> registerArgument(column.columnType, argument)
         }
     }
@@ -84,6 +84,18 @@ class QueryBuilder(
     }
 
     override fun toString(): String = internalBuilder.toString()
+}
+
+/** Appends all arguments to this [QueryBuilder]. */
+fun QueryBuilder.append(vararg expr: Any): QueryBuilder = apply {
+    for (item in expr) {
+        when (item) {
+            is Char -> append(item)
+            is String -> append(item)
+            is Expression<*> -> append(item)
+            else -> throw IllegalArgumentException("Can't append $item as it has unknown type")
+        }
+    }
 }
 
 /** Appends all the elements separated using [separator] and using the given [prefix] and [postfix] if supplied. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
@@ -1,40 +1,58 @@
 package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.sql.statements.DefaultValueMarker
-import java.util.*
 
-class QueryBuilder(val prepared: Boolean) {
+/**
+ * An object to which SQL expressions and values can be appended.
+ */
+class QueryBuilder(
+    /** Whether the query is parameterized or not. */
+    val prepared: Boolean
+) {
     private val internalBuilder = StringBuilder()
-    val args = ArrayList<Pair<IColumnType, Any?>>()
+    private val _args = mutableListOf<Pair<IColumnType, Any?>>()
+    /** Returns the list of arguments used in this query. */
+    val args: List<Pair<IColumnType, Any?>> get() = _args
 
-    fun <T> Iterable<T>.appendTo(separator: CharSequence = ", ", prefix: CharSequence = "", postfix: CharSequence = "", transform: (QueryBuilder.(T) -> Unit)) {
+    operator fun invoke(body: QueryBuilder.() -> Unit): Unit = body()
+
+    /** Appends all the elements separated using [separator] and using the given [prefix] and [postfix] if supplied. */
+    fun <T> Iterable<T>.appendTo(
+        separator: CharSequence = ", ",
+        prefix: CharSequence = "",
+        postfix: CharSequence = "",
+        transform: QueryBuilder.(T) -> Unit
+    ) {
         internalBuilder.append(prefix)
-        for ((count, element) in this.withIndex()) {
-            if (count > 0) internalBuilder.append(separator)
+        forEachIndexed { index, element ->
+            if (index > 0) internalBuilder.append(separator)
             transform(element)
         }
         internalBuilder.append(postfix)
     }
 
-    operator fun Expression<*>.unaryPlus() = this@QueryBuilder.also { toQueryBuilder(it) }
-
-    fun append(vararg expr: Any) = apply {
-        expr.forEach {
-            when(it) {
-                is Expression<*> -> +it
-                is String -> +it
-                is Char -> +it
-                else -> throw IllegalArgumentException("Can't append $it as it has unknown type")
+    /** Appends all arguments to this [QueryBuilder]. */
+    fun append(vararg expr: Any): QueryBuilder = apply {
+        for (item in expr) {
+            when (item) {
+                is Expression<*> -> +item
+                is String -> +item
+                is Char -> +item
+                else -> throw IllegalArgumentException("Can't append $item as it has unknown type")
             }
         }
     }
-    operator fun Char.unaryPlus() = this@QueryBuilder.also { internalBuilder.append(this) }
-    operator fun String.unaryPlus() = this@QueryBuilder.also { internalBuilder.append(this) }
 
-    operator fun invoke(body : QueryBuilder.()->Unit) = body()
+    /** Appends the receiver [Char] to this [QueryBuilder]. */
+    operator fun Char.unaryPlus(): QueryBuilder = this@QueryBuilder.also { internalBuilder.append(this) }
 
-    override fun toString(): String = internalBuilder.toString()
+    /** Appends the receiver [String] to this [QueryBuilder]. */
+    operator fun String.unaryPlus(): QueryBuilder = this@QueryBuilder.also { internalBuilder.append(this) }
 
+    /** Appends the receiver [Expression] to this [QueryBuilder]. */
+    operator fun Expression<*>.unaryPlus(): QueryBuilder = this@QueryBuilder.also(this::toQueryBuilder)
+
+    /** Adds the specified [argument] as a value of the specified [column]. */
     fun <T> registerArgument(column: Column<*>, argument: T) {
         when (argument) {
             is Expression<*> -> +argument
@@ -42,51 +60,74 @@ class QueryBuilder(val prepared: Boolean) {
             else -> registerArgument(column.columnType, argument)
         }
     }
-    fun <T> registerArgument(sqlType: IColumnType, argument: T) = registerArguments(sqlType, listOf(argument))
 
+    /** Adds the specified [argument] as a value of the specified [sqlType]. */
+    fun <T> registerArgument(sqlType: IColumnType, argument: T): Unit = registerArguments(sqlType, listOf(argument))
+
+    /** Adds the specified sequence of [arguments] as values of the specified [sqlType]. */
     fun <T> registerArguments(sqlType: IColumnType, arguments: Iterable<T>) {
         fun toString(value: T) = when {
             prepared && value is String -> value
             else -> sqlType.valueToString(value)
         }
-        val argumentsAndStrings = arguments.map { it to toString(it) }.sortedBy { it.second }
 
-        argumentsAndStrings.appendTo {
-            if (prepared) {
-                args.add(sqlType to it.first)
-                append("?")
-            } else {
-                append(it.second)
+        arguments.map { it to toString(it) }
+            .sortedBy { it.second }
+            .appendTo {
+                if (prepared) {
+                    _args.add(sqlType to it.first)
+                    append("?")
+                } else {
+                    append(it.second)
+                }
             }
-        }
     }
+
+    override fun toString(): String = internalBuilder.toString()
 }
 
-fun <T> Iterable<T>.appendTo(builder: QueryBuilder, separator: CharSequence = ", ", prefix: CharSequence = "",
-                             postfix: CharSequence = "", transform: (QueryBuilder.(T) -> Unit)) = builder.apply {
-   this@appendTo.appendTo(separator, prefix, postfix, transform)
-}
+/** Appends all the elements separated using [separator] and using the given [prefix] and [postfix] if supplied. */
+fun <T> Iterable<T>.appendTo(
+    builder: QueryBuilder,
+    separator: CharSequence = ", ",
+    prefix: CharSequence = "",
+    postfix: CharSequence = "",
+    transform: QueryBuilder.(T) -> Unit
+): QueryBuilder = builder.apply { this@appendTo.appendTo(separator, prefix, postfix, transform) }
 
+
+/**
+ * Represents an SQL expression of type [T].
+ */
 abstract class Expression<T> {
-    private val _hashCode by lazy {
-        toString().hashCode()
-    }
+    private val _hashCode: Int by lazy { toString().hashCode() }
 
+    /** Appends the SQL representation of this expression to the specified [queryBuilder]. */
     abstract fun toQueryBuilder(queryBuilder: QueryBuilder)
 
-    override fun equals(other: Any?): Boolean = (other as? Expression<*>)?.toString() == toString()
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Expression<*>) return false
+
+        if (toString() != other.toString()) return false
+
+        return true
+    }
 
     override fun hashCode(): Int = _hashCode
 
     override fun toString(): String = QueryBuilder(false).append(this).toString()
 
     companion object {
-        inline fun <T, E: Expression<T>> build(builder: SqlExpressionBuilder.()->E): E =
-                SqlExpressionBuilder.builder()
+        /** Builds a new [Expression] using the provided [builder]. */
+        inline fun <T, E : Expression<T>> build(builder: SqlExpressionBuilder.() -> E): E = SqlExpressionBuilder.builder()
     }
 }
 
+/**
+ * Represents an SQL expression of type [T], but with a specific column type.
+ */
 abstract class ExpressionWithColumnType<T> : Expression<T>() {
-    // used for operations with literals
+    /** Returns the column type of this expression. Used for operations with literals. */
     abstract val columnType: IColumnType
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -134,7 +134,7 @@ class Trim<T : String?>(
 // General-Purpose Aggregate Functions
 
 /**
- * Represents an SQL function that returns the minimum value of [expr] across all non-null input values.
+ * Represents an SQL function that returns the minimum value of [expr] across all non-null input values, or `null` if there are no non-null values.
  */
 class Min<T : Comparable<T>, in S : T?>(
     /** Returns the expression from which the minimum value is obtained. */
@@ -145,7 +145,7 @@ class Min<T : Comparable<T>, in S : T?>(
 }
 
 /**
- * Represents an SQL function that returns the maximum value of [expr] across all non-null input values.
+ * Represents an SQL function that returns the maximum value of [expr] across all non-null input values, or `null` if there are no non-null values.
  */
 class Max<T : Comparable<T>, in S : T?>(
     /** Returns the expression from which the maximum value is obtained. */
@@ -156,7 +156,7 @@ class Max<T : Comparable<T>, in S : T?>(
 }
 
 /**
- * Represents an SQL function that returns the average (arithmetic mean) of all non-null input values.
+ * Represents an SQL function that returns the average (arithmetic mean) of all non-null input values, or `null` if there are no non-null values.
  */
 class Avg<T : Comparable<T>, in S : T?>(
     /** Returns the expression from which the average is calculated. */
@@ -166,7 +166,7 @@ class Avg<T : Comparable<T>, in S : T?>(
 }
 
 /**
- * Represents an SQL function that returns the sum of [expr] across all non-null input values.
+ * Represents an SQL function that returns the sum of [expr] across all non-null input values, or `null` if there are no non-null values.
  */
 class Sum<T>(
     /** Returns the expression from which the sum is calculated. */
@@ -197,7 +197,8 @@ class Count(
 // Aggregate Functions for Statistics
 
 /**
- * Represents an SQL function that returns the population standard deviation of the input values.
+ * Represents an SQL function that returns the population standard deviation of the non-null input values,
+ * or `null` if there are no non-null values.
  */
 class StdDevPop<T>(
     /** Returns the expression from which the population standard deviation is calculated. */
@@ -208,7 +209,8 @@ class StdDevPop<T>(
 }
 
 /**
- * Represents an SQL function that returns the sample standard deviation of the input values.
+ * Represents an SQL function that returns the sample standard deviation of the non-null input values,
+ * or `null` if there are no non-null values.
  */
 class StdDevSamp<T>(
     /** Returns the expression from which the sample standard deviation is calculated. */
@@ -219,7 +221,8 @@ class StdDevSamp<T>(
 }
 
 /**
- * Represents an SQL function that returns the population variance of the input values (square of the population standard deviation).
+ * Represents an SQL function that returns the population variance of the non-null input values (square of the population standard deviation),
+ * or `null` if there are no non-null values.
  */
 class VarPop<T>(
     /** Returns the expression from which the population variance is calculated. */
@@ -230,7 +233,8 @@ class VarPop<T>(
 }
 
 /**
- * Represents an SQL function that returns the sample variance of the input values (square of the sample standard deviation).
+ * Represents an SQL function that returns the sample variance of the non-null input values (square of the sample standard deviation),
+ * or `null` if there are no non-null values.
  */
 class VarSamp<T>(
     /** Returns the expression from which the sample variance is calculated. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -2,12 +2,190 @@ package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.math.BigDecimal
-import java.util.*
 
+/**
+ * Represents an SQL function.
+ */
 abstract class Function<T>(override val columnType: IColumnType) : ExpressionWithColumnType<T>()
 
-class Count(val expr: Expression<*>, val distinct: Boolean = false): Function<Int>(IntegerColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder)= queryBuilder {
+/**
+ * Represents a custom SQL function.
+ */
+open class CustomFunction<T>(
+    /** Returns the name of the function. */
+    val functionName: String,
+    _columnType: IColumnType,
+    /** Returns the list of arguments of this function. */
+    vararg val expr: Expression<*>
+) : Function<T>(_columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append(functionName, '(')
+        expr.toList().appendTo { +it }
+        append(')')
+    }
+}
+
+/**
+ * Represents a custom SQL binary operator.
+ */
+open class CustomOperator<T>(
+    /** Returns the name of the operator. */
+    val operatorName: String,
+    _columnType: IColumnType,
+    /** Returns the left-hand side operand. */
+    val expr1: Expression<*>,
+    /** Returns the right-hand side operand. */
+    val expr2: Expression<*>
+) : Function<T>(_columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append('(', expr1, ' ', operatorName, ' ', expr2, ')')
+    }
+}
+
+
+// Mathematical Functions
+
+/**
+ * Represents an SQL function that returns a random value in the range 0.0 <= x < 1.0, using the specified [seed].
+ *
+ * **Note:** Some vendors generate values outside this range, or ignore the given seed, check the documentation.
+ */
+class Random(
+    /** Returns the seed. */
+    val seed: Int? = null
+) : Function<BigDecimal>(DecimalColumnType(38, 20)) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { +currentDialect.functionProvider.random(seed) }
+}
+
+
+// String Functions
+
+/**
+ * Represents an SQL function that converts [expr] to lower case.
+ */
+class LowerCase<T : String?>(
+    /** Returns the expression to convert. */
+    val expr: Expression<T>
+) : Function<T>(VarCharColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("LOWER(", expr, ")") }
+}
+
+/**
+ * Represents an SQL function that converts [expr] to upper case.
+ */
+class UpperCase<T : String?>(
+    /** Returns the expression to convert. */
+    val expr: Expression<T>
+) : Function<T>(VarCharColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("UPPER(", expr, ")") }
+}
+
+/**
+ * Represents an SQL function that concatenates the text representations of all non-null input values from [expr], separated by [separator].
+ */
+class Concat<T : String?>(
+    /** Returns the delimiter. */
+    val separator: String,
+    /** Returns the expressions being concatenated. */
+    vararg val expr: Expression<T>
+) : Function<T>(VarCharColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.concat(separator, queryBuilder, *expr)
+}
+
+/**
+ * Represents an SQL function that concatenates the text representation of all non-null input values of each group from [expr], separated by [separator]
+ */
+class GroupConcat<T : String?>(
+    /** Returns grouped expression being concatenated. */
+    val expr: Expression<T>,
+    /** Returns the delimiter. */
+    val separator: String?,
+    /** Returns `true` if only distinct elements are concatenated, `false` otherwise. */
+    val distinct: Boolean,
+    /** Returns the order in which the elements of each group are sorted. */
+    vararg val orderBy: Pair<Expression<*>, SortOrder>
+) : Function<T>(VarCharColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.groupConcat(this, queryBuilder)
+}
+
+/**
+ * Represents an SQL function that extract a substring from [expr] that begins at the specified [start] and with the specified [length].
+ */
+class Substring<T : String?>(
+    private val expr: Expression<T>,
+    private val start: Expression<Int>,
+    /** Returns the length of the substring. */
+    val length: Expression<Int>
+) : Function<T>(VarCharColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.substring(expr, start, length, queryBuilder)
+}
+
+/**
+ * Represents an SQL function that remove the longest string containing only spaces from both ends of [expr]
+ */
+class Trim<T : String?>(
+    /** Returns the expression being trimmed. */
+    val expr: Expression<T>
+) : Function<T>(VarCharColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("TRIM(", expr, ")") }
+}
+
+
+// General-Purpose Aggregate Functions
+
+/**
+ * Represents an SQL function that returns the minimum value of [expr] across all non-null input values.
+ */
+class Min<T : Comparable<T>, in S : T?>(
+    /** Returns the expression from which the minimum value is obtained. */
+    val expr: Expression<in S>,
+    _columnType: IColumnType
+) : Function<T?>(_columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("MIN(", expr, ")") }
+}
+
+/**
+ * Represents an SQL function that returns the maximum value of [expr] across all non-null input values.
+ */
+class Max<T : Comparable<T>, in S : T?>(
+    /** Returns the expression from which the maximum value is obtained. */
+    val expr: Expression<in S>,
+    _columnType: IColumnType
+) : Function<T?>(_columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("MAX(", expr, ")") }
+}
+
+/**
+ * Represents an SQL function that returns the average (arithmetic mean) of all non-null input values.
+ */
+class Avg<T : Comparable<T>, in S : T?>(
+    /** Returns the expression from which the average is calculated. */
+    val expr: Expression<in S>, scale: Int
+) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("AVG(", expr, ")") }
+}
+
+/**
+ * Represents an SQL function that returns the sum of [expr] across all non-null input values.
+ */
+class Sum<T>(
+    /** Returns the expression from which the sum is calculated. */
+    val expr: Expression<T>,
+    _columnType: IColumnType
+) : Function<T?>(_columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("SUM(", expr, ")") }
+}
+
+/**
+ * Represents an SQL function that returns the number of input rows for which the value of [expr] is not null.
+ */
+class Count(
+    /** Returns the expression from which the rows are counted. */
+    val expr: Expression<*>,
+    /** Returns whether only distinct element should be count. */
+    val distinct: Boolean = false
+) : Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         +"COUNT("
         if (distinct) +"DISTINCT "
         +expr
@@ -15,113 +193,87 @@ class Count(val expr: Expression<*>, val distinct: Boolean = false): Function<In
     }
 }
 
-open class CustomFunction<T>(val functionName: String, _columnType: IColumnType, vararg val expr: Expression<*>) : Function<T>(_columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        append(functionName, '(')
-        expr.toList().appendTo { +it }
-        append(')')
-    }
+
+// Aggregate Functions for Statistics
+
+/**
+ * Represents an SQL function that returns the population standard deviation of the input values.
+ */
+class StdDevPop<T>(
+    /** Returns the expression from which the population standard deviation is calculated. */
+    val expr: Expression<T>,
+    scale: Int
+) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("STDDEV_POP(", expr, ")") }
 }
 
-// create a Function corresponding to a SQL binary operator
-open class CustomOperator<T>(val operatorName: String, _columnType: IColumnType, val expr1: Expression<*>, val expr2: Expression<*>) : Function<T>(_columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        append('(', expr1, ' ', operatorName, ' ', expr2, ')')
-    }
+/**
+ * Represents an SQL function that returns the sample standard deviation of the input values.
+ */
+class StdDevSamp<T>(
+    /** Returns the expression from which the sample standard deviation is calculated. */
+    val expr: Expression<T>,
+    scale: Int
+) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("STDDEV_SAMP(", expr, ")") }
 }
 
-class NextVal(val seq: Sequence) : Function<Int>(IntegerColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        currentDialect.functionProvider.nextVal(seq, queryBuilder)
-    }
+/**
+ * Represents an SQL function that returns the population variance of the input values (square of the population standard deviation).
+ */
+class VarPop<T>(
+    /** Returns the expression from which the population variance is calculated. */
+    val expr: Expression<T>,
+    scale: Int
+) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("VAR_POP(", expr, ")") }
 }
 
-class LowerCase<T: String?>(val expr: Expression<T>) : Function<T>(VarCharColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("LOWER(", expr,")") }
-}
-
-class UpperCase<T: String?>(val expr: Expression<T>) : Function<T>(VarCharColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("UPPER(", expr,")") }
-}
-
-class Min<T:Comparable<T>, in S:T?>(val expr: Expression<in S>, _columnType: IColumnType): Function<T?>(_columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("MIN(", expr,")") }
-}
-
-class Max<T:Comparable<T>, in S:T?>(val expr: Expression<in S>, _columnType: IColumnType): Function<T?>(_columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("MAX(", expr,")") }
-}
-
-class Avg<T:Comparable<T>, in S:T?>(val expr: Expression<in S>, scale: Int): Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder)= queryBuilder { append("AVG(", expr,")") }
-}
-
-class StdDevPop<T>(val expr: Expression<T>, scale: Int): Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("STDDEV_POP(", expr,")") }
-}
-
-class StdDevSamp<T>(val expr: Expression<T>, scale: Int): Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("STDDEV_SAMP(", expr,")") }
-}
-
-class VarPop<T>(val expr: Expression<T>, scale: Int): Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("VAR_POP(", expr,")") }
-}
-
-class VarSamp<T>(val expr: Expression<T>, scale: Int): Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("VAR_SAMP(", expr,")") }
-}
-
-class Sum<T>(val expr: Expression<T>, _columnType: IColumnType): Function<T?>(_columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("SUM(", expr,")") }
-}
-
-class Coalesce<out T, S:T?, R:T>(private val expr: ExpressionWithColumnType<S>,
-                                 private val alternate: ExpressionWithColumnType<out T>): Function<R>(alternate.columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("COALESCE(", expr, ", ", alternate, ")") }
-}
-
-class Substring<T:String?>(private val expr: Expression<T>, private val start: Expression<Int>,
-                           val length: Expression<Int>): Function<T>(VarCharColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        currentDialect.functionProvider.substring(expr, start, length, queryBuilder)
-    }
+/**
+ * Represents an SQL function that returns the sample variance of the input values (square of the sample standard deviation).
+ */
+class VarSamp<T>(
+    /** Returns the expression from which the sample variance is calculated. */
+    val expr: Expression<T>,
+    scale: Int
+) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("VAR_SAMP(", expr, ")") }
 }
 
 
-class Random(val seed: Int? = null) : Function<BigDecimal>(DecimalColumnType(38, 20)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { +currentDialect.functionProvider.random(seed) }
+// Sequence Manipulation Functions
+
+/**
+ * Represents an SQL function that advances the specified [seq] and returns the new value.
+ */
+class NextVal(
+    /** Returns the sequence from which the next value is obtained. */
+    val seq: Sequence
+) : Function<Int>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.nextVal(seq, queryBuilder)
 }
 
-class Cast<T>(val expr: Expression<*>, columnType: IColumnType) : Function<T?>(columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        currentDialect.functionProvider.cast(expr, columnType, queryBuilder)
-    }
-}
 
-class Trim<T:String?>(val expr: Expression<T>): Function<T>(VarCharColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("TRIM(", expr,")") }
-}
+// Conditional Expressions
 
 class Case(val value: Expression<*>? = null) {
-    fun<T> When (cond: Expression<Boolean>, result: Expression<T>) : CaseWhen<T> =
-            CaseWhen<T>(value).When (cond, result)
+    fun <T> When(cond: Expression<Boolean>, result: Expression<T>): CaseWhen<T> = CaseWhen<T>(value).When(cond, result)
 }
 
-class CaseWhen<T> (val value: Expression<*>?) {
-    val cases: ArrayList<Pair<Expression<Boolean>, Expression<out T>>> =  ArrayList()
+class CaseWhen<T>(val value: Expression<*>?) {
+    val cases: MutableList<Pair<Expression<Boolean>, Expression<out T>>> = mutableListOf()
 
     @Suppress("UNCHECKED_CAST")
-    fun <R:T> When (cond: Expression<Boolean>, result: Expression<R>) : CaseWhen<R> {
-        cases.add( cond to result )
+    fun <R : T> When(cond: Expression<Boolean>, result: Expression<R>): CaseWhen<R> {
+        cases.add(cond to result)
         return this as CaseWhen<R>
     }
 
-    fun <R:T> Else(e: Expression<R>) : Expression<R> = CaseWhenElse(this, e)
+    fun <R : T> Else(e: Expression<R>): Expression<R> = CaseWhenElse(this, e)
 }
 
-class CaseWhenElse<T, R:T> (val caseWhen: CaseWhen<T>, val elseResult: Expression<R>) : Expression<R>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+class CaseWhenElse<T, R : T>(val caseWhen: CaseWhen<T>, val elseResult: Expression<R>) : Expression<R>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("CASE ")
         if (caseWhen.value != null)
             +caseWhen.value
@@ -134,19 +286,26 @@ class CaseWhenElse<T, R:T> (val caseWhen: CaseWhen<T>, val elseResult: Expressio
     }
 }
 
-class GroupConcat<T : String?>(
-        val expr: Expression<T>,
-        val separator: String?,
-        val distinct: Boolean,
-        vararg val orderBy: Pair<Expression<*>, SortOrder>
-): Function<T>(VarCharColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        currentDialect.functionProvider.groupConcat(this, queryBuilder)
-    }
+/**
+ * Represents an SQL function that returns the first of its arguments that is not null.
+ */
+class Coalesce<out T, S : T?, R : T>(
+    private val expr: ExpressionWithColumnType<S>,
+    private val alternate: ExpressionWithColumnType<out T>
+) : Function<R>(alternate.columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("COALESCE(", expr, ", ", alternate, ")") }
 }
 
-class Concat<T: String?>(val separator: String, vararg val expr: Expression<T>) : Function<T>(VarCharColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        currentDialect.functionProvider.concat(separator, queryBuilder, *expr)
-    }
+
+// Value Expressions
+
+/**
+ * Represents an SQL function that specifies a conversion from one data type to another.
+ */
+class Cast<T>(
+    /** Returns the expression being casted. */
+    val expr: Expression<*>,
+    columnType: IColumnType
+) : Function<T?>(columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.cast(expr, columnType, queryBuilder)
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -198,44 +198,48 @@ class IsNotNullOp(
  * Represents an SQL operator that adds [expr2] to [expr1].
  */
 class PlusOp<T, S : T>(
-    /** Returns the left-hand side operand. */
+    /** The left-hand side operand. */
     expr1: Expression<T>,
-    /** Returns the right-hand side operand. */
+    /** The right-hand side operand. */
     expr2: Expression<S>,
-    override val columnType: IColumnType
+    /** The column type of this expression. */
+    columnType: IColumnType
 ) : CustomOperator<T>("+", columnType, expr1, expr2)
 
 /**
  * Represents an SQL operator that subtracts [expr2] from [expr1].
  */
 class MinusOp<T, S : T>(
-    /** Returns the left-hand side operand. */
+    /** The left-hand side operand. */
     expr1: Expression<T>,
-    /** Returns the right-hand side operand. */
+    /** The right-hand side operand. */
     expr2: Expression<S>,
-    override val columnType: IColumnType
+    /** The column type of this expression. */
+    columnType: IColumnType
 ) : CustomOperator<T>("-", columnType, expr1, expr2)
 
 /**
  * Represents an SQL operator that multiplies [expr1] by [expr2].
  */
 class TimesOp<T, S : T>(
-    /** Returns the left-hand side operand. */
+    /** The left-hand side operand. */
     expr1: Expression<T>,
-    /** Returns the right-hand side operand. */
+    /** The right-hand side operand. */
     expr2: Expression<S>,
-    override val columnType: IColumnType
+    /** The column type of this expression. */
+    columnType: IColumnType
 ) : CustomOperator<T>("*", columnType, expr1, expr2)
 
 /**
  * Represents an SQL operator that divides [expr1] by [expr2].
  */
 class DivideOp<T, S : T>(
-    /** Returns the left-hand side operand. */
+    /** The left-hand side operand. */
     expr1: Expression<T>,
-    /** Returns the right-hand side operand. */
+    /** The right-hand side operand. */
     expr2: Expression<S>,
-    override val columnType: IColumnType
+    /** The column type of this expression. */
+    columnType: IColumnType
 ) : CustomOperator<T>("/", columnType, expr1, expr2)
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -26,7 +26,6 @@ abstract class Op<T> : Expression<T>() {
     }
 
     /** Boolean operator corresponding to the SQL value `FALSE` */
-
     object FALSE : Op<Boolean>() {
         override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
             when (currentDialect) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -6,89 +6,368 @@ import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.jetbrains.exposed.sql.vendors.currentDialectIfAvailable
 
+/**
+ * Represents an SQL operator.
+ */
 abstract class Op<T> : Expression<T>() {
     companion object {
+        /** Builds a new operator using provided [op]. */
         inline fun <T> build(op: SqlExpressionBuilder.() -> Op<T>): Op<T> = SqlExpressionBuilder.op()
     }
 
+    /** Boolean operator corresponding to the SQL value `TRUE` */
     object TRUE : Op<Boolean>() {
-        override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-            when(currentDialect) {
-                is SQLServerDialect, is OracleDialect -> Op.build { booleanLiteral(true) eq booleanLiteral(true) }.toQueryBuilder(this)
+        override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+            when (currentDialect) {
+                is SQLServerDialect, is OracleDialect -> build { booleanLiteral(true) eq booleanLiteral(true) }.toQueryBuilder(this)
                 else -> append(currentDialect.dataTypeProvider.booleanToStatementString(true))
             }
         }
     }
+
+    /** Boolean operator corresponding to the SQL value `FALSE` */
     object FALSE : Op<Boolean>() {
-        override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-            when(currentDialect) {
-                is SQLServerDialect, is OracleDialect -> Op.build { booleanLiteral(true) eq booleanLiteral(false) }.toQueryBuilder(this)
+        override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+            when (currentDialect) {
+                is SQLServerDialect, is OracleDialect -> build { booleanLiteral(true) eq booleanLiteral(false) }.toQueryBuilder(this)
                 else -> append(currentDialect.dataTypeProvider.booleanToStatementString(false))
             }
         }
     }
 }
 
-infix fun Expression<Boolean>.and(op: Expression<Boolean>): Op<Boolean> = when {
-    this is AndOp && op is AndOp -> AndOp(ArrayList(expressions).apply{ addAll(op.expressions) })
-    this is AndOp -> AndOp(ArrayList(expressions).apply{ add(op) })
-    op is AndOp -> AndOp(ArrayList<Expression<Boolean>>(op.expressions.size + 1).apply {
-        add(this@and)
-        addAll(op.expressions)
-    })
-    else -> AndOp(ArrayList<Expression<Boolean>>().apply{
-        add(this@and)
-        add(op)
-    })
+
+// Logical Operators
+
+/**
+ * Represents a logical operator that inverts the specified boolean [expr].
+ */
+class NotOp<T>(
+    /** Returns the expression being inverted. */
+    val expr: Expression<T>
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("NOT (", expr, ")") }
 }
 
-infix fun Op<Boolean>.or(op: Expression<Boolean>): Op<Boolean> = when {
-    this is OrOp && op is OrOp -> OrOp(ArrayList(expressions).apply{ addAll(op.expressions) })
-    this is OrOp -> OrOp(ArrayList(expressions).apply{ add(op) })
-    op is OrOp -> OrOp(ArrayList<Expression<Boolean>>(op.expressions.size + 1).apply {
-        add(this@or)
-        addAll(op.expressions)
-    })
-    else -> OrOp(ArrayList<Expression<Boolean>>().apply{
-        add(this@or)
-        add(op)
-    })
-}
-
-fun List<Op<Boolean>>.compoundAnd() = reduce { op, nextOp -> op and nextOp }
-fun List<Op<Boolean>>.compoundOr() = reduce { op, nextOp -> op or nextOp }
-
-fun not(op: Expression<Boolean>): Op<Boolean> = NotOp(op)
-
-class IsNullOp(val expr: Expression<*>) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append(expr, " IS NULL") }
-}
-
-class IsNotNullOp(val expr: Expression<*>) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append(expr, " IS NOT NULL") }
-}
-
-class LiteralOp<T>(override val columnType: IColumnType, val value: T): ExpressionWithColumnType<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { +columnType.valueToString(value) }
-}
-
-class Between(val expr: Expression<*>, val from: LiteralOp<*>, val to: LiteralOp<*>) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        append(expr, " BETWEEN ", from, " AND ", to)
+/**
+ * Represent a logical operator that performs an operation between all the specified [expressions].
+ * This is the base class for the `and` and `or` operators:
+ *
+ * @see AndOp
+ * @see OrOp
+ */
+abstract class CompoundBooleanOp<T : CompoundBooleanOp<T>>(
+    private val operator: String,
+    internal val expressions: List<Expression<Boolean>>
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        expressions.appendTo(this, separator = operator) { appendExpression(it) }
     }
 }
 
-class NoOpConversion<T, S>(val expr: Expression<T>, override val columnType: IColumnType): ExpressionWithColumnType<S>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { +expr }
+/**
+ * Represents a logical operator that performs an `and` operation between all the specified [expressions].
+ */
+class AndOp(expressions: List<Expression<Boolean>>) : CompoundBooleanOp<AndOp>(" AND ", expressions)
+
+/**
+ * Represents a logical operator that performs an `or` operation between all the specified [expressions].
+ */
+class OrOp(expressions: List<Expression<Boolean>>) : CompoundBooleanOp<AndOp>(" OR ", expressions)
+
+/** Returns the inverse of this boolean expression. */
+fun not(op: Expression<Boolean>): Op<Boolean> = NotOp(op)
+
+/** Returns the result of performing a logical `and` operation between this expression and the [op]. */
+infix fun Expression<Boolean>.and(op: Expression<Boolean>): Op<Boolean> = when {
+    this is AndOp && op is AndOp -> AndOp(expressions + op.expressions)
+    this is AndOp -> AndOp(expressions + op)
+    op is AndOp -> AndOp(ArrayList<Expression<Boolean>>(op.expressions.size + 1).also {
+        it.add(this)
+        it.addAll(op.expressions)
+    })
+    else -> AndOp(listOf(this, op))
 }
 
-class InListOrNotInListOp<T>(val expr: ExpressionWithColumnType<T>, val list: Iterable<T>, val isInList: Boolean = true): Op<Boolean>() {
+/** Returns the result of performing a logical `or` operation between this expression and the [op]. */
+infix fun Expression<Boolean>.or(op: Expression<Boolean>): Op<Boolean> = when {
+    this is OrOp && op is OrOp -> OrOp(expressions + op.expressions)
+    this is OrOp -> OrOp(expressions + op)
+    op is OrOp -> OrOp(ArrayList<Expression<Boolean>>(op.expressions.size + 1).also {
+        it.add(this)
+        it.addAll(op.expressions)
+    })
+    else -> OrOp(listOf(this, op))
+}
 
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+/** Reduces this list to a single expression by performing an `and` operation between all the expressions in the list. */
+fun List<Op<Boolean>>.compoundAnd(): Op<Boolean> = reduce(Op<Boolean>::and)
+
+/** Reduces this list to a single expression by performing an `or` operation between all the expressions in the list. */
+fun List<Op<Boolean>>.compoundOr(): Op<Boolean> = reduce(Op<Boolean>::or)
+
+
+// Comparison Operators
+
+/**
+ * Represents a comparison between [expr1] and [expr2] using the given SQL [opSign].
+ */
+abstract class ComparisonOp(
+    /** Returns the left-hand side operand. */
+    val expr1: Expression<*>,
+    /** Returns the right-hand side operand. */
+    val expr2: Expression<*>,
+    /** Returns the symbol of the comparison operation. */
+    val opSign: String
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        appendExpression(expr1)
+        append(" $opSign ")
+        appendExpression(expr2)
+    }
+}
+
+/**
+ * Represents an SQL operator that checks if [expr1] is equals to [expr2].
+ */
+class EqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "=")
+
+/**
+ * Represents an SQL operator that checks if [expr1] is not equals to [expr2].
+ */
+class NeqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "<>")
+
+/**
+ * Represents an SQL operator that checks if [expr1] is less than [expr2].
+ */
+class LessOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "<")
+
+/**
+ * Represents an SQL operator that checks if [expr1] is less than or equal to [expr2].
+ */
+class LessEqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "<=")
+
+/**
+ * Represents an SQL operator that checks if [expr1] is greater than [expr2].
+ */
+class GreaterOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, ">")
+
+/**
+ * Represents an SQL operator that checks if [expr1] is greater than or equal to [expr2].
+ */
+class GreaterEqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, ">=")
+
+/**
+ * Represents an SQL operator that checks if the specified [expr] is between the values [from] and [to].
+ */
+class Between(
+    /** The expression being checked. */
+    val expr: Expression<*>,
+    /** Returns the lower limit of the range to check against. */
+    val from: LiteralOp<*>,
+    /** Returns the upper limit of the range to check against. */
+    val to: LiteralOp<*>
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append(expr, " BETWEEN ", from, " AND ", to) }
+}
+
+/**
+ * Represents an SQL operator that checks if the specified [expr] is null.
+ */
+class IsNullOp(
+    /** The expression being checked. */
+    val expr: Expression<*>
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append(expr, " IS NULL") }
+}
+
+/**
+ * Represents an SQL operator that checks if the specified [expr] is not null.
+ */
+class IsNotNullOp(
+    /** The expression being checked. */
+    val expr: Expression<*>
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append(expr, " IS NOT NULL") }
+}
+
+
+// Mathematical Operators
+
+/**
+ * Represents an SQL operator that adds [expr2] to [expr1].
+ */
+class PlusOp<T, S : T>(
+    /** Returns the left-hand side operand. */
+    val expr1: Expression<T>,
+    /** Returns the right-hand side operand. */
+    val expr2: Expression<S>,
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append(expr1, '+', expr2) }
+}
+
+/**
+ * Represents an SQL operator that subtracts [expr2] from [expr1].
+ */
+class MinusOp<T, S : T>(
+    /** Returns the left-hand side operand. */
+    val expr1: Expression<T>,
+    /** Returns the right-hand side operand. */
+    val expr2: Expression<S>,
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append(expr1, '-', expr2) }
+}
+
+/**
+ * Represents an SQL operator that multiplies [expr1] by [expr2].
+ */
+class TimesOp<T, S : T>(
+    /** Returns the left-hand side operand. */
+    val expr1: Expression<T>,
+    /** Returns the right-hand side operand. */
+    val expr2: Expression<S>,
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append(expr1, '*', expr2) }
+}
+
+/**
+ * Represents an SQL operator that divides [expr1] by [expr2].
+ */
+class DivideOp<T, S : T>(
+    /** Returns the left-hand side operand. */
+    val expr1: Expression<T>,
+    /** Returns the right-hand side operand. */
+    val expr2: Expression<S>,
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append('(', expr1, " / ", expr2, ')') }
+}
+
+/**
+ * Represents an SQL operator that calculates the remainder of dividing [expr1] by [expr2].
+ */
+class ModOp<T : Number?, S : Number?>(
+    /** Returns the left-hand side operand. */
+    val expr1: Expression<T>,
+    /** Returns the right-hand side operand. */
+    val expr2: Expression<S>,
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        when (currentDialectIfAvailable) {
+            is OracleDialect -> append("MOD(", expr1, ", ", expr2, ")")
+            else -> append('(', expr1, " % ", expr2, ')')
+        }
+    }
+}
+
+
+// Pattern Matching
+
+/**
+ * Represents an SQL operator that checks if [expr1] matches [expr2].
+ */
+class LikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "LIKE")
+
+/**
+ * Represents an SQL operator that checks if [expr1] doesn't match [expr2].
+ */
+class NotLikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "NOT LIKE")
+
+/**
+ * Represents an SQL operator that checks if [expr1] matches the regular expression [expr2].
+ */
+class RegexpOp<T : String?>(
+    /** Returns the expression being checked. */
+    val expr1: Expression<T>,
+    /** Returns the regular expression [expr1] is checked against. */
+    val expr2: Expression<String>,
+    /** Returns `true` if the regular expression is case sensitive, `false` otherwise. */
+    val caseSensitive: Boolean
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        currentDialect.functionProvider.regexp(expr1, expr2, caseSensitive, queryBuilder)
+    }
+}
+
+/**
+ * Represents an SQL operator that checks if [expr1] doesn't match the regular expression [expr2].
+ */
+@Deprecated("Use NotOp(RegexpOp()) instead", ReplaceWith("NotOp(RegexpOp(expr1, expr2, true))"), DeprecationLevel.ERROR)
+class NotRegexpOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "NOT REGEXP")
+
+
+// Subquery Expressions
+
+/**
+ * Represents an SQL operator that checks if [query] returns at least one row.
+ */
+class exists(
+    /** Returns the query being checked. */
+    val query: Query
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("EXISTS (")
+        query.prepareSQL(this)
+        append(")")
+    }
+}
+
+/**
+ * Represents an SQL operator that checks if [query] doesn't returns any row.
+ */
+class notExists(
+    /** Returns the query being checked. */
+    val query: Query
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("NOT EXISTS (")
+        query.prepareSQL(this)
+        append(")")
+    }
+}
+
+/**
+ * Represents an SQL operator that checks if [expr] is equals to any row returned from [query].
+ */
+class InSubQueryOp<T>(
+    /** Returns the expression compared to each row of the query result. */
+    val expr: Expression<T>,
+    /** Returns the query to check against. */
+    val query: Query
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append(expr, " IN (")
+        query.prepareSQL(this)
+        +")"
+    }
+}
+
+
+// Array Comparisons
+
+/**
+ * Represents an SQL operator that checks if [expr] is equals to any element from [list].
+ */
+class InListOrNotInListOp<T>(
+    /** Returns the expression compared to each element of the list. */
+    val expr: ExpressionWithColumnType<T>,
+    /** Returns the query to check against. */
+    val list: Iterable<T>,
+    /** Returns `true` if the check is inverted, `false` otherwise. */
+    val isInList: Boolean = true
+) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         list.iterator().let { i ->
             if (!i.hasNext()) {
-                val op = if (isInList) Op.FALSE else Op.TRUE
-                +op
+                if (isInList) {
+                    +FALSE
+                } else {
+                    +TRUE
+                }
             } else {
                 val first = i.next()
                 if (!i.hasNext()) {
@@ -104,9 +383,7 @@ class InListOrNotInListOp<T>(val expr: ExpressionWithColumnType<T>, val list: It
                         isInList -> append(" IN (")
                         else -> append(" NOT IN (")
                     }
-
                     registerArguments(expr.columnType, list)
-
                     append(")")
                 }
             }
@@ -114,123 +391,100 @@ class InListOrNotInListOp<T>(val expr: ExpressionWithColumnType<T>, val list: It
     }
 }
 
-class InSubQueryOp<T>(val expr: Expression<T>, val query: Query): Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        append(expr, " IN (")
-        query.prepareSQL(this)
-        +")"
-    }
+
+// Literals
+
+/**
+ * Represents the specified [value] as an SQL literal, using the specified [columnType] to convert the value.
+ */
+class LiteralOp<T>(
+    override val columnType: IColumnType,
+    /** Returns the value being used as a literal. */
+    val value: T
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { +columnType.valueToString(value) }
+
 }
 
-class QueryParameter<T>(val value: T, val sqlType: IColumnType) : Expression<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { registerArgument(sqlType, value) }
+/** Returns the specified [value] as a boolean literal. */
+fun booleanLiteral(value: Boolean): LiteralOp<Boolean> = LiteralOp(BooleanColumnType(), value)
+
+/** Returns the specified [value] as a short literal. */
+fun shortLiteral(value: Short): LiteralOp<Short> = LiteralOp(ShortColumnType(), value)
+
+/** Returns the specified [value] as an int literal. */
+fun intLiteral(value: Int): LiteralOp<Int> = LiteralOp(IntegerColumnType(), value)
+
+/** Returns the specified [value] as a long literal. */
+fun longLiteral(value: Long): LiteralOp<Long> = LiteralOp(LongColumnType(), value)
+
+/** Returns the specified [value] as a float literal. */
+fun floatLiteral(value: Float): LiteralOp<Float> = LiteralOp(FloatColumnType(), value)
+
+/** Returns the specified [value] as a double literal. */
+fun doubleLiteral(value: Double): LiteralOp<Double> = LiteralOp(DoubleColumnType(), value)
+
+/** Returns the specified [value] as a string literal. */
+fun stringLiteral(value: String): LiteralOp<String> = LiteralOp(VarCharColumnType(), value)
+
+
+// Query Parameters
+
+/**
+ * Represents the specified [value] as a query parameter, using the specified [sqlType] to convert the value.
+ */
+class QueryParameter<T>(
+    /** Returns the value being used as a query parameter. */
+    val value: T,
+    /** Returns the column type of this expression. */
+    val sqlType: IColumnType
+) : Expression<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { registerArgument(sqlType, value) }
 }
 
-fun <T:Comparable<T>> idParam(value: EntityID<T>, column: Column<EntityID<T>>): Expression<EntityID<T>> = QueryParameter(value, EntityIDColumnType(column))
+/** Returns the specified [value] as a query parameter with the same type as [column]. */
+fun <T : Comparable<T>> idParam(value: EntityID<T>, column: Column<EntityID<T>>): Expression<EntityID<T>> = QueryParameter(value, EntityIDColumnType(column))
+
+/** Returns the specified [value] as a boolean query parameter. */
 fun booleanParam(value: Boolean): Expression<Boolean> = QueryParameter(value, BooleanColumnType())
+
+/** Returns the specified [value] as a short query parameter. */
 fun shortParam(value: Short): Expression<Short> = QueryParameter(value, ShortColumnType())
+
+/** Returns the specified [value] as an int query parameter. */
 fun intParam(value: Int): Expression<Int> = QueryParameter(value, IntegerColumnType())
+
+/** Returns the specified [value] as a long query parameter. */
 fun longParam(value: Long): Expression<Long> = QueryParameter(value, LongColumnType())
+
+/** Returns the specified [value] as a float query parameter. */
 fun floatParam(value: Float): Expression<Float> = QueryParameter(value, FloatColumnType())
+
+/** Returns the specified [value] as a double query parameter. */
 fun doubleParam(value: Double): Expression<Double> = QueryParameter(value, DoubleColumnType())
+
+/** Returns the specified [value] as a string query parameter. */
 fun stringParam(value: String): Expression<String> = QueryParameter(value, VarCharColumnType())
 
-fun booleanLiteral(value: Boolean): LiteralOp<Boolean> = LiteralOp(BooleanColumnType(), value)
-fun shortLiteral(value: Short): LiteralOp<Short> = LiteralOp(ShortColumnType(), value)
-fun intLiteral(value: Int): LiteralOp<Int> = LiteralOp(IntegerColumnType(), value)
-fun longLiteral(value: Long): LiteralOp<Long> = LiteralOp(LongColumnType(), value)
-fun floatLiteral(value: Float): LiteralOp<Float> = LiteralOp(FloatColumnType(), value)
-fun doubleLiteral(value: Double): LiteralOp<Double> = LiteralOp(DoubleColumnType(), value)
-fun stringLiteral(value: String): LiteralOp<String> = LiteralOp(VarCharColumnType(), value)
+
+// Misc.
+
+/**
+ * Represents an SQL operator that doesn't perform any operation.
+ * This is mainly used to change between column types.
+ */
+class NoOpConversion<T, S>(
+    /** Returns the expression whose type is being changed. */
+    val expr: Expression<T>,
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<S>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { +expr }
+}
 
 private fun QueryBuilder.appendExpression(expr: Expression<*>) {
     if (expr is CompoundBooleanOp<*>) {
         append("(", expr, ")")
     } else {
         append(expr)
-    }
-}
-
-abstract class ComparisonOp(val expr1: Expression<*>, val expr2: Expression<*>, val opSign: String) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        appendExpression(expr1)
-        append(" $opSign ")
-        appendExpression(expr2)
-    }
-}
-
-class EqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "=")
-class NeqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "<>")
-class LessOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "<")
-class LessEqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "<=")
-class GreaterOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, ">")
-class GreaterEqOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, ">=")
-class LikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "LIKE")
-class NotLikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "NOT LIKE")
-
-@Deprecated("Use not(RegexpOp()) instead", level = DeprecationLevel.ERROR)
-class NotRegexpOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "NOT REGEXP")
-
-abstract class CompoundBooleanOp<T:CompoundBooleanOp<T>>(private val operator: String, internal val expressions: List<Expression<Boolean>>) : Op<Boolean> () {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        expressions.forEachIndexed { indx, el ->
-            if (indx > 0) append(operator)
-            appendExpression(el)
-        }
-    }
-}
-
-class AndOp(expressions: List<Expression<Boolean>>) : CompoundBooleanOp<AndOp>(" AND ", expressions)
-
-class OrOp(expressions: List<Expression<Boolean>>) : CompoundBooleanOp<AndOp>(" OR ", expressions)
-
-class RegexpOp<T:String?>(val expr1: Expression<T>, val expr2: Expression<String>, val caseSensitive: Boolean) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        currentDialect.functionProvider.regexp(expr1, expr2, caseSensitive, queryBuilder)
-    }
-}
-
-class NotOp<T>(val expr: Expression<T>) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("NOT (", expr, ")") }
-}
-
-class exists(val query: Query) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        append("EXISTS (")
-        query.prepareSQL(queryBuilder)
-        append(")")
-    }
-}
-
-class notExists(val query: Query) : Op<Boolean>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        append("NOT EXISTS (")
-        query.prepareSQL(queryBuilder)
-        append(")")
-    }
-}
-
-class PlusOp<T, S: T>(val expr1: Expression<T>, val expr2: Expression<S>, override val columnType: IColumnType): ExpressionWithColumnType<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append(expr1, '+', expr2) }
-}
-
-class MinusOp<T, S: T>(val expr1: Expression<T>, val expr2: Expression<S>, override val columnType: IColumnType): ExpressionWithColumnType<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append(expr1, '-', expr2) }
-}
-
-class TimesOp<T, S: T>(val expr1: Expression<T>, val expr2: Expression<S>, override val columnType: IColumnType): ExpressionWithColumnType<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append(expr1, '*', expr2) }
-}
-
-class DivideOp<T, S: T>(val expr1: Expression<T>, val expr2: Expression<S>, override val columnType: IColumnType): ExpressionWithColumnType<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append('(', expr1, " / ", expr2, ')') }
-}
-
-class ModOp<T:Number?, S: Number?>(val expr1: Expression<T>, val expr2: Expression<S>, override val columnType: IColumnType): ExpressionWithColumnType<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        when(currentDialectIfAvailable) {
-            is OracleDialect -> append("MOD(", expr1, ", ", expr2, ")")
-            else -> append('(', expr1, " % ", expr2, ')')
-        }
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -36,16 +36,16 @@ fun <T : String?> Expression<T>.trim(): Trim<T> = Trim(this)
 
 // General-Purpose Aggregate Functions
 
-/** Returns the minimum value of this expression across all non-null input values. */
+/** Returns the minimum value of this expression across all non-null input values, or `null` if there are no non-null values. */
 fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.min(): Min<T, S> = Min<T, S>(this, this.columnType)
 
-/** Returns the maximum value of this expression across all non-null input values. */
+/** Returns the maximum value of this expression across all non-null input values, or `null` if there are no non-null values. */
 fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.max(): Max<T, S> = Max<T, S>(this, this.columnType)
 
-/** Returns the average (arithmetic mean) value of this expression across all non-null input values. */
+/** Returns the average (arithmetic mean) value of this expression across all non-null input values, or `null` if there are no non-null values. */
 fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.avg(scale: Int = 2): Avg<T, S> = Avg<T, S>(this, scale)
 
-/** Returns the sum of this expression across all non-null input values. */
+/** Returns the sum of this expression across all non-null input values, or `null` if there are no non-null values. */
 fun <T : Any?> ExpressionWithColumnType<T>.sum(): Sum<T> = Sum(this, this.columnType)
 
 /** Returns the number of input rows for which the value of this expression is not null. */
@@ -58,28 +58,28 @@ fun Column<*>.countDistinct(): Count = Count(this, true)
 // Aggregate Functions for Statistics
 
 /**
- * Returns the population standard deviation of the input values.
+ * Returns the population standard deviation of the non-null input values, or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
 fun <T : Any?> ExpressionWithColumnType<T>.stdDevPop(scale: Int = 2): StdDevPop<T> = StdDevPop(this, scale)
 
 /**
- * Returns the sample standard deviation of the input values.
+ * Returns the sample standard deviation of the non-null input values, or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
 fun <T : Any?> ExpressionWithColumnType<T>.stdDevSamp(scale: Int = 2): StdDevSamp<T> = StdDevSamp(this, scale)
 
 /**
- * Returns the population variance of the input values (square of the population standard deviation).
+ * Returns the population variance of the non-null input values (square of the population standard deviation), or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
 fun <T : Any?> ExpressionWithColumnType<T>.varPop(scale: Int = 2): VarPop<T> = VarPop(this, scale)
 
 /**
- * Returns the sample variance of the input values (square of the sample standard deviation).
+ * Returns the sample variance of the non-null input values (square of the sample standard deviation), or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -1,4 +1,3 @@
-@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.dao.id.EntityID
@@ -8,210 +7,372 @@ import org.jetbrains.exposed.sql.vendors.FunctionProvider
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.math.BigDecimal
 
-fun ExpressionWithColumnType<*>.count() : Function<Int> = Count(this)
+// String Functions
 
-fun Column<*>.countDistinct() : Function<Int> = Count(this, true)
+/** Converts this string expression to lower case. */
+fun <T : String?> Expression<T>.lowerCase(): LowerCase<T> = LowerCase(this)
 
-fun<T:Comparable<T>, S:T?> ExpressionWithColumnType<in S>.min()  : ExpressionWithColumnType<T?> = Min<T, S>(this, this.columnType)
+/** Converts this string expression to upper case. */
+fun <T : String?> Expression<T>.upperCase(): UpperCase<T> = UpperCase(this)
 
-fun<T:Comparable<T>, S:T?> ExpressionWithColumnType<in S>.max() : ExpressionWithColumnType<T?> = Max<T, S>(this, this.columnType)
+fun <T : String?> Expression<T>.groupConcat(
+    separator: String? = null,
+    distinct: Boolean = false,
+    orderBy: Pair<Expression<*>, SortOrder>
+): GroupConcat<T> = GroupConcat(this, separator, distinct, orderBy)
 
-fun<T:Comparable<T>, S:T?> ExpressionWithColumnType<in S>.avg(scale: Int = 2)  : ExpressionWithColumnType<BigDecimal?> = Avg<T, S>(this, scale)
+fun <T : String?> Expression<T>.groupConcat(
+    separator: String? = null,
+    distinct: Boolean = false,
+    orderBy: Array<Pair<Expression<*>, SortOrder>> = emptyArray()
+): GroupConcat<T> = GroupConcat(this, separator, distinct, *orderBy)
 
-fun<T:Any?> ExpressionWithColumnType<T>.stdDevPop(scale: Int = 2) = StdDevPop(this, scale)
+/** Extract a substring from this string expression that begins at the specified [start] and with the specified [length]. */
+fun <T : String?> Expression<T>.substring(start: Int, length: Int): Substring<T> = Substring(this, intLiteral(start), intLiteral(length))
 
-fun<T:Any?> ExpressionWithColumnType<T>.stdDevSamp(scale: Int = 2) = StdDevSamp(this, scale)
-
-fun<T:Any?> ExpressionWithColumnType<T>.varPop(scale: Int = 2) = VarPop(this, scale)
-
-fun<T:Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2) = VarSamp(this, scale)
-
-fun<T:Any?> ExpressionWithColumnType<T>.sum() = Sum(this, this.columnType)
-
-fun<R:Any> Expression<*>.castTo(columnType: IColumnType) = Cast<R>(this, columnType)
-
-fun<T:String?> Expression<T>.substring(start: Int, length: Int) : Function<T> =
-        Substring(this, LiteralOp(IntegerColumnType(), start), LiteralOp(IntegerColumnType(), length))
-
-fun<T:String?> Expression<T>.trim() : Function<T> = Trim(this)
-
-fun<T:String?> Expression<T>.lowerCase() : Function<T> = LowerCase(this)
-fun<T:String?> Expression<T>.upperCase() : Function<T> = UpperCase(this)
-
-fun Sequence.nextVal() : Function<Int> = NextVal(this)
-
-fun<T:Any?> ExpressionWithColumnType<T>.function(functionName: String) : Function<T?> = CustomFunction(functionName, columnType, this)
-fun CustomStringFunction(functionName: String, vararg params: Expression<*>) = CustomFunction<String?>(functionName, VarCharColumnType(), *params)
-fun CustomLongFunction(functionName: String, vararg params: Expression<*>) = CustomFunction<Long?>(functionName, LongColumnType(), *params)
-
-fun <T : String?> Expression<T>.groupConcat(separator: String? = null, distinct: Boolean = false, orderBy: Pair<Expression<*>,SortOrder>): GroupConcat<T> =
-        GroupConcat(this, separator, distinct, orderBy)
-
-fun <T : String?> Expression<T>.groupConcat(separator: String? = null, distinct: Boolean = false, orderBy: Array<Pair<Expression<*>,SortOrder>> = emptyArray()): GroupConcat<T> =
-        GroupConcat(this, separator, distinct, *orderBy)
+/** Removes the longest string containing only spaces from both ends of string expression. */
+fun <T : String?> Expression<T>.trim(): Trim<T> = Trim(this)
 
 
+// General-Purpose Aggregate Functions
+
+/** Returns the minimum value of this expression across all non-null input values. */
+fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.min(): Min<T, S> = Min<T, S>(this, this.columnType)
+
+/** Returns the maximum value of this expression across all non-null input values. */
+fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.max(): Max<T, S> = Max<T, S>(this, this.columnType)
+
+/** Returns the average (arithmetic mean) value of this expression across all non-null input values. */
+fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.avg(scale: Int = 2): Avg<T, S> = Avg<T, S>(this, scale)
+
+/** Returns the sum of this expression across all non-null input values. */
+fun <T : Any?> ExpressionWithColumnType<T>.sum(): Sum<T> = Sum(this, this.columnType)
+
+/** Returns the number of input rows for which the value of this expression is not null. */
+fun ExpressionWithColumnType<*>.count(): Count = Count(this)
+
+/** Returns the number of distinct input rows for which the value of this expression is not null. */
+fun Column<*>.countDistinct(): Count = Count(this, true)
+
+
+// Aggregate Functions for Statistics
+
+/**
+ * Returns the population standard deviation of the input values.
+ *
+ * @param scale The scale of the decimal column expression returned.
+ */
+fun <T : Any?> ExpressionWithColumnType<T>.stdDevPop(scale: Int = 2): StdDevPop<T> = StdDevPop(this, scale)
+
+/**
+ * Returns the sample standard deviation of the input values.
+ *
+ * @param scale The scale of the decimal column expression returned.
+ */
+fun <T : Any?> ExpressionWithColumnType<T>.stdDevSamp(scale: Int = 2): StdDevSamp<T> = StdDevSamp(this, scale)
+
+/**
+ * Returns the population variance of the input values (square of the population standard deviation).
+ *
+ * @param scale The scale of the decimal column expression returned.
+ */
+fun <T : Any?> ExpressionWithColumnType<T>.varPop(scale: Int = 2): VarPop<T> = VarPop(this, scale)
+
+/**
+ * Returns the sample variance of the input values (square of the sample standard deviation).
+ *
+ * @param scale The scale of the decimal column expression returned.
+ */
+fun <T : Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> = VarSamp(this, scale)
+
+
+// Sequence Manipulation Functions
+
+/** Advances this sequence and returns the new value. */
+fun Sequence.nextVal(): NextVal = NextVal(this)
+
+
+// Value Expressions
+
+/** Specifies a conversion from one data type to another. */
+fun <R : Any> Expression<*>.castTo(columnType: IColumnType): Cast<R> = Cast(this, columnType)
+
+
+// Misc.
+
+/**
+ * Calls a custom SQL function with the specified [functionName] and passes this expression as its only argument.
+ */
+fun <T : Any?> ExpressionWithColumnType<T>.function(functionName: String): CustomFunction<T?> = CustomFunction(functionName, columnType, this)
+
+/**
+ * Calls a custom SQL function with the specified [functionName], that returns a string, and passing [params] as its arguments.
+ */
+fun CustomStringFunction(
+    functionName: String,
+    vararg params: Expression<*>
+): CustomFunction<String?> = CustomFunction(functionName, VarCharColumnType(), *params)
+
+/**
+ * Calls a custom SQL function with the specified [functionName], that returns a long, and passing [params] as its arguments.
+ */
+fun CustomLongFunction(
+    functionName: String,
+    vararg params: Expression<*>
+): CustomFunction<Long?> = CustomFunction(functionName, LongColumnType(), *params)
+
+
+/**
+ * Builder object for creating SQL expressions.
+ */
 object SqlExpressionBuilder {
-    fun <T, S:T?, E:ExpressionWithColumnType<S>, R:T> coalesce(expr: E, alternate: ExpressionWithColumnType<out T>) : ExpressionWithColumnType<R> =
-            Coalesce(expr, alternate)
 
-    fun case(value: Expression<*>? = null) = Case(value)
+    // Comparison Operators
 
-    fun<T, S:T?> ExpressionWithColumnType<in S>.wrap(value: T): Expression<T> = QueryParameter(value, columnType)
+    /** Checks if this expression is equals to some [t] value. */
+    infix fun <T> ExpressionWithColumnType<T>.eq(t: T): Op<Boolean> = if (t == null) isNull() else EqOp(this, wrap(t))
 
-    infix fun <T> ExpressionWithColumnType<T>.eq(t: T) : Op<Boolean> {
+    /** Checks if this expression is equals to some [other] expression. */
+    infix fun <T, S1 : T?, S2 : T?> Expression<in S1>.eq(other: Expression<in S2>): EqOp = EqOp(this, other)
+
+    /** Checks if this expression is equals to some [t] value. */
+    infix fun <T : Comparable<T>, E : EntityID<T>?> ExpressionWithColumnType<E>.eq(t: T?): Op<Boolean> {
         if (t == null) {
             return isNull()
         }
-        return EqOp(this, wrap(t))
-    }
-
-    infix fun <T:Comparable<T>, E:EntityID<T>?> ExpressionWithColumnType<E>.eq(t: T?) : Op<Boolean> {
-        if (t == null) {
-            return isNull()
-        }
-        @Suppress("UNCHECKED_CAST") val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
+        @Suppress("UNCHECKED_CAST")
+        val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
         return EqOp(this, wrap(entityID))
     }
 
-    infix fun<T, S1: T?, S2: T?> Expression<in S1>.eq(other: Expression<in S2>) : Op<Boolean> = EqOp(this, other)
 
-    infix fun <T> ExpressionWithColumnType<T>.neq(other: T): Op<Boolean> {
-        if (other == null) {
-            return isNotNull()
-        }
+    /** Checks if this expression is not equals to some [other] value. */
+    infix fun <T> ExpressionWithColumnType<T>.neq(other: T): Op<Boolean> = if (other == null) isNotNull() else NeqOp(this, wrap(other))
 
-        return NeqOp(this, wrap(other))
-    }
+    /** Checks if this expression is not equals to some [other] expression. */
+    infix fun <T, S1 : T?, S2 : T?> Expression<in S1>.neq(other: Expression<in S2>): NeqOp = NeqOp(this, other)
 
-    infix fun <T:Comparable<T>> ExpressionWithColumnType<EntityID<T>>.neq(t: T?) : Op<Boolean> {
-        if (t == null) {
-            return isNotNull()
-        }
-        return NeqOp(this, wrap(t))
-    }
+    /** Checks if this expression is not equals to some [t] value. */
+    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.neq(t: T?): Op<Boolean> = if (t == null) isNotNull() else NeqOp(this, wrap(t))
 
-    infix fun <T, S1: T?, S2: T?> Expression<in S1>.neq(other: Expression<in S2>) : Op<Boolean> = NeqOp(this, other)
 
-    fun<T> ExpressionWithColumnType<T>.isNull(): Op<Boolean> = IsNullOp(this)
+    /** Checks if this expression is less than some [t] value. */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.less(t: T): LessOp = LessOp(this, wrap(t))
 
-    fun<T> ExpressionWithColumnType<T>.isNotNull(): Op<Boolean> = IsNotNullOp(this)
+    /** Checks if this expression is less than some [other] expression. */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.less(other: Expression<in S>): LessOp = LessOp(this, other)
 
-    infix fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.less(t: T) : Op<Boolean> = LessOp(this, wrap(t))
-
+    /** Checks if this expression is less than some [t] value. */
     @JvmName("lessEntityID")
-    infix fun<T:Comparable<T>> ExpressionWithColumnType<EntityID<T>>.less(t: T) : Op<Boolean> = LessOp(this, wrap(t))
+    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.less(t: T): LessOp = LessOp(this, wrap(t))
 
-    fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.less(other: Expression<in S>) = LessOp(this, other)
 
-    infix fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.lessEq(t: T) : Op<Boolean> = LessEqOp(this, wrap(t))
+    /** Checks if this expression is less than or equal to some [t] value */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.lessEq(t: T): LessEqOp = LessEqOp(this, wrap(t))
 
+    /** Checks if this expression is less than or equal to some [other] expression */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.lessEq(other: Expression<in S>): LessEqOp = LessEqOp(this, other)
+
+    /** Checks if this expression is less than or equal to some [t] value */
     @JvmName("lessEqEntityID")
-    infix fun<T:Comparable<T>> ExpressionWithColumnType<EntityID<T>>.lessEq(t: T) : Op<Boolean> = LessEqOp(this, wrap(t))
+    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.lessEq(t: T): LessEqOp = LessEqOp(this, wrap(t))
 
-    fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.lessEq(other: Expression<in S>) : Op<Boolean> = LessEqOp(this, other)
 
-    infix fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.greater(t: T) : Op<Boolean> = GreaterOp(this, wrap(t))
+    /** Checks if this expression is greater than some [t] value. */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.greater(t: T): GreaterOp = GreaterOp(this, wrap(t))
 
+    /** Checks if this expression is greater than some [other] expression. */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.greater(other: Expression<in S>): GreaterOp = GreaterOp(this, other)
+
+    /** Checks if this expression is greater than some [t] value. */
     @JvmName("greaterEntityID")
-    infix fun<T:Comparable<T>> ExpressionWithColumnType<EntityID<T>>.greater(t: T) : Op<Boolean> = GreaterOp(this, wrap(t))
+    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.greater(t: T): GreaterOp = GreaterOp(this, wrap(t))
 
-    fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.greater(other: Expression<in S>) : Op<Boolean> = GreaterOp(this, other)
 
-    infix fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.greaterEq(t: T) : Op<Boolean> = GreaterEqOp(this, wrap(t))
+    /** Checks if this expression is greater than or equal to some [t] value */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.greaterEq(t: T): GreaterEqOp = GreaterEqOp(this, wrap(t))
 
+    /** Checks if this expression is greater than or equal to some [other] expression */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.greaterEq(other: Expression<in S>): GreaterEqOp = GreaterEqOp(this, other)
+
+    /** Checks if this expression is greater than or equal to some [t] value */
     @JvmName("greaterEqEntityID")
-    infix fun<T:Comparable<T>> ExpressionWithColumnType<EntityID<T>>.greaterEq(t: T) : Op<Boolean> = GreaterEqOp(this, wrap(t))
+    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.greaterEq(t: T): GreaterEqOp = GreaterEqOp(this, wrap(t))
 
-    fun<T:Comparable<T>, S: T?> ExpressionWithColumnType<in S>.greaterEq(other: Expression<in S>) : Op<Boolean> = GreaterEqOp(this, other)
 
-    operator fun<T, S: T> ExpressionWithColumnType<T>.plus(other: Expression<S>) : ExpressionWithColumnType<T> = PlusOp(this, other, columnType)
+    // Comparison Predicates
 
-    operator fun<T> ExpressionWithColumnType<T>.plus(t: T) : ExpressionWithColumnType<T> = PlusOp(this, wrap(t), columnType)
+    /** Returns `true` if this expression is between the values [from] and [to], `false` otherwise. */
+    fun <T, S : T?> ExpressionWithColumnType<S>.between(from: T, to: T): Between = Between(this, asLiteral(from), asLiteral(to))
 
-    operator fun<T, S: T> ExpressionWithColumnType<T>.minus(other: Expression<S>) : ExpressionWithColumnType<T> = MinusOp(this, other, columnType)
+    /** Returns `true` if this expression is null, `false` otherwise. */
+    fun <T> ExpressionWithColumnType<T>.isNull(): IsNullOp = IsNullOp(this)
 
-    operator fun<T> ExpressionWithColumnType<T>.minus(t: T) : ExpressionWithColumnType<T> = MinusOp(this, wrap(t), columnType)
+    /** Returns `true` if this expression is not null, `false` otherwise. */
+    fun <T> ExpressionWithColumnType<T>.isNotNull(): IsNotNullOp = IsNotNullOp(this)
 
-    operator fun<T, S: T> ExpressionWithColumnType<T>.times(other: Expression<S>) : ExpressionWithColumnType<T> = TimesOp(this, other, columnType)
 
-    operator fun<T> ExpressionWithColumnType<T>.times(t: T) : ExpressionWithColumnType<T> = TimesOp(this, wrap(t), columnType)
+    // Mathematical Operators
 
-    operator fun<T, S: T> ExpressionWithColumnType<T>.div(other: Expression<S>) : ExpressionWithColumnType<T> = DivideOp(this, other, columnType)
+    /** Adds the [t] value to this expression. */
+    infix operator fun <T> ExpressionWithColumnType<T>.plus(t: T): PlusOp<T, T> = PlusOp(this, wrap(t), columnType)
 
-    operator fun<T> ExpressionWithColumnType<T>.div(t: T) : ExpressionWithColumnType<T> = DivideOp(this, wrap(t), columnType)
+    /** Adds the [other] expression to this expression. */
+    infix operator fun <T, S : T> ExpressionWithColumnType<T>.plus(other: Expression<S>): PlusOp<T, S> = PlusOp(this, other, columnType)
 
-    operator fun<T:Number?, S: Number> ExpressionWithColumnType<T>.rem(other: Expression<S>) : ExpressionWithColumnType<T> = ModOp(this, other, columnType)
 
-    operator fun<T:Number?, S: T> ExpressionWithColumnType<T>.rem(t: S) : ExpressionWithColumnType<T> = ModOp(this, wrap(t), columnType)
+    /** Subtracts the [t] value from this expression. */
+    infix operator fun <T> ExpressionWithColumnType<T>.minus(t: T): MinusOp<T, T> = MinusOp(this, wrap(t), columnType)
 
-    infix fun<T:Number?, S: Number> ExpressionWithColumnType<T>.mod(other: Expression<S>) : ExpressionWithColumnType<T> = this % other
+    /** Subtracts the [other] expression from this expression. */
+    infix operator fun <T, S : T> ExpressionWithColumnType<T>.minus(other: Expression<S>): MinusOp<T, S> = MinusOp(this, other, columnType)
 
-    infix fun<T:Number?, S: T> ExpressionWithColumnType<T>.mod(t: S) : ExpressionWithColumnType<T> = this % t
 
-    infix fun<T:String?> ExpressionWithColumnType<T>.like(pattern: String): Op<Boolean> = LikeOp(this, QueryParameter(pattern, columnType))
+    /** Multiplies this expression by the [t] value. */
+    infix operator fun <T> ExpressionWithColumnType<T>.times(t: T): TimesOp<T, T> = TimesOp(this, wrap(t), columnType)
 
+    /** Multiplies this expression by the [other] expression. */
+    infix operator fun <T, S : T> ExpressionWithColumnType<T>.times(other: Expression<S>): TimesOp<T, S> = TimesOp(this, other, columnType)
+
+
+    /** Divides this expression by the [t] value. */
+    infix operator fun <T> ExpressionWithColumnType<T>.div(t: T): DivideOp<T, T> = DivideOp(this, wrap(t), columnType)
+
+    /** Divides this expression by the [other] expression. */
+    infix operator fun <T, S : T> ExpressionWithColumnType<T>.div(other: Expression<S>): DivideOp<T, S> = DivideOp(this, other, columnType)
+
+
+    /** Calculates the remainder of dividing this expression by the [t] value. */
+    infix operator fun <T : Number?, S : T> ExpressionWithColumnType<T>.rem(t: S): ModOp<T, S> = ModOp(this, wrap(t), columnType)
+
+    /** Calculates the remainder of dividing this expression by the [other] expression. */
+    infix operator fun <T : Number?, S : Number> ExpressionWithColumnType<T>.rem(other: Expression<S>): ModOp<T, S> = ModOp(this, other, columnType)
+
+
+    /** Calculates the remainder of dividing this expression by the [t] value. */
+    infix fun <T : Number?, S : T> ExpressionWithColumnType<T>.mod(t: S): ModOp<T, S> = this % t
+
+    /** Calculates the remainder of dividing this expression by the [other] expression. */
+    infix fun <T : Number?, S : Number> ExpressionWithColumnType<T>.mod(other: Expression<S>): ModOp<T, S> = this % other
+
+
+    // String Functions
+
+    /** Concatenates the text representations of all the [expr]. */
+    fun <T : String?> concat(vararg expr: Expression<T>): Concat<T> = Concat("", *expr)
+
+    /** Concatenates the text representations of all the [expr] using the specified [separator]. */
+    fun <T : String?> concat(separator: String = "", expr: List<Expression<T>>): Concat<T> = Concat(separator, *expr.toTypedArray())
+
+
+    // Pattern Matching
+
+    /** Checks if this expression matches the specified [pattern]. */
+    infix fun <T : String?> ExpressionWithColumnType<T>.like(pattern: String): LikeOp = LikeOp(this, stringParam(pattern))
+
+    /** Checks if this expression matches the specified [pattern]. */
     @JvmName("likeWithEntityID")
-    infix fun ExpressionWithColumnType<EntityID<String>>.like(pattern: String): Op<Boolean> = LikeOp(this, QueryParameter(pattern, columnType))
+    infix fun ExpressionWithColumnType<EntityID<String>>.like(pattern: String): LikeOp = LikeOp(this, stringParam(pattern))
 
-    infix fun<T:String?> ExpressionWithColumnType<T>.notLike(pattern: String): Op<Boolean> = NotLikeOp(this, QueryParameter(pattern, columnType))
+    /** Checks if this expression matches the specified [pattern]. */
+    infix fun <T : String?> ExpressionWithColumnType<T>.match(pattern: String): Op<Boolean> = match(pattern, null)
 
+    /** Checks if this expression matches the specified [pattern] using the specified match [mode]. */
+    fun <T : String?> ExpressionWithColumnType<T>.match(
+        pattern: String,
+        mode: FunctionProvider.MatchMode?
+    ): Op<Boolean> = with(currentDialect.functionProvider) { this@match.match(pattern, mode) }
+
+    /** Checks if this expression doesn't match the specified [pattern]. */
+    infix fun <T : String?> ExpressionWithColumnType<T>.notLike(pattern: String): NotLikeOp = NotLikeOp(this, stringParam(pattern))
+
+    /** Checks if this expression doesn't match the specified [pattern]. */
     @JvmName("notLikeWithEntityID")
-    infix fun ExpressionWithColumnType<EntityID<String>>.notLike(pattern: String): Op<Boolean> = NotLikeOp(this, QueryParameter(pattern, columnType))
+    infix fun ExpressionWithColumnType<EntityID<String>>.notLike(pattern: String): NotLikeOp = NotLikeOp(this, stringParam(pattern))
 
-    /*
-     * Function will apply case-sensitive regexp function
-     */
-    infix fun<T:String?> ExpressionWithColumnType<T>.regexp(pattern: String): Op<Boolean> = RegexpOp(this, QueryParameter(pattern, columnType), true)
+    /** Checks if this expression matches the [pattern]. Supports regular expressions. */
+    infix fun <T : String?> ExpressionWithColumnType<T>.regexp(pattern: String): RegexpOp<T> = RegexpOp(this, stringParam(pattern), true)
 
-    fun<T:String?> ExpressionWithColumnType<T>.regexp(pattern: Expression<String>, caseSensitive: Boolean = true): Op<Boolean> = RegexpOp(this, pattern, caseSensitive)
+    /** Checks if this expression matches the [pattern]. Supports regular expressions. */
+    fun <T : String?> ExpressionWithColumnType<T>.regexp(
+        pattern: Expression<String>,
+        caseSensitive: Boolean = true
+    ): RegexpOp<T> = RegexpOp(this, pattern, caseSensitive)
 
-    @Deprecated("Use not(RegexpOp()) instead", level = DeprecationLevel.ERROR)
-    infix fun<T:String?> ExpressionWithColumnType<T>.notRegexp(pattern: String): Op<Boolean> = TODO()
+    /** Checks if this expression doesn't match the [pattern]. Supports regular expressions. */
+    @Deprecated("Use not(RegexpOp()) instead", ReplaceWith("regexp(pattern).not()"), DeprecationLevel.ERROR)
+    infix fun <T : String?> ExpressionWithColumnType<T>.notRegexp(pattern: String): Op<Boolean> = TODO()
 
-    infix fun<T> ExpressionWithColumnType<T>.inList(list: Iterable<T>): Op<Boolean> = InListOrNotInListOp(this, list, isInList = true)
 
+    // Conditional Expressions
+
+    /** Returns the first of its arguments that is not null. */
+    fun <T, S : T?, E : ExpressionWithColumnType<S>, R : T> coalesce(expr: E, alternate: ExpressionWithColumnType<out T>): Coalesce<T?, S, T?> =
+        Coalesce(expr, alternate)
+
+    fun case(value: Expression<*>? = null): Case = Case(value)
+
+
+    // Subquery Expressions
+
+    /** Checks if this expression is equals to any row returned from [query]. */
+    infix fun <T> ExpressionWithColumnType<T>.inSubQuery(query: Query): InSubQueryOp<T> = InSubQueryOp(this, query)
+
+
+    // Array Comparisons
+
+    /** Checks if this expression is equals to any element from [list]. */
+    infix fun <T> ExpressionWithColumnType<T>.inList(list: Iterable<T>): InListOrNotInListOp<T> = InListOrNotInListOp(this, list, isInList = true)
+
+    /** Checks if this expression is equals to any element from [list]. */
     @Suppress("UNCHECKED_CAST")
     @JvmName("inListIds")
-    infix fun<T:Comparable<T>> Column<EntityID<T>>.inList(list: Iterable<T>): Op<Boolean> {
+    infix fun <T : Comparable<T>> Column<EntityID<T>>.inList(list: Iterable<T>): InListOrNotInListOp<EntityID<T>> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return inList(list.map { EntityIDFunctionProvider.createEntityID(it, idTable) })
     }
 
-    infix fun<T> ExpressionWithColumnType<T>.notInList(list: Iterable<T>): Op<Boolean> = InListOrNotInListOp(this, list, isInList = false)
+    /** Checks if this expression is not equals to any element from [list]. */
+    infix fun <T> ExpressionWithColumnType<T>.notInList(list: Iterable<T>): InListOrNotInListOp<T> = InListOrNotInListOp(this, list, isInList = false)
 
+    /** Checks if this expression is not equals to any element from [list]. */
     @Suppress("UNCHECKED_CAST")
     @JvmName("notInListIds")
-    infix fun<T:Comparable<T>> Column<EntityID<T>>.notInList(list: Iterable<T>): Op<Boolean> {
+    infix fun <T : Comparable<T>> Column<EntityID<T>>.notInList(list: Iterable<T>): InListOrNotInListOp<EntityID<T>> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return notInList(list.map { EntityIDFunctionProvider.createEntityID(it, idTable) })
     }
 
-    infix fun<T> ExpressionWithColumnType<T>.inSubQuery(query: Query): Op<Boolean> = InSubQueryOp(this, query)
 
+    // Misc.
+
+    /** Returns the specified [value] as a query parameter of type [T]. */
     @Suppress("UNCHECKED_CAST")
-    fun<T, S: T?> ExpressionWithColumnType<S>.asLiteral(value: T) = when (value) {
+    fun <T, S : T?> ExpressionWithColumnType<in S>.wrap(value: T): QueryParameter<T> = when (value) {
+        is Boolean -> booleanParam(value)
+        is Short -> shortParam(value)
+        is Int -> intParam(value)
+        is Long -> longParam(value)
+        is Float -> floatParam(value)
+        is Double -> doubleParam(value)
+        is String -> stringParam(value)
+        else -> QueryParameter(value, columnType)
+    } as QueryParameter<T>
+
+    /** Returns the specified [value] as a literal of type [T]. */
+    @Suppress("UNCHECKED_CAST")
+    fun <T, S : T?> ExpressionWithColumnType<S>.asLiteral(value: T): LiteralOp<T> = when (value) {
         is Boolean -> booleanLiteral(value)
+        is Short -> shortLiteral(value)
         is Int -> intLiteral(value)
         is Long -> longLiteral(value)
+        is Float -> floatLiteral(value)
+        is Double -> doubleLiteral(value)
         is String -> stringLiteral(value)
         is ByteArray -> stringLiteral(value.toString(Charsets.UTF_8))
         else -> LiteralOp(columnType, value)
     } as LiteralOp<T>
 
-    fun<T, S: T?> ExpressionWithColumnType<S>.between(from: T, to: T): Op<Boolean> = Between(this, asLiteral(from), asLiteral(to))
-
-    fun ExpressionWithColumnType<Int>.intToDecimal(): ExpressionWithColumnType<BigDecimal> = NoOpConversion(this, DecimalColumnType(15, 0))
-
-    fun <T : String?> ExpressionWithColumnType<T>.match(pattern: String, mode: FunctionProvider.MatchMode?): Op<Boolean> {
-        return with(currentDialect.functionProvider) {
-            this@match.match(pattern, mode)
-        }
-    }
-
-    infix fun <T: String?> ExpressionWithColumnType<T>.match(pattern: String): Op<Boolean> = match(pattern, null)
-
-    fun <T:String?> concat(vararg expr: Expression<T>) = Concat("", *expr)
-    fun <T:String?> concat(separator: String = "", expr: List<Expression<T>>) = Concat(separator, *expr.toTypedArray())
+    fun ExpressionWithColumnType<Int>.intToDecimal(): NoOpConversion<Int, BigDecimal> = NoOpConversion(this, DecimalColumnType(15, 0))
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.sql.vendors
 import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.Sequence
+import org.jetbrains.exposed.sql.append
 
 internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
     override fun nextVal(seq: Sequence, builder: QueryBuilder) = builder {


### PR DESCRIPTION
### Changes
- Added KDoc comments to most public declarations.
- Rearranged some declarations to group them by functionality.
- Reformatted code to follow Kotlin Coding Conventions.
- Created backing property for `args` property in `QueryBuilder` class.
- Refactored `args` property to use `mutableListOf()` instead of `ArrayList()` in `QueryBuilder` class.
- Refactored `toQueryBuilder` function in `CustomFunction` class, now uses `asList` instead of `toList`to avoid copying the original array.
- Refactored `cases` property in `CaseWhen` class to use `mutableListOf()` instead of `ArrayList()`.
- Refactored `and` and `or` functions from `Op.kt` to be more idiomatic.
- Updated function return types to match the class returned instead of a superclass.
- Added `infix` modifier to mathematical operators in `SqlExpressionBuilder`.
- Replaced manual `QueryParameter` creation with call to `stringParam` in `SqlExpressionBuilder`.
- Added missing cases to `wrap` and `asLiteral` functions in `SqlExpressionBuilder`.

### Additional changes
@Tapac there are some additional changes I thought of, but I wanted to know your opinion about them first.

#### 1. Return type of functions in `SQLExpressionBuilder.kt`
Initially the return type of these functions was completely mixed:
- Some functions returned the most _specific_ sub-class, like `sum()` that returned `Sum<T>`.
- Some functions returned some intermediary class, like `count()` that returned `Function<Int>`.
- Some functions returned the most _generic_ super-class, like `max()` that returned `ExpressionWithColumnType<T?>`.

In this case I decided to go with the corresponding class for each function (like the first example), so that everything is consistent, while not breaking any existing code.

Choosing a more _generic_ super-class may break some existing code.

#### 2. Refactor `QueryBuilder` to _match_ `StringBuilder`
- Adding `append` methods for each accepted type: `Char`, `String` and `Expression<*>`.
- Refactoring `unaryPlus` member methods to extension methods.

Applying these changes to the `QueryBuilder` may break some existing code.