### PR TITLE
notInSubQuery functionality

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -122,6 +122,14 @@ class InSubQueryOp<T>(val expr: Expression<T>, val query: Query): Op<Boolean>() 
     }
 }
 
+class NotInSubQueryOp<T>(val expr: Expression<T>, val query: Query) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        append(expr, " NOT IN (")
+        query.prepareSQL(this)
+        +")"
+    }
+}
+
 class QueryParameter<T>(val value: T, val sqlType: IColumnType) : Expression<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { registerArgument(sqlType, value) }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -190,6 +190,8 @@ object SqlExpressionBuilder {
 
     infix fun<T> ExpressionWithColumnType<T>.inSubQuery(query: Query): Op<Boolean> = InSubQueryOp(this, query)
 
+    infix fun <T> ExpressionWithColumnType<T>.notInSubQuery(query: Query): Op<Boolean> = NotInSubQueryOp(this, query)
+
     @Suppress("UNCHECKED_CAST")
     fun<T, S: T?> ExpressionWithColumnType<S>.asLiteral(value: T) = when (value) {
         is Boolean -> booleanLiteral(value)


### PR DESCRIPTION
We have `inSubQuery` feature but there is no its counterpart `notInSubQuery`. Now we can have it. 
Covered with tests.