### PR TITLE
UpdateBuilder: allow check if column is set

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -15,6 +15,8 @@ import org.jetbrains.exposed.sql.Table
 
 abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) : Statement<T>(type, targets) {
     protected val values: MutableMap<Column<*>, Any?> = LinkedHashMap()
+    
+    open operator fun contains(column: Column<*>): Boolean = values.contains(column)
 
     open operator fun <S> set(column: Column<S>, value: S) {
         when {


### PR DESCRIPTION
Allow for setting a column using an update builder if it hasn't already been set.

This is a work-around for issue #1316.