### PR TITLE
Correct styling issues in the documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,18 @@
 [![Download](https://api.bintray.com/packages/kotlin/exposed/exposed-core/images/download.svg) ](https://bintray.com/kotlin/exposed/exposed-core/_latestVersion)
 [![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 
-Welcome to **Exposed ORM framework** written for [Kotlin language](https://github.com/JetBrains/kotlin) and has two layers of database access: typesafe SQL wrapping DSL and lightweight data access objects.
+Welcome to **Exposed**, an ORM framework for 
+[Kotlin](https://github.com/JetBrains/kotlin).
+Exposed offers two levels of database access: typesafe SQL
+wrapping DSL and lightweight data access objects.
+Our official mascot is Cuttlefish, which is best known for its
+outstanding mimicry abilities letting it blend seamlessly in
+any environment. Just like our mascot, Exposed can mimic a variety
+of database engines and help you build database applications
+without hard dependencies on any specific database engine, and
+switch between them with very little or no changes in your code.
 
-We are glad to introduce our official mascot—Cuttlefish, that is best known for its outstanding mimicry abilities letting it blend seamlessly in any environment. Just like Exposed, that can mimic a variety of database engines and help you build database applications without hard dependencies on any specific database engine, and switch between them with very little or no changes in your code.
-
-## Database Support
+## Supported Databases
 
 * H2
 * MySQL


### PR DESCRIPTION
There were a few minor styling issues in the first paragraph of the documentation. I rephrased a couple of sentences and joined the two first paragraphs so that the documentation gets shorter and cleaner for a reader.

Let me know what you think. You can check the updated README [in my fork](https://github.com/Shpota/Exposed/tree/update-documentation) of the repository.

It would also be great if a native speaker read the documentation.