### PR TITLE
Make DefaultValueMarker public

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
@@ -9,7 +9,7 @@ import java.sql.SQLException
 import java.util.*
 
 
-internal object DefaultValueMarker {
+object DefaultValueMarker {
     override fun toString(): String = "DEFAULT"
 }
 


### PR DESCRIPTION
Make DefaultValueMarker public so that used in function valueToString of custom ColumnType, for example:
``` kotlin
class JsonColumnType(
        private val objectMapper: ObjectMapper = OBJECT_MAPPER,
) : TextColumnType() {
    override fun valueToString(value: Any?): String {
        return if (value is JsonNode) {
            nonNullValueToString(value)
        } else {
            super.valueToString(value)
        }
        null -> {
            check(nullable) { "NULL in non-nullable column" }
            "NULL"
        }
        DefaultValueMarker -> "DEFAULT"
        is JsonNode -> // JsonNode is also an Iterable
            nonNullValueToString(value)
        is Iterable<*> -> value.joinToString(",", transform = ::valueToString)
        else -> nonNullValueToString(value)
    }
    // ...
}
```
