### PR TITLE
like and notLike mothods works with string expression

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -287,6 +287,13 @@ interface ISqlExpressionBuilder {
     @JvmName("likeWithEntityID")
     infix fun Expression<EntityID<String>>.like(pattern: String): LikeOp = LikeOp(this, stringParam(pattern))
 
+    /** Checks if this expression matches the specified [expression]. */
+    infix fun <T : String?> Expression<T>.like(expression: ExpressionWithColumnType<String>): LikeOp = LikeOp(this, expression)
+
+    /** Checks if this expression matches the specified [expression]. */
+    @JvmName("likeWithEntityIDAndExpression")
+    infix fun Expression<EntityID<String>>.like(expression: ExpressionWithColumnType<String>): LikeOp = LikeOp(this, expression)
+
     /** Checks if this expression matches the specified [pattern]. */
     infix fun <T : String?> Expression<T>.match(pattern: String): Op<Boolean> = match(pattern, null)
 
@@ -302,6 +309,13 @@ interface ISqlExpressionBuilder {
     /** Checks if this expression doesn't match the specified [pattern]. */
     @JvmName("notLikeWithEntityID")
     infix fun Expression<EntityID<String>>.notLike(pattern: String): NotLikeOp = NotLikeOp(this, stringParam(pattern))
+
+    /** Checks if this expression doesn't match the specified [pattern]. */
+    infix fun <T : String?> Expression<T>.notLike(expression: ExpressionWithColumnType<String>): NotLikeOp = NotLikeOp(this, expression)
+
+    /** Checks if this expression doesn't match the specified [pattern]. */
+    @JvmName("notLikeWithEntityIDAndExpression")
+    infix fun Expression<EntityID<String>>.notLike(expression: ExpressionWithColumnType<String>): NotLikeOp = NotLikeOp(this, expression)
 
     /** Checks if this expression matches the [pattern]. Supports regular expressions. */
     infix fun <T : String?> Expression<T>.regexp(pattern: String): RegexpOp<T> = RegexpOp(this, stringParam(pattern), true)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
@@ -11,6 +11,9 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.upperCase
 import org.junit.Test
 
+/**
+ * This class contains tests for logical sql operators
+ */
 class WhereConditionsTests: DatabaseTestsBase() {
   object User: Table() {
     val name = varchar("name", 20)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
@@ -27,7 +27,7 @@ class WhereConditionsTests: DatabaseTestsBase() {
       }.map { it[User.name] }
 
       assertEquals(1, namesResult.size)
-      assertEquals("Hichem", namesResult.first())
+      assertEquals("HICHEM", namesResult.first())
     }
   }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
@@ -8,6 +8,7 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.stringLiteral
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.upperCase
 import org.junit.Test
 
 class WhereConditionsTests: DatabaseTestsBase() {
@@ -19,10 +20,10 @@ class WhereConditionsTests: DatabaseTestsBase() {
   fun whereLikeExpressionTest() {
     withTables(User) {
       User.insert {
-        it[name] = "Hichem"
+        it[name] = "HICHEM"
       }
       val namesResult = User.select {
-        User.name like stringLiteral("Hich%")
+        User.name like stringLiteral("Hich%").upperCase()
       }.map { it[User.name] }
 
       assertEquals(1, namesResult.size)
@@ -34,10 +35,10 @@ class WhereConditionsTests: DatabaseTestsBase() {
   fun whereNotLikeExpressionTest() {
     withTables(User) {
       User.insert {
-        it[name] = "Hichem"
+        it[name] = "HICHEM"
       }
       val namesResult = User.select {
-        User.name notLike stringLiteral("Hich%")
+        User.name notLike stringLiteral("Hich%").upperCase()
       }.map { it }
 
       assertTrue(namesResult.isEmpty())

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/WhereConditionsTests.kt
@@ -1,0 +1,46 @@
+package org.jetbrains.exposed.sql.tests.shared.ddl
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.stringLiteral
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.junit.Test
+
+class WhereConditionsTests: DatabaseTestsBase() {
+  object User: Table() {
+    val name = varchar("name", 20)
+  }
+
+  @Test
+  fun whereLikeExpressionTest() {
+    withTables(User) {
+      User.insert {
+        it[name] = "Hichem"
+      }
+      val namesResult = User.select {
+        User.name like stringLiteral("Hich%")
+      }.map { it[User.name] }
+
+      assertEquals(1, namesResult.size)
+      assertEquals("Hichem", namesResult.first())
+    }
+  }
+
+  @Test
+  fun whereNotLikeExpressionTest() {
+    withTables(User) {
+      User.insert {
+        it[name] = "Hichem"
+      }
+      val namesResult = User.select {
+        User.name notLike stringLiteral("Hich%")
+      }.map { it }
+
+      assertTrue(namesResult.isEmpty())
+    }
+  }
+}


### PR DESCRIPTION
Actually `like` and `notLike` methods accepts string arguments but not expressions.

In this PR we can do this:
````KOTLIN
val str = "Hich%"

User.select {
        User.name like stringLiteral(str).upperCase()
}
````

works also with string expressions like `Column<String>`