### PR TITLE
Replace transaction scope w/ local variable

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
@@ -11,7 +11,7 @@ val Transaction.entityCache : EntityCache by transactionScope { EntityCache(this
 
 @Suppress("UNCHECKED_CAST")
 class EntityCache(private val transaction: Transaction) {
-    internal var flushingEntities by transactionScope { false }
+    private var flushingEntities = false
     val data = LinkedHashMap<IdTable<*>, MutableMap<Any, Entity<*>>>()
     val inserts = LinkedHashMap<IdTable<*>, MutableList<Entity<*>>>()
     val referrers = HashMap<EntityID<*>, MutableMap<Column<*>, SizedIterable<*>>>()


### PR DESCRIPTION
There are two reasons to do this:
1. The `EntityCache` is already within a `transactionScope`.
2. Even if 1) was not true, the purpose of the variable is to prevent the same cache from recursively flushing.  If there were multiple caches within the same transaction it would be fine if both flushed at the same time.

Extracted backwards-compatible change from #1133.