### PR TITLE
remove "SQLite doesn't support LIMIT in UPDATE/DELETE clause." exception

### DIFF
--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     api(kotlin("stdlib"))
+    api(kotlin("stdlib-jdk8"))
     api(kotlin("reflect"))
     api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", Versions.kotlinCoroutines)
     api("org.slf4j", "slf4j-api", "1.7.25")

--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
 
 dependencies {
     api(kotlin("stdlib"))
-    api(kotlin("stdlib-jdk8"))
     api(kotlin("reflect"))
     api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", Versions.kotlinCoroutines)
     api("org.slf4j", "slf4j-api", "1.7.25")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -105,9 +105,6 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         where: Op<Boolean>?,
         transaction: Transaction
     ): String {
-        if (limit != null) {
-            transaction.throwUnsupportedException("SQLite doesn't support LIMIT in UPDATE clause.")
-        }
         return super.update(target, columnsAndValues, limit, where, transaction)
     }
 
@@ -118,9 +115,6 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         limit: Int?,
         transaction: Transaction
     ): String {
-        if (limit != null) {
-            transaction.throwUnsupportedException("SQLite doesn't support LIMIT in DELETE clause.")
-        }
         val def = super.delete(false, table, where, limit, transaction)
         return if (ignore) def.replaceFirst("DELETE", "DELETE OR IGNORE") else def
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -1,17 +1,28 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
-import org.jetbrains.exposed.sql.deleteAll
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.select
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Test
 
 class DeleteTests : DatabaseTestsBase() {
+    private val notSupportLimit by lazy {
+        val exclude = arrayListOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.ORACLE)
+        if (!SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT) {
+            exclude.add(TestDB.SQLITE)
+        }
+        exclude
+    }
+
+
     @Test
     fun testDelete01() {
         withCitiesAndUsers { cities, users, userData ->
@@ -30,12 +41,24 @@ class DeleteTests : DatabaseTestsBase() {
 
     @Test
     fun testDeleteWithLimitAndOffset01() {
-        withCitiesAndUsers(exclude = listOf(TestDB.SQLITE, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.ORACLE)) { cities, users, userData ->
+        withCitiesAndUsers(exclude = notSupportLimit) { _, _, userData ->
             userData.deleteWhere(limit = 1) { userData.value eq 20 }
             userData.slice(userData.user_id, userData.value).select { userData.value eq 20 }.let {
                 assertEquals(1L, it.count())
                 val expected = if (currentDialectTest is H2Dialect) "smth" else "eugene"
                 assertEquals(expected, it.single()[userData.user_id])
+            }
+        }
+    }
+
+    @Test
+    fun testDeleteWithLimit02() {
+        val dialects = TestDB.values().toList() - notSupportLimit
+        withCitiesAndUsers(dialects) { _, _, userData ->
+            expectException<UnsupportedByDialectException> {
+                userData.deleteWhere(limit = 1) {
+                    userData.value eq 20
+                }
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
@@ -29,7 +29,7 @@ class UpdateTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdateWithLimit01() {
-        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) { _, users, _ ->
+        withCitiesAndUsers(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) { _, users, _ ->
             val aNames = users.slice(users.name).select { users.id like "a%" }.map { it[users.name] }
             assertEquals(2, aNames.size)
 
@@ -46,7 +46,7 @@ class UpdateTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdateWithLimit02() {
-        val dialects = TestDB.values().toList() - listOf(TestDB.SQLITE, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)
+        val dialects = TestDB.values().toList() - listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)
         withCitiesAndUsers(dialects) { _, users, _ ->
             expectException<UnsupportedByDialectException> {
                 users.update({ users.id like "a%" }, 1) {


### PR DESCRIPTION
LIMIT in UPDATE and DELETE clause are supported in SQLite.
[optional_limit_and_order_by_clauses in delete clause](https://sqlite.org/lang_delete.html#optional_limit_and_order_by_clauses)
[optional_limit_and_order_by_clauses in update clause](https://sqlite.org/lang_update.html#optional_limit_and_order_by_clauses)