### PR TITLE
Relax type of batch insert body parameter to allow nullable values

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -86,7 +86,7 @@ fun <Key:Comparable<Key>, T: IdTable<Key>> T.insertAndGetId(body: T.(InsertState
 /**
  * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testBatchInsert01
  */
-fun <T:Table, E:Any> T.batchInsert(
+fun <T:Table, E> T.batchInsert(
     data: Iterable<E>,
     ignore: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,


### PR DESCRIPTION
Resolves #847 

> Technically speaking. If you are able to provide meaningful insert statement for null value, handling the null case should be allowed. In same manner as here is no not-null constraint for plain insert.

If there are other similar types that could be relaxed, let me know and I can add those as well.