### PR TITLE
Set schema when calling Database.connect()

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -100,7 +100,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             }
 
             if(schema != null) {
-                with(database.transactionManager.newTransaction()) {
+                transaction {
                     SchemaUtils.setSchema(schema)
                 }
             }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -100,7 +100,9 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             }
 
             if(schema != null) {
-                SchemaUtils.setSchema(schema)
+                transaction {
+                    SchemaUtils.setSchema(schema)
+                }
             }
 
             return database
@@ -110,7 +112,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
          * Attempts to make a connection to a database from a [DataSource]
          * for advanced behaviors such as connection pooling.
          *
-         * @param dataSource        the DataSource
+         * @param dataSource        the data source to create the connection
          * @param schema            the default schema to use
          * @param setupConnection   used to apply operations on the [dataSource] connection
          * @param manager           used to register a transaction manager
@@ -130,6 +132,14 @@ class Database private constructor(private val resolvedVendor: String? = null, v
                              manager = manager)
         }
 
+        /**
+         * Attempts to make a pooled connection to a database
+         *
+         * @param dataSource        the data source to create the connection
+         * @param schema            the default schema to use
+         * @param setupConnection   used to apply operations on the [dataSource] connection
+         * @param manager           used to register a transaction manager
+         */
         @Deprecated(level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("connectPool(datasource, setupConnection, manager)"), message = "Use connectPool instead")
         fun connect(
             dataSource: ConnectionPoolDataSource,
@@ -146,13 +156,21 @@ class Database private constructor(private val resolvedVendor: String? = null, v
                              manager = manager)
         }
 
+        /**
+         * Attempts to make a pooled connection to a database
+         *
+         * @param dataSource        the data source to create the connection
+         * @param schema            the default schema to use
+         * @param setupConnection   used to apply operations on the [dataSource] connection
+         * @param manager           used to register a transaction manager
+         */
         fun connectPool(
-                dataSource: ConnectionPoolDataSource,
-                schema: Schema? = null,
-                setupConnection: (Connection) -> Unit = {},
-                manager: (Database) -> TransactionManager = {
-                    ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS)
-                }
+            dataSource: ConnectionPoolDataSource,
+            schema: Schema? = null,
+            setupConnection: (Connection) -> Unit = {},
+            manager: (Database) -> TransactionManager = {
+                ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS)
+            }
         ): Database {
             return doConnect(explicitVendor = null,
                              getNewConnection = { dataSource.pooledConnection.connection!! },

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -100,7 +100,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             }
 
             if(schema != null) {
-                transaction {
+                with(database.transactionManager.newTransaction()) {
                     SchemaUtils.setSchema(schema)
                 }
             }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -12,7 +12,9 @@ import java.util.concurrent.ConcurrentHashMap
 import javax.sql.ConnectionPoolDataSource
 import javax.sql.DataSource
 
-class Database private constructor(private val resolvedVendor: String? = null, val connector: () -> ExposedConnection<*>) {
+class Database private constructor(private val resolvedVendor: String? = null,
+                                   val schema: Schema? = null,
+                                   val connector: () -> ExposedConnection<*>) {
 
     var useNestedTransactions: Boolean = false
 
@@ -119,7 +121,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             setupConnection: (Connection) -> Unit = {},
             manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
-            val database = Database(explicitVendor) {
+            val database = Database(explicitVendor, schema = schema) {
                 connectionInstanceImpl(getNewConnection().apply { setupConnection(this) })
             }.apply {
                 TransactionManager.registerManager(this, manager(this))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.sql.transactions
 
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.SqlLogger
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.exposedLogger
@@ -167,6 +168,9 @@ fun <T> inTopLevelTransaction(
             val transaction = db.transactionManager.newTransaction(transactionIsolation, outerTransaction)
 
             try {
+                if(transaction.db.schema != null) {
+                        SchemaUtils.setSchema(transaction.db.schema!!)
+                }
                 val answer = transaction.statement()
                 transaction.commit()
                 return answer

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -66,7 +66,8 @@ enum class TestDB(val connection: () -> String, val driver: String, val user: St
             ":${System.getProperty("exposed.test.mariadb.port", "3306")}/testdb"},
             "org.mariadb.jdbc.Driver");
 
-    fun connect() = Database.connect(connection(), user = user, password = pass, driver = driver)
+    fun connect(schema: Schema? = null) =
+            Database.connect(connection(), user = user, password = pass, schema = schema, driver = driver)
 
     companion object {
         fun enabledInTests(): List<TestDB> {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -5,7 +5,6 @@ import org.jetbrains.exposed.sql.Schema
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
-import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.vendors.ColumnMetadata
 import org.junit.Test
@@ -66,7 +65,7 @@ class ConnectionTests : DatabaseTestsBase() {
             TestDB.MYSQL.connect(schema = schema)
 
             transaction {
-                val schemaName = TransactionManager.current().db.identifierManager.inProperCase(schema.identifier)
+                val schemaName = db.identifierManager.inProperCase(schema.identifier)
 
                 // Make sure that the used schema is what we set in [connect] method
                 assertEquals(schemaName, connection.schema)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -62,7 +62,7 @@ class ConnectionTests : DatabaseTestsBase() {
             transaction { SchemaUtils.createSchema(schema) }
 
             // Connect with specifying [schema] as a default schema
-            TestDB.MYSQL.connect(schema = schema)
+            TestDB.H2.connect(schema = schema)
 
             transaction {
                 val schemaName = db.identifierManager.inProperCase(schema.identifier)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -52,7 +52,7 @@ class ConnectionTimeoutTest : DatabaseTestsBase(){
     @Test
     fun `connect fail causes repeated connect attempts`(){
         val datasource = ExceptionOnGetConnectionDataSource()
-        val db = Database.connect(datasource = datasource)
+        val db = Database.connect(dataSource = datasource)
 
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, 42, db) {
@@ -115,7 +115,7 @@ class ConnectionExceptions {
         Class.forName(TestDB.H2.driver).newInstance()
 
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
-        val db = Database.connect(datasource = wrappingDataSource)
+        val db = Database.connect(dataSource = wrappingDataSource)
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
                 this.exec("BROKEN_SQL_THAT_CAUSES_EXCEPTION()")
@@ -148,7 +148,7 @@ class ConnectionExceptions {
         Class.forName(TestDB.H2.driver).newInstance()
 
         val wrappingDataSource = WrappingDataSource(TestDB.H2, connectionDecorator)
-        val db = Database.connect(datasource = wrappingDataSource)
+        val db = Database.connect(dataSource = wrappingDataSource)
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
                 this.exec("SELECT 1;")
@@ -171,7 +171,7 @@ class ConnectionExceptions {
         Class.forName(TestDB.H2.driver).newInstance()
 
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
-        val db = Database.connect(datasource = wrappingDataSource)
+        val db = Database.connect(dataSource = wrappingDataSource)
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
                 this.exec("SELECT 1;")


### PR DESCRIPTION
This PR is to add the option of specifying default schema when calling `Database.connect()`

//Usage:

````Kotlin
Database.connect(url, user, password, schema = Schema("myschema"), setupConnection, manager)
````

OR

````Kotlin
Database.connect({ jdbcConnection }, schema = Schema("myschema"), setupConnection, manager)
````

OR

````Kotlin
Database.connect({ dataSource }, schema = Schema("myschema"), setupConnection, manager)
````