### PR TITLE
Supporting subqueries in insert and update statements

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -200,14 +200,6 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     }
 }
 
-class QueryExpression<T>(val query: AbstractQuery<*>) : Expression<T>(), ComplexExpression {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        append("(")
-        query.prepareSQL(this)
-        +")"
-    }
-}
-
 /**
  * Mutate Query instance and add `andPart` to where condition with `and` operator.
  * @return same Query instance which was provided as a receiver.
@@ -227,5 +219,3 @@ fun Query.orWhere(andPart: SqlExpressionBuilder.() -> Op<Boolean>) = adjustWhere
     if (this == null) expr
     else this or expr
 }
-
-fun <T> Query.expression(): QueryExpression<T> = QueryExpression(this)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -200,6 +200,14 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     }
 }
 
+class QueryExpression<T>(val query: AbstractQuery<*>) : Expression<T>(), ComplexExpression {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("(")
+        query.prepareSQL(this)
+        +")"
+    }
+}
+
 /**
  * Mutate Query instance and add `andPart` to where condition with `and` operator.
  * @return same Query instance which was provided as a receiver.
@@ -219,3 +227,5 @@ fun Query.orWhere(andPart: SqlExpressionBuilder.() -> Op<Boolean>) = adjustWhere
     if (this == null) expr
     else this or expr
 }
+
+fun <T> Query.expression(): QueryExpression<T> = QueryExpression(this)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -10,7 +10,7 @@ import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.Query
 import org.jetbrains.exposed.sql.SqlExpressionBuilder
 import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.expression
+import org.jetbrains.exposed.sql.wrapAsExpression
 
 /**
  * @author max
@@ -56,7 +56,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
 
     open operator fun <T, S : T, E : Expression<S>> set(column: Column<T>, value: E) = update(column, value)
 
-    open operator fun <S> set(column: Column<S>, value: Query) = update(column, value.expression<S>())
+    open operator fun <S> set(column: Column<S>, value: Query) = update(column, wrapAsExpression(value))
 
     open operator fun <S> set(column: CompositeColumn<S>, value: S) {
         column.getRealColumnsWithValues(value).forEach { (realColumn, itsValue) -> set(realColumn as Column<Any?>, itsValue) }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -7,8 +7,10 @@ import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.CompositeColumn
 import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.Query
 import org.jetbrains.exposed.sql.SqlExpressionBuilder
 import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.expression
 
 /**
  * @author max
@@ -53,6 +55,8 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
     }
 
     open operator fun <T, S : T, E : Expression<S>> set(column: Column<T>, value: E) = update(column, value)
+
+    open operator fun <S> set(column: Column<S>, value: Query) = update(column, value.expression<S>())
 
     open operator fun <S> set(column: CompositeColumn<S>, value: S) {
         column.getRealColumnsWithValues(value).forEach { (realColumn, itsValue) -> set(realColumn as Column<Any?>, itsValue) }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -402,7 +402,7 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    fun `test subquery in an insert or update statement`() {
+    @Test fun `test subquery in an insert or update statement`() {
         val tab1 = object : Table("tab1") {
             val id = varchar("id", 10)
         }
@@ -415,15 +415,15 @@ class InsertTests : DatabaseTestsBase() {
             tab2.insert { it[id] = "foo" }
             tab2.insert { it[id] = "bar" }
 
-            // User sub query in an insert
-            tab1.insert { it[id] = tab2.slice(tab2.id).select { tab1.id eq "foo" } }
+            // Use sub query in an insert
+            tab1.insert { it[id] = tab2.slice(tab2.id).select { tab2.id eq "foo" } }
 
             // Check inserted data
             val insertedId = tab1.slice(tab1.id).selectAll().single()[tab1.id]
             assertEquals("foo", insertedId)
 
-            // User sub query in an update
-            tab1.update({ tab1.id eq "foo" }) { it[id] = tab2.slice(tab2.id).select { tab1.id eq "bar" } }
+            // Use sub query in an update
+            tab1.update({ tab1.id eq "foo" }) { it[id] = tab2.slice(tab2.id).select { tab2.id eq "bar" } }
 
             // Check updated data
             val updatedId = tab1.slice(tab1.id).selectAll().single()[tab1.id]

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -402,6 +402,35 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
+    fun `test subquery in an insert or update statement`() {
+        val tab1 = object : Table("tab1") {
+            val id = varchar("id", 10)
+        }
+        val tab2 = object : Table("tab2") {
+            val id = varchar("id", 10)
+        }
+
+        withTables(tab1, tab2) {
+            // Initial data
+            tab2.insert { it[id] = "foo" }
+            tab2.insert { it[id] = "bar" }
+
+            // User sub query in an insert
+            tab1.insert { it[id] = tab2.slice(tab2.id).select { tab1.id eq "foo" } }
+
+            // Check inserted data
+            val insertedId = tab1.slice(tab1.id).selectAll().single()[tab1.id]
+            assertEquals("foo", insertedId)
+
+            // User sub query in an update
+            tab1.update({ tab1.id eq "foo" }) { it[id] = tab2.slice(tab2.id).select { tab1.id eq "bar" } }
+
+            // Check updated data
+            val updatedId = tab1.slice(tab1.id).selectAll().single()[tab1.id]
+            assertEquals("bar", updatedId)
+        }
+    }
+
     /*
     @Test fun testGeneratedKey04() {
         val CharIdTable = object : IdTable<String>("charId") {


### PR DESCRIPTION
Fixes #1327 

Code sample:
````KOTLIN
tab1.insert { it[id] = tab2.slice(tab2.id).select { tab2.id eq "foo" } }
````

### Limitation
Just like `eqSubQuery`, we cannot do a type checking at compile time for this assignement  ( `it[id] = tab2.slice(tab2.id).select { tab1.id eq "foo" }`) as we don't have the return type of the query.