### PR TITLE
Ignore missing fields in Exposed's table instead of crashing when using createMissingTablesAndColumns

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -170,9 +170,9 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
             metadata.getImportedKeys(databaseName, oracleSchema, table).iterate {
                 val fromTableName = getString("FKTABLE_NAME")!!
                 val fromColumnName = identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(getString("FKCOLUMN_NAME")!!)
-                val fromColumn = allTables.getValue(fromTableName).columns.first {
+                val fromColumn = allTables.getValue(fromTableName).columns.firstOrNull {
                     identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(it.nameInDatabaseCase()) == fromColumnName
-                }
+                } ?: return@iterate null // Do not crash if there are missing fields in Exposed's tables
                 val constraintName = getString("FK_NAME")!!
                 val targetTableName = getString("PKTABLE_NAME")!!
                 val targetColumnName = identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(getString("PKCOLUMN_NAME")!!)
@@ -188,7 +188,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                         onDelete = constraintDeleteRule,
                         name = constraintName
                 )
-            }
+            }.filterNotNull()
         }
     }
 


### PR DESCRIPTION
I'm not sure if this is intentional or not, this fixes the issue I was having in https://github.com/JetBrains/Exposed/issues/849#issuecomment-625520283

# Reproducing the issue
Run this code
```kotlin
fun main() {
	println("hello")

	val db = Database.connect("jdbc:postgresql://localhost:5432/test", driver = "org.postgresql.Driver", user = "postgres", password = "postgres")

	transaction(db) {
		SchemaUtils.createMissingTablesAndColumns(
				OriginalTable,
				ExternalReference
		)
	}

	println("done")
}

object OriginalTable : LongIdTable() {
	val extReference = optReference("external", ExternalReference)
}

object ExternalReference : LongIdTable() {
	val integer = integer("integer")
}
```

Now, try commenting out the `extReference` from the `OriginalTable` object
```kotlin
object OriginalTable : LongIdTable() {
	val extReference = optReference("external", ExternalReference)
}
```

Run the code again, and...
```
Exception in thread "main" java.util.NoSuchElementException: Collection contains no element matching the predicate.
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcDatabaseMetadataImpl$tableConstraints$$inlined$associateWith$lambda$1.invoke(JdbcDatabaseMetadataImpl.kt:213)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcDatabaseMetadataImpl$tableConstraints$$inlined$associateWith$lambda$1.invoke(JdbcDatabaseMetadataImpl.kt:13)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcDatabaseMetadataImplKt.iterate(JdbcDatabaseMetadataImpl.kt:206)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcDatabaseMetadataImpl.tableConstraints(JdbcDatabaseMetadataImpl.kt:170)
	at org.jetbrains.exposed.sql.vendors.VendorDialect$fillConstraintCacheForTables$1.invoke(Default.kt:675)
	at org.jetbrains.exposed.sql.vendors.VendorDialect$fillConstraintCacheForTables$1.invoke(Default.kt:582)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcConnectionImpl.metadata(JdbcConnectionImpl.kt:51)
	at org.jetbrains.exposed.sql.Database.metadata$exposed_core(Database.kt:29)
	at org.jetbrains.exposed.sql.vendors.VendorDialect.fillConstraintCacheForTables(Default.kt:675)
	at org.jetbrains.exposed.sql.vendors.VendorDialect.columnConstraints(Default.kt:653)
	at org.jetbrains.exposed.sql.SchemaUtils.addMissingColumnsStatements(SchemaUtils.kt:144)
	at org.jetbrains.exposed.sql.SchemaUtils.createMissingTablesAndColumns(SchemaUtils.kt:240)
	at org.jetbrains.exposed.sql.SchemaUtils.createMissingTablesAndColumns$default(SchemaUtils.kt:228)
	at org.jetbrains.exposed.sql.statements.jdbc.TestKt$main$1.invoke(Test.kt:16)
	at org.jetbrains.exposed.sql.statements.jdbc.TestKt$main$1.invoke(Test.kt)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt$inTopLevelTransaction$1.invoke(ThreadLocalTransactionManager.kt:163)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt$inTopLevelTransaction$2.invoke(ThreadLocalTransactionManager.kt:204)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:212)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction(ThreadLocalTransactionManager.kt:203)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt$transaction$1.invoke(ThreadLocalTransactionManager.kt:141)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:212)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction(ThreadLocalTransactionManager.kt:113)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction(ThreadLocalTransactionManager.kt:111)
	at org.jetbrains.exposed.sql.statements.jdbc.TestKt.main(Test.kt:15)
	at org.jetbrains.exposed.sql.statements.jdbc.TestKt.main(Test.kt)
```

This pull request changes the check to a `firstOrNull` check and, if it is null, Exposed will just silently ignore the missing field instead of crashing. I did some tests and couldn't find any issues with it.

This issue wasn't present on Exposed 0.17.7 (the previous version I was using on my app, I tried upgrading to Exposed 0.24.1 today and... well, I found that bug), so that's why I think it is a regression and not an intentional change.

I found that issue because, in my case, my application had references on a table but due to the application evolution (deprecation and other reasons) the references ended up being removed from the exposed table, but they still exist on the database. Currently it is impossible for me to use newer Exposed versions due to that change.

*Maybe* adding a "do strict checks" boolean would be better? Then Exposed would catch the error correctly and show a nice message to the user if they enabled the "do strict checks" feature.

**tl;dr:** Exposed crashes if you use `createMissingTablesAndColumns` if the table in the database has foreign keys but you didn't add those references to the table in Exposed itself. This pull request makes Exposed just silently ignore the missing references instead of crashing.
