### PR TITLE
specify at least one column in Table.slice()

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -95,13 +95,7 @@ abstract class ColumnSet : FieldSet {
     abstract fun crossJoin(otherTable: ColumnSet): Join
 
     /** Specifies a subset of [columns] of this [ColumnSet]. */
-    fun slice(vararg columns: Expression<*>): FieldSet = Slice(this, columns.toList())
-    @Deprecated(
-            message = "Specify at least one column",
-            replaceWith = ReplaceWith(""),
-            level = DeprecationLevel.ERROR
-    )
-    fun slice(): FieldSet = Slice(this, columns.toList())
+    fun slice(column: Expression<*>, vararg columns: Expression<*>): FieldSet = Slice(this, listOf(column) + columns)
 
     /** Specifies a subset of [columns] of this [ColumnSet]. */
     fun slice(columns: List<Expression<*>>): FieldSet = Slice(this, columns)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -96,6 +96,12 @@ abstract class ColumnSet : FieldSet {
 
     /** Specifies a subset of [columns] of this [ColumnSet]. */
     fun slice(vararg columns: Expression<*>): FieldSet = Slice(this, columns.toList())
+    @Deprecated(
+            message = "Specify at least one column",
+            replaceWith = ReplaceWith(""),
+            level = DeprecationLevel.ERROR
+    )
+    fun slice(): FieldSet = Slice(this, columns.toList())
 
     /** Specifies a subset of [columns] of this [ColumnSet]. */
     fun slice(columns: List<Expression<*>>): FieldSet = Slice(this, columns)


### PR DESCRIPTION
Exposed allows: 
````Kotlin 
Users.slice().selectAll()
```` 
which outputs `SELECT  FROM USERS`
and then : Syntax error from databse

This PR is to try to prevent at compile time calling slice() without parameters by showing this error:

![image](https://user-images.githubusercontent.com/57005249/100528840-695c6e80-31e1-11eb-967e-cd780c9f9029.png)
