### PR TITLE
Quick fix addition for #991

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
@@ -106,7 +106,7 @@ class JavaLocalDateTimeColumnType : ColumnType(), IDateColumnType {
 
     override fun notNullValueToDB(value: Any): Any {
         if (value is LocalDateTime) {
-            return java.sql.Timestamp.from(value.atZone(ZoneId.systemDefault()).toInstant())
+            return java.sql.Timestamp(value.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli())
         }
         return value
     }


### PR DESCRIPTION
The current fix for #991 missed the usage of `Timestamp.from()`. This change should fix that.