### PR TITLE
Support various expressions in concat function

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -83,12 +83,12 @@ class UpperCase<T : String?>(
 /**
  * Represents an SQL function that concatenates the text representations of all non-null input values from [expr], separated by [separator].
  */
-class Concat<T : String?>(
+class Concat(
     /** Returns the delimiter. */
     val separator: String,
     /** Returns the expressions being concatenated. */
-    vararg val expr: Expression<T>
-) : Function<T>(VarCharColumnType()) {
+    vararg val expr: Expression<*>
+) : Function<String>(VarCharColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.concat(separator, queryBuilder, *expr)
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -260,11 +260,10 @@ interface ISqlExpressionBuilder {
     // String Functions
 
     /** Concatenates the text representations of all the [expr]. */
-    fun <T : String?> concat(vararg expr: Expression<T>): Concat<T> = Concat("", *expr)
+    fun concat(vararg expr: Expression<*>): Concat = Concat("", *expr)
 
     /** Concatenates the text representations of all the [expr] using the specified [separator]. */
-    fun <T : String?> concat(separator: String = "", expr: List<Expression<T>>): Concat<T> = Concat(separator, *expr.toTypedArray())
-
+    fun concat(separator: String = "", expr: List<Expression<*>>): Concat = Concat(separator, *expr.toTypedArray())
 
     // Pattern Matching
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -146,7 +146,7 @@ abstract class FunctionProvider {
      * @param queryBuilder Query builder to append the SQL function to.
      * @param expr String expressions to concatenate.
      */
-    open fun <T : String?> concat(separator: String, queryBuilder: QueryBuilder, vararg expr: Expression<T>): Unit = queryBuilder {
+    open fun concat(separator: String, queryBuilder: QueryBuilder, vararg expr: Expression<*>): Unit = queryBuilder {
         if (separator == "") {
             append("CONCAT(")
         } else {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -53,10 +53,10 @@ internal object OracleFunctionProvider : FunctionProvider() {
         prefix: String
     ): Unit = super.substring(expr, start, length, builder, "SUBSTR")
 
-    override fun <T : String?> concat(
+    override fun concat(
         separator: String,
         queryBuilder: QueryBuilder,
-        vararg expr: Expression<T>
+        vararg expr: Expression<*>
     ): Unit = queryBuilder {
         if (separator == "") {
             expr.toList().appendTo(separator = " || ") { +it }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -27,7 +27,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         prefix: String
     ): Unit = super.substring(expr, start, length, builder, "substr")
 
-    override fun <T : String?> concat(separator: String, queryBuilder: QueryBuilder, vararg expr: Expression<T>) = queryBuilder {
+    override fun concat(separator: String, queryBuilder: QueryBuilder, vararg expr: Expression<*>) = queryBuilder {
         if (separator == "") {
             expr.toList().appendTo(this, separator = " || ") { +it }
         } else {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/FunctionsTests.kt
@@ -174,6 +174,18 @@ class FunctionsTests : DatabaseTestsBase() {
         }
     }
 
+    @Test fun testConcatWithNumbers() {
+        withCitiesAndUsers { _, _, data ->
+            val concatField = concat(data.user_id, stringLiteral(" - "), data.comment, stringLiteral(" - "), data.value)
+            val result = data.slice(concatField).select{ data.user_id eq "sergey" }.single()
+            assertEquals("sergey - Comment for Sergey - 30", result[concatField])
+
+            val concatField2 = concat("!", listOf(data.user_id, data.comment, data.value))
+            val result2 = data.slice(concatField2).select{ data.user_id eq "sergey" }.single()
+            assertEquals("sergey!Comment for Sergey!30", result2[concatField2])
+        }
+    }
+
     @Test
     fun testCustomStringFunctions01() {
         withCitiesAndUsers { cities, _, _ ->


### PR DESCRIPTION
I saw that it was explicitly done to use only String expressions in this [PR](https://github.com/JetBrains/Exposed/commit/b1c07da8abb60689ad11509713040d2e261f3745)

But `CONCAT` works with different types of expressions and it is not obligatory to use only `Expression<String>`.

