### PR TITLE
ExposedDatabaseMetadata#tableConstraints: fix it works correctly when column names need quoting

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -125,11 +125,15 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
             metadata.getImportedKeys(databaseName, oracleSchema, table).iterate {
                 val fromTableName = getString("FKTABLE_NAME")!!
                 val fromColumnName = identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(getString("FKCOLUMN_NAME")!!)
-                val fromColumn = allTables.getValue(fromTableName).columns.first { it.nameInDatabaseCase() == fromColumnName }
+                val fromColumn = allTables.getValue(fromTableName).columns.first {
+                    identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(it.nameInDatabaseCase()) == fromColumnName
+                }
                 val constraintName = getString("FK_NAME")!!
                 val targetTableName = getString("PKTABLE_NAME")!!
                 val targetColumnName = identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(getString("PKCOLUMN_NAME")!!)
-                val targetColumn = allTables.getValue(targetTableName).columns.first { it.nameInDatabaseCase() == targetColumnName }
+                val targetColumn = allTables.getValue(targetTableName).columns.first {
+                    identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(it.nameInDatabaseCase()) == targetColumnName
+                }
                 val constraintUpdateRule = ReferenceOption.resolveRefOptionFromJdbc(getInt("UPDATE_RULE"))
                 val constraintDeleteRule = ReferenceOption.resolveRefOptionFromJdbc(getInt("DELETE_RULE"))
                 ForeignKeyConstraint(

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -29,4 +29,22 @@ class ConnectionTests : DatabaseTestsBase() {
             assertEquals(expected, columnMetadata)
         }
     }
+
+    // GitHub issue #838
+    @Test
+    @Suppress("unused")
+    fun testTableConstraints() {
+        val parent = object : LongIdTable("parent") {
+            val scale = integer("scale").uniqueIndex()
+        }
+        val child = object : LongIdTable("child") {
+            val scale = reference("scale", parent.scale)
+        }
+        withTables(listOf(TestDB.MYSQL), child) {
+            val constraints = connection.metadata {
+                tableConstraints(listOf(child))
+            }
+            assertEquals(2, constraints.keys.size)
+        }
+    }
 }


### PR DESCRIPTION
Fixes #838 