### PR TITLE
A fix for issue #1112: don't break apart the table names when decidin…

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -150,8 +150,8 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
     }
 
     fun identity(table: Table): String =
-            (table as? Alias<*>)?.let { "${identity(it.delegate)} ${db.identifierManager.quoteIfNecessary(it.alias)}"}
-                ?: db.identifierManager.quoteIfNecessary(table.tableName.inProperCase())
+            (table as? Alias<*>)?.let { "${identity(it.delegate)} ${db.identifierManager.quoteTokenIfNecessary(it.alias)}"}
+                ?: db.identifierManager.quoteTokenIfNecessary(table.tableName.inProperCase())
 
     fun fullIdentity(column: Column<*>): String = QueryBuilder(false).also {
         fullIdentity(column, it)
@@ -159,9 +159,9 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
 
     internal fun fullIdentity(column: Column<*>, queryBuilder: QueryBuilder) = queryBuilder {
         if (column.table is Alias<*>)
-            append(db.identifierManager.quoteIfNecessary(column.table.alias))
+            append(db.identifierManager.quoteTokenIfNecessary(column.table.alias))
         else
-            append(db.identifierManager.quoteIfNecessary(column.table.tableName.inProperCase()))
+            append(db.identifierManager.quoteTokenIfNecessary(column.table.tableName.inProperCase()))
         append('.')
         append(identity(column))
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
@@ -91,7 +91,7 @@ abstract class IdentifierManagerApi {
 
     fun cutIfNecessaryAndQuote(identity: String) = quoteIfNecessary(identity.take(identifierLengthLimit))
 
-    private fun quoteTokenIfNecessary(token: String) : String = if (needQuotes(token)) quote(token) else token
+    fun quoteTokenIfNecessary(token: String) : String = if (needQuotes(token)) quote(token) else token
 
     private fun quote(identity: String) = "$quoteString$identity$quoteString".trim()
 }


### PR DESCRIPTION
The table names are for some reason broken apart and then quotes logic is applied on each of those "subtokens".
But table name should be treated atomically as dots are legal characters in it - while the entire table name needs be surrounded with the quotes in case it contains some dots in the name.