### PR TITLE
Introduce operators for bitwise expressions and bitflag checks

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
@@ -290,6 +291,44 @@ class ModOp<T : Number?, S : Number?>(
         when (currentDialectIfAvailable) {
             is OracleDialect -> append("MOD(", expr1, ", ", expr2, ")")
             else -> append('(', expr1, " % ", expr2, ')')
+        }
+    }
+}
+
+/**
+ * Represents an SQL operator that performs a bitwise `and` on [expr1] and [expr2].
+ */
+class AndBitOp<T, S : T>(
+    /** The left-hand side operand. */
+    val expr1: Expression<T>,
+    /** The right-hand side operand. */
+    val expr2: Expression<S>,
+    /** The column type of this expression. */
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        when (currentDialectIfAvailable) {
+            is OracleDialect, is H2Dialect -> append("BITAND(", expr1, ", ", expr2, ")")
+            else -> append('(', expr1, " & ", expr2, ')')
+        }
+    }
+}
+
+/**
+ * Represents an SQL operator that performs a bitwise `or` on [expr1] and [expr2].
+ */
+class OrBitOp<T, S : T>(
+    /** The left-hand side operand. */
+    val expr1: Expression<T>,
+    /** The right-hand side operand. */
+    val expr2: Expression<S>,
+    /** The column type of this expression. */
+    override val columnType: IColumnType
+) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        when (currentDialectIfAvailable) {
+            is OracleDialect, is H2Dialect -> append("BITOR(", expr1, ", ", expr2, ")")
+            else -> append('(', expr1, " | ", expr2, ')')
         }
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -269,6 +269,12 @@ interface ISqlExpressionBuilder {
      */
     infix fun <T> ExpressionWithColumnType<T>.bitwiseOr(t: T): OrBitOp<T, T> = OrBitOp(this, wrap(t), columnType)
 
+
+    /**
+     * Performs a bitwise `or` on this expression and [t].
+     */
+    infix fun <T> ExpressionWithColumnType<T>.bitwiseXor(t: T): XorBitOp<T, T> = XorBitOp(this, wrap(t), columnType)
+
     /**
      * Performs a bitwise `and` on this expression and [t].
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -259,6 +259,21 @@ interface ISqlExpressionBuilder {
     /** Calculates the remainder of dividing this expression by the [other] expression. */
     infix fun <T : Number?, S : Number> ExpressionWithColumnType<T>.mod(other: Expression<S>): ModOp<T, S> = this % other
 
+    /**
+     * Performs a bitwise `and` on this expression and [t].
+     */
+    infix fun <T> ExpressionWithColumnType<T>.and(t: T): AndBitOp<T, T> = AndBitOp(this, wrap(t), columnType)
+
+    /**
+     * Performs a bitwise `or` on this expression and [t].
+     */
+    infix fun <T> ExpressionWithColumnType<T>.or(t: T): OrBitOp<T, T> = OrBitOp(this, wrap(t), columnType)
+
+    /**
+     * Performs a bitwise `and` on this expression and [t].
+     */
+    infix fun <T> ExpressionWithColumnType<T>.hasFlag(t: T): EqOp = EqOp(AndBitOp(this, wrap(t), columnType), wrap(t))
+
     // String Functions
 
     /** Concatenates the text representations of all the [expr]. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -262,12 +262,12 @@ interface ISqlExpressionBuilder {
     /**
      * Performs a bitwise `and` on this expression and [t].
      */
-    infix fun <T> ExpressionWithColumnType<T>.and(t: T): AndBitOp<T, T> = AndBitOp(this, wrap(t), columnType)
+    infix fun <T> ExpressionWithColumnType<T>.bitwiseAnd(t: T): AndBitOp<T, T> = AndBitOp(this, wrap(t), columnType)
 
     /**
      * Performs a bitwise `or` on this expression and [t].
      */
-    infix fun <T> ExpressionWithColumnType<T>.or(t: T): OrBitOp<T, T> = OrBitOp(this, wrap(t), columnType)
+    infix fun <T> ExpressionWithColumnType<T>.bitwiseOr(t: T): OrBitOp<T, T> = OrBitOp(this, wrap(t), columnType)
 
     /**
      * Performs a bitwise `and` on this expression and [t].

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DMLTestData.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DMLTestData.kt
@@ -20,7 +20,13 @@ object DMLTestsData {
         val id: Column<String> = varchar("id", 10)
         val name: Column<String> = varchar("name", length = 50)
         val cityId: Column<Int?> = reference("city_id", Cities.id).nullable()
+        val flags: Column<Int> = integer("flags").default(0)
         override val primaryKey = PrimaryKey(id)
+
+        object Flags {
+            const val IS_ADMIN = 0b1
+            const val HAS_DATA = 0b1000
+        }
     }
 
     object UserData : Table() {
@@ -32,6 +38,7 @@ object DMLTestsData {
 
 fun DatabaseTestsBase.withCitiesAndUsers(exclude: List<TestDB> = emptyList(), statement: Transaction.(cities: DMLTestsData.Cities, users: DMLTestsData.Users, userData: DMLTestsData.UserData) -> Unit) {
     val Users = DMLTestsData.Users
+    val UserFlags = DMLTestsData.Users.Flags
     val Cities = DMLTestsData.Cities
     val UserData = DMLTestsData.UserData
 
@@ -52,18 +59,21 @@ fun DatabaseTestsBase.withCitiesAndUsers(exclude: List<TestDB> = emptyList(), st
             it[id] = "andrey"
             it[name] = "Andrey"
             it[cityId] = saintPetersburgId
+            it[flags] = UserFlags.IS_ADMIN
         }
 
         Users.insert {
             it[id] = "sergey"
             it[name] = "Sergey"
             it[cityId] = munichId
+            it[flags] = UserFlags.IS_ADMIN or UserFlags.HAS_DATA
         }
 
         Users.insert {
             it[id] = "eugene"
             it[name] = "Eugene"
             it[cityId] = munichId
+            it[flags] = UserFlags.HAS_DATA
         }
 
         Users.insert {
@@ -76,6 +86,7 @@ fun DatabaseTestsBase.withCitiesAndUsers(exclude: List<TestDB> = emptyList(), st
             it[id] = "smth"
             it[name] = "Something"
             it[cityId] = null
+            it[flags] = UserFlags.HAS_DATA
         }
 
         UserData.insert {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertSelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertSelectTests.kt
@@ -39,7 +39,7 @@ class InsertSelectTests : DatabaseTestsBase() {
         withCitiesAndUsers { cities, users, userData ->
             val userCount = users.selectAll().count()
             val nullableExpression = Random() as Expression<BigDecimal?>
-            users.insert(users.slice(nullableExpression.castTo<String>(VarCharColumnType()).substring(1, 10), stringParam("Foo"), intParam(1)).selectAll())
+            users.insert(users.slice(nullableExpression.castTo<String>(VarCharColumnType()).substring(1, 10), stringParam("Foo"), intParam(1), intLiteral(0)).selectAll())
             val r = users.select { users.name eq "Foo" }.toList()
             assertEquals(userCount, r.size.toLong())
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -67,7 +67,7 @@ class FunctionsTests : DatabaseTestsBase() {
     fun testCalc04() {
         withCitiesAndUsers { cities, users, userData ->
             val adminFlag = DMLTestsData.Users.Flags.IS_ADMIN
-            val admin = Expression.build { AndBitOp(users.flags, intParam(adminFlag), IntegerColumnType()) eq adminFlag }
+            val admin = Expression.build { (users.flags bitwiseAnd adminFlag) eq adminFlag }
             val r = users.slice(users.id, admin).selectAll().orderBy(users.id).toList()
             assertEquals(5, r.size)
             val trueType = when (currentDialectTest) {
@@ -92,7 +92,7 @@ class FunctionsTests : DatabaseTestsBase() {
     fun testCalc05() {
         withCitiesAndUsers { cities, users, userData ->
             val extra = 0b10
-            val flagsWithExtra = Expression.build { OrBitOp(users.flags, intParam(extra), IntegerColumnType()) }
+            val flagsWithExtra = Expression.build { users.flags bitwiseOr extra }
             val r = users.slice(users.id, flagsWithExtra).selectAll().orderBy(users.id).toList()
             assertEquals(5, r.size)
             assertEquals(0b0010, r[0][flagsWithExtra])

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -10,9 +10,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.tests.shared.dml.withCitiesAndUsers
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
-import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Test
 import kotlin.test.assertNotNull
 
@@ -70,21 +68,11 @@ class FunctionsTests : DatabaseTestsBase() {
             val admin = Expression.build { (users.flags bitwiseAnd adminFlag) eq adminFlag }
             val r = users.slice(users.id, admin).selectAll().orderBy(users.id).toList()
             assertEquals(5, r.size)
-            val trueType = when (currentDialectTest) {
-                is MysqlDialect -> 1L
-                is SQLiteDialect -> 1
-                else -> true
-            }
-            val falseType = when (currentDialectTest) {
-                is MysqlDialect -> 0L
-                is SQLiteDialect -> 0
-                else -> false
-            }
-            assertEquals(falseType, r[0][admin])
-            assertEquals(trueType, r[1][admin])
-            assertEquals(falseType, r[2][admin])
-            assertEquals(trueType, r[3][admin])
-            assertEquals(falseType, r[4][admin])
+            assertEquals(false, r[0][admin])
+            assertEquals(true, r[1][admin])
+            assertEquals(false, r[2][admin])
+            assertEquals(true, r[3][admin])
+            assertEquals(false, r[4][admin])
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -92,6 +92,20 @@ class FunctionsTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testCalc06() {
+        withCitiesAndUsers { cities, users, userData ->
+            val flagsWithXor = Expression.build { users.flags bitwiseXor 0b111 }
+            val r = users.slice(users.id, flagsWithXor).selectAll().orderBy(users.id).toList()
+            assertEquals(5, r.size)
+            assertEquals(0b0111, r[0][flagsWithXor])
+            assertEquals(0b0110, r[1][flagsWithXor])
+            assertEquals(0b1111, r[2][flagsWithXor])
+            assertEquals(0b1110, r[3][flagsWithXor])
+            assertEquals(0b1111, r[4][flagsWithXor])
+        }
+    }
+
+    @Test
     fun testFlag01() {
         withCitiesAndUsers { cities, users, userData ->
             val adminFlag = DMLTestsData.Users.Flags.IS_ADMIN


### PR DESCRIPTION
Inspired by `ModOp` and `AndOp`/`OrOp`, introduces support for bitwise operations in the query (`and` and `or`).
Additionally, there's a helper function `hasFlag` that checks if a bitflag is set on an expression by evaluating to `(expr & flag) = flag` or an equivalent in the current dialect.