### PR TITLE
FEAT / FIX: support parameter placeholder escaping

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
@@ -93,11 +93,11 @@ fun StatementContext.expandArgs(transaction: Transaction) : String {
             
             val char = sql[i]
             if (char == '?') {
-                if (sql.getOrNull(i + 1) == '?') {
-                    skipChar = true
-                    continue
-                }
                 if (quoteStack.isEmpty()) {
+                    if (sql.getOrNull(i + 1) == '?') {
+                        skipChar = true
+                        continue
+                    }
                     append(sql.substring(lastPos, i))
                     lastPos = i + 1
                     val (col, value) = iterator.next()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
@@ -84,9 +84,19 @@ fun StatementContext.expandArgs(transaction: Transaction) : String {
     return buildString {
         val quoteStack = Stack<Char>()
         var lastPos = 0
+        var skipChar = false
         for (i in 0..sql.length - 1) {
+            if(skipChar) {
+                skipChar = false
+                continue
+            }
+            
             val char = sql[i]
             if (char == '?') {
+                if (sql.getOrNull(i + 1) == '?') {
+                    skipChar = true
+                    continue
+                }
                 if (quoteStack.isEmpty()) {
                     append(sql.substring(lastPos, i))
                     lastPos = i + 1

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
@@ -84,18 +84,13 @@ fun StatementContext.expandArgs(transaction: Transaction) : String {
     return buildString {
         val quoteStack = Stack<Char>()
         var lastPos = 0
-        var skipChar = false
-        for (i in 0..sql.length - 1) {
-            if(skipChar) {
-                skipChar = false
-                continue
-            }
-            
+        var i = -1
+        while (++i < sql.length) {
             val char = sql[i]
             if (char == '?') {
                 if (quoteStack.isEmpty()) {
                     if (sql.getOrNull(i + 1) == '?') {
-                        skipChar = true
+                        ++i
                         continue
                     }
                     append(sql.substring(lastPos, i))


### PR DESCRIPTION
escape parameter placeholder '?' by double question mark '??'

PostgreSQL documentation - https://jdbc.postgresql.org/documentation/head/statement.html
* In JDBC, the question mark (?) is the placeholder for the positional parameters of a PreparedStatement. There are, however, a number of PostgreSQL operators that contain a question mark. To keep such question marks in a SQL statement from being interpreted as positional parameters, use two question marks (??) as escape sequence. You can also use this escape sequence in a Statement, but that is not required. Specifically only in a Statement a single (?) can be used as an operator.

should resolve https://github.com/JetBrains/Exposed/issues/890