### PR TITLE
fix com.github.dockerjava.api.exception.NotFoundException: Status 404…

### DIFF
--- a/exposed-java-time/build.gradle.kts
+++ b/exposed-java-time/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 
     testImplementation("com.opentable.components", "otj-pg-embedded", "0.12.0")
-    testRuntimeOnly("org.testcontainers", "testcontainers", "1.14.3")
+    testRuntimeOnly("org.testcontainers", "testcontainers", "1.15.3")
 
     setupTestDriverDependencies(dialect) { group, artifactId, version ->
         testImplementation(group, artifactId, version)

--- a/exposed-jodatime/build.gradle.kts
+++ b/exposed-jodatime/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 
     testImplementation("com.opentable.components", "otj-pg-embedded", "0.12.0")
-    testRuntimeOnly("org.testcontainers", "testcontainers", "1.14.3")
+    testRuntimeOnly("org.testcontainers", "testcontainers", "1.15.3")
 
     setupTestDriverDependencies(dialect) { group, artifactId, version ->
         testImplementation(group, artifactId, version)

--- a/exposed-money/build.gradle.kts
+++ b/exposed-money/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testImplementation("org.xerial", "sqlite-jdbc", "3.23.1")
     testImplementation("com.h2database", "h2", "1.4.199")
     testImplementation("org.javamoney", "moneta", "1.3")
-    testRuntimeOnly("org.testcontainers", "testcontainers", "1.14.3")
+    testRuntimeOnly("org.testcontainers", "testcontainers", "1.15.3")
     setupTestDriverDependencies(dialect) { group, artifactId, version ->
         testImplementation(group, artifactId, version)
     }

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -28,8 +28,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx","kotlinx-coroutines-debug", Versions.kotlinCoroutines)
 
     implementation("com.opentable.components", "otj-pg-embedded", "0.12.0")
-    implementation("org.testcontainers", "testcontainers", "1.14.3")
-    implementation("org.testcontainers", "mysql", "1.14.3")
+    implementation("org.testcontainers", "testcontainers", "1.15.3")
+    implementation("org.testcontainers", "mysql", "1.15.3")
 
     implementation("com.h2database", "h2", Versions.h2)
 


### PR DESCRIPTION
Fixes 
```
com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"No such image: testcontainers/ryuk:0.3.0"}
``` 

[Docker 20.10 introduced a new version of the API, 1.41, where they removed quite a few deprecations, and we were using one of them. If you were getting "No such image: testcontainers/ryuk:0.3.0" - that's the cause.](https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.1)