### PR TITLE
Add support for MySQL 'ON UPDATE CURRENT_TIMESTAMP' default expression

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -20,6 +20,11 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
     override fun uintegerType(): String = "INT UNSIGNED"
 
     override fun ulongType(): String = "BIGINT UNSIGNED"
+
+    override fun processForDefaultValue(e: Expression<*>): String = when {
+        e is MysqlDialect.OnUpdateCurrentTimestamp<*> -> QueryBuilder(false).also(e::ddlDefault).toString()
+        else -> super.processForDefaultValue(e)
+    }
 }
 
 internal open class MysqlFunctionProvider : FunctionProvider() {
@@ -117,14 +122,25 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         TransactionManager.current().db.isVersionCovers(BigDecimal("8.0"))
     }
 
+    abstract class OnUpdateCurrentTimestamp<T>(private val currentTimestamp: Expression<T>) : Expression<T>() {
+
+        fun ddlDefault(queryBuilder: QueryBuilder) = queryBuilder {
+            currentTimestamp.toQueryBuilder(this)
+            +" ON UPDATE "
+            currentTimestamp.toQueryBuilder(this)
+        }
+
+        override fun toQueryBuilder(queryBuilder: QueryBuilder) = currentTimestamp.toQueryBuilder(queryBuilder)
+    }
+
     override val supportsCreateSequence: Boolean = false
 
     fun isFractionDateTimeSupported(): Boolean = TransactionManager.current().db.isVersionCovers(BigDecimal("5.6"))
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean {
         if (super.isAllowedAsColumnDefault(e)) return true
-        val acceptableDefaults = arrayOf("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NOW()", "CURRENT_TIMESTAMP(6)", "NOW(6)")
-        return e.toString().trim() in acceptableDefaults && isFractionDateTimeSupported()
+        val acceptableDefaults = setOf("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP()", "NOW()", "CURRENT_TIMESTAMP(6)", "NOW(6)")
+        return e.toString().split("ON UPDATE").all { it.trim() in acceptableDefaults } && isFractionDateTimeSupported()
     }
 
     override fun fillConstraintCacheForTables(tables: List<Table>) {

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateFunctions.kt
@@ -32,6 +32,11 @@ class CurrentTimestamp<T : Temporal> : Expression<T>() {
     }
 }
 
+/**
+ * Expression of MySQL syntax `DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`
+ */
+class CurrentTimestampOnUpdateCurrentTimestamp<T : Temporal> : MysqlDialect.OnUpdateCurrentTimestamp<T>(CurrentTimestamp<T>())
+
 class Year<T : Temporal?>(val expr: Expression<T>) : Function<Int>(IntegerColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         currentDialect.functionProvider.year(expr, queryBuilder)

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -280,6 +280,52 @@ class DefaultsTest : DatabaseTestsBase() {
     }
 
     @Test
+    fun testMySQLOnUpdateDefaultExpressions() {
+        val foo = object : IntIdTable("foo") {
+            val name = text("name")
+            val defaultDateTimeAutoUpdate = datetime("defaultDateTimeAutoUpdate").defaultExpression(CurrentTimestampOnUpdateCurrentTimestamp())
+        }
+
+        val fool = object : IntIdTable("foo") {
+            val name = text("name")
+        }
+
+        val initDateTime = LocalDateTime.now()
+        withTables(TestDB.values().toList() - TestDB.MYSQL - TestDB.MARIADB, foo) {
+
+            val id = fool.insertAndGetId {
+                it[fool.name] = "bar"
+            }
+            val result = foo.select { foo.id eq id }.single()
+
+            assertEquals("bar", result[foo.name])
+            val firstAutoUpdateTime = result[foo.defaultDateTimeAutoUpdate]
+            assert(firstAutoUpdateTime > initDateTime)
+
+
+            fool.update({ fool.id eq id }) {
+                it[fool.name] = "baz"
+            }
+            val result2 = foo.select { foo.id eq id }.single()
+
+            assertEquals("baz", result2[foo.name])
+            val secondAutoUpdateTime = result2[foo.defaultDateTimeAutoUpdate]
+            assert(secondAutoUpdateTime > firstAutoUpdateTime)
+
+
+            val id2 = foo.insertAndGetId {
+                it[foo.name] = "bah"
+            }
+            val result3 = foo.select { foo.id eq id2 }.single()
+
+            assertEquals("bah", result3[foo.name])
+            val thirdAutoUpdateTime = result3[foo.defaultDateTimeAutoUpdate]
+            assert(thirdAutoUpdateTime > secondAutoUpdateTime)
+        }
+    }
+
+
+    @Test
     fun testBetweenFunction() {
         val foo = object : IntIdTable("foo") {
             val dt = datetime("dateTime")


### PR DESCRIPTION
Adds support for [MySQL `column DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP` syntax](https://dev.mysql.com/doc/refman/8.0/en/timestamp-initialization.html).

This default statement is useful when other app updated the row, but without/forget assigning the "update time" column.

Test statements output:
```
SQL: CREATE TABLE IF NOT EXISTS foo (id INT AUTO_INCREMENT PRIMARY KEY, `name` TEXT NOT NULL, defaultDateTimeAutoUpdate DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) NOT NULL)
SQL: INSERT INTO foo (`name`) VALUES ('bar')
SQL: SELECT foo.id, foo.`name`, foo.defaultDateTimeAutoUpdate FROM foo WHERE foo.id = 1
SQL: UPDATE foo SET `name`='baz' WHERE foo.id = 1
SQL: SELECT foo.id, foo.`name`, foo.defaultDateTimeAutoUpdate FROM foo WHERE foo.id = 1
SQL: INSERT INTO foo (defaultDateTimeAutoUpdate, `name`) VALUES (CURRENT_TIMESTAMP(6), 'bah')
SQL: SELECT foo.id, foo.`name`, foo.defaultDateTimeAutoUpdate FROM foo WHERE foo.id = 2
SQL: DROP TABLE IF EXISTS foo
```