### PR TITLE
Add batchInsert with Sequence

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -88,13 +88,26 @@ fun <T : Table, E> T.batchInsert(
     ignore: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
+): List<ResultRow> = batchInsert(data.iterator(), ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+
+fun <T : Table, E> T.batchInsert(
+    data: kotlin.sequences.Sequence<E>,
+    ignore: Boolean = false,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchInsertStatement.(E) -> Unit
+): List<ResultRow> = batchInsert(data.iterator(), ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+
+private fun <T : Table, E> T.batchInsert(
+    data: Iterator<E>,
+    ignoreErrors: Boolean = false,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> {
-    if (data.count() == 0) return emptyList()
     fun newBatchStatement(): BatchInsertStatement {
         return if (currentDialect is SQLServerDialect && this.autoIncColumn != null) {
-            SQLServerBatchInsertStatement(this, ignore, shouldReturnGeneratedValues)
+            SQLServerBatchInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
         } else {
-            BatchInsertStatement(this, ignore, shouldReturnGeneratedValues)
+            BatchInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
         }
     }
     var statement = newBatchStatement()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectBatchedTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectBatchedTests.kt
@@ -1,12 +1,11 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
-import org.jetbrains.exposed.sql.batchInsert
-import org.jetbrains.exposed.sql.selectAllBatched
-import org.jetbrains.exposed.sql.selectBatched
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.junit.Test
 import java.util.*
+import kotlin.test.*
 
 class SelectBatchedTests : DatabaseTestsBase() {
     @Test
@@ -64,6 +63,19 @@ class SelectBatchedTests : DatabaseTestsBase() {
                 .toList().map { it.toCityNameList() }
 
             assertEqualLists(emptyList(), batches)
+        }
+    }
+
+    @Test
+    fun `batchInserting using a sequence should work`() {
+        val Cities = DMLTestsData.Cities
+        withTables(Cities) {
+            val names = List(25) { UUID.randomUUID().toString() }.asSequence()
+            Cities.batchInsert(names) { name -> this[Cities.name] = name }
+
+            val batches = Cities.selectAll().toList().toCityNameList()
+
+            assertEquals(25, batches.size)
         }
     }
 


### PR DESCRIPTION
Currently, `Sequence.asIterable` does not work, as `data.count == 0` is called, which terminates the sequence before inserting all values.