### PR TITLE
Fix failing test due calling single on emptyList()

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -187,7 +187,7 @@ class InsertTests : DatabaseTestsBase() {
             val names = emptySequence<String>()
             Cities.batchInsert(names) { name -> this[Cities.name] = name }
 
-            val batchesSize = Cities.selectAll().toList()
+            val batchesSize = Cities.selectAll().count()
 
             assertEquals(0, batchesSize)
         }


### PR DESCRIPTION
`EmptySequence` results into an `emptyList`, but the custom `assertEquals` overload with a `List` calls `single`, which fails.