### PR TITLE
Removal of duplicate columns for existing indices read from the database

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -165,7 +165,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                 val tColumns = table.columns.associateBy { transaction.identity(it) }
                 tmpIndices.filterNot { it.key.first in pkNames }
                     .mapNotNull { (index, columns) ->
-                        columns.mapNotNull { cn -> tColumns[cn] }.takeIf { c -> c.size == columns.size }?.let { c -> Index(c, index.second, index.first) }
+                        columns.distinct().mapNotNull { cn -> tColumns[cn] }.takeIf { c -> c.size == columns.size }?.let { c -> Index(c, index.second, index.first) }
                     }
             }
         }


### PR DESCRIPTION
The `org.jetbrains.exposed.sql.statements.jdbc.JdbcDatabaseMetadataImpl#existingIndices` method returns indices in which the same column may be contained several times.

As a result, not all indices are created correctly in `org.jetbrains.exposed.sql.QueriesKt#checkMissingIndices` because `org.jetbrains.exposed.sql.Index#onlyNameDiffer` checks the columns and extracts them from the table definition (` org.jetbrains.exposed .sql.Table`) only read unique columns per index.