### PR TITLE
Make coalesce support multiple arguments

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -300,11 +300,16 @@ class CaseWhenElse<T, R : T>(val caseWhen: CaseWhen<T>, val elseResult: Expressi
 /**
  * Represents an SQL function that returns the first of its arguments that is not null.
  */
-class Coalesce<out T, S : T?, R : T>(
-    private val expr: ExpressionWithColumnType<S>,
-    private val alternate: ExpressionWithColumnType<out T>
-) : Function<R>(alternate.columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("COALESCE(", expr, ", ", alternate, ")") }
+class Coalesce<out T>(
+    private vararg val expressions: ExpressionWithColumnType<T?>,
+) : Function<R>(expressions.first().columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        expressions.toList().appendTo(
+            prefix = "COALESCE(",
+            postfix = ")",
+            separator = ", "
+        ) { +it }
+    }
 }
 
 // Value Expressions


### PR DESCRIPTION
Currently the `coalesce` function does not support multiple arguments. This PR resolves this.