### PR TITLE
fix database name extension property

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -205,4 +205,4 @@ class Database private constructor(private val resolvedVendor: String? = null, v
 
 interface DatabaseConnectionAutoRegistration : (Connection) -> ExposedConnection<*>
 
-val Database.name: String get() = url.substringAfterLast('/').substringBefore('?')
+val Database.name: String get() = url.substringBefore('?').substringAfterLast('/')


### PR DESCRIPTION
When using the serverTimezone (e.g. Europe/Moscow) parameter when connecting to a database, the property returned wrong the database name