### PR TITLE
[WIP] UNSIGNED column support

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -230,6 +230,33 @@ class LongColumnType : ColumnType() {
 }
 
 /**
+ * Numeric column for storing unsigned 8-byte integers.
+ */
+@ExperimentalUnsignedTypes
+class ULongColumnType : ColumnType() {
+    override fun sqlType(): String = currentDialect.dataTypeProvider.ulongType()
+    override fun valueFromDB(value: Any): ULong {
+        return when (value) {
+            is ULong -> value
+            is Long -> value.takeIf { it >= 0 }?.toULong()
+            is Number -> value.toLong().takeIf { it >= 0 }?.toULong()
+            is String -> value.toULong()
+            else -> error("Unexpected value of type Long: $value of ${value::class.qualifiedName}")
+        } ?: error("negative value but type is ULong: $value")
+    }
+
+    override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
+        val v = if (value is ULong) value.toLong() else value
+        super.setParameter(stmt, index, v)
+    }
+
+    override fun notNullValueToDB(value: Any): Any {
+        val v = if (value is ULong) value.toLong() else value
+        return super.notNullValueToDB(v)
+    }
+}
+
+/**
  * Numeric column for storing 4-byte (single precision) floating-point numbers.
  */
 class FloatColumnType : ColumnType() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -183,8 +183,9 @@ class Count(
     /** Returns the expression from which the rows are counted. */
     val expr: Expression<*>,
     /** Returns whether only distinct element should be count. */
-    val distinct: Boolean = false
-) : Function<Long>(LongColumnType()) {
+    val distinct: Boolean,
+    _columnType: IColumnType
+) : Function<Long>(_columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         +"COUNT("
         if (distinct) +"DISTINCT "

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -183,9 +183,8 @@ class Count(
     /** Returns the expression from which the rows are counted. */
     val expr: Expression<*>,
     /** Returns whether only distinct element should be count. */
-    val distinct: Boolean,
-    _columnType: IColumnType
-) : Function<Long>(_columnType) {
+    val distinct: Boolean = false
+) : Function<Long>(LongColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         +"COUNT("
         if (distinct) +"DISTINCT "

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -433,6 +433,10 @@ fun intLiteral(value: Int): LiteralOp<Int> = LiteralOp(IntegerColumnType(), valu
 /** Returns the specified [value] as a long literal. */
 fun longLiteral(value: Long): LiteralOp<Long> = LiteralOp(LongColumnType(), value)
 
+/** Returns the specified [value] as a unsigned long literal. */
+@ExperimentalUnsignedTypes
+fun ulongLiteral(value: ULong): LiteralOp<ULong> = LiteralOp(ULongColumnType(), value)
+
 /** Returns the specified [value] as a float literal. */
 fun floatLiteral(value: Float): LiteralOp<Float> = LiteralOp(FloatColumnType(), value)
 
@@ -474,6 +478,10 @@ fun intParam(value: Int): Expression<Int> = QueryParameter(value, IntegerColumnT
 
 /** Returns the specified [value] as a long query parameter. */
 fun longParam(value: Long): Expression<Long> = QueryParameter(value, LongColumnType())
+
+/** Returns the specified [value] as a unsigned long query parameter. */
+@ExperimentalUnsignedTypes
+fun ulongParam(value: ULong): Expression<ULong> = QueryParameter(value, ULongColumnType())
 
 /** Returns the specified [value] as a float query parameter. */
 fun floatParam(value: Float): Expression<Float> = QueryParameter(value, FloatColumnType())

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -49,10 +49,10 @@ fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.avg(scale: Int = 
 fun <T : Any?> ExpressionWithColumnType<T>.sum(): Sum<T> = Sum(this, this.columnType)
 
 /** Returns the number of input rows for which the value of this expression is not null. */
-fun ExpressionWithColumnType<*>.count(): Count = Count(this)
+fun ExpressionWithColumnType<*>.count(): Count = Count(this, false, this.columnType)
 
 /** Returns the number of distinct input rows for which the value of this expression is not null. */
-fun Column<*>.countDistinct(): Count = Count(this, true)
+fun Column<*>.countDistinct(): Count = Count(this, true, this.columnType)
 
 
 // Aggregate Functions for Statistics
@@ -352,12 +352,14 @@ interface ISqlExpressionBuilder {
 
     /** Returns the specified [value] as a query parameter of type [T]. */
     @Suppress("UNCHECKED_CAST")
+    @ExperimentalUnsignedTypes
     fun <T, S : T?> ExpressionWithColumnType<in S>.wrap(value: T): QueryParameter<T> = when (value) {
         is Boolean -> booleanParam(value)
         is Byte -> byteParam(value)
         is Short -> shortParam(value)
         is Int -> intParam(value)
         is Long -> longParam(value)
+        is ULong -> ulongParam(value)
         is Float -> floatParam(value)
         is Double -> doubleParam(value)
         is String -> stringParam(value)
@@ -366,12 +368,14 @@ interface ISqlExpressionBuilder {
 
     /** Returns the specified [value] as a literal of type [T]. */
     @Suppress("UNCHECKED_CAST")
+    @ExperimentalUnsignedTypes
     fun <T, S : T?> ExpressionWithColumnType<S>.asLiteral(value: T): LiteralOp<T> = when (value) {
         is Boolean -> booleanLiteral(value)
         is Byte -> byteLiteral(value)
         is Short -> shortLiteral(value)
         is Int -> intLiteral(value)
         is Long -> longLiteral(value)
+        is ULong -> ulongLiteral(value)
         is Float -> floatLiteral(value)
         is Double -> doubleLiteral(value)
         is String -> stringLiteral(value)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -352,7 +352,7 @@ interface ISqlExpressionBuilder {
 
     /** Returns the specified [value] as a query parameter of type [T]. */
     @Suppress("UNCHECKED_CAST")
-    @ExperimentalUnsignedTypes
+//    @ExperimentalUnsignedTypes
     fun <T, S : T?> ExpressionWithColumnType<in S>.wrap(value: T): QueryParameter<T> = when (value) {
         is Boolean -> booleanParam(value)
         is Byte -> byteParam(value)
@@ -368,7 +368,7 @@ interface ISqlExpressionBuilder {
 
     /** Returns the specified [value] as a literal of type [T]. */
     @Suppress("UNCHECKED_CAST")
-    @ExperimentalUnsignedTypes
+//    @ExperimentalUnsignedTypes
     fun <T, S : T?> ExpressionWithColumnType<S>.asLiteral(value: T): LiteralOp<T> = when (value) {
         is Boolean -> booleanLiteral(value)
         is Byte -> byteLiteral(value)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -49,10 +49,10 @@ fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.avg(scale: Int = 
 fun <T : Any?> ExpressionWithColumnType<T>.sum(): Sum<T> = Sum(this, this.columnType)
 
 /** Returns the number of input rows for which the value of this expression is not null. */
-fun ExpressionWithColumnType<*>.count(): Count = Count(this, false, this.columnType)
+fun ExpressionWithColumnType<*>.count(): Count = Count(this)
 
 /** Returns the number of distinct input rows for which the value of this expression is not null. */
-fun Column<*>.countDistinct(): Count = Count(this, true, this.columnType)
+fun Column<*>.countDistinct(): Count = Count(this, true)
 
 
 // Aggregate Functions for Statistics

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -479,6 +479,10 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /** Creates a numeric column, with the specified [name], for storing 8-byte integers. */
     fun long(name: String): Column<Long> = registerColumn(name, LongColumnType())
 
+    /** Creates a numeric column, with the specified [name], for storing 8-byte unsigned integers. */
+    @ExperimentalUnsignedTypes
+    fun ulong(name: String): Column<ULong> = registerColumn(name, ULongColumnType())
+
     /** Creates a numeric column, with the specified [name], for storing 4-byte (single precision) floating-point numbers. */
     fun float(name: String): Column<Float> = registerColumn(name, FloatColumnType())
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -26,6 +26,9 @@ abstract class DataTypeProvider {
     /** Numeric type for storing 8-byte integers. */
     open fun longType(): String = "BIGINT"
 
+    /** Numeric type for storing 8-byte unsigned integers. */
+    open fun ulongType(): String = "BIGINT"
+
     /** Numeric type for storing 8-byte integers, and marked as auto-increment. */
     open fun longAutoincType(): String = "BIGINT AUTO_INCREMENT"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -12,6 +12,8 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
     }
 
     override fun dateTimeType(): String = if ((currentDialect as MysqlDialect).isFractionDateTimeSupported()) "DATETIME(6)" else "DATETIME"
+
+    override fun ulongType(): String = "BIGINT UNSIGNED"
 }
 
 internal open class MysqlFunctionProvider : FunctionProvider() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -9,6 +9,7 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun integerType(): String = "NUMBER(12)"
     override fun integerAutoincType(): String = "NUMBER(12)"
     override fun longType(): String = "NUMBER(19)"
+    override fun ulongType(): String = "UNSIGNED BIGINT"
     override fun longAutoincType(): String = "NUMBER(19)"
     override fun textType(): String = "CLOB"
     override fun binaryType(): String = "BLOB"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -494,6 +494,22 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @ExperimentalUnsignedTypes
+    @Test fun testUlongColumnType() {
+        val UlongTable = object: Table("ulongTable") {
+            val ulong = ulong("ulong")
+        }
+
+        withTables(UlongTable){
+            UlongTable.insert {
+                it[ulong] = 123uL
+            }
+            val result = UlongTable.selectAll().toList()
+            assertEquals(1, result.size)
+            assertEquals(123uL, result.single()[UlongTable.ulong])
+        }
+    }
+
     @Test fun testDeleteMissingTable() {
         val missingTable = Table("missingTable")
         withDb {


### PR DESCRIPTION
Adds support for UNSIGNED column type. https://github.com/JetBrains/Exposed/issues/199
As far as I investigated, UNSIGNED syntax seems to be supported only on Oracle and MySQL.
https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html
https://docs.oracle.com/cd/B28359_01/gateways.111/b31048/apa.htm#g635398

At the first step, I implemented it only for BIGINT type.

If this PR's direction is correct I proceed to implement for INT, SMALLINT, TINYINT, otherwise I plan to close this PR.