### PR TITLE
Specific text column types for MySQL and SQLServer.

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -21,6 +21,8 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
     override fun uintegerType(): String = "INT UNSIGNED"
 
     override fun ulongType(): String = "BIGINT UNSIGNED"
+
+    override fun textType(): String = "longtext"
 }
 
 internal open class MysqlFunctionProvider : FunctionProvider() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -19,6 +19,12 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
     override fun dateTimeType(): String = "DATETIME2"
     override fun booleanType(): String = "BIT"
     override fun booleanToStatementString(bool: Boolean): String = if (bool) "1" else "0"
+
+    /**
+     * varchar is used instead of "text" because it will be removed in future
+     * https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver15
+     */
+    override fun textType(): String = "VARCHAR(MAX)"
 }
 
 internal object SQLServerFunctionProvider : FunctionProvider() {


### PR DESCRIPTION
This commit introduces special sql types, instead of generic 'TEXT' column type, for MySQL and SQLServer dialects.

'longtext' is used for MySQL
'VARCHAR(MAX)' is used for SQLServer

Without this change Exposed fails to create text columns on MySQL and SQLServer due to missing column length.