### PR TITLE
Fix README.md of exposed-bom

### DIFF
--- a/exposed-bom/README.md
+++ b/exposed-bom/README.md
@@ -3,7 +3,7 @@ Bill of Materials for all Exposed modules
 
 # Maven
 ```xml
-<!-- Versions after 0.30.1 -->
+<!-- Versions after 0.32.1 -->
 <repositories>
     <repository>
         <id>mavenCentral</id>
@@ -15,9 +15,9 @@ Bill of Materials for all Exposed modules
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>org.jboss.bom</groupId>
-            <artifactId>jboss-javaee-6.0-with-tools</artifactId>
-            <version>0.31.2</version>
+            <groupId>org.jetbrains.exposed</groupId>
+            <artifactId>exposed-bom</artifactId>
+            <version>0.32.1</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -46,12 +46,12 @@ Bill of Materials for all Exposed modules
 # Gradle
 ```kotlin
 repositories {
-  // Versions after 0.30.1
+  // Versions after 0.32.1
   mavenCentral()
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.exposed:exposed-bom:0.31.2"))
+    implementation(platform("org.jetbrains.exposed:exposed-bom:0.32.1"))
     implementation("org.jetbrains.exposed", "exposed-core")
     implementation("org.jetbrains.exposed", "exposed-dao")
     implementation("org.jetbrains.exposed", "exposed-jdbc")


### PR DESCRIPTION
Both Maven and Gradle configuration parameters were incorrect.
According to https://repo1.maven.org/maven2/org/jetbrains/exposed/exposed-bom/maven-metadata.xml the first available version of exposed-bom is 0.32.1