### PR TITLE
primary key declaration fixes

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -370,6 +370,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         init {
             checkMultipleDeclaration()
             for (column in columns) column.markPrimaryKey()
+            columns.sortWith(compareBy { !it.columnType.isAutoInc })
         }
 
         /**
@@ -394,10 +395,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
             val table = this@Table
             if (table.columns.any { it.indexInPK != null }) {
                 removeOldPrimaryKey()
-                exposedLogger.error(
-                    "Confusion between multiple declarations of primary key on ${table.tableName}. " +
-                            "Use only override val primaryKey=PrimaryKey() declaration."
-                )
             }
         }
 
@@ -436,6 +433,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <T> Column<T>.primaryKey(indx: Int? = null): Column<T> = apply {
         require(indx == null || table.columns.none { it.indexInPK == indx }) { "Table $tableName already contains PK at $indx" }
         indexInPK = indx ?: table.columns.count { it.indexInPK != null } + 1
+        exposedLogger.error(
+                "primaryKey(indx) method is deprecated. Use override val primaryKey=PrimaryKey() declaration instead."
+        )
     }
 
     // EntityID columns

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -43,7 +43,7 @@ internal object H2FunctionProvider : FunctionProvider() {
     ): String {
         val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
         val primaryKeys = table.primaryKey?.columns?.toList() ?: emptyList()
-        val uniqueCols = columns.filter { it in uniqueIdxCols } + primaryKeys
+        val uniqueCols = (columns.filter { it in uniqueIdxCols } + primaryKeys).distinct()
         val borderDate = Date(118, 2, 18)
         return when {
             // INSERT IGNORE support added in H2 version 1.4.197 (2018-03-18)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -43,7 +43,7 @@ internal object H2FunctionProvider : FunctionProvider() {
     ): String {
         val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
         val primaryKeys = table.primaryKey?.columns?.toList() ?: emptyList()
-        val uniqueCols = (columns.filter { it in uniqueIdxCols } + primaryKeys).distinct()
+        val uniqueCols = (uniqueIdxCols  + primaryKeys).distinct()
         val borderDate = Date(118, 2, 18)
         return when {
             // INSERT IGNORE support added in H2 version 1.4.197 (2018-03-18)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -42,7 +42,8 @@ internal object H2FunctionProvider : FunctionProvider() {
         transaction: Transaction
     ): String {
         val uniqueIdxCols = table.indices.filter { it.unique }.flatMap { it.columns.toList() }
-        val uniqueCols = columns.filter { it.indexInPK != null || it in uniqueIdxCols }
+        val primaryKeys = table.primaryKey?.columns?.toList() ?: emptyList()
+        val uniqueCols = columns.filter { it in uniqueIdxCols } + primaryKeys
         val borderDate = Date(118, 2, 18)
         return when {
             // INSERT IGNORE support added in H2 version 1.4.197 (2018-03-18)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -174,8 +174,8 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
 
         val def = super.insert(false, table, columns, sql, transaction)
 
-        val uniqueCols = columns.filter { it.indexInPK != null }.sortedBy { it.indexInPK }
-        if (uniqueCols.isEmpty()) {
+        val uniqueCols = table.primaryKey?.columns
+        if (uniqueCols.isNullOrEmpty()) {
             transaction.throwUnsupportedException("PostgreSQL replace table must supply at least one primary key.")
         }
         val conflictKey = uniqueCols.joinToString { transaction.identity(it) }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
@@ -39,11 +39,15 @@ class H2Tests : DatabaseTestsBase() {
     }
 
     object Testing : Table("H2_TESTING") {
-        val id = integer("id").primaryKey().autoIncrement() // Column<Int>
+        val id = integer("id").autoIncrement() // Column<Int>
+
+        override val primaryKey = PrimaryKey(id)
     }
 
     object RefTable : Table() {
-        val id = integer("id").primaryKey().autoIncrement() // Column<Int>
+        val id = integer("id").autoIncrement() // Column<Int>
         val ref = reference("test", Testing.id)
+
+        override val primaryKey = PrimaryKey(id)
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
@@ -18,7 +18,9 @@ import java.sql.Connection
 class CoroutineTests : DatabaseTestsBase() {
 
     object Testing : Table("COROUTINE_TESTING") {
-        val id = integer("id").primaryKey().autoIncrement() // Column<Int>
+        val id = integer("id").autoIncrement() // Column<Int>
+
+        override val primaryKey = PrimaryKey(id)
     }
 
     @Rule

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -22,9 +22,11 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     @Test
     fun testCreateMissingTablesAndColumns01() {
         val TestTable = object : Table("test_table") {
-            val id = integer("id").primaryKey()
+            val id = integer("id")
             val name = varchar("name", length = 42)
             val time = long("time").uniqueIndex()
+
+            override val primaryKey = PrimaryKey(id)
         }
 
         withTables(excludeSettings = listOf(TestDB.H2_MYSQL), tables = *arrayOf(TestTable)) {
@@ -37,11 +39,13 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     @Test
     fun testCreateMissingTablesAndColumns02() {
         val TestTable = object : IdTable<String>("Users2") {
-            override val id: Column<EntityID<String>> = varchar("id", 64).clientDefault { UUID.randomUUID().toString() }.primaryKey().entityId()
+            override val id: Column<EntityID<String>> = varchar("id", 64).clientDefault { UUID.randomUUID().toString() }.entityId()
 
             val name = varchar("name", 255)
             val email = varchar("email", 255).uniqueIndex()
             val camelCased = varchar("camelCased", 255).index()
+
+            override val primaryKey = PrimaryKey(id)
         }
 
         withDb { dbSetting ->

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -150,8 +150,10 @@ class InsertTests : DatabaseTestsBase() {
     }
 
     object LongIdTable : Table() {
-        val id = long("id").autoIncrement("long_id_seq").primaryKey()
+        val id = long("id").autoIncrement("long_id_seq")
         val name = text("name")
+
+        override val primaryKey = PrimaryKey(id)
     }
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
@@ -54,11 +54,15 @@ class JoinTests : DatabaseTestsBase() {
     @Test
     fun testJoin04() {
         val Numbers = object : Table() {
-            val id = integer("id").primaryKey()
+            val id = integer("id")
+
+            override val primaryKey = PrimaryKey(id)
         }
 
         val Names = object : Table() {
-            val name = varchar("name", 10).primaryKey()
+            val name = varchar("name", 10)
+
+            override val primaryKey = PrimaryKey(name)
         }
 
         val Map = object : Table() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -11,10 +11,12 @@ class ReplaceTests : DatabaseTestsBase() {
     @Test
     fun testReplace01() {
         val NewAuth = object : Table() {
-            val username = varchar("username", 16).primaryKey()
+            val username = varchar("username", 16)
             val session = binary("session", 64)
             val timestamp = long("timestamp").default(0)
             val serverID = varchar("serverID", 64).default("")
+
+            override val primaryKey = PrimaryKey(username)
         }
         // Only MySQL supp
         withTables(TestDB.values().toList() - listOf(TestDB.MYSQL, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG), NewAuth) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -27,12 +27,14 @@ import kotlin.test.assertNull
 object EntityTestsData {
 
     object YTable: IdTable<String>("YTable") {
-        override val id: Column<EntityID<String>> = varchar("uuid", 36).primaryKey().entityId().clientDefault {
+        override val id: Column<EntityID<String>> = varchar("uuid", 36).entityId().clientDefault {
             EntityID(UUID.randomUUID().toString(), YTable)
         }
 
         val x = bool("x").default(true)
         val blob = blob("content").nullable()
+
+        override val primaryKey = PrimaryKey(id)
     }
 
     object XTable: IntIdTable("XTable") {
@@ -566,8 +568,10 @@ class EntityTests: DatabaseTestsBase() {
     }
 
     object SchoolHolidays : Table(name = "school_holidays") {
-        val school          = reference("school_id", Schools, ReferenceOption.CASCADE, ReferenceOption.CASCADE).primaryKey(0)
-        val holiday         = reference("holiday_id", Holidays, ReferenceOption.CASCADE, ReferenceOption.CASCADE).primaryKey(1)
+        val school          = reference("school_id", Schools, ReferenceOption.CASCADE, ReferenceOption.CASCADE)
+        val holiday         = reference("holiday_id", Holidays, ReferenceOption.CASCADE, ReferenceOption.CASCADE)
+
+        override val primaryKey = PrimaryKey(school, holiday)
     }
 
     object Schools : IntIdTable(name = "school") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ImmutableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ImmutableEntityTest.kt
@@ -16,9 +16,11 @@ class ImmutableEntityTest : DatabaseTestsBase() {
 
     object Schema {
         object Organization : IdTable<Long>() {
-            override val id = long("id").autoIncrement().primaryKey().entityId()
+            override val id = long("id").autoIncrement().entityId()
             val name = varchar("name", 256)
             val etag = long("etag").default(0)
+
+            override val primaryKey = PrimaryKey(id)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/SelfReferenceTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/SelfReferenceTest.kt
@@ -28,25 +28,33 @@ class SortByReferenceTest {
 
     object TestTables {
         object cities : Table() {
-            val id = integer("id").autoIncrement().primaryKey()
+            val id = integer("id").autoIncrement()
             val name = varchar("name", 50)
             val strange_id = varchar("strange_id", 10).references(strangeTable.id)
+
+            override val primaryKey = PrimaryKey(id)
         }
 
         object users : Table() {
-            val id = varchar("id", 10).primaryKey()
+            val id = varchar("id", 10)
             val name = varchar("name", length = 50)
             val cityId = (integer("city_id") references cities.id).nullable()
+
+            override val primaryKey = PrimaryKey(id)
         }
 
         object noRefereeTable : Table() {
-            val id = varchar("id", 10).primaryKey()
+            val id = varchar("id", 10)
             val col1 = varchar("col1", 10)
+
+            override val primaryKey = PrimaryKey(id)
         }
 
         object refereeTable : Table() {
-            val id = varchar("id", 10).primaryKey()
+            val id = varchar("id", 10)
             val ref = reference("ref", noRefereeTable.id)
+
+            override val primaryKey = PrimaryKey(id)
         }
 
         object referencedTable : IntIdTable() {
@@ -54,10 +62,12 @@ class SortByReferenceTest {
         }
 
         object strangeTable : Table() {
-            val id = varchar("id", 10).primaryKey()
+            val id = varchar("id", 10)
             val user_id = varchar("user_id", 10) references users.id
             val comment = varchar("comment", 30)
             val value = integer("value")
+
+            override val primaryKey = PrimaryKey(id)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
@@ -18,8 +18,10 @@ object ViaTestData {
     }
 
     object StringsTable: IdTable<Long>("") {
-        override val id: Column<EntityID<Long>> = long("id").autoIncrement().primaryKey().entityId()
+        override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
         val text = varchar("text", 10)
+
+        override val primaryKey = PrimaryKey(id)
     }
 
     object ConnectionTable: Table() {


### PR DESCRIPTION
This PR is to improve the primary key declaration.

- When using both deprecated and new declaration for primarykey, the new one is taken and the deprecated is silently ignored. (without logging the "confusion between mutiple declaration" error)

- When using the deprecated method, an error is logged telling to use the new declaration instead.

- Use of the new declaration in all tests.

- Some duplicated tests was removed.
  