### PR TITLE
Allow to define default logger

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -56,10 +56,6 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
     // prepare statement as key and count to execution time as value
     val statementStats = hashMapOf<String, Pair<Int, Long>>()
 
-    init {
-        addLogger(Slf4jSqlDebugLogger)
-    }
-
     override fun commit() {
         globalInterceptors.forEach { it.beforeCommit(this) }
         interceptors.forEach { it.beforeCommit(this) }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -2,8 +2,10 @@ package org.jetbrains.exposed.sql.transactions
 
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Slf4jSqlDebugLogger
 import org.jetbrains.exposed.sql.SqlLogger
 import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.exposedLogger
 import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import org.jetbrains.exposed.sql.statements.api.ExposedSavepoint
@@ -23,6 +25,8 @@ class ThreadLocalTransactionManager(
             return field
         }
 
+    override var defaultLogger: SqlLogger = Slf4jSqlDebugLogger
+
     val threadLocal = ThreadLocal<Transaction>()
 
     override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction =
@@ -37,6 +41,7 @@ class ThreadLocalTransactionManager(
             )
             ).apply {
                 bindTransactionToThread(this)
+                addLogger(defaultLogger)
             }
 
     override fun currentOrNull(): Transaction? = threadLocal.get()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.exposed.sql.transactions
 
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Slf4jSqlDebugLogger
+import org.jetbrains.exposed.sql.SqlLogger
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import java.sql.Connection
@@ -34,6 +36,8 @@ private object NotInitializedManager : TransactionManager {
 
     override var defaultRepetitionAttempts: Int = -1
 
+    override var defaultLogger: SqlLogger = Slf4jSqlDebugLogger
+
     override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction = error("Please call Database.connect() before using this code")
 
     override fun currentOrNull(): Transaction? = error("Please call Database.connect() before using this code")
@@ -48,6 +52,8 @@ interface TransactionManager {
     var defaultIsolationLevel: Int
 
     var defaultRepetitionAttempts: Int
+
+    var defaultLogger: SqlLogger
 
     fun newTransaction(isolation: Int = defaultIsolationLevel, outerTransaction: Transaction? = null): Transaction
 

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.spring
 
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SqlLogger
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.addLogger
@@ -29,6 +30,8 @@ class SpringTransactionManager(
     }
 
     private val db = Database.connect(_dataSource) { this }
+
+    override var defaultLogger: SqlLogger = StdOutSqlLogger
 
     @Volatile override var defaultIsolationLevel: Int = -1
         get() {
@@ -102,7 +105,7 @@ class SpringTransactionManager(
         return Transaction(transactionImpl).apply {
             TransactionSynchronizationManager.bindResource(this@SpringTransactionManager, this)
             if (showSql) {
-                addLogger(StdOutSqlLogger)
+                addLogger(defaultLogger)
             }
         }
     }


### PR DESCRIPTION
Fixes #1330 

The way to use this feature is as following :

````KOTLIN
        val db = Database.connect(...)

        db.transactionManager.defaultLogger = MyLogger()
````

This keeps initially `Slf4jSqlDebugLogger` as the default logger and gives the ability to change it.