### PR TITLE
Fix bom for gradle projects

### DIFF
--- a/exposed-bom/build.gradle.kts
+++ b/exposed-bom/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
                         if (!artifactId.endsWith("-metadata") &&
                             !artifactId.endsWith("-kotlinMultiplatform")
                         ) {
-                            api(platform(project(":${it.name}")))
+                            api(project(":${it.name}"))
                         }
                     }
                 }


### PR DESCRIPTION
When adding the bom as a gradle platform, like this:

```
implementation(platform("org.jetbrains.exposed:exposed-bom:0.34.1"))
```

Gradle fails with the following error:

```
         > No matching variant of org.jetbrains.exposed:exposed-core:0.34.1 was found. The consumer was configured to find an API of a component compatible with Java 11, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.gradle.category' with value 'platform', attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm', attribute 'javaModule' with value 'true' but:
             - Variant 'apiElements' capability org.jetbrains.exposed:exposed-core:0.34.1 declares an API of a component compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm':
                 - Incompatible because this component declares a component, as well as attribute 'org.gradle.category' with value 'library' and the consumer needed a component, as well as attribute 'org.gradle.category' with value 'platform'
```

This change resolves that error.