### PR TITLE
improvement of create/drop schema and adding some options

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Schema.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Schema.kt
@@ -2,8 +2,6 @@ package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.transactions.TransactionManager
-import org.jetbrains.exposed.sql.vendors.MariaDBDialect
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.lang.StringBuilder
 
@@ -13,14 +11,31 @@ import java.lang.StringBuilder
  * @param name the schema name
  * @param authorization owner_name Specifies the name of the database-level
  * principal that will own the schema.
+ * @param password used only for oracle schema.
+ * @param defaultTablespace used only for oracle schema.
+ * @param temporaryTablespace used only for oracle schema.
+ * @param quota used only for oracle schema.
+ * @param on used only for oracle schema.
+ *
  *
  */
-class Schema(private val name: String, val authorization: String? = null) {
+class Schema(private val name: String,
+             val authorization: String? = null,
+             val password: String? = null,
+             val defaultTablespace: String? = null,
+             val temporaryTablespace: String? = null,
+             val quota: String? = null,
+             val on: String? = null) {
 
     val identifier get() = TransactionManager.current().db.identifierManager.cutIfNecessaryAndQuote(name)
 
     val ddl: List<String>
         get() = createStatement()
+
+    /**
+     * Checks if this schema exists or not.
+     */
+    fun exists(): Boolean = currentDialect.schemaExists(this)
 
     fun createStatement(): List<String> {
 
@@ -28,43 +43,20 @@ class Schema(private val name: String, val authorization: String? = null) {
             throw UnsupportedByDialectException("The current dialect doesn't support create schema statement", currentDialect)
         }
 
-        val createSchemaDDL = buildString {
-            append("CREATE SCHEMA ")
-            if (currentDialect.supportsIfNotExists) {
-                append("IF NOT EXISTS ")
-            }
-            append(identifier)
-
-            if(currentDialect !is MysqlDialect && currentDialect !is MariaDBDialect) {
-                appendIfNotNull(" AUTHORIZATION ", authorization)
-            } else if (authorization != null) {
-                throw UnsupportedByDialectException("${currentDialect.name} do not have database owners. " +
-                        "You can use GRANT to allow or deny rights on database.", currentDialect)
-            }
-        }
-
-        return listOf(createSchemaDDL)
+        return listOf(currentDialect.createSchema(this))
     }
 
-    fun dropStatement(): List<String> {
+    fun dropStatement(cascade: Boolean): List<String> {
         if (!currentDialect.supportsCreateSchema ) {
             throw UnsupportedByDialectException("The current dialect doesn't support drop schema statement", currentDialect)
         }
 
-        val dropSchemaDDL = buildString {
-            append("DROP SCHEMA ")
-            if (currentDialect.supportsIfNotExists) {
-                append("IF EXISTS ")
-            }
-            append(identifier)
-        }
-
-        return listOf(dropSchemaDDL)
+        return listOf(currentDialect.dropSchema(this, cascade))
     }
 
     fun setSchemaStatement(): List<String> {
         if (!currentDialect.supportsCreateSchema ) {
-            throw UnsupportedByDialectException("The current dialect doesn't schemas", currentDialect)
+            throw UnsupportedByDialectException("The current dialect doesn't support schemas", currentDialect)
         }
 
         return listOf(currentDialect.setSchema(this))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -24,6 +24,7 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     )
     abstract val currentScheme: String
     abstract val tableNames: Map<String, List<String>>
+    abstract val schemaNames: List<String>
 
     abstract fun columns(vararg tables: Table) : Map<Table, List<ColumnMetadata>>
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.sql.vendors
 
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.math.BigDecimal
@@ -171,6 +172,18 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
     override fun dropIndex(tableName: String, indexName: String): String = "ALTER TABLE $tableName DROP INDEX $indexName"
 
     override fun setSchema(schema: Schema): String = "USE ${schema.identifier}"
+
+    override fun createSchema(schema: Schema): String = buildString {
+        append("CREATE SCHEMA IF NOT EXISTS ", schema.identifier)
+
+        if (schema.authorization != null) {
+            throw UnsupportedByDialectException("${currentDialect.name} do not have database owners. " +
+                    "You can use GRANT to allow or deny rights on database.", currentDialect)
+        }
+
+    }
+
+    override fun dropSchema(schema: Schema, cascade: Boolean): String = "DROP SCHEMA IF EXISTS ${schema.identifier}"
 
     companion object {
         /** MySQL dialect name */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -230,6 +230,27 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
 
     override fun setSchema(schema: Schema): String = "ALTER SESSION SET CURRENT_SCHEMA = ${schema.identifier}"
 
+    override fun createSchema(schema: Schema): String = buildString {
+        if ((schema.quota == null) xor (schema.on == null)) {
+            throw IllegalArgumentException("You must either provide both <quota> and <on> options or non of them")
+        }
+
+        append("CREATE USER ", schema.identifier)
+        append(" IDENTIFIED BY ", schema.password)
+        appendIfNotNull(" DEFAULT TABLESPACE ", schema.defaultTablespace)
+        appendIfNotNull(" TEMPORARY TABLESPACE ", schema.temporaryTablespace)
+        appendIfNotNull(" QUOTA ", schema.quota)
+        appendIfNotNull(" ON ", schema.on)
+    }
+
+    override fun dropSchema(schema: Schema, cascade: Boolean): String = buildString {
+        append("DROP USER ", schema.identifier)
+
+        if(cascade) {
+            append(" CASCADE")
+        }
+    }
+
     companion object {
         /** Oracle dialect name */
         const val dialectName: String = "oracle"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -156,6 +156,19 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
 
     override fun setSchema(schema: Schema): String = "ALTER USER ${schema.authorization} WITH DEFAULT_SCHEMA = ${schema.identifier}"
 
+    override fun createSchema(schema: Schema): String = buildString {
+        append("CREATE SCHEMA ", schema.identifier)
+        appendIfNotNull(" AUTHORIZATION ", schema.authorization)
+    }
+
+    override fun dropSchema(schema: Schema, cascade: Boolean): String = buildString {
+        append("DROP SCHEMA ", schema.identifier)
+
+        if(cascade) {
+            append(" CASCADE")
+        }
+    }
+
     companion object {
         /** SQLServer dialect name */
         const val dialectName: String = "sqlserver"

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -56,6 +56,21 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         }
     }
 
+    /** Returns a list of existing schema names. */
+    override val schemaNames: List<String> get() = schemaNames()
+
+    /** Returns a list of existing schema names. */
+    private fun schemaNames(): List<String> = with(metadata) {
+        val useCatalogInsteadOfScheme = currentDialect is MysqlDialect
+
+        val schemas = when {
+                useCatalogInsteadOfScheme -> catalogs.iterate { getString("TABLE_CAT") }
+                else -> schemas.iterate { getString("TABLE_SCHEM") }
+            }
+
+        return schemas.map { identifierManager.inProperCase(it) }
+    }
+
     private fun ResultSet.extractColumns(tables: Array<out Table>, extract: (ResultSet) -> Pair<String, ColumnMetadata>): Map<Table, List<ColumnMetadata>> {
         val mapping = tables.associateBy { it.nameInDatabaseCase() }
         val result = HashMap<Table, MutableList<ColumnMetadata>>()

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -154,7 +154,24 @@ abstract class DatabaseTestsBase {
         }
     }
 
+    fun withSchemas (excludeSettings: List<TestDB>, vararg schemas: Schema, statement: Transaction.() -> Unit) {
+        (TestDB.enabledInTests() - excludeSettings).forEach {
+            withDb(it) {
+                SchemaUtils.createSchema(*schemas)
+                try {
+                    statement()
+                    commit() // Need commit to persist data before drop schemas
+                } finally {
+                    SchemaUtils.dropSchema(*schemas, cascade = true)
+                    commit()
+                }
+            }
+        }
+    }
+
     fun withTables (vararg tables: Table, statement: Transaction.() -> Unit) = withTables(excludeSettings = emptyList(), tables = *tables, statement = statement)
+
+    fun withSchemas (vararg schemas: Schema, statement: Transaction.() -> Unit) = withSchemas(excludeSettings = emptyList(), schemas = *schemas, statement = statement)
 
     fun addIfNotExistsIfSupported() = if (currentDialectTest.supportsIfNotExists) {
         "IF NOT EXISTS "

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -650,25 +650,18 @@ class DDLTests : DatabaseTestsBase() {
 
     @Test
     fun createTableWithForeignKeyToAnotherSchema() {
-        withDb(excludeSettings = listOf(TestDB.SQLITE)) {
-            try {
-                exec("CREATE SCHEMA ${"one".inProperCase()}")
-                exec("CREATE SCHEMA ${"two".inProperCase()}")
-                SchemaUtils.create(TableFromSchemeOne, TableFromSchemeTwo)
-                val idFromOne = TableFromSchemeOne.insertAndGetId { }
+        val one = Schema("one")
+        val two = Schema("two")
+        withSchemas(excludeSettings = listOf(TestDB.SQLITE), schemas = *arrayOf(two, one)) {
+            SchemaUtils.create(TableFromSchemeOne, TableFromSchemeTwo)
+            val idFromOne = TableFromSchemeOne.insertAndGetId { }
 
-                TableFromSchemeTwo.insert {
-                    it[reference] = idFromOne
-                }
-
-                assertEquals(1L, TableFromSchemeOne.selectAll().count())
-                assertEquals(1L, TableFromSchemeTwo.selectAll().count())
-            } finally {
-                if(currentDialectTest is PostgreSQLDialect) {
-                    exec("DROP SCHEMA IF EXISTS ${"one".inProperCase()} CASCADE")
-                    exec("DROP SCHEMA IF EXISTS ${"two".inProperCase()} CASCADE")
-                }
+            TableFromSchemeTwo.insert {
+                it[reference] = idFromOne
             }
+
+            assertEquals(1L, TableFromSchemeOne.selectAll().count())
+            assertEquals(1L, TableFromSchemeTwo.selectAll().count())
         }
     }
 


### PR DESCRIPTION
- **`Schema.exists()` method** : All existing schema names are stored in a cache variable. This cache is used by `Schema.exists()` method to check if the schema exists or not.

- **create/drop schema safely** : When attemps to create (or drop) schemas, the exists() method is used to determine which schemas to create/drop. => This way, if we create an existing schema and the dialect doesn't support "if not exists", Exposed will not create it. (same thing for drop schema).

- **Changing the oracle implementation** : a schema == user,  so to create schema you should use `create user` statement and there are many options added that you can specify.

- **`cascade` option in dropSchema(schema, cascade = false)** : used to drop schema and all of its objects and all objects that depend on those objects.

- **withSchemas() method for unit tests** : just like `withTables()` but will create schemas and after test execution will drop them. 