### PR TITLE
Remove confusing comment

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -8,9 +8,6 @@ import org.jetbrains.exposed.sql.vendors.inProperCase
 import java.sql.ResultSet
 import java.sql.SQLException
 
-/**
- * isIgnore is supported for mysql only
- */
 open class InsertStatement<Key:Any>(val table: Table, val isIgnore: Boolean = false) : UpdateBuilder<Int>(StatementType.INSERT, listOf(table)) {
     var resultedValues: List<ResultRow>? = null
         private set


### PR DESCRIPTION
The comment is really confusing. In reality, the flag is supported for more than just MySQL. I tested the flag on Postgres and had the following query generated by the library:
`INSERT INTO test_insert_ignore (some_value) VALUES ($1) ON CONFLICT DO NOTHING RETURNING *`
The code behind it is: 
```
    override fun insert(
        ignore: Boolean,
        table: Table,
        columns: List<Column<*>>,
        expr: String,
        transaction: Transaction
    ): String {
        val def = super.insert(false, table, columns, expr, transaction)
        return if (ignore) "$def $onConflictIgnore" else def
    }
```
According to my reasoning, the flag is also supported for H2 and SQLite.  Fix me if I'm wrong. 