### PR TITLE
Fix for SQLite override PrimaryKey

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -79,7 +79,7 @@ class Column<T>(
 
         when {
             !isPKColumn && isSQLiteAutoIncColumn -> tr.throwUnsupportedException("Auto-increment could be applied only to primary key column")
-            isSQLiteAutoIncColumn && (!isOneColumnPK() || table.isCustomPKNameDefined()) && table.primaryKey != null -> append(currentDialect.dataTypeProvider.integerType())
+            isSQLiteAutoIncColumn && (!isOneColumnPK() || table.isCustomPKNameDefined()) && table.primaryKey != null && table.primaryKey.columns[0].name != this@Column.name -> append(currentDialect.dataTypeProvider.integerType())
             else -> append(colType.sqlType())
         }
 


### PR DESCRIPTION
While using SQLite3 dialect and trying to create a table with autoincrement() and overriding primaryKey, the generated Table does not increment or insert the primary key value.

#1258  SQLite table ignoring primaryKey override