### PR TITLE
Narrow scope of referring cache evictions

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
@@ -93,7 +93,10 @@ class EntityCache(private val transaction: Transaction) {
     }
 
     internal fun removeTablesReferrers(insertedTables: Collection<Table>) {
-        referrers.filterValues { it.any { it.key.table in insertedTables } }.map { it.key }.forEach {
+        referrers.mapNotNull { (entityId, entityReferrers) ->
+            entityReferrers.filterKeys { it.table in insertedTables }.keys.forEach { entityReferrers.remove(it) }
+            entityId.takeIf { entityReferrers.isEmpty() }
+        }.forEach {
             referrers.remove(it)
         }
     }


### PR DESCRIPTION
This change will prevent inserts and deletes on a single table from evicting all cache entries on any referring entity.