### PR TITLE
docs/README.md: fix hardcoded logo link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/sunalex/Exposed/blob/master/logo.png" alt="Exposed" width="315" />
+<img src="./logo.png" alt="Exposed" width="315" />
 
 [![JetBrains team project](https://jb.gg/badges/team.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![Kotlinlang Slack Channel](https://img.shields.io/badge/slack-@kotlinlang/exposed-yellow.svg?logo=slack?style=flat)](https://kotlinlang.slack.com/archives/C0CG7E0A1)


### PR DESCRIPTION
Currenty, `README.md` uses hardcoded image link to repository where it originates from. There are two issues:
1. It probably should refer to _this_ repository,
2. It probably should not depend on any network resource at all, since the image is co-located with the README.
So, I've changed it to a relative link.

Even though GitHub shows README on main page, it works fine. Intellij IDEA preview works too.