### PR TITLE
Fix entity cache flushing when executing query

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
@@ -52,7 +52,7 @@ class EntityLifecycleInterceptor : GlobalStatementInterceptor {
 
     private fun Transaction.flushEntities(query: Query) {
         // Flush data before executing query or results may be unpredictable
-        val tables = query.set.source.columns.map { it.table }.filterIsInstance(IdTable::class.java).toSet()
+        val tables = query.targets.filterIsInstance(IdTable::class.java).toSet()
         entityCache.flush(tables)
     }
 }


### PR DESCRIPTION
The set of source columns may be empty in some cases, such as `SELECT COUNT(*) ...`.  Instead we should flush any table that the query might touch.