### PR TITLE
Use Postgres single precision data type

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -7,6 +7,7 @@ import java.util.*
 
 internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun byteType(): String = "SMALLINT"
+    override fun floatType(): Float = "REAL"
     override fun integerAutoincType(): String = "SERIAL"
     override fun longAutoincType(): String = "BIGSERIAL"
     override fun uuidType(): String = "uuid"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun byteType(): String = "SMALLINT"
-    override fun floatType(): Float = "REAL"
+    override fun floatType(): String = "REAL"
     override fun integerAutoincType(): String = "SERIAL"
     override fun longAutoincType(): String = "BIGSERIAL"
     override fun uuidType(): String = "uuid"


### PR DESCRIPTION
Using "org.postgresql:postgresql:42.2.16" converts `FLOAT` to `float8`, which uses double precision. It should be single precision, which is `real` using 4 bytes.
 
Reference: https://www.postgresql.org/docs/current/datatype-numeric.html