### PR TITLE
remove call to super.equals

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -129,7 +129,6 @@ class Column<T>(
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Column<*>) return false
-        if (!super.equals(other)) return false
 
         if (table != other.table) return false
         if (name != other.name) return false


### PR DESCRIPTION
the super.Expression.equals contains  
https://github.com/JetBrains/Exposed/blob/6fb5a3cf39eef4f1b240fe7e98857189f70f5970/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt#L136
where `toString` resolves to 
https://github.com/JetBrains/Exposed/blob/6fb5a3cf39eef4f1b240fe7e98857189f70f5970/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt#L143

The problem here is that the same Column created from different places will inevitably have difference javaClass names. 
Such Column instantiations are required to build migration tools or when cache is dropped and columns and tables are read "from database". 
The column comparision should not be performed by technical informtion, but by busyness information only. That is, table name, column name and types should be compared. 