### PR TITLE
Support JDBC driver for iSeries DB2

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -70,6 +70,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             registerDialect(OracleDialect.dialectName) { OracleDialect() }
             registerDialect(SQLServerDialect.dialectName) { SQLServerDialect() }
             registerDialect(MariaDBDialect.dialectName) { MariaDBDialect() }
+            registerDialect(DB2Dialect.dialectName) { DB2Dialect() }
         }
 
         fun registerDialect(prefix:String, dialect: () -> DatabaseDialect) {
@@ -131,6 +132,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             url.startsWith("jdbc:oracle") -> "oracle.jdbc.OracleDriver"
             url.startsWith("jdbc:sqlite") -> "org.sqlite.JDBC"
             url.startsWith("jdbc:sqlserver") -> "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+            url.startsWith("jdbc:as400") -> "com.ibm.as400.access.AS400JDBCDriver"
             else -> error("Database driver not found for $url")
         }
 
@@ -143,6 +145,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             url.startsWith("jdbc:oracle") -> OracleDialect.dialectName
             url.startsWith("jdbc:sqlite") -> SQLiteDialect.dialectName
             url.startsWith("jdbc:sqlserver") -> SQLServerDialect.dialectName
+            url.startsWith("jdbc:as400") -> DB2Dialect.dialectName
             else -> error("Can't resolve dialect for connection: $url")
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DB2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DB2.kt
@@ -1,0 +1,37 @@
+package org.jetbrains.exposed.sql.vendors
+
+import org.jetbrains.exposed.sql.*
+
+internal object DB2DataTypeProvider : DataTypeProvider() {
+    override fun binaryType(): String {
+        exposedLogger.error("The length of the Binary column is missing.")
+        error("The length of the Binary column is missing.")
+    }
+
+    override fun dateTimeType(): String = "TIMESTAMP"
+
+    override fun ulongType(): String = "BIGINT"
+
+    override fun textType(): String = "VARCHAR(32704)"
+}
+
+internal open class DB2FunctionProvider : FunctionProvider() {
+    internal object INSTANCE : DB2FunctionProvider()
+
+    override fun random(seed: Int?) = "RAND(${seed?.toString().orEmpty()})"
+}
+
+/**
+ * DB2 dialect implementation.
+ */
+class DB2Dialect : VendorDialect(dialectName, DB2DataTypeProvider, DB2FunctionProvider.INSTANCE) {
+    override val name: String = dialectName
+    override val functionProvider: FunctionProvider = MariaDBFunctionProvider
+    override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
+
+
+    companion object {
+        /** DB2 dialect name */
+        const val dialectName: String = "db2"
+    }
+}

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -28,6 +28,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
             "pgjdbc-ng" -> PostgreSQLNGDialect.dialectName
             "PostgreSQL JDBC Driver" -> PostgreSQLDialect.dialectName
             "Oracle JDBC driver" -> OracleDialect.dialectName
+            "AS/400 Toolbox for Java JDBC Driver" -> DB2Dialect.dialectName
             else -> {
                 if (driverName.startsWith("Microsoft JDBC Driver "))
                     SQLServerDialect.dialectName


### PR DESCRIPTION
I found this framework recently and want to use it in combination with an iSeries / AS400 DB2 database.
Unfortunately, I couldn't get it to work with the required JDBC driver jt400.

What have I done?
I used the jt400 driver with Exposed Spring Starter. The error message  `Unsupported driver AS / 400 Toolbox for Java JDBC Driver detected` appeared during the first transaction.

```
 <!-- https://mvnrepository.com/artifact/net.sf.jt400/jt400 -->
    <dependency>
      <groupId>net.sf.jt400</groupId>
      <artifactId>jt400-jdk8</artifactId>
      <version>10.3</version>
    </dependency>
```

```
    <!-- https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-spring-boot-starter -->
    <dependency>
      <groupId>org.jetbrains.exposed</groupId>
      <artifactId>exposed-spring-boot-starter</artifactId>
      <version>0.25.1</version>
    </dependency>
```


For this reason, I created a PULL request that supports the JDBC driver jt400 and at the same time adds the DB2 dialect.