### PR TITLE
Add LENGTH function

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.sql
 
+import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.math.BigDecimal
 
@@ -106,6 +107,14 @@ class GroupConcat<T : String?>(
     vararg val orderBy: Pair<Expression<*>, SortOrder>
 ) : Function<T>(VarCharColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.groupConcat(this, queryBuilder)
+}
+
+/**
+ * Returns the length of the string value as a result of [expr].
+ */
+
+class Length<T: String?>(val expr: Expression<T>) : Function<T>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = currentDialect.functionProvider.length(this, queryBuilder)
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.sql
 
-import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.math.BigDecimal
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -33,6 +33,9 @@ fun <T : String?> Expression<T>.substring(start: Int, length: Int): Substring<T>
 /** Removes the longest string containing only spaces from both ends of string expression. */
 fun <T : String?> Expression<T>.trim(): Trim<T> = Trim(this)
 
+/** Returns the length of the string value. */
+fun <T: String?> Expression<T>.length() : Length<T> = Length(this)
+
 
 // General-Purpose Aggregate Functions
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -188,6 +188,17 @@ abstract class FunctionProvider {
         append(")")
     }
 
+    /**
+     * SQL Function that returns the number of characters in a string.
+     *
+     * @param expr Group concat options.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
+
+    open fun <T: String?> length(expr: Length<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        queryBuilder { append("LENGTH(", expr, ')') }
+    }
+
     // Pattern matching
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -45,6 +45,8 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         }
     }
 
+    override fun <T : String?> length(expr: Length<T>, queryBuilder: QueryBuilder) = queryBuilder { append("LEN(", expr, ')') }
+
     override fun <T : String?> regexp(
         expr1: Expression<T>,
         pattern: Expression<String>,

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/FunctionsTests.kt
@@ -76,15 +76,9 @@ class FunctionsTests : DatabaseTestsBase() {
 
     @Test
     fun testLengthWithCount01() {
-        class LengthFunction<T: ExpressionWithColumnType<String>>(val exp: T) : Function<Int>(IntegerColumnType()) {
-            override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-                if (currentDialectTest is SQLServerDialect) append("LEN(", exp, ')')
-                else append("LENGTH(", exp, ')')
-            }
-        }
         withCitiesAndUsers { cities, _, _ ->
-            val sumOfLength = LengthFunction(cities.name).sum()
-            val expectedValue = cities.selectAll().sumBy{ it[cities.name].length }
+            val sumOfLength = Length(cities.name).sum()
+            val expectedValue = cities.selectAll().sumBy { it[cities.name].length }
 
             val results = cities.slice(sumOfLength).selectAll().toList()
             assertEquals(1, results.size)
@@ -132,7 +126,8 @@ class FunctionsTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testRegexp01() {
+    @Test
+    fun testRegexp01() {
         withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER)) { _, users, _ ->
             assertEquals(2L, users.select { users.id regexp "a.+" }.count())
             assertEquals(1L, users.select { users.id regexp "an.+" }.count())
@@ -141,7 +136,8 @@ class FunctionsTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testRegexp02() {
+    @Test
+    fun testRegexp02() {
         withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER)) { _, users, _ ->
             assertEquals(2L, users.select { users.id.regexp(stringLiteral("a.+")) }.count())
             assertEquals(1L, users.select { users.id.regexp(stringLiteral("an.+")) }.count())
@@ -150,7 +146,8 @@ class FunctionsTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testConcat01() {
+    @Test
+    fun testConcat01() {
         withCitiesAndUsers { cities, _, _ ->
             val concatField = concat(stringLiteral("Foo"), stringLiteral("Bar"))
             val result = cities.slice(concatField).selectAll().limit(1).single()
@@ -162,26 +159,28 @@ class FunctionsTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testConcat02() {
+    @Test
+    fun testConcat02() {
         withCitiesAndUsers { _, users, _ ->
             val concatField = concat(users.id, stringLiteral(" - "), users.name)
-            val result = users.slice(concatField).select{ users.id eq "andrey" }.single()
+            val result = users.slice(concatField).select { users.id eq "andrey" }.single()
             assertEquals("andrey - Andrey", result[concatField])
 
             val concatField2 = concat("!", listOf(users.id, users.name))
-            val result2 = users.slice(concatField2).select{ users.id eq "andrey" }.single()
+            val result2 = users.slice(concatField2).select { users.id eq "andrey" }.single()
             assertEquals("andrey!Andrey", result2[concatField2])
         }
     }
 
-    @Test fun testConcatWithNumbers() {
+    @Test
+    fun testConcatWithNumbers() {
         withCitiesAndUsers { _, _, data ->
             val concatField = concat(data.user_id, stringLiteral(" - "), data.comment, stringLiteral(" - "), data.value)
-            val result = data.slice(concatField).select{ data.user_id eq "sergey" }.single()
+            val result = data.slice(concatField).select { data.user_id eq "sergey" }.single()
             assertEquals("sergey - Comment for Sergey - 30", result[concatField])
 
             val concatField2 = concat("!", listOf(data.user_id, data.comment, data.value))
-            val result2 = data.slice(concatField2).select{ data.user_id eq "sergey" }.single()
+            val result2 = data.slice(concatField2).select { data.user_id eq "sergey" }.single()
             assertEquals("sergey!Comment for Sergey!30", result2[concatField2])
         }
     }


### PR DESCRIPTION
# Overview
Issue #1059 requested a LENGTH function that returns the length of a string value of a query result.

## Notes

There already was a unit test that existed for LENGTH, so what I did was instead of creating a new test I simply recycled the existing one and moved the private class creation out of the test class and into the main classes. 