### PR TITLE
Allow eager loading of any iterable

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
@@ -170,17 +170,10 @@ private fun <ID: Comparable<ID>> List<Entity<ID>>.preloadRelations(vararg relati
     }
 }
 
-
-fun <SRCID : Comparable<SRCID>, SRC: Entity<SRCID>, REF : Entity<*>> List<SRC>
-        .with(vararg relations: KProperty1<out REF, Any?>) : List<SRC>
-        = this.apply {
-    preloadRelations(*relations)
+fun <SRCID : Comparable<SRCID>, SRC: Entity<SRCID>, REF : Entity<*>, T: Iterable<SRC>> T.with(vararg relations: KProperty1<out REF, Any?>): T = apply {
+    toList().preloadRelations(*relations)
 }
 
-fun <SRCID : Comparable<SRCID>, SRC: Entity<SRCID>> SRC.load(vararg relations: KProperty1<out Entity<*>, Any?>) : SRC {
+fun <SRCID : Comparable<SRCID>, SRC: Entity<SRCID>> SRC.load(vararg relations: KProperty1<out Entity<*>, Any?>): SRC = apply {
     listOf(this).with(*relations)
-    return this
 }
-
-fun <SRCID : Comparable<SRCID>, SRC: Entity<SRCID>> SizedIterable<SRC>.with(vararg relations: KProperty1<out Entity<*>, Any?>) : List<SRC>
-        = this.toList().with(*relations)

--- a/exposed-tests/.gitignore
+++ b/exposed-tests/.gitignore
@@ -1,0 +1,1 @@
+jetbrains.db


### PR DESCRIPTION
This change allows consumers to eager load any `Iterable`, as opposed to exclusively `List` or `SizedIterable`.  The eager loading code operates on a `List`, and `SizedIterable` is converted to a `List` before eager loading.  This process can be used for any `Iterable`.