### PR TITLE
Improve performance of ResultIterator

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
@@ -72,7 +72,7 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(targets: List<Table>) : Sized
     protected inner class ResultIterator(val rs: ResultSet) : Iterator<ResultRow> {
         private var hasNext: Boolean? = null
 
-        private val fields = set.realFields
+        private val fields = set.realFields.toSet()
 
         override operator fun next(): ResultRow {
             if (hasNext == null) hasNext()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
@@ -77,8 +77,8 @@ class ResultRow(val fieldIndex: Map<Expression<*>, Int>) {
     internal object NotInitializedValue
 
     companion object {
-        fun create(rs: ResultSet, fields: List<Expression<*>>): ResultRow {
-            val fieldsIndex = fields.distinct().mapIndexed { i, field ->
+        fun create(rs: ResultSet, fields: Set<Expression<*>>): ResultRow {
+            val fieldsIndex = fields.mapIndexed { i, field ->
                 val value = (field as? Column<*>)?.columnType?.readObject(rs, i + 1) ?: rs.getObject(i + 1)
                 (field to i) to value
             }.toMap()


### PR DESCRIPTION
do not recompute distinct fields for each row. This appeared in profiler flame graph when I fetched 200k rows from a DB.

![image](https://user-images.githubusercontent.com/18138/115034620-ff144400-9ecb-11eb-8af9-05bc3d94caf2.png)
