### PR TITLE
Add function to remove logger directly in Transaction

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLLog.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLLog.kt
@@ -64,3 +64,10 @@ fun Transaction.addLogger(vararg logger: SqlLogger) : CompositeSqlLogger {
         registerInterceptor(this)
     }
 }
+
+fun Transaction.removeLogger(vararg logger: SqlLogger) : CompositeSqlLogger {
+    return CompositeSqlLogger().apply {
+        logger.forEach { this.removeLogger(it) }
+        registerInterceptor(this)
+    }
+}


### PR DESCRIPTION
Now it's easier to remove loggers, you can do it directly in the Transaction block.