### PR TITLE
Fix counting unions

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Union.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Union.kt
@@ -78,7 +78,7 @@ class Union(
                 append(currentDialect.functionProvider.queryLimit(it, offset, true))
             }
 
-            if (count) append(") as subquery")
+            if (count) append(") subquery")
         }
         return builder.toString()
     }


### PR DESCRIPTION
Counting union results is currently broken on some databases (read oracledb) that don't support the as keyword when aliasing tables (or sub queries).  According to this [SO post](https://stackoverflow.com/questions/20479135/oracle-as-keyword-and-subqueries/20479233#20479233) the SQL 99 ANSI standard does not require the AS keyword when aliasing tables (or sub queries). So removing the as keyword on the union count query should fix this and be compatible with all RDBMS following the standard.