### PR TITLE
Update readme.md for release 0.29.1

### DIFF
--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -18,7 +18,7 @@ This starter will give you the latest version of [Exposed](https://github.com/Je
   <dependency>
     <groupId>org.jetbrains.exposed</groupId>
     <artifactId>exposed-spring-boot-starter</artifactId>
-    <version>0.21.2</version>
+    <version>0.29.1</version>
   </dependency>
 </dependencies>
 ```
@@ -28,7 +28,7 @@ repositories {
   jcenter()
 }
 dependencies {
-  implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.21.2'
+  implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.29.1'
 }
 ```
 


### PR DESCRIPTION
This fixes a typo, version 0.21.2 does not exists