### PR TITLE
Use concat when strings are added

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -219,6 +219,7 @@ open class SqlExpressionBuilderClass {
     /** Adds the [other] expression to this expression. */
     infix operator fun <T, S : T> ExpressionWithColumnType<T>.plus(other: Expression<S>): PlusOp<T, S> = PlusOp(this, other, columnType)
 
+    infix operator fun ExpressionWithColumnType<String>.plus(t: String) = concat(this, wrap(t))
 
     /** Subtracts the [t] value from this expression. */
     infix operator fun <T> ExpressionWithColumnType<T>.minus(t: T): MinusOp<T, T> = MinusOp(this, wrap(t), columnType)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -219,7 +219,11 @@ open class SqlExpressionBuilderClass {
     /** Adds the [other] expression to this expression. */
     infix operator fun <T, S : T> ExpressionWithColumnType<T>.plus(other: Expression<S>): PlusOp<T, S> = PlusOp(this, other, columnType)
 
-    infix operator fun ExpressionWithColumnType<String>.plus(t: String) = concat(this, wrap(t))
+    infix operator fun Expression<String>.plus(t: String) = concat(this, stringParam(t))
+
+    infix operator fun Expression<String>.plus(t: Expression<String>) = concat(this, t)
+
+    infix operator fun String.plus(t: Expression<String>) = concat(stringParam(this), t)
 
     /** Subtracts the [t] value from this expression. */
     infix operator fun <T> ExpressionWithColumnType<T>.minus(t: T): MinusOp<T, T> = MinusOp(this, wrap(t), columnType)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/FunctionsTests.kt
@@ -173,7 +173,25 @@ class FunctionsTests : DatabaseTestsBase() {
             assertEquals("andrey!Andrey", result2[concatField2])
         }
     }
+   
+    @Test fun testConcatUsingPlusOperator() {
+        withCitiesAndUsers { _, users, _ ->
 
+            val concatField = SqlExpressionBuilder.run { users.id + " - " + users.name }
+            val result = users.slice(concatField).select{ users.id eq "andrey" }.single()
+            assertEquals("andrey - Andrey", result[concatField])
+
+            val concatField2 = SqlExpressionBuilder.run { users.id + users.name }
+            val result2 = users.slice(concatField2).select{ users.id eq "andrey" }.single()
+            assertEquals("andreyAndrey", result2[concatField2])
+
+            val concatField3 = SqlExpressionBuilder.run { "Hi " plus users.name + "!"}
+            val result3 = users.slice(concatField3).select{ users.id eq "andrey" }.single()
+            assertEquals("Hi Andrey!", result3[concatField3])
+
+        }
+    }
+    
     @Test
     fun testCustomStringFunctions01() {
         withCitiesAndUsers { cities, _, _ ->


### PR DESCRIPTION
I get this error when I try to update with a plus concatenation:

>  org.jetbrains.exposed.exceptions.ExposedSQLException: org.h2.jdbc.JdbcSQLFeatureNotSupportedException: Caracteristica no soportada: "VARCHAR +"
Feature not supported: "VARCHAR +"; S

The code to test is this:
```kotlin
        Country.update {
           with(SqlExpressionBuilder) {
               it[name] = name + "ABC"
           }
        }
```

I think that Strings should concat by default. 