### PR TITLE
#1370 redo datetime/timestamp comparison in tests

### DIFF
--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -6,10 +6,13 @@ import org.jetbrains.exposed.sql.jodatime.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
+import org.jetbrains.exposed.sql.vendors.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
+import org.junit.Assert
 import org.junit.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlin.test.assertEquals
 
 open class JodaTimeBaseTest : DatabaseTestsBase() {
@@ -47,12 +50,8 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
 fun assertEqualDateTime(d1: DateTime?, d2: DateTime?) {
     when {
         d1 == null && d2 == null -> return
-        d1 == null && d2 != null -> error("d1 is null while d2 is not on ${currentDialectTest.name}")
+        d1 == null -> error("d1 is null while d2 is not on ${currentDialectTest.name}")
         d2 == null -> error("d1 is not null while d2 is null on ${currentDialectTest.name}")
-        d1 == null -> error("Impossible")
-        // Mysql doesn't support millis prior 5.6.4
-        (currentDialectTest as? MysqlDialect)?.isFractionDateTimeSupported() == false ->
-            assertEquals(d1.millis / 1000, d2.millis / 1000, "Failed on ${currentDialectTest.name}")
         else -> assertEquals(d1.millis, d2.millis, "Failed on ${currentDialectTest.name}")
     }
 }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -7,11 +7,12 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
-import org.jetbrains.exposed.sql.vendors.DatabaseDialect
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
-import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
-import org.jetbrains.exposed.sql.vendors.SQLiteDialect
+import org.jetbrains.exposed.sql.vendors.*
+import org.junit.Assert.fail
 import org.junit.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.ZoneOffset
 import kotlin.test.assertEquals
 
 open class KotlinTimeBaseTest : DatabaseTestsBase() {
@@ -93,54 +94,52 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
 fun assertEqualDateTime(d1: LocalDateTime?, d2: LocalDateTime?) {
     when {
         d1 == null && d2 == null -> return
-        d1 == null && d2 != null -> error("d1 is null while d2 is not on ${currentDialectTest.name}")
+        d1 == null -> error("d1 is null while d2 is not on ${currentDialectTest.name}")
         d2 == null -> error("d1 is not null while d2 is null on ${currentDialectTest.name}")
-        d1 == null -> error("Impossible")
-        (currentDialectTest as? MysqlDialect)?.isFractionDateTimeSupported() == false ->
-            assertEquals(d1.toInstant(TimeZone.UTC).toEpochMilliseconds() / 1000, d2.toInstant(TimeZone.UTC).toEpochMilliseconds() / 1000, "Failed on ${currentDialectTest.name}")
         else -> {
-            val d1Nanos = currentDialectTest.extractNanos(d1)
-            val d2Nanos = currentDialectTest.extractNanos(d1)
-            assertEquals(d1.second + d1Nanos, d2.second + d2Nanos, "Failed on ${currentDialectTest.name}")
+            assertEquals(d1.toJavaLocalDateTime().toEpochSecond(ZoneOffset.UTC), d2.toJavaLocalDateTime().toEpochSecond(ZoneOffset.UTC), "Failed on epoch seconds ${currentDialectTest.name}")
+            assertEqualFractionalPart(d1.nanosecond, d2.nanosecond)
         }
     }
 }
 
-//fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {
-//    when {
-//        d1 == null && d2 == null -> return
-//        d1 == null && d2 != null -> error("d1 is null while d2 is not on ${currentDialectTest.name}")
-//        d2 == null -> error("d1 is not null while d2 is null on ${currentDialectTest.name}")
-//        d1 == null -> error("Impossible")
-//        d1 is LocalDateTime && d2 is LocalDateTime && (currentDialectTest as? MysqlDialect)?.isFractionDateTimeSupported() == false ->
-//            assertEquals(d1.toInstant(ZoneOffset.UTC).toEpochMilli() / 1000, d2.toInstant(ZoneOffset.UTC).toEpochMilli() / 1000, "Failed on ${currentDialectTest.name}")
-//        d1 is Instant && d2 is Instant && (currentDialectTest as? MysqlDialect)?.isFractionDateTimeSupported() == false ->
-//            assertEquals(d1.toEpochMilli() / 1000, d2.toEpochMilli() / 1000, "Failed on ${currentDialectTest.name}")
-//        d1 is Instant && d2 is Instant -> assertEquals(d1.toEpochMilli(), d2.toEpochMilli(), "Failed on ${currentDialectTest.name}")
-//        d1 is LocalTime && d2 is LocalTime && d2.nano == 0 -> assertEquals<LocalTime>(d1.withNano(0), d2, "Failed on ${currentDialectTest.name}")
-//        d1 is LocalTime && d2 is LocalTime -> assertEquals<LocalTime>(d1, d2, "Failed on ${currentDialectTest.name}")
-//        d1 is LocalDateTime && d2 is LocalDateTime -> {
-//            val d1Nanos = currentDialectTest.extractNanos(d1)
-//            val d2Nanos = currentDialectTest.extractNanos(d1)
-//            assertEquals(d1.second + d1Nanos, d2.second + d2Nanos, "Failed on ${currentDialectTest.name}")
-//        }
-//        else -> assertEquals(d1, d2, "Failed on ${currentDialectTest.name}")
-//    }
-//}
-
-private fun DatabaseDialect.extractNanos(dt: LocalDateTime) = when (this) {
-    is MysqlDialect -> dt.nanosecond.toString().take(6).toInt() // 1000000 ns
-    is SQLiteDialect -> 0
-    is PostgreSQLDialect -> dt.nanosecond.toString().take(1).toInt() // 1 ms
-    else -> dt.nanosecond
+private fun assertEqualFractionalPart(nano1: Int, nano2: Int) {
+    when (currentDialectTest) {
+        // nanoseconds (H2, Oracle & Sqlite could be here)
+        // assertEquals(nano1, nano2, "Failed on nano ${currentDialectTest.name}")
+        // accurate to 100 nanoseconds
+        is SQLServerDialect -> assertEquals(roundTo100Nanos(nano1), roundTo100Nanos(nano2), "Failed on 1/10th microseconds ${currentDialectTest.name}")
+        // microseconds
+        is H2Dialect, is MariaDBDialect, is PostgreSQLDialect, is PostgreSQLNGDialect -> assertEquals(roundToMicro(nano1), roundToMicro(nano2), "Failed on microseconds ${currentDialectTest.name}")
+        is MysqlDialect ->
+            if ((currentDialectTest as? MysqlDialect)?.isFractionDateTimeSupported() == true) {
+                // this should be uncommented, but mysql has different microseconds between save & read
+//                assertEquals(roundToMicro(nano1), roundToMicro(nano2), "Failed on microseconds ${currentDialectTest.name}")
+            } else {
+                // don't compare fractional part
+            }
+        // milliseconds
+        is OracleDialect -> assertEquals(roundToMilli(nano1), roundToMilli(nano2), "Failed on milliseconds ${currentDialectTest.name}")
+        is SQLiteDialect -> assertEquals(floorToMilli(nano1), floorToMilli(nano2), "Failed on milliseconds ${currentDialectTest.name}")
+        else -> fail("Unknown dialect ${currentDialectTest.name}")
+    }
 }
 
-//fun equalDateTime(d1: Temporal?, d2: Temporal?) = try {
-//    assertEqualDateTime(d1, d2)
-//    true
-//} catch (e: Exception) {
-//    false
-//}
+private fun roundTo100Nanos(nanos: Int): Int {
+    return BigDecimal(nanos).divide(BigDecimal(100), RoundingMode.HALF_UP).toInt()
+}
+
+private fun roundToMicro(nanos: Int): Int {
+    return BigDecimal(nanos).divide(BigDecimal(1_000), RoundingMode.HALF_UP).toInt()
+}
+
+private fun roundToMilli(nanos: Int): Int {
+    return BigDecimal(nanos).divide(BigDecimal(1_000_000), RoundingMode.HALF_UP).toInt()
+}
+
+private fun floorToMilli(nanos: Int): Int {
+    return nanos / 1_000_000
+}
 
 val today: LocalDate = now().date
 


### PR DESCRIPTION
Hi - here's my attempt at improving the datetime/timestamp comparison in tests.  
I'm using the precision that Exposed has enabled for each dialect, but a lot of them can go to a higher precision.  See my issue for comments.
There are 2 lines commented out for Mysql.  The comparison seems odd, but this is existing behaviour and the tests aren't comparing the nanoseconds at all for a lot of cases.
I'm also unable to run the suite successfully on my machine (https://github.com/JetBrains/Exposed/issues/1368).

I'm attempting to fix these tests so we can merge the PR https://github.com/JetBrains/Exposed/pull/1223.

Another idea might be to have a variable tied to all dialect, which could be overridden.