### PR TITLE
IdTable contracts primary key definition

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
@@ -10,6 +10,7 @@ interface EntityIDFactory {
 
 object EntityIDFunctionProvider {
     private val factory: EntityIDFactory
+
     init {
         factory = ServiceLoader.load(EntityIDFactory::class.java, EntityIDFactory::class.java.classLoader).firstOrNull()
             ?: object : EntityIDFactory {
@@ -30,6 +31,7 @@ object EntityIDFunctionProvider {
  */
 abstract class IdTable<T : Comparable<T>>(name: String = "") : Table(name) {
     abstract val id: Column<EntityID<T>>
+    final override val primaryKey by lazy { PrimaryKey(id) }
 }
 
 /**
@@ -40,7 +42,6 @@ abstract class IdTable<T : Comparable<T>>(name: String = "") : Table(name) {
  */
 open class IntIdTable(name: String = "", columnName: String = "id") : IdTable<Int>(name) {
     override val id: Column<EntityID<Int>> = integer(columnName).autoIncrement().entityId()
-    override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
 }
 
 /**
@@ -51,7 +52,6 @@ open class IntIdTable(name: String = "", columnName: String = "id") : IdTable<In
  */
 open class LongIdTable(name: String = "", columnName: String = "id") : IdTable<Long>(name) {
     override val id: Column<EntityID<Long>> = long(columnName).autoIncrement().entityId()
-    override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
 }
 
 /**
@@ -68,5 +68,4 @@ open class UUIDTable(name: String = "", columnName: String = "id") : IdTable<UUI
     override val id: Column<EntityID<UUID>> = uuid(columnName)
         .autoGenerate()
         .entityId()
-    override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
@@ -31,7 +31,8 @@ object EntityIDFunctionProvider {
  */
 abstract class IdTable<T : Comparable<T>>(name: String = "") : Table(name) {
     abstract val id: Column<EntityID<T>>
-    final override val primaryKey by lazy { PrimaryKey(id) }
+    /** this method shoulb be made final */
+    override val primaryKey by lazy { PrimaryKey(id) }
 }
 
 /**

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -438,8 +438,6 @@ class DDLTests : DatabaseTestsBase() {
 
     private abstract class EntityTable(name: String = "") : IdTable<String>(name) {
         override val id: Column<EntityID<String>> = varchar("id", 64).clientDefault { UUID.randomUUID().toString() }.entityId()
-
-        override val primaryKey = PrimaryKey(id)
     }
 
     @Test fun complexTest01() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -46,8 +46,6 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             val name = varchar("name", 255)
             val email = varchar("email", 255).uniqueIndex()
             val camelCased = varchar("camelCased", 255).index()
-
-            override val primaryKey = PrimaryKey(id)
         }
 
         withDb { dbSetting ->
@@ -353,7 +351,6 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         val usersTable = object : IdTable<String>("users") {
             override var id: Column<EntityID<String>> = varchar("id", 190).entityId()
 
-            override val primaryKey = PrimaryKey(id)
         }
         withDb {
             try {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
@@ -19,14 +19,11 @@ class `Table id not in Record Test issue 1341` : DatabaseTestsBase() {
         val second = varchar("second", 50)
 
         override val id = integer("id").autoIncrement().entityId()
-
-        override val primaryKey = PrimaryKey(id)
     }
 
     object AccountsTable : IdTable<Int>("accounts_table") {
         val name = reference("name", NamesTable)
         override val id: Column<EntityID<Int>> = integer("id").autoIncrement().entityId()
-        override val primaryKey = PrimaryKey(id)
     }
 
     class Names(id: EntityID<Int>) : IntEntity(id) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -30,8 +30,6 @@ object EntityTestsData {
 
         val x = bool("x").default(true)
         val blob = blob("content").nullable()
-
-        override val primaryKey = PrimaryKey(id)
     }
 
     object XTable : IntIdTable("XTable") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ImmutableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ImmutableEntityTest.kt
@@ -19,8 +19,6 @@ class ImmutableEntityTest : DatabaseTestsBase() {
             override val id = long("id").autoIncrement().entityId()
             val name = varchar("name", 256)
             val etag = long("etag").default(0)
-
-            override val primaryKey = PrimaryKey(id)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
@@ -20,8 +20,6 @@ object ViaTestData {
     object StringsTable : IdTable<Long>("") {
         override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
         val text = varchar("text", 10)
-
-        override val primaryKey = PrimaryKey(id)
     }
 
     interface IConnectionTable {


### PR DESCRIPTION
IdTable does not serve it purpose: to be full-fledged ID-centered class with primaryKey as a part of a external protocol.