### PR TITLE
Remove unnecessary runtime exception and trim sql on long-running query warning

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -158,7 +158,7 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
         }
 
         if (delta > (warnLongQueriesDuration ?: Long.MAX_VALUE)) {
-            exposedLogger.warn("Long query: ${describeStatement(delta, lazySQL.value)}", RuntimeException())
+            exposedLogger.warn("Long query: ${describeStatement(delta, lazySQL.value).trim()}")
         }
 
         return answer.first?.let { stmt.body(it) }


### PR DESCRIPTION
Removing extra white space in the long query warning. Also removed runtime throwable that doesn't give any useful information.