### PR TITLE
Support Long SEQUENCE result

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -256,7 +256,12 @@ class NextVal(
 ) : Function<Int>(IntegerColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.nextVal(seq, queryBuilder)
 }
-
+class NextValLong(
+        /** Returns the sequence from which the next value is obtained. */
+        val seq: Sequence
+) : Function<Long>(LongColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.nextVal(seq, queryBuilder)
+}
 
 // Conditional Expressions
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -90,6 +90,7 @@ fun <T : Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> =
 
 /** Advances this sequence and returns the new value. */
 fun Sequence.nextVal(): NextVal = NextVal(this)
+fun Sequence.nextValLong(): NextValLong = NextValLong(this)
 
 
 // Value Expressions

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateSequenceTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateSequenceTest.kt
@@ -80,8 +80,43 @@ class SequencesTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun `test select with nextValLong`() {
+        withTables(DeveloperLong) {
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.createSequence(myseq)
+                    val nextVal = myseq.nextValLong()
+                    DeveloperLong.insert {
+                        it[id] = nextVal
+                        it[name] = "Hichem"
+                    }
+
+                    val firstValue = DeveloperLong.slice(nextVal).selectAll().single()[nextVal]
+                    val secondValue = DeveloperLong.slice(nextVal).selectAll().single()[nextVal]
+
+                    val expFirstValue = myseq.startWith!! + myseq.incrementBy!!.toLong()
+                    assertEquals(expFirstValue, firstValue)
+
+                    val expSecondValue = expFirstValue + myseq.incrementBy!!.toLong()
+                    assertEquals(expSecondValue, secondValue)
+
+                } finally {
+                    SchemaUtils.dropSequence(myseq)
+                }
+            }
+        }
+    }
+
     private object Developer : Table() {
         val id = integer("id")
+        var name = varchar("name", 25)
+
+        override val primaryKey = PrimaryKey(id, name)
+    }
+
+    private object DeveloperLong : Table() {
+        val id = long("id")
         var name = varchar("name", 25)
 
         override val primaryKey = PrimaryKey(id, name)


### PR DESCRIPTION
Hi all. This is my first PR here, I hope this is enough (support + tests) but can include any worthwhile suggestions

I am integrating with a postgresql schema that uses int8 (8 byte) integers as a primary key. The schema is originally integrated with Hibernate, and it uses uses a `SEQUENCE` to generate primary keys for rows. A SEQUENCE uses an 8-byte integer data type.

When I defined a Sequence using exposed and tried to assign the nextval as the `id` value, it can't find a `set` method that actually works so doesn't compile

https://github.com/JetBrains/Exposed/wiki/DSL#use-the-nextval-function

I dug into the tests here and could see that using `Long` column type was the issue, so I added a new extension function for Sequence that returns a NextValLong https://github.com/afk11/Exposed/commit/877a566e6fe18041383d668f511d8ce879b88c8f#diff-f8fe3aecbff74b7ed8a14ef5a1e99b99R259

With these changes, callers with a Long column type can call `myseq.nextValLong()` and the code will compile + run successfully

I've included a test, a clone of the existing one for Int's. 

I'm a little new to the ecosystem so if there's a more idiomatic way to achieve what this patch does I'm all 