### PR TITLE
Ash/tx rework

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -106,7 +106,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             explicitVendor: String?,
             getNewConnection: () -> Connection,
             setupConnection: (Connection) -> Unit = {},
-            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS) }
+            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_READ_ONLY, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return Database(explicitVendor) {
                 connectionInstanceImpl(getNewConnection().apply { setupConnection(this) })
@@ -118,16 +118,17 @@ class Database private constructor(private val resolvedVendor: String? = null, v
         fun connect(
             datasource: DataSource,
             setupConnection: (Connection) -> Unit = {},
-            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS) }
+            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_READ_ONLY, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return doConnect(explicitVendor = null, getNewConnection = { datasource.connection!! }, setupConnection = setupConnection, manager = manager)
         }
 
         @Deprecated(level = DeprecationLevel.ERROR, replaceWith = ReplaceWith("connectPool(datasource, setupConnection, manager)"), message = "Use connectPool instead")
+
         fun connect(
             datasource: ConnectionPoolDataSource,
             setupConnection: (Connection) -> Unit = {},
-            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS) }
+            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_READ_ONLY, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return doConnect(explicitVendor = null, getNewConnection = { datasource.pooledConnection.connection!! }, setupConnection = setupConnection, manager = manager)
         }
@@ -135,14 +136,14 @@ class Database private constructor(private val resolvedVendor: String? = null, v
         fun connectPool(
             datasource: ConnectionPoolDataSource,
             setupConnection: (Connection) -> Unit = {},
-            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS) }
+            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_READ_ONLY, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return doConnect(explicitVendor = null, getNewConnection = { datasource.pooledConnection.connection!! }, setupConnection = setupConnection, manager = manager)
         }
 
         fun connect(
             getNewConnection: () -> Connection,
-            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS) }
+            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_READ_ONLY, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             return doConnect(explicitVendor = null, getNewConnection = getNewConnection, manager = manager)
         }
@@ -153,7 +154,7 @@ class Database private constructor(private val resolvedVendor: String? = null, v
             user: String = "",
             password: String = "",
             setupConnection: (Connection) -> Unit = {},
-            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_REPETITION_ATTEMPTS) }
+            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it, DEFAULT_READ_ONLY, DEFAULT_REPETITION_ATTEMPTS) }
         ): Database {
             Class.forName(driver).newInstance()
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ConnectionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ConnectionApi.kt
@@ -6,6 +6,7 @@ interface ExposedConnection<OriginalConnection : Any> {
     fun rollback()
     fun close()
     var autoCommit: Boolean
+    var isReadOnly: Boolean
     var transactionIsolation: Int
     val connection: OriginalConnection
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -9,10 +9,10 @@ import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import org.jetbrains.exposed.sql.statements.api.ExposedSavepoint
 import java.sql.SQLException
 
-class ThreadLocalTransactionManager(
-    private val db: Database,
-    @Volatile override var defaultRepetitionAttempts: Int
-) : TransactionManager {
+
+class ThreadLocalTransactionManager(private val db: Database,
+                                    @Volatile override val readOnly: Boolean,
+                                    @Volatile override var defaultRepetitionAttempts: Int) : TransactionManager {
 
     @Volatile override var defaultIsolationLevel: Int = -1
         get() {
@@ -24,16 +24,15 @@ class ThreadLocalTransactionManager(
 
     val threadLocal = ThreadLocal<Transaction>()
 
-    override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction =
-        (
-            outerTransaction?.takeIf { !db.useNestedTransactions } ?: Transaction(
-                ThreadLocalTransaction(
-                    db = db,
-                    transactionIsolation = outerTransaction?.transactionIsolation ?: isolation,
-                    threadLocal = threadLocal,
-                    outerTransaction = outerTransaction
-                )
-            )
+    override fun newTransaction(isolation: Int, readOnly: Boolean, outerTransaction: Transaction?): Transaction =
+        (outerTransaction?.takeIf { !db.useNestedTransactions } ?: Transaction(
+            ThreadLocalTransaction(
+                db = db,
+                transactionIsolation = outerTransaction?.transactionIsolation ?: isolation,
+                readOnly = outerTransaction?.readOnly ?: readOnly,
+                threadLocal = threadLocal,
+                outerTransaction = outerTransaction
+            ))
             ).apply {
             bindTransactionToThread(this)
         }
@@ -50,12 +49,17 @@ class ThreadLocalTransactionManager(
     private class ThreadLocalTransaction(
         override val db: Database,
         override val transactionIsolation: Int,
+        override val readOnly: Boolean,
         val threadLocal: ThreadLocal<Transaction>,
         override val outerTransaction: Transaction?
     ) : TransactionInterface {
 
         private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) {
             outerTransaction?.connection ?: db.connector().apply {
+                // The order of `setReadOnly` and `setAutoCommit` is important.
+                // Some drivers start a transaction right after `setAutoCommit(false)`,
+                // which makes `setReadOnly` throw an exception if it is called after `setAutoCommit`
+                isReadOnly = this@ThreadLocalTransaction.readOnly
                 autoCommit = false
                 transactionIsolation = this@ThreadLocalTransaction.transactionIsolation
             }
@@ -118,15 +122,16 @@ class ThreadLocalTransactionManager(
 }
 
 fun <T> transaction(db: Database? = null, statement: Transaction.() -> T): T =
-    transaction(db.transactionManager.defaultIsolationLevel, db.transactionManager.defaultRepetitionAttempts, db, statement)
+    transaction(db.transactionManager.defaultIsolationLevel, db.transactionManager.defaultReadOnly,
+            db.transactionManager.defaultRepetitionAttempts, db, statement)
 
-fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Database? = null, statement: Transaction.() -> T): T = keepAndRestoreTransactionRefAfterRun(db) {
+fun <T> transaction(transactionIsolation: Int, readOnly: Boolean, repetitionAttempts: Int, db: Database? = null, statement: Transaction.() -> T): T = keepAndRestoreTransactionRefAfterRun(db) {
     val outer = TransactionManager.currentOrNull()
 
     if (outer != null && (db == null || outer.db == db)) {
         val outerManager = outer.db.transactionManager
 
-        val transaction = outerManager.newTransaction(transactionIsolation, outer)
+        val transaction = outerManager.newTransaction(transactionIsolation, readOnly, outer)
         try {
             transaction.statement().also {
                 if (outer.db.useNestedTransactions)
@@ -148,16 +153,17 @@ fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Data
             } finally {
                 TransactionManager.resetCurrent(currentManager)
             }
-        } ?: inTopLevelTransaction(transactionIsolation, repetitionAttempts, db, null, statement)
+        } ?: inTopLevelTransaction(transactionIsolation, readOnly, repetitionAttempts, db, null, statement)
     }
 }
 
 fun <T> inTopLevelTransaction(
-    transactionIsolation: Int,
-    repetitionAttempts: Int,
-    db: Database? = null,
-    outerTransaction: Transaction? = null,
-    statement: Transaction.() -> T
+        transactionIsolation: Int,
+        readOnly: Boolean,
+        repetitionAttempts: Int,
+        db: Database? = null,
+        outerTransaction: Transaction? = null,
+        statement: Transaction.() -> T
 ): T {
 
     fun run(): T {
@@ -167,7 +173,7 @@ fun <T> inTopLevelTransaction(
 
         while (true) {
             db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
-            val transaction = db.transactionManager.newTransaction(transactionIsolation, outerTransaction)
+            val transaction = db.transactionManager.newTransaction(transactionIsolation, readOnly, outerTransaction)
 
             try {
                 val answer = transaction.statement()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -29,6 +29,8 @@ interface TransactionInterface {
 
 const val DEFAULT_ISOLATION_LEVEL = Connection.TRANSACTION_REPEATABLE_READ
 
+const val DEFAULT_READ_ONLY = false
+
 const val DEFAULT_REPETITION_ATTEMPTS = 3
 
 private object NotInitializedManager : TransactionManager {
@@ -38,7 +40,7 @@ private object NotInitializedManager : TransactionManager {
 
     override var defaultRepetitionAttempts: Int = -1
 
-    override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction = error("Please call Database.connect() before using this code")
+    override fun newTransaction(isolation: Int, readOnly: Boolean, outerTransaction: Transaction?): Transaction = error("Please call Database.connect() before using this code")
 
     override fun currentOrNull(): Transaction? = error("Please call Database.connect() before using this code")
 
@@ -55,7 +57,11 @@ interface TransactionManager {
 
     var defaultRepetitionAttempts: Int
 
-    fun newTransaction(isolation: Int = defaultIsolationLevel, outerTransaction: Transaction? = null): Transaction
+    fun newTransaction(
+        isolation: Int = defaultIsolationLevel,
+        readOnly: Boolean = defaultReadOnly,
+        outerTransaction: Transaction? = null
+    ): Transaction
 
     fun currentOrNull(): Transaction?
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -16,6 +16,8 @@ interface TransactionInterface {
 
     val transactionIsolation: Int
 
+    val readOnly: Boolean
+
     val outerTransaction: Transaction?
 
     fun commit()
@@ -32,6 +34,8 @@ const val DEFAULT_REPETITION_ATTEMPTS = 3
 private object NotInitializedManager : TransactionManager {
     override var defaultIsolationLevel: Int = -1
 
+    override var defaultReadOnly: Boolean = false
+
     override var defaultRepetitionAttempts: Int = -1
 
     override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction = error("Please call Database.connect() before using this code")
@@ -46,6 +50,8 @@ private object NotInitializedManager : TransactionManager {
 interface TransactionManager {
 
     var defaultIsolationLevel: Int
+
+    var defaultReadOnly: Boolean
 
     var defaultRepetitionAttempts: Int
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -40,6 +40,10 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
         get() = connection.autoCommit
         set(value) { connection.autoCommit = value }
 
+    override var isReadOnly: Boolean
+        get() = connection.isReadOnly
+        set(value) { connection.setReadOnly(value) }
+
     override var transactionIsolation: Int
         get() = connection.transactionIsolation
         set(value) { connection.transactionIsolation = value }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -45,6 +45,7 @@ enum class TestDB(
         beforeConnection = { if (runTestContainersMySQL()) mySQLProcess },
         afterTestFinished = { if (runTestContainersMySQL()) mySQLProcess.close() }
     ),
+
     POSTGRESQL(
         { "jdbc:postgresql://localhost:12346/template1?user=postgres&password=&lc_messages=en_US.UTF-8" }, "org.postgresql.Driver",
         beforeConnection = { postgresSQLProcess }, afterTestFinished = { postgresSQLProcess.close() }
@@ -62,7 +63,7 @@ enum class TestDB(
         beforeConnection = {
             Locale.setDefault(Locale.ENGLISH)
             val tmp = Database.connect(ORACLE.connection(), user = "sys as sysdba", password = "Oracle18", driver = ORACLE.driver)
-            transaction(Connection.TRANSACTION_READ_COMMITTED, 1, tmp) {
+            transaction(Connection.TRANSACTION_READ_COMMITTED, false, 1, tmp) {
                 try {
                     exec("DROP USER ExposedTest CASCADE")
                 } catch (e: Exception) { // ignore
@@ -154,7 +155,7 @@ abstract class DatabaseTestsBase {
 
         val database = dbSettings.db!!
 
-        transaction(database.transactionManager.defaultIsolationLevel, 1, db = database) {
+        transaction(database.transactionManager.defaultIsolationLevel, false, 1, db = database) {
             statement(dbSettings)
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
@@ -176,7 +176,7 @@ class MultiDatabaseEntityTest {
                 b2Reread.y = null
             }
         }
-        inTopLevelTransaction(Connection.TRANSACTION_READ_COMMITTED, 1, db1) {
+        inTopLevelTransaction(Connection.TRANSACTION_READ_COMMITTED, false, 1, db1) {
             assertNull(EntityTestsData.BEntity.testCache(db1b1.id))
             val b1Reread = EntityTestsData.BEntity[db1b1.id]
             assertEquals(db1b1.id, b1Reread.id)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
@@ -58,7 +58,7 @@ class NestedTransactionsTest : DatabaseTestsBase() {
             assertNotNull(TransactionManager.currentOrNull())
 
             try {
-                inTopLevelTransaction(this.transactionIsolation, 1) {
+                inTopLevelTransaction(this.transactionIsolation, false, 1) {
                     throw IllegalStateException("Should be rethrow")
                 }
             } catch (e: Exception) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -55,7 +55,7 @@ class ConnectionTimeoutTest : DatabaseTestsBase() {
         val db = Database.connect(datasource = datasource)
 
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 42, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, false, 42, db) {
                 exec("SELECT 1;")
                 // NO OP
             }
@@ -117,7 +117,7 @@ class ConnectionExceptions {
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, false, 5, db) {
                 this.exec("BROKEN_SQL_THAT_CAUSES_EXCEPTION()")
             }
             fail("Should have thrown an exception")
@@ -150,7 +150,7 @@ class ConnectionExceptions {
         val wrappingDataSource = WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, false, 5, db) {
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")
@@ -173,7 +173,7 @@ class ConnectionExceptions {
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, false, 5, db) {
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")
@@ -264,7 +264,7 @@ class RollbackTransactionTest : DatabaseTestsBase() {
     @Test
     fun testRollbackWithoutSavepoints() {
         withTables(RollbackTable) {
-            inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, 1) {
+            inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, false, 1) {
                 RollbackTable.insert { it[value] = "before-dummy" }
                 transaction {
                     assertEquals(1L, RollbackTable.select { RollbackTable.value eq "before-dummy" }.count())
@@ -287,7 +287,7 @@ class RollbackTransactionTest : DatabaseTestsBase() {
         withTables(RollbackTable) {
             try {
                 db.useNestedTransactions = true
-                inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, 1) {
+                inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, false, 1) {
                     RollbackTable.insert { it[value] = "before-dummy" }
                     transaction {
                         assertEquals(1L, RollbackTable.select { RollbackTable.value eq "before-dummy" }.count())
@@ -314,7 +314,7 @@ class TransactionIsolationTest : DatabaseTestsBase() {
     @Test
     fun `test what transaction isolation was applied`() {
         withDb {
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 assertEquals(Connection.TRANSACTION_SERIALIZABLE, this.connection.transactionIsolation)
             }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -543,7 +543,7 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     private fun <T> newTransaction(statement: Transaction.() -> T) =
-        inTopLevelTransaction(TransactionManager.manager.defaultIsolationLevel, 1, null, null, statement)
+        inTopLevelTransaction(TransactionManager.manager.defaultIsolationLevel, false, 1, null, null, statement)
 
     @Test fun sharingEntityBetweenTransactions() {
         withTables(Humans) {
@@ -700,7 +700,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 School.all().with(School::region)
                 assertNotNull(School.testCache(school1.id))
                 assertNotNull(School.testCache(school2.id))
@@ -728,7 +728,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 School.find {
                     Schools.id eq school1.id
                 }.first().load(School::region)
@@ -769,7 +769,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 School.all().with(School::region, School::secondaryRegion)
                 assertNotNull(School.testCache(school1.id))
                 assertNotNull(School.testCache(school2.id))
@@ -800,7 +800,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 val school2 = School.find {
                     Schools.id eq school1.id
                 }.first().load(School::secondaryRegion)
@@ -860,7 +860,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 val cache = TransactionManager.current().entityCache
 
                 School.all().with(School::students)
@@ -904,7 +904,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 val cache = TransactionManager.current().entityCache
 
                 School.find { Schools.id eq school1.id }.first().load(School::students)
@@ -950,7 +950,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 School.all().with(School::students, Student::detentions)
                 val cache = TransactionManager.current().entityCache
 
@@ -1016,7 +1016,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 School.all().with(School::holidays)
                 val cache = TransactionManager.current().entityCache
                 assertEquals(true, cache.referrers.containsKey(school1.id))
@@ -1171,7 +1171,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 Student.all().with(Student::bio)
                 val cache = TransactionManager.current().entityCache
 
@@ -1218,7 +1218,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, false, 1) {
                 Student.all().first().load(Student::bio)
                 val cache = TransactionManager.current().entityCache
 


### PR DESCRIPTION
1. add read only specification. Some database's require less resources (PG does that for snapshot transactions + it may assign virtual id instead of stable one) if it is guaranteed that connection is unable to write anything. More, it provide a guarantee that connection is unable to mess with data. 
2. provide optional transaction setup callback. Useful for setting up catalogue or scheme - properties that are unsetable in current implementation. 