### PR TITLE
Modify checking for entity creation #925

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -47,7 +47,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T: Entity<ID>>(val table: Id
      */
     fun reload(entity: Entity<ID>, flush: Boolean = false): T? {
         if (flush) {
-            if (entity.id._value == null)
+            if (entity.isNewEntity())
                 TransactionManager.current().entityCache.flushInserts(table)
             else
                 entity.flush()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -157,6 +157,21 @@ class EntityTests: DatabaseTestsBase() {
         }
     }
 
+    @Test fun testNewWithIdAndRefresh() {
+        val objectsToVerify = arrayListOf<Pair<Human, TestDB>>()
+        withTables(Humans) { testDb ->
+            val x = Human.new(2) {
+                h = "foo"
+            }
+            x.refresh(flush = true)
+            objectsToVerify.add(x to testDb)
+        }
+        objectsToVerify.forEach { (human, testDb) ->
+            assertEquals("foo", human.h, "Failed on ${testDb.name}" )
+            assertEquals(2, human.id.value, "Failed on ${testDb.name}" )
+        }
+    }
+
     internal object OneAutoFieldTable : IntIdTable("single")
     internal class SingleFieldEntity(id: EntityID<Int>) : IntEntity(id) {
         companion object : IntEntityClass<SingleFieldEntity>(OneAutoFieldTable)


### PR DESCRIPTION
Created entity using new(id: ID?, ...) method has id._value.
Then `id._value == null` can't check for entity creation.

These entities are in transaction entity cache's inserts.
And I fixed #925 using it.
