### PR TITLE
Use testcontainers for MySQL instead of mysql-connector-mxj

### DIFF
--- a/exposed-java-time/build.gradle.kts
+++ b/exposed-java-time/build.gradle.kts
@@ -23,9 +23,9 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 
     testImplementation("com.opentable.components", "otj-pg-embedded", "0.12.0")
-    testImplementation("mysql", "mysql-connector-mxj", Versions.mysqlMxj)
     testImplementation("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
     testImplementation("com.h2database", "h2", Versions.h2)
+    testRuntimeOnly("org.testcontainers", "testcontainers", "1.14.3")
 
     when (dialect) {
         "mariadb" ->    testImplementation("org.mariadb.jdbc", "mariadb-java-client", Versions.mariaDB)

--- a/exposed-jodatime/build.gradle.kts
+++ b/exposed-jodatime/build.gradle.kts
@@ -21,9 +21,9 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 
     testImplementation("com.opentable.components", "otj-pg-embedded", "0.12.0")
-    testImplementation("mysql", "mysql-connector-mxj", Versions.mysqlMxj)
     testImplementation("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
     testImplementation("com.h2database", "h2", Versions.h2)
+    testRuntimeOnly("org.testcontainers", "testcontainers", "1.14.3")
 
     when (dialect) {
         "mariadb" ->    testImplementation("org.mariadb.jdbc", "mariadb-java-client", Versions.mariaDB)

--- a/exposed-money/build.gradle.kts
+++ b/exposed-money/build.gradle.kts
@@ -21,10 +21,10 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 
     testImplementation("com.opentable.components", "otj-pg-embedded", "0.12.0")
-    testImplementation("mysql", "mysql-connector-mxj", "5.0.12")
     testImplementation("org.xerial", "sqlite-jdbc", "3.23.1")
     testImplementation("com.h2database", "h2", "1.4.199")
     testImplementation("org.javamoney", "moneta", "1.3")
+    testRuntimeOnly("org.testcontainers", "testcontainers", "1.14.3")
 
     when (dialect) {
         "mariadb" ->    testImplementation("org.mariadb.jdbc", "mariadb-java-client", "2.4.1")

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -27,9 +27,10 @@ dependencies {
     implementation("org.jetbrains.kotlinx","kotlinx-coroutines-debug", Versions.kotlinCoroutines)
 
     implementation("com.opentable.components", "otj-pg-embedded", "0.12.0")
-    implementation("mysql", "mysql-connector-mxj", Versions.mysqlMxj)
     implementation("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
     implementation("com.h2database", "h2", Versions.h2)
+    implementation("org.testcontainers", "testcontainers", "1.14.3")
+    implementation("org.testcontainers", "mysql", "1.14.3")
 
     when (dialect) {
         "mariadb" ->    implementation("org.mariadb.jdbc", "mariadb-java-client", Versions.mariaDB)

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -19,8 +19,8 @@ enum class TestDB(val connection: () -> String, val driver: String, val user: St
     SQLITE({"jdbc:sqlite:file:test?mode=memory&cache=shared"}, "org.sqlite.JDBC"),
     MYSQL(
         connection = { "${mySQLProcess.jdbcUrl}?createDatabaseIfNotExist=true&characterEncoding=UTF-8&useSSL=false" },
-        user = mySQLProcess.username,
-        pass = mySQLProcess.password,
+        user = "root",
+        pass = "test",
         driver = "com.mysql.jdbc.Driver",
         beforeConnection = { mySQLProcess },
         afterTestFinished = { mySQLProcess.close() }
@@ -84,9 +84,12 @@ private val postgresSQLProcess by lazy {
 internal class SpecifiedMySQLContainer(val image: String) : MySQLContainer<SpecifiedMySQLContainer>(image)
 
 private val mySQLProcess by lazy {
-    SpecifiedMySQLContainer(image = "mysql:5").withDatabaseName("testdb").withExposedPorts().apply {
-        start()
-    }
+    SpecifiedMySQLContainer(image = "mysql:5")
+            .withDatabaseName("testdb")
+            .withEnv("MYSQL_ROOT_PASSWORD", "test")
+            .withExposedPorts().apply {
+               start()
+            }
 }
 
 abstract class DatabaseTestsBase {

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -1,15 +1,11 @@
 package org.jetbrains.exposed.sql.tests
 
-import com.mysql.management.MysqldResource
-import com.mysql.management.driverlaunched.MysqldResourceNotFoundException
-import com.mysql.management.driverlaunched.ServerLauncherSocketFactory
-import com.mysql.management.util.Files
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import org.h2.engine.Mode
 import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.transactions.transactionManager
+import org.testcontainers.containers.MySQLContainer
 import java.sql.Connection
 import java.util.*
 import kotlin.concurrent.thread
@@ -21,25 +17,14 @@ enum class TestDB(val connection: () -> String, val driver: String, val user: St
         Mode.getInstance("MySQL").convertInsertNullToZero = false
     }),
     SQLITE({"jdbc:sqlite:file:test?mode=memory&cache=shared"}, "org.sqlite.JDBC"),
-    MYSQL({
-            val host = System.getProperty("exposed.test.mysql.host") ?: System.getProperty("exposed.test.mysql8.host")
-            val port = System.getProperty("exposed.test.mysql.port") ?: System.getProperty("exposed.test.mysql8.port")
-            host?.let { dockerHost ->
-                "jdbc:mysql://$dockerHost:$port/testdb?useSSL=false&characterEncoding=UTF-8"
-            } ?: "jdbc:mysql:mxj://localhost:12345/testdb1?createDatabaseIfNotExist=true&characterEncoding=UTF-8&server.initialize-user=false&user=root&password="
-        },
+    MYSQL(
+        connection = { "${mySQLProcess.jdbcUrl}?createDatabaseIfNotExist=true&characterEncoding=UTF-8&useSSL=false" },
+        user = mySQLProcess.username,
+        pass = mySQLProcess.password,
         driver = "com.mysql.jdbc.Driver",
-        beforeConnection = { System.setProperty(Files.USE_TEST_DIR, java.lang.Boolean.TRUE!!.toString()); Files().cleanTestDir(); Unit },
-        afterTestFinished = {
-            try {
-                val baseDir = com.mysql.management.util.Files().tmp(MysqldResource.MYSQL_C_MXJ)
-                ServerLauncherSocketFactory.shutdown(baseDir, null)
-            } catch (e: MysqldResourceNotFoundException) {
-                exposedLogger.warn(e.message, e)
-            } finally {
-                Files().cleanTestDir()
-            }
-        }),
+        beforeConnection = { mySQLProcess },
+        afterTestFinished = { mySQLProcess.close() }
+    ),
     POSTGRESQL({"jdbc:postgresql://localhost:12346/template1?user=postgres&password=&lc_messages=en_US.UTF-8"}, "org.postgresql.Driver",
             beforeConnection = { postgresSQLProcess }, afterTestFinished = { postgresSQLProcess.close() }),
     POSTGRESQLNG({"jdbc:pgsql://localhost:12346/template1?user=postgres&password="}, "com.impossibl.postgres.jdbc.PGDriver",
@@ -93,6 +78,15 @@ private val postgresSQLProcess by lazy {
                 EmbeddedPostgres::class.java.getResourceAsStream("/postgresql-$system-x86_64.txz")
             }
             .setPort(12346).start()
+}
+
+// MySQLContainer has to be extended, otherwise it leads to Kotlin compiler issues: https://github.com/testcontainers/testcontainers-java/issues/318
+internal class SpecifiedMySQLContainer(val image: String) : MySQLContainer<SpecifiedMySQLContainer>(image)
+
+private val mySQLProcess by lazy {
+    SpecifiedMySQLContainer(image = "mysql:5").withDatabaseName("testdb").withExposedPorts().apply {
+        start()
+    }
 }
 
 abstract class DatabaseTestsBase {


### PR DESCRIPTION
The mxj library is flaky and doesn't work on various platforms due to being outdated.

This PR is related to #894 and #947.