### PR TITLE
* Changed Table to ITable and ColumnSet to IColumnSet

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.exposed.dao.id
 
-open class EntityID<T:Comparable<T>> protected constructor(val table: IdTable<T>, id: T?) : Comparable<EntityID<T>> {
-    constructor(id:T, table: IdTable<T>) : this(table, id)
+open class EntityID<T:Comparable<T>> protected constructor(val table: IdTableInterface<T>, id: T?) : Comparable<EntityID<T>> {
+    constructor(id:T, table: IdTableInterface<T>) : this(table, id)
     var _value: Any? = id
     val value: T get() {
         if (_value == null) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
@@ -1,11 +1,12 @@
 package org.jetbrains.exposed.dao.id
 
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ITable
 import org.jetbrains.exposed.sql.Table
 import java.util.*
 
 interface EntityIDFactory {
-    fun <T:Comparable<T>> createEntityID(value: T, table: IdTable<T>) : EntityID<T>
+    fun <T:Comparable<T>> createEntityID(value: T, table: IdTableInterface<T>) : EntityID<T>
 }
 
 object EntityIDFunctionProvider {
@@ -13,23 +14,33 @@ object EntityIDFunctionProvider {
     init {
         factory = ServiceLoader.load(EntityIDFactory::class.java, EntityIDFactory::class.java.classLoader).firstOrNull()
                 ?: object : EntityIDFactory {
-                    override fun <T : Comparable<T>> createEntityID(value: T, table: IdTable<T>): EntityID<T> {
+                    override fun <T : Comparable<T>> createEntityID(value: T, table: IdTableInterface<T>): EntityID<T> {
                         return EntityID(value, table)
                     }
                 }
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun <T:Comparable<T>> createEntityID(value: T, table: IdTable<T>) = factory.createEntityID(value, table)
+    fun <T:Comparable<T>> createEntityID(value: T, table: IdTableInterface<T>) = factory.createEntityID(value, table)
 }
+
+
+/**
+ * Base interface for an identity table which could be referenced from another tables.
+ *
+ */
+interface IdTableInterface<T:Comparable<T>>: ITable {
+    val id : Column<EntityID<T>>
+}
+
 
 /**
  * Base class for an identity table which could be referenced from another tables.
  *
  * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
  */
-abstract class IdTable<T:Comparable<T>>(name: String = ""): Table(name) {
-    abstract val id : Column<EntityID<T>>
+abstract class IdTable<T:Comparable<T>>(name: String = ""): Table(name), IdTableInterface<T> {
+    abstract override val id : Column<EntityID<T>>
 }
 
 /**
@@ -38,7 +49,7 @@ abstract class IdTable<T:Comparable<T>>(name: String = ""): Table(name) {
  * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
  * @param columnName name for a primary key, "id" by default
  */
-open class IntIdTable(name: String = "", columnName: String = "id") : IdTable<Int>(name) {
+open class IntIdTable(name: String = "", columnName: String = "id") : IdTable<Int>(name), IntIdTableInterface {
     override val id: Column<EntityID<Int>> = integer(columnName).autoIncrement().entityId()
     override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
 }
@@ -49,7 +60,7 @@ open class IntIdTable(name: String = "", columnName: String = "id") : IdTable<In
  * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
  * @param columnName name for a primary key, "id" by default
  */
-open class LongIdTable(name: String = "", columnName: String = "id") : IdTable<Long>(name) {
+open class LongIdTable(name: String = "", columnName: String = "id") : IdTable<Long>(name), LongIdTableInterface {
     override val id: Column<EntityID<Long>> = long(columnName).autoIncrement().entityId()
     override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
 }
@@ -64,7 +75,7 @@ open class LongIdTable(name: String = "", columnName: String = "id") : IdTable<L
  * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
  * @param columnName name for a primary key, "id" by default
  */
-open class UUIDTable(name: String = "", columnName: String = "id") : IdTable<UUID>(name) {
+open class UUIDTable(name: String = "", columnName: String = "id") : IdTable<UUID>(name), UUIDTableInterface {
     override val id: Column<EntityID<UUID>> = uuid(columnName)
             .autoGenerate()
             .entityId()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTableInterfaces.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTableInterfaces.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.exposed.dao.id
+
+import org.jetbrains.exposed.sql.Column
+import java.util.*
+
+
+/**
+ * Identity interface with autoincrement int primary key
+ *
+ * You should use IntIdTable implementation
+ */
+interface IntIdTableInterface: IdTableInterface<Int> {
+    override val id: Column<EntityID<Int>>
+}
+
+/**
+ * Identity interface with autoincrement long primary key
+ *
+ * You should use LongIdTable implementation
+ */
+interface LongIdTableInterface: IdTableInterface<Long> {
+    override val id: Column<EntityID<Long>>
+}
+
+/**
+ * Identity interface with autoincrement long primary key
+ *
+ * You should use UUIDIdTable implementation
+ */
+interface UUIDTableInterface: IdTableInterface<UUID> {
+    override val id: Column<EntityID<UUID>>
+}
+

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTableNext.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTableNext.kt
@@ -1,0 +1,59 @@
+package org.jetbrains.exposed.dao.id
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.PrimaryKey
+import org.jetbrains.exposed.sql.Table
+import java.util.*
+
+
+/**
+ * Base class for an every ITable table that use entity id.
+ *
+ * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
+ */
+internal class NextIdTableBase<T:Comparable<T>>(name: String = ""): Table(name),
+    IdTableInterface<T> {
+    override lateinit var id : Column<EntityID<T>> // is overrided and is not called.
+}
+
+fun <T:Comparable<T>>createIdTable(name: String): IdTableInterface<T> = NextIdTableBase(name)
+
+/**
+ * Identity table with autoincrement integer primary key
+ *
+ * @param columnName name for a primary key, "id" by default
+ * @param table parent table that will manager the table.
+ * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
+ */
+open class NextIntIdTable(table: IdTableInterface<Int>, columnName: String = "id"): IdTableInterface<Int> by table, IntIdTableInterface {
+    constructor(name: String = "", columnName: String = "id"): this(createIdTable<Int>(name), columnName)
+    override val id: Column<EntityID<Int>> = integer(columnName).autoIncrement().entityId()
+    override val primaryKey by lazy { PrimaryKey(id, table=this) }
+}
+
+
+/**
+ * Identity table with autoincrement long primary key
+ *
+ * @param columnName name for a primary key, "id" by default
+ * @param table parent table that will manager the table.
+ * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
+ */
+open class NextLongIdTable(table: IdTableInterface<Long>, columnName: String = "id"): IdTableInterface<Long> by table, LongIdTableInterface {
+    constructor(name: String = "", columnName: String = "id"): this(createIdTable<Long>(name), columnName)
+    override val id: Column<EntityID<Long>> = long(columnName).autoIncrement().entityId()
+    override val primaryKey by lazy { PrimaryKey(id, table=this) }
+}
+
+/**
+ * Identity table with autoincrement uuid primary key
+ *
+ * @param columnName name for a primary key, "id" by default
+ * @param table parent table that will manager the table.
+ * @param name table name, by default name will be resolved from a class name with "Table" suffix removed (if present)
+ */
+open class NextUUIDTable(table: IdTableInterface<UUID>, columnName: String = "id"): IdTableInterface<UUID> by table, UUIDTableInterface {
+    constructor(name: String = "", columnName: String = "id"): this(createIdTable<UUID>(name), columnName)
+    override val id: Column<EntityID<UUID>> = uuid(columnName).autoGenerate().entityId()
+    override val primaryKey by lazy { PrimaryKey(id, table=this) }
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -15,7 +15,7 @@ private val comparator: Comparator<Column<*>> = compareBy({ it.table.tableName }
  */
 class Column<T>(
     /** Table where the columns is declared. */
-    val table: Table,
+    val table: ITable,
     /** Name of the column. */
     val name: String,
     /** Data type of the column. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -2,7 +2,7 @@ package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import org.jetbrains.exposed.sql.statements.DefaultValueMarker
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
@@ -132,7 +132,7 @@ val Column<*>.autoIncSeqName: String?
 class EntityIDColumnType<T : Comparable<T>>(val idColumn: Column<T>) : ColumnType() {
 
     init {
-        require(idColumn.table is IdTable<*>) { "EntityId supported only for IdTables" }
+        require(idColumn.table is IdTableInterface<*>) { "EntityId supported only for IdTables" }
     }
 
     override fun sqlType(): String = idColumn.columnType.sqlType()
@@ -157,7 +157,7 @@ class EntityIDColumnType<T : Comparable<T>>(val idColumn: Column<T>) : ColumnTyp
             is EntityID<*> -> value.value as T
             else -> idColumn.columnType.valueFromDB(value) as T
         },
-        idColumn.table as IdTable<T>
+        idColumn.table as IdTableInterface<T>
     )
 
     override fun equals(other: Any?): Boolean {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -143,7 +143,7 @@ data class CheckConstraint(
     }
 
     companion object {
-        internal fun from(table: Table, name: String, op: Op<Boolean>): CheckConstraint {
+        internal fun from(table: ITable, name: String, op: Op<Boolean>): CheckConstraint {
             require(name.isNotBlank()) { "Check constraint name cannot be blank" }
             val tr = TransactionManager.current()
             val identifierManager = tr.db.identifierManager
@@ -168,7 +168,7 @@ data class Index(
     val indexType: String? = null
 ) : DdlAware {
     /** Table where the index is defined. */
-    val table: Table
+    val table: ITable
     /** Name of the index. */
     val indexName: String
         get() = customName ?: buildString {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -50,14 +50,14 @@ open class Query(set: FieldSet, where: Op<Boolean>?): SizedIterable<ResultRow>, 
      * @param body builder for new column set, current [set.source] used as a receiver and current [set] as an , you are expected to slice it
      * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testAdjustQuerySlice
      */
-    fun adjustSlice(body: ColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
+    fun adjustSlice(body: IColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
 
     /**
      * Changes [set.source] field of a Query, [set.fields] will be preserved
      * @param body builder for new column set, previous value used as a receiver
      * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testAdjustQueryColumnSet
      */
-    fun adjustColumnSet(body: ColumnSet.() -> ColumnSet): Query {
+    fun adjustColumnSet(body: IColumnSet.() -> IColumnSet): Query {
         return adjustSlice { oldSlice -> body().slice(oldSlice.fields) }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -2,7 +2,7 @@ package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import org.jetbrains.exposed.sql.vendors.FunctionProvider
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.math.BigDecimal
@@ -154,7 +154,7 @@ interface ISqlExpressionBuilder {
             return isNull()
         }
         @Suppress("UNCHECKED_CAST")
-        val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
+        val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTableInterface<T>
         val entityID = EntityID(t, table)
         return EqOp(this, wrap(entityID))
     }
@@ -344,7 +344,7 @@ interface ISqlExpressionBuilder {
     @Suppress("UNCHECKED_CAST")
     @JvmName("inListIds")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.inList(list: Iterable<T>): InListOrNotInListOp<EntityID<T>> {
-        val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
+        val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTableInterface<T>
         return inList(list.map { EntityIDFunctionProvider.createEntityID(it, idTable) })
     }
 
@@ -355,7 +355,7 @@ interface ISqlExpressionBuilder {
     @Suppress("UNCHECKED_CAST")
     @JvmName("notInListIds")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.notInList(list: Iterable<T>): InListOrNotInListOp<EntityID<T>> {
-        val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
+        val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTableInterface<T>
         return notInList(list.map { EntityIDFunctionProvider.createEntityID(it, idTable) })
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -149,7 +149,7 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
         return answer.first?.let { stmt.body(it) }
     }
 
-    fun identity(table: Table): String =
+    fun identity(table: ITable): String =
             (table as? Alias<*>)?.let { "${identity(it.delegate)} ${db.identifierManager.quoteIfNecessary(it.alias)}"}
                 ?: db.identifierManager.quoteIfNecessary(table.tableName.inProperCase())
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchInsertStatement.kt
@@ -8,7 +8,7 @@ import java.util.*
 
 class BatchDataInconsistentException(message : String) : Exception(message)
 
-open class BatchInsertStatement(table: Table, ignore: Boolean = false,
+open class BatchInsertStatement(table: ITable, ignore: Boolean = false,
                                 protected val shouldReturnGeneratedValues: Boolean = true): InsertStatement<List<ResultRow>>(table, ignore) {
 
     override val isAlwaysBatch = true
@@ -80,7 +80,7 @@ open class BatchInsertStatement(table: Table, ignore: Boolean = false,
     }
 }
 
-open class SQLServerBatchInsertStatement(table: Table, ignore: Boolean = false, shouldReturnGeneratedValues: Boolean = true) : BatchInsertStatement(table, ignore, shouldReturnGeneratedValues) {
+open class SQLServerBatchInsertStatement(table: ITable, ignore: Boolean = false, shouldReturnGeneratedValues: Boolean = true) : BatchInsertStatement(table, ignore, shouldReturnGeneratedValues) {
     override val isAlwaysBatch: Boolean = false
     private val OUTPUT_ROW_LIMIT = 1000
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpdateStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpdateStatement.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.exposed.sql.statements
 
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.IColumnType
@@ -9,7 +9,7 @@ import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import java.util.*
 
-open class BatchUpdateStatement(val table: IdTable<*>): UpdateStatement(table, null) {
+open class BatchUpdateStatement(val table: IdTableInterface<*>): UpdateStatement(table, null) {
     val data = ArrayList<Pair<EntityID<*>, Map<Column<*>, Any?>>>()
 
     override val firstDataSet: List<Pair<Column<*>, Any?>> get() = data.first().second.toList()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
@@ -3,7 +3,7 @@ package org.jetbrains.exposed.sql.statements
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 
-open class DeleteStatement(val table: Table, val where: Op<Boolean>? = null, val isIgnore: Boolean = false, val limit: Int? = null, val offset: Long? = null): Statement<Int>(StatementType.DELETE, listOf(table)) {
+open class DeleteStatement(val table: ITable, val where: Op<Boolean>? = null, val isIgnore: Boolean = false, val limit: Int? = null, val offset: Long? = null): Statement<Int>(StatementType.DELETE, listOf(table)) {
 
     override fun PreparedStatementApi.executeInternal(transaction: Transaction): Int {
         return executeUpdate()
@@ -18,9 +18,9 @@ open class DeleteStatement(val table: Table, val where: Op<Boolean>? = null, val
     }
 
     companion object {
-        fun where(transaction: Transaction, table: Table, op: Op<Boolean>, isIgnore: Boolean = false, limit: Int? = null, offset: Long? = null): Int
+        fun where(transaction: Transaction, table: ITable, op: Op<Boolean>, isIgnore: Boolean = false, limit: Int? = null, offset: Long? = null): Int
             = DeleteStatement(table, op, isIgnore, limit, offset).execute(transaction) ?: 0
 
-        fun all(transaction: Transaction, table: Table): Int = DeleteStatement(table).execute(transaction) ?: 0
+        fun all(transaction: Transaction, table: ITable): Int = DeleteStatement(table).execute(transaction) ?: 0
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.sql.vendors.inProperCase
 import java.sql.ResultSet
 import java.sql.SQLException
 
-open class InsertStatement<Key:Any>(val table: Table, val isIgnore: Boolean = false) : UpdateBuilder<Int>(StatementType.INSERT, listOf(table)) {
+open class InsertStatement<Key:Any>(val table: ITable, val isIgnore: Boolean = false) : UpdateBuilder<Int>(StatementType.INSERT, listOf(table)) {
     var resultedValues: List<ResultRow>? = null
         private set
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.exposed.sql.statements
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import org.jetbrains.exposed.sql.Transaction
 
-open class ReplaceStatement<Key:Any>(table: Table) : InsertStatement<Key>(table) {
+open class ReplaceStatement<Key:Any>(table: ITable) : InsertStatement<Key>(table) {
     override fun prepareSQL(transaction: Transaction): String = transaction.db.dialect.functionProvider.replace(table, arguments!!.first(), transaction)
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
@@ -2,7 +2,7 @@ package org.jetbrains.exposed.sql.statements
 
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.IColumnType
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import java.sql.SQLException
@@ -13,7 +13,7 @@ internal object DefaultValueMarker {
     override fun toString(): String = "DEFAULT"
 }
 
-abstract class Statement<out T>(val type: StatementType, val targets: List<Table>) {
+abstract class Statement<out T>(val type: StatementType, val targets: List<ITable>) {
 
     abstract fun PreparedStatementApi.executeInternal(transaction: Transaction): T?
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -9,7 +9,7 @@ import java.util.*
  * @author max
  */
 
-abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>): Statement<T>(type, targets) {
+abstract class UpdateBuilder<out T>(type: StatementType, targets: List<ITable>): Statement<T>(type, targets) {
     protected val values: MutableMap<Column<*>, Any?> = LinkedHashMap()
 
     open operator fun <S> set(column: Column<S>, value: S) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 
-open class UpdateStatement(val targetsSet: ColumnSet, val limit: Int?, val where: Op<Boolean>? = null): UpdateBuilder<Int>(StatementType.UPDATE, targetsSet.targetTables()) {
+open class UpdateStatement(val targetsSet: IColumnSet, val limit: Int?, val where: Op<Boolean>? = null): UpdateBuilder<Int>(StatementType.UPDATE, targetsSet.targetTables()) {
 
     open val firstDataSet: List<Pair<Column<*>, Any?>> get() = values.toList()
 
@@ -15,7 +15,7 @@ open class UpdateStatement(val targetsSet: ColumnSet, val limit: Int?, val where
 
     override fun prepareSQL(transaction: Transaction): String {
         return when (targetsSet) {
-            is Table -> transaction.db.dialect.functionProvider.update(targetsSet, firstDataSet, limit, where, transaction)
+            is ITable -> transaction.db.dialect.functionProvider.update(targetsSet, firstDataSet, limit, where, transaction)
             is Join -> transaction.db.dialect.functionProvider.update(targetsSet, firstDataSet, limit, where, transaction)
             else -> transaction.throwUnsupportedException("UPDATE with ${targetsSet::class.simpleName} unsupported")
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -2,7 +2,7 @@ package org.jetbrains.exposed.sql.statements.api
 
 import org.jetbrains.exposed.sql.ForeignKeyConstraint
 import org.jetbrains.exposed.sql.Index
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import org.jetbrains.exposed.sql.vendors.ColumnMetadata
 import java.math.BigDecimal
 
@@ -29,11 +29,11 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     abstract val tableNames: Map<String, List<String>>
     abstract val schemaNames: List<String>
 
-    abstract fun columns(vararg tables: Table) : Map<Table, List<ColumnMetadata>>
+    abstract fun columns(vararg tables: ITable) : Map<ITable, List<ColumnMetadata>>
 
-    abstract fun existingIndices(vararg tables: Table): Map<Table, List<Index>>
+    abstract fun existingIndices(vararg tables: ITable): Map<ITable, List<Index>>
 
-    abstract fun tableConstraints(tables: List<Table>): Map<String, List<ForeignKeyConstraint>>
+    abstract fun tableConstraints(tables: List<ITable>): Map<String, List<ForeignKeyConstraint>>
 
     abstract fun cleanCache()
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -29,7 +29,7 @@ internal object H2FunctionProvider : FunctionProvider() {
 
     override fun insert(
         ignore: Boolean,
-        table: Table,
+        table: ITable,
         columns: List<Column<*>>,
         expr: String,
         transaction: Transaction
@@ -96,7 +96,7 @@ internal object H2FunctionProvider : FunctionProvider() {
     }
 
     override fun replace(
-        table: Table,
+        table: ITable,
         data: List<Pair<Column<*>, Any?>>,
         transaction: Transaction
     ): String {
@@ -142,7 +142,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
     override val supportsMultipleGeneratedKeys: Boolean = false
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean get() = !TransactionManager.current().isMySQLMode
 
-    override fun existingIndices(vararg tables: Table): Map<Table, List<Index>> =
+    override fun existingIndices(vararg tables: ITable): Map<ITable, List<Index>> =
         super.existingIndices(*tables).mapValues { entry -> entry.value.filterNot { it.indexName.startsWith("PRIMARY_KEY_") } }.filterValues { it.isNotEmpty() }
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -56,7 +56,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
+    override fun replace(table: ITable, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
         val builder = QueryBuilder(true)
         val columns = data.joinToString { transaction.identity(it.first) }
         val values = builder.apply { data.appendTo { registerArgument(it.first.columnType, it.second) } }.toString()
@@ -74,12 +74,12 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
 
     override val DEFAULT_VALUE_EXPRESSION: String = "() VALUES ()"
 
-    override fun insert(ignore: Boolean, table: Table, columns: List<Column<*>>, expr: String, transaction: Transaction): String {
+    override fun insert(ignore: Boolean, table: ITable, columns: List<Column<*>>, expr: String, transaction: Transaction): String {
         val def = super.insert(false, table, columns, expr, transaction)
         return if (ignore) def.replaceFirst("INSERT", "INSERT IGNORE") else def
     }
 
-    override fun delete(ignore: Boolean, table: Table, where: String?, limit: Int?, transaction: Transaction): String {
+    override fun delete(ignore: Boolean, table: ITable, where: String?, limit: Int?, transaction: Transaction): String {
         val def = super.delete(false, table, where, limit, transaction)
         return if (ignore) def.replaceFirst("DELETE", "DELETE IGNORE") else def
     }
@@ -127,7 +127,7 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         return e.toString().trim() in acceptableDefaults && isFractionDateTimeSupported()
     }
 
-    override fun fillConstraintCacheForTables(tables: List<Table>) {
+    override fun fillConstraintCacheForTables(tables: List<ITable>) {
         val allTables = SchemaUtils.sortTablesByReferences(tables).associateBy { it.nameInDatabaseCase() }
         val allTableNames = allTables.keys
         val inTableList = allTableNames.joinToString("','", prefix = " ku.TABLE_NAME IN ('", postfix = "')")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -127,7 +127,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
 
     override fun insert(
         ignore: Boolean,
-        table: Table,
+        table: ITable,
         columns: List<Column<*>>,
         expr: String,
         transaction: Transaction
@@ -144,7 +144,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
     }
 
     override fun update(
-        target: Table,
+        target: ITable,
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
@@ -202,7 +202,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
 
     override fun delete(
         ignore: Boolean,
-        table: Table,
+        table: ITable,
         where: String?,
         limit: Int?,
         transaction: Transaction

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -94,7 +94,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
 
     override fun insert(
         ignore: Boolean,
-        table: Table,
+        table: ITable,
         columns: List<Column<*>>,
         expr: String,
         transaction: Transaction
@@ -104,7 +104,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
     }
 
     override fun update(
-        target: Table,
+        target: ITable,
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
@@ -161,7 +161,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
     }
 
     override fun replace(
-        table: Table,
+        table: ITable,
         data: List<Pair<Column<*>, Any?>>,
         transaction: Transaction
     ): String {
@@ -186,7 +186,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
 
     override fun delete(
         ignore: Boolean,
-        table: Table,
+        table: ITable,
         where: String?,
         limit: Int?,
         transaction: Transaction

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -76,7 +76,7 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         append("DATEPART(MINUTE, ", expr, ")")
     }
 
-    override fun update(target: Table, columnsAndValues: List<Pair<Column<*>, Any?>>, limit: Int?, where: Op<Boolean>?, transaction: Transaction): String {
+    override fun update(target: ITable, columnsAndValues: List<Pair<Column<*>, Any?>>, limit: Int?, where: Op<Boolean>?, transaction: Transaction): String {
         val def = super.update(target, columnsAndValues, null, where, transaction)
         return if (limit != null) def.replaceFirst("UPDATE", "UPDATE TOP($limit)") else def
     }
@@ -125,7 +125,7 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         toString()
     }
 
-    override fun delete(ignore: Boolean, table: Table, where: String?, limit: Int?, transaction: Transaction): String {
+    override fun delete(ignore: Boolean, table: ITable, where: String?, limit: Int?, transaction: Transaction): String {
         val def = super.delete(ignore, table, where, null, transaction)
         return if (limit != null) def.replaceFirst("DELETE", "DELETE TOP($limit)") else def
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -94,7 +94,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
 
     override fun insert(
         ignore: Boolean,
-        table: Table,
+        table: ITable,
         columns: List<Column<*>>,
         expr: String,
         transaction: Transaction
@@ -104,7 +104,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
     }
 
     override fun update(
-        target: Table,
+        target: ITable,
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
@@ -118,7 +118,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
 
     override fun delete(
         ignore: Boolean,
-        table: Table,
+        table: ITable,
         where: String?,
         limit: Int?,
         transaction: Transaction

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityID.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityID.kt
@@ -1,10 +1,10 @@
 package org.jetbrains.exposed.dao
 
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 
-class DaoEntityID<T:Comparable<T>>(id: T?, table: IdTable<T>) : EntityID<T>(table, id) {
+class DaoEntityID<T:Comparable<T>>(id: T?, table: IdTableInterface<T>) : EntityID<T>(table, id) {
     override fun invokeOnNoValue() {
         TransactionManager.current().entityCache.flushInserts(table)
     }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityIDFactory.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityIDFactory.kt
@@ -2,10 +2,10 @@ package org.jetbrains.exposed.dao
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFactory
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 
 class DaoEntityIDFactory : EntityIDFactory {
-    override fun <T : Comparable<T>> createEntityID(value: T, table: IdTable<T>): EntityID<T> {
+    override fun <T : Comparable<T>> createEntityID(value: T, table: IdTableInterface<T>): EntityID<T> {
         return DaoEntityID(value, table)
     }
 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Deprecations.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Deprecations.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.exposed.dao
 
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Table
 import java.util.*
@@ -10,8 +10,8 @@ import java.util.*
         replaceWith = ReplaceWith("org.jetbrains.exposed.dao.id.EntityID<T>"),
         level = DeprecationLevel.WARNING
 )
-open class EntityID<T:Comparable<T>> protected constructor(val table: IdTable<T>, id: T?) : Comparable<EntityID<T>> {
-    constructor(id:T, table: IdTable<T>) : this(table, id)
+open class EntityID<T:Comparable<T>> protected constructor(val table: IdTableInterface<T>, id: T?) : Comparable<EntityID<T>> {
+    constructor(id:T, table: IdTableInterface<T>) : this(table, id)
     var _value: Any? = id
     val value: T get() {
         if (_value == null) {

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -139,7 +139,7 @@ open class Entity<ID:Comparable<ID>>(val id: EntityID<ID>) {
         column.setValue(o, desc, toColumn(value))
     }
 
-    infix fun <TID:Comparable<TID>, Target: Entity<TID>> EntityClass<TID, Target>.via(table: Table): InnerTableLink<ID, Entity<ID>, TID, Target> =
+    infix fun <TID:Comparable<TID>, Target: Entity<TID>> EntityClass<TID, Target>.via(table: ITable): InnerTableLink<ID, Entity<ID>, TID, Target> =
             InnerTableLink(table, this@via)
 
     fun <TID:Comparable<TID>, Target: Entity<TID>> EntityClass<TID, Target>.via(sourceColumn: Column<EntityID<ID>>, targetColumn: Column<EntityID<TID>>) =

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.exposed.dao
 
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import org.jetbrains.exposed.sql.Query
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.statements.*
@@ -52,7 +52,7 @@ class EntityLifecycleInterceptor : GlobalStatementInterceptor {
 
     private fun Transaction.flushEntities(query: Query) {
         // Flush data before executing query or results may be unpredictable
-        val tables = query.set.source.columns.map { it.table }.filterIsInstance(IdTable::class.java).toSet()
+        val tables = query.set.source.columns.map { it.table }.filterIsInstance(IdTableInterface::class.java).toSet()
         entityCache.flush(tables)
     }
 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
@@ -8,10 +8,10 @@ import kotlin.reflect.KProperty
 
 @Suppress("UNCHECKED_CAST")
 class InnerTableLink<SID:Comparable<SID>, Source: Entity<SID>, ID:Comparable<ID>, Target: Entity<ID>>(
-        val table: Table,
-        val target: EntityClass<ID, Target>,
-        val sourceColumn: Column<EntityID<SID>>? = null,
-        _targetColumn: Column<EntityID<ID>>? = null) : ReadWriteProperty<Source, SizedIterable<Target>> {
+    val table: ITable,
+    val target: EntityClass<ID, Target>,
+    val sourceColumn: Column<EntityID<SID>>? = null,
+    _targetColumn: Column<EntityID<ID>>? = null) : ReadWriteProperty<Source, SizedIterable<Target>> {
     init {
         _targetColumn?.let {
             requireNotNull(sourceColumn) { "Both source and target columns should be specified"}

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/IntEntity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/IntEntity.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.exposed.dao
 
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 
 abstract class IntEntity(id: EntityID<Int>) : Entity<Int>(id)
 
-abstract class IntEntityClass<out E: IntEntity>(table: IdTable<Int>, entityType: Class<E>? = null) : EntityClass<Int, E>(table, entityType)
+abstract class IntEntityClass<out E: IntEntity>(table: IdTableInterface<Int>, entityType: Class<E>? = null) : EntityClass<Int, E>(table, entityType)

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/LongEntity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/LongEntity.kt
@@ -1,9 +1,9 @@
 package org.jetbrains.exposed.dao
 
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 
 abstract class LongEntity(id: EntityID<Long>) : Entity<Long>(id)
 
-abstract class LongEntityClass<out E: LongEntity>(table: IdTable<Long>, entityType: Class<E>? = null) : EntityClass<Long, E>(table, entityType)
+abstract class LongEntityClass<out E: LongEntity>(table: IdTableInterface<Long>, entityType: Class<E>? = null) : EntityClass<Long, E>(table, entityType)
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.exposed.dao
 
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.emptySized
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 
-private fun checkReference(reference: Column<*>, factoryTable: IdTable<*>) {
+private fun checkReference(reference: Column<*>, factoryTable: IdTableInterface<*>) {
     val refColumn = reference.referee ?: error("Column $reference is not a reference")
     val targetTable = refColumn.table
     if (factoryTable != targetTable) {

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/UUIDEntity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/UUIDEntity.kt
@@ -1,10 +1,10 @@
 package org.jetbrains.exposed.dao
 
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IdTableInterface
 import java.util.*
 
 abstract class UUIDEntity(id: EntityID<UUID>) : Entity<UUID>(id)
 
-abstract class UUIDEntityClass<out E: UUIDEntity>(table: IdTable<UUID>, entityType: Class<E>? = null) : EntityClass<UUID, E>(table, entityType)
+abstract class UUIDEntityClass<out E: UUIDEntity>(table: IdTableInterface<UUID>, entityType: Class<E>? = null) : EntityClass<UUID, E>(table, entityType)
 

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/java-time/JavaDateColumnType.kt
@@ -205,25 +205,25 @@ class JavaDurationColumnType : ColumnType() {
  *
  * @param name The column name
  */
-fun Table.date(name: String): Column<LocalDate> = registerColumn(name, JavaLocalDateColumnType())
+fun ITable.date(name: String): Column<LocalDate> = registerColumn(name, JavaLocalDateColumnType())
 
 /**
  * A datetime column to store both a date and a time.
  *
  * @param name The column name
  */
-fun Table.datetime(name: String): Column<LocalDateTime> = registerColumn(name, JavaLocalDateTimeColumnType())
+fun ITable.datetime(name: String): Column<LocalDateTime> = registerColumn(name, JavaLocalDateTimeColumnType())
 
 /**
  * A timestamp column to store both a date and a time.
  *
  * @param name The column name
  */
-fun Table.timestamp(name: String): Column<Instant> = registerColumn(name, JavaInstantColumnType())
+fun ITable.timestamp(name: String): Column<Instant> = registerColumn(name, JavaInstantColumnType())
 
 /**
  * A date column to store a duration.
  *
  * @param name The column name
  */
-fun Table.duration(name: String): Column<Duration> = registerColumn(name, JavaDurationColumnType())
+fun ITable.duration(name: String): Column<Duration> = registerColumn(name, JavaDurationColumnType())

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
@@ -3,7 +3,7 @@ package org.jetbrains.exposed.sql.jodatime
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ColumnType
 import org.jetbrains.exposed.sql.IDateColumnType
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.joda.time.DateTime
@@ -92,11 +92,11 @@ class DateColumnType(val time: Boolean): ColumnType(), IDateColumnType {
  *
  * @param name The column name
  */
-fun Table.date(name: String): Column<DateTime> = registerColumn(name, DateColumnType(false))
+fun ITable.date(name: String): Column<DateTime> = registerColumn(name, DateColumnType(false))
 
 /**
  * A datetime column to store both a date and a time.
  *
  * @param name The column name
  */
-fun Table.datetime(name: String): Column<DateTime> = registerColumn(name, DateColumnType(true))
+fun ITable.datetime(name: String): Column<DateTime> = registerColumn(name, DateColumnType(true))

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -316,7 +316,7 @@ class JodaTimeDefaultsTest : JodaTimeBaseTest() {
     }
 }
 
-fun Table.insertAndWait(duration: Long) {
+fun ITable.insertAndWait(duration: Long) {
     this.insert {  }
     TransactionManager.current().commit()
     Thread.sleep(duration)

--- a/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CompositeMoneyColumn.kt
+++ b/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CompositeMoneyColumn.kt
@@ -3,7 +3,7 @@ package org.jetbrains.exposed.sql.money
 import org.jetbrains.exposed.sql.BiCompositeColumn
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.DecimalColumnType
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import java.math.BigDecimal
 import javax.money.CurrencyUnit
 import javax.money.Monetary
@@ -40,7 +40,7 @@ class CompositeMoneyColumn<T1 : BigDecimal?, T2 : CurrencyUnit?, R : MonetaryAmo
         }
 )
 
-fun CompositeMoneyColumn(table: Table, precision: Int, scale: Int, amountName: String, currencyName: String) =
+fun CompositeMoneyColumn(table: ITable, precision: Int, scale: Int, amountName: String, currencyName: String) =
     CompositeMoneyColumn<BigDecimal, CurrencyUnit, MonetaryAmount>(
         amount = Column(table, amountName, DecimalColumnType(precision, scale)),
         currency = Column(table, currencyName, CurrencyColumnType())

--- a/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CompositeMoneyColumnType.kt
+++ b/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CompositeMoneyColumnType.kt
@@ -1,16 +1,16 @@
 package org.jetbrains.exposed.sql.money
 
 import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import java.math.BigDecimal
 import javax.money.CurrencyUnit
 import javax.money.MonetaryAmount
 
-fun Table.compositeMoney(precision: Int, scale: Int, amountName: String, currencyName: String = amountName + "_C") =
+fun ITable.compositeMoney(precision: Int, scale: Int, amountName: String, currencyName: String = amountName + "_C") =
         registerCompositeColumn(CompositeMoneyColumn(this, precision, scale, amountName, currencyName))
 
 
-fun Table.compositeMoney(amountColumn: Column<BigDecimal>, currencyColumn: Column<CurrencyUnit>): CompositeMoneyColumn<BigDecimal, CurrencyUnit, MonetaryAmount> {
+fun ITable.compositeMoney(amountColumn: Column<BigDecimal>, currencyColumn: Column<CurrencyUnit>): CompositeMoneyColumn<BigDecimal, CurrencyUnit, MonetaryAmount> {
     return CompositeMoneyColumn<BigDecimal, CurrencyUnit, MonetaryAmount>(amountColumn, currencyColumn).also {
         if (amountColumn !in columns && currencyColumn !in columns) {
             registerCompositeColumn(it)
@@ -19,7 +19,7 @@ fun Table.compositeMoney(amountColumn: Column<BigDecimal>, currencyColumn: Colum
 }
 
 @JvmName("compositeMoneyNullable")
-fun Table.compositeMoney(amountColumn: Column<BigDecimal?>, currencyColumn: Column<CurrencyUnit?>): CompositeMoneyColumn<BigDecimal?, CurrencyUnit?, MonetaryAmount?> {
+fun ITable.compositeMoney(amountColumn: Column<BigDecimal?>, currencyColumn: Column<CurrencyUnit?>): CompositeMoneyColumn<BigDecimal?, CurrencyUnit?, MonetaryAmount?> {
     return CompositeMoneyColumn<BigDecimal?, CurrencyUnit?, MonetaryAmount?>(amountColumn, currencyColumn).also {
         if (amountColumn !in columns && currencyColumn !in columns) {
             registerCompositeColumn(it)

--- a/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CurrencyColumnType.kt
+++ b/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CurrencyColumnType.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.exposed.sql.money
 
 import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import org.jetbrains.exposed.sql.VarCharColumnType
 import javax.money.CurrencyUnit
 import javax.money.Monetary
@@ -31,4 +31,4 @@ class CurrencyColumnType : VarCharColumnType(3) {
 
 }
 
-fun Table.currency(name: String): Column<CurrencyUnit> = registerColumn(name, CurrencyColumnType())
+fun ITable.currency(name: String): Column<CurrencyUnit> = registerColumn(name, CurrencyColumnType())

--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/DatabaseInitializer.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/DatabaseInitializer.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.exposed.spring
 
 import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.ITable
 import org.slf4j.LoggerFactory
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
@@ -33,11 +33,11 @@ open class DatabaseInitializer(private val applicationContext: ApplicationContex
     }
 }
 
-fun discoverExposedTables(applicationContext: ApplicationContext, excludedPackages: List<String>): List<Table> {
+fun discoverExposedTables(applicationContext: ApplicationContext, excludedPackages: List<String>): List<ITable> {
     val provider = ClassPathScanningCandidateComponentProvider(false)
-    provider.addIncludeFilter(AssignableTypeFilter(Table::class.java))
+    provider.addIncludeFilter(AssignableTypeFilter(ITable::class.java))
     excludedPackages.forEach { provider.addExcludeFilter(RegexPatternTypeFilter(Pattern.compile(it.replace(".", "\\.") + ".*"))) }
     val packages = AutoConfigurationPackages.get(applicationContext)
     val components = packages.map { provider.findCandidateComponents(it) }.flatten()
-    return components.map { Class.forName(it.beanClassName).kotlin.objectInstance as Table }
+    return components.map { Class.forName(it.beanClassName).kotlin.objectInstance as ITable }
 }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -143,7 +143,7 @@ abstract class DatabaseTestsBase {
         }
     }
 
-    fun withTables (excludeSettings: List<TestDB>, vararg tables: Table, statement: Transaction.(TestDB) -> Unit) {
+    fun withTables (excludeSettings: List<TestDB>, vararg tables: ITable, statement: Transaction.(TestDB) -> Unit) {
         (TestDB.enabledInTests() - excludeSettings).forEach { testDB ->
             withDb(testDB) {
                 addLogger(StdOutSqlLogger)
@@ -175,7 +175,7 @@ abstract class DatabaseTestsBase {
         }
     }
 
-    fun withTables (vararg tables: Table, statement: Transaction.(TestDB) -> Unit) = withTables(excludeSettings = emptyList(), tables = *tables, statement = statement)
+    fun withTables (vararg tables: ITable, statement: Transaction.(TestDB) -> Unit) = withTables(excludeSettings = emptyList(), tables = *tables, statement = statement)
 
     fun withSchemas (vararg schemas: Schema, statement: Transaction.() -> Unit) = withSchemas(excludeSettings = emptyList(), schemas = *schemas, statement = statement)
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/sql/InheritanceExample.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/sql/InheritanceExample.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.exposed.sql.tests.shared
+
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.dao.id.IntIdTableInterface
+import org.jetbrains.exposed.dao.id.NextIntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Test
+import java.util.*
+
+
+interface SoftDeleteTable {
+    val deleted: Column<Boolean>
+}
+
+
+class SoftDeleteTableImpl(val table: ITable): SoftDeleteTable, ITable by table {
+    override var deleted: Column<Boolean> = bool("is_deleted")
+}
+
+interface TimeStampTable {
+    val timestamp: Column<String>
+}
+
+class TimeStampTableImpl(val table: ITable): TimeStampTable, ITable by table {
+    override var timestamp: Column<String> = varchar("timestamp", 50)
+}
+
+// create a table that join every interface with their respective delegation
+val baseTable = IntIdTable()
+// create a proxy that adds columns to that baseTable
+object BookTable2: IntIdTableInterface by baseTable,
+                        SoftDeleteTable by SoftDeleteTableImpl(baseTable),
+                        TimeStampTable by TimeStampTableImpl(baseTable) {
+    var name  = varchar("name", 100)
+}
+
+fun main() {
+    Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver", user = "root", password = "")
+
+    transaction {
+        addLogger(StdOutSqlLogger)
+
+        SchemaUtils.create (BookTable2)
+
+        val bookTableId = BookTable2.insert {
+            it[name] = "St. Petersburg"
+            it[deleted] = false
+            it[timestamp] = Date().toString()
+        } get BookTable2.id
+
+        SchemaUtils.drop (BookTable2)
+    }
+}
+
+class SamplesSQL {
+    @Test
+    fun ensureSamplesDoesntCrash(){
+        main()
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
@@ -43,7 +43,7 @@ class AdjustQueryTests : DatabaseTestsBase() {
             val expectedColumnSet = users innerJoin cities
             queryAdjusted.adjustColumnSet { innerJoin(cities) }
             val actualColumnSet = queryAdjusted.set.source
-            fun ColumnSet.repr(): String = QueryBuilder(false).also { this.describe(TransactionManager.current(), it ) }.toString()
+            fun IColumnSet.repr(): String = QueryBuilder(false).also { this.describe(TransactionManager.current(), it ) }.toString()
 
             assertNotEquals(oldColumnSet.repr(), actualColumnSet.repr())
             assertEquals(expectedColumnSet.repr(), actualColumnSet.repr())

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 group=org.jetbrains.exposed
 version=0.28.2-SNAPSHOT
-dialect=none
+dialect=postgres

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 group=org.jetbrains.exposed
 version=0.28.2-SNAPSHOT
-dialect=postgres
+dialect=none


### PR DESCRIPTION
Hi @Tapac 

I'm here again with a big change, I hope that you could review and accept it because It was a big challenge. 

Months ago, I was working on a way of work with inheritance,  I published a way to make it [with delegation classes](https://github.com/JetBrains/Exposed/issues/812#issuecomment-593078229), the problem was that we had to create two tables, copy columns, and other weird things.

Then recently I retake the problem and I came with a "simple" change but with a big pull request, for summary is to change Table class to Interface (Yes it is big change)

I will explain why, how to do and how it will impact. 

### Motivations:
1. At the moment there are not way to declare columns outside the table declaration or create table objects dynamically. I tried to make it but primary key is lazy and I had problems with that, we need to separate logic of column declaration of the table class, then you could create tables dynamically. With this we could create a way to make a DAO with annotations or something like that. 
2. Flexibility to extend Exposed more easily, we can implement many interfaces but only one class, for example if I had SoftDelete table that add some extra functionality, I had to create it for IdKey LongKey and UUIDKey, with interfaces we only need to implement the interface one time and after delegate it.
3. This is the big thing: Inheritance multiple with delegation classes (there are an example in a test that I created)

### Solution
- Work with Tables as Interfaces. 

Strategies to migrate:
- Move Table to ITable Interface and ColumnSet with IColumnSet Interface
- Keep Table and ColumnSet to backward compatibility. 
- Interfaces not support internals functions, move the internal functions to internal functions extensions. 
- Interfaces not support inner class, move primary key inner class to simple class and deprecate inner class.
- Add IdTables that use interface delegation instead extends Table, this was done with Next suffix, because could break many thing that IdTables doesn't extend of Table. 
- Keep all test with minimal changes

### Breaking changes
- I tried to keep tests without change but It was not possible I had to edit two test files with utilities, because some tests create some extension function over "Table" and now EntityClass will return "ITable" (the super class, no tables), then it breaks the extension function, but I couldn't do anything but fix it, the same for ColumnSet. (see `AdjustQueryTests.kt` and `DatabaseTestsBase.kt`)
- Then If someone used `ColumnSet` or `Table` class, this could break their project, but them are sintaxis errors that could be fixed with a replace all. 
- Functions in classes are final by default, but when I moved to interface, them are open because interfaces doesn't support final, and IDE give us warning "Calling non-final function integer in constructor " in every open Table class. An option could be create extension functions, but everyone will have to import, we could deprecate inherit functions and after remove it, but we have some extension functions over Column<> and these functions cant be taken out of the interface. 

Anyway  there are not real breaking change. 

### How Inheritance works:

Inheritance is one of my principal motivations, but it is not the one, months ago I was working In my custom DAO implementation and this could be nice.

```kotlin

interface SoftDeleteTable {
    val deleted: Column<Boolean>
}


class SoftDeleteTableImpl(val table: ITable): SoftDeleteTable, ITable by table {
    override var deleted: Column<Boolean> = bool("is_deleted")
}

interface TimeStampTable {
    val timestamp: Column<String>
}

class TimeStampTableImpl(val table: ITable): TimeStampTable, ITable by table {
    override var timestamp: Column<String> = varchar("timestamp", 50)
}

// create a table that will join every interface with their respective delegation
val baseTable = IntIdTable()
// create a proxy that adds columns to that baseTable
object BookTable2: IntIdTableInterface by baseTable,
                        SoftDeleteTable by SoftDeleteTableImpl(baseTable),
                        TimeStampTable by TimeStampTableImpl(baseTable) {
    var name  = varchar("name", 100)
}

fun main() {
    Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver", user = "root", password = "")

    transaction {
        addLogger(StdOutSqlLogger)

        SchemaUtils.create (BookTable2)

        val bookTableId = BookTable2.insert {
            it[name] = "St. Petersburg"
            it[deleted] = false
            it[timestamp] = Date().toString()
        } get BookTable2.id

        SchemaUtils.drop (BookTable2)
    }
}
```

or something like this:


```kotlin
interface SoftDeleteTable {
    val deleted: Column<Boolean>
}

fun ITable.withSoftDelete(): SoftDeleteTable = object: SoftDeleteTable, ITable by this {
    // Anonymus implementation of SoftDelete that add columns to the current table. 
    override val deleted = bool("is_active").default(false)
}


class CountryTable(val table: ITable = Table()): SoftDeleteTable by table.withSoftDelete() {
    val name = varchar("name", 255)
    val isActive = bool("is_active").default(false)
}
```

Greats and happy new year!. 

