### PR TITLE
Implement native H2SQL replace

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
@@ -10,8 +10,8 @@ import kotlin.test.assertFailsWith
 class H2Tests : DatabaseTestsBase() {
 
     @Test
-    fun insertInH2WithMySQLMode() {
-        withDb(TestDB.H2_MYSQL) {
+    fun insertInH2() {
+        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2)) {
 
             SchemaUtils.drop(Testing)
             SchemaUtils.create(Testing)
@@ -26,8 +26,8 @@ class H2Tests : DatabaseTestsBase() {
     }
 
     @Test
-    fun replaceAsInsertInH2WithMySQLMode() {
-        withDb(TestDB.H2_MYSQL) {
+    fun replaceAsInsertInH2() {
+        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2)) {
 
             SchemaUtils.drop(Testing)
             SchemaUtils.create(Testing)
@@ -42,8 +42,8 @@ class H2Tests : DatabaseTestsBase() {
     }
 
     @Test
-    fun replaceAsUpdateInH2WithMySQLMode() {
-        withDb(TestDB.H2_MYSQL) {
+    fun replaceAsUpdateInH2() {
+        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2)) {
 
             SchemaUtils.drop(Testing)
             SchemaUtils.create(Testing)
@@ -63,26 +63,12 @@ class H2Tests : DatabaseTestsBase() {
 
     @Test
     fun emptyReplace() {
-        withDb(TestDB.H2_MYSQL) {
+        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2)) {
 
             SchemaUtils.drop(Testing)
             SchemaUtils.create(Testing)
 
             Testing.replace {}
-        }
-    }
-
-    @Test
-    fun replaceInH2WithoutMySQLMode() {
-        withDb(TestDB.SQLITE) {
-
-            SchemaUtils.drop(Testing, RefTable)
-            SchemaUtils.create(Testing, RefTable)
-            assertFailsWith(UnsupportedOperationException::class) {
-                Testing.replace {
-                    it[Testing.id] = 1
-                }
-            }
         }
     }
 


### PR DESCRIPTION
# Objective

Re-implement `Queries.replace()` for H2SQL using the native `MERGE INTO` syntax described [in the h2sql docs](http://www.h2database.com/html/commands.html#merge_into)

# Implementation notes

When no data is present, this returns an empty query (tested with `H2Tests.emptyReplace()`.

Since the syntax is identical to `INSERT INTO`, I have used `super.insert()` to generate a plain insert statement and then replaced the keyword `INSERT` with `MERGE`.  I am not using `H2FunctionProvider.insert` because it also attempts to provide partial replace functionality and could produce an invalid `MERGE INTO` statement.

# Testing notes

I have added `SchemaUtils.drop(Testing) to the existing tests because it guarantees an empty state between tests.  Without this, new replace tests were failing due to existing data.

I have added explicit tests of the use of `replace()` for insert and update.

I have expanded tests to cover both H2SQL modes, _standard_ and _MySQL compatibility_.