### PR TITLE
Add composite foreign key

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -14,7 +14,7 @@ private val comparator: Comparator<Column<*>> = compareBy({ it.table.tableName }
  * Represents a column.
  */
 class Column<T>(
-    /** Table where the columns is declared. */
+    /** Table where the columns are declared. */
     val table: Table,
     /** Name of the column. */
     val name: String,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -25,7 +25,7 @@ class Column<T>(
 
     /** Returns the column that this column references. */
     val referee: Column<*>?
-        get() = foreignKey?.target
+        get() = foreignKey?.targetOf(this)
 
     /** Returns the column that this column references, casted as a column of type [S], or `null` if the cast fails. */
     @Suppress("UNCHECKED_CAST")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -143,6 +143,8 @@ data class ForeignKeyConstraint(
     operator fun plus(other: ForeignKeyConstraint): ForeignKeyConstraint {
         return copy(references = references + other.references)
     }
+
+    override fun toString() = "ForeignKeyConstraint(fkName='$fkName')"
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -51,30 +51,45 @@ enum class ReferenceOption {
  * Represents a foreign key constraint.
  */
 data class ForeignKeyConstraint(
-    val target: Column<*>,
-    val from: Column<*>,
+    val references: Map<Column<*>, Column<*>>,
     private val onUpdate: ReferenceOption?,
     private val onDelete: ReferenceOption?,
     private val name: String?
 ) : DdlAware {
+    constructor(
+        target: Column<*>,
+        from: Column<*>,
+        onUpdate: ReferenceOption?,
+        onDelete: ReferenceOption?,
+        name: String?
+    ) : this(mapOf(from to target), onUpdate, onDelete, name)
+
     private val tx: Transaction
         get() = TransactionManager.current()
 
-    /** Name of the child table. */
-    val targetTable: String
-        get() = tx.identity(target.table)
+    val target: LinkedHashSet<Column<*>> = LinkedHashSet(references.values)
 
-    /** Name of the foreign key column. */
-    val targetColumn: String
-        get() = tx.identity(target)
+    val targetTable: Table = target.first().table
+
+    /** Name of the child table. */
+    val targetTableName: String
+        get() = tx.identity(targetTable)
+
+    /** Names of the foreign key columns. */
+    private val targetColumns: String
+        get() = target.joinToString { tx.identity(it) }
+
+    val from: LinkedHashSet<Column<*>> = LinkedHashSet(references.keys)
+
+    val fromTable: Table = from.first().table
 
     /** Name of the parent table. */
-    val fromTable: String
-        get() = tx.identity(from.table)
+    val fromTableName: String
+        get() = tx.identity(fromTable)
 
-    /** Name of the key column from the parent table. */
-    val fromColumn
-        get() = tx.identity(from)
+    /** Names of the key columns from the parent table. */
+    private val fromColumns: String
+        get() = from.joinToString { tx.identity(it) }
 
     /** Reference option when performing update operations. */
     val updateRule: ReferenceOption?
@@ -91,27 +106,27 @@ data class ForeignKeyConstraint(
     /** Name of this constraint. */
     val fkName: String
         get() = tx.db.identifierManager.cutIfNecessaryAndQuote(
-            name ?: "fk_${from.table.tableNameWithoutScheme}_${from.name}_${target.name}"
+            name ?: "fk_${fromTable.tableNameWithoutScheme}_${from.joinToString("_") { it.name }}__${target.joinToString("_") { it.name }}"
         ).inProperCase()
     internal val foreignKeyPart: String
         get() = buildString {
             if (fkName.isNotBlank()) {
                 append("CONSTRAINT $fkName ")
             }
-            append("FOREIGN KEY ($fromColumn) REFERENCES $targetTable($targetColumn)")
+            append("FOREIGN KEY ($fromColumns) REFERENCES $targetTableName($targetColumns)")
             if (deleteRule != ReferenceOption.NO_ACTION) {
                 append(" ON DELETE $deleteRule")
             }
             if (updateRule != ReferenceOption.NO_ACTION) {
                 if (currentDialect is OracleDialect) {
-                    exposedLogger.warn("Oracle doesn't support FOREIGN KEY with ON UPDATE clause. Please check your $fromTable table.")
+                    exposedLogger.warn("Oracle doesn't support FOREIGN KEY with ON UPDATE clause. Please check your $fromTableName table.")
                 } else {
                     append(" ON UPDATE $updateRule")
                 }
             }
         }
 
-    override fun createStatement(): List<String> = listOf("ALTER TABLE $fromTable ADD $foreignKeyPart")
+    override fun createStatement(): List<String> = listOf("ALTER TABLE $fromTableName ADD $foreignKeyPart")
 
     override fun modifyStatement(): List<String> = dropStatement() + createStatement()
 
@@ -120,7 +135,13 @@ data class ForeignKeyConstraint(
             is MysqlDialect -> "FOREIGN KEY"
             else -> "CONSTRAINT"
         }
-        return listOf("ALTER TABLE $fromTable DROP $constraintType $fkName")
+        return listOf("ALTER TABLE $fromTableName DROP $constraintType $fkName")
+    }
+
+    fun targetOf(from: Column<*>): Column<*>? = references[from]
+
+    operator fun plus(other: ForeignKeyConstraint): ForeignKeyConstraint {
+        return copy(references = references + other.references)
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -128,14 +128,16 @@ object SchemaUtils {
         return createFKey(foreignKey)
     }
 
-    fun createFKey(foreignKey: ForeignKeyConstraint): List<String> {
-        val allFromColumnsBelongsToTheSameTable = foreignKey.from.all { it.table == foreignKey.fromTable }
-        require(allFromColumnsBelongsToTheSameTable) { "not all referencing columns of $foreignKey belong to the same table " }
-        val allTargetColumnsBelongToTheSameTable = foreignKey.target.all { it.table == foreignKey.targetTable }
-        require(allTargetColumnsBelongToTheSameTable) { "not all referenced columns of $foreignKey belong to the same table " }
-        require(foreignKey.from.size == foreignKey.target.size) { "$foreignKey referencing columns are not in accordance with referenced" }
-        require(foreignKey.deleteRule != null || foreignKey.updateRule != null) { "$foreignKey has no reference constraint actions" }
-        return foreignKey.createStatement()
+    fun createFKey(foreignKey: ForeignKeyConstraint): List<String> = with(foreignKey) {
+        val allFromColumnsBelongsToTheSameTable = from.all { it.table == fromTable }
+        require(allFromColumnsBelongsToTheSameTable) { "not all referencing columns of $foreignKey belong to the same table" }
+        val allTargetColumnsBelongToTheSameTable = target.all { it.table == targetTable }
+        require(allTargetColumnsBelongToTheSameTable) { "not all referenced columns of $foreignKey belong to the same table" }
+        require(from.size == target.size) { "$foreignKey referencing columns are not in accordance with referenced" }
+        require(deleteRule != null || updateRule != null) { "$foreignKey has no reference constraint actions" }
+        require(target.toHashSet().size == target.size) { "not all referenced columns of $foreignKey are unique" }
+
+        return createStatement()
     }
 
     fun createIndex(index: Index) = index.createStatement()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -117,9 +117,13 @@ object SchemaUtils {
         }
     }
 
-    fun createFKey(reference: Column<*>): List<String> {
-        val foreignKey = reference.foreignKey
-        require(foreignKey != null && (foreignKey.deleteRule != null || foreignKey.updateRule != null)) { "$reference does not reference anything" }
+    fun createFKey(foreignKey: ForeignKeyConstraint): List<String> {
+        val allFromColumnsBelongsToTheSameTable = foreignKey.from.all { it.table == foreignKey.fromTable }
+        require(allFromColumnsBelongsToTheSameTable) { "not all referencing columns of $foreignKey belong to the same table " }
+        val allTargetColumnsBelongToTheSameTable = foreignKey.target.all { it.table == foreignKey.targetTable }
+        require(allTargetColumnsBelongToTheSameTable) { "not all referenced columns of $foreignKey belong to the same table " }
+        require(foreignKey.from.size == foreignKey.target.size) { "$foreignKey referencing columns are not in accordance with referenced" }
+        require(foreignKey.deleteRule != null || foreignKey.updateRule != null) { "$foreignKey has no reference constraint actions" }
         return foreignKey.createStatement()
     }
 
@@ -204,19 +208,16 @@ object SchemaUtils {
                 }
 
                 for (table in tables) {
-                    for (column in table.columns) {
-                        val foreignKey = column.foreignKey
-                        if (foreignKey != null) {
-                            val existingConstraint = existingColumnConstraint[table to column]?.firstOrNull()
-                            if (existingConstraint == null) {
-                                statements.addAll(createFKey(column))
-                            } else if (existingConstraint.targetTable != foreignKey.targetTable ||
-                                foreignKey.deleteRule != existingConstraint.deleteRule ||
-                                foreignKey.updateRule != existingConstraint.updateRule
-                            ) {
-                                statements.addAll(existingConstraint.dropStatement())
-                                statements.addAll(createFKey(column))
-                            }
+                    for (foreignKey in table.foreignKeys) {
+                        val existingConstraint = existingColumnConstraint[table to foreignKey.from]?.firstOrNull()
+                        if (existingConstraint == null) {
+                            statements.addAll(createFKey(foreignKey))
+                        } else if (existingConstraint.targetTable != foreignKey.targetTable ||
+                            foreignKey.deleteRule != existingConstraint.deleteRule ||
+                            foreignKey.updateRule != existingConstraint.updateRule
+                        ) {
+                            statements.addAll(existingConstraint.dropStatement())
+                            statements.addAll(createFKey(foreignKey))
                         }
                     }
                 }
@@ -397,7 +398,7 @@ object SchemaUtils {
         val fKeyConstraints = currentDialect.columnConstraints(*tables).keys
         val existingIndices = currentDialect.existingIndices(*tables)
         fun List<Index>.filterFKeys() = if (isMysql) {
-            filterNot { it.table to it.columns.singleOrNull() in fKeyConstraints }
+            filterNot { it.table to LinkedHashSet(it.columns) in fKeyConstraints }
         } else {
             this
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -210,7 +210,7 @@ object SchemaUtils {
                             val existingConstraint = existingColumnConstraint[table to column]?.firstOrNull()
                             if (existingConstraint == null) {
                                 statements.addAll(createFKey(column))
-                            } else if (existingConstraint.target.table != foreignKey.target.table ||
+                            } else if (existingConstraint.targetTable != foreignKey.targetTable ||
                                 foreignKey.deleteRule != existingConstraint.deleteRule ||
                                 foreignKey.updateRule != existingConstraint.updateRule
                             ) {
@@ -352,7 +352,7 @@ object SchemaUtils {
                 val constraint = fk.first()
                 val fkPartToLog = fk.joinToString(", ") { it.fkName }
                 exposedLogger.warn(
-                    "\t\t\t'${pair.first}'.'${pair.second}' -> '${constraint.fromTable}'.'${constraint.fromColumn}':\t$fkPartToLog"
+                    "\t\t\t'${pair.first}'.'${pair.second}' -> '${constraint.fromTableName}':\t$fkPartToLog"
                 )
             }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -117,6 +117,17 @@ object SchemaUtils {
         }
     }
 
+    @Deprecated(
+        "Will be removed in upcoming releases. Please use overloaded version instead",
+        ReplaceWith("createFKey(checkNotNull(reference.foreignKey) { \"${"$"}reference does not reference anything\" })"),
+        DeprecationLevel.WARNING
+    )
+    fun createFKey(reference: Column<*>): List<String> {
+        val foreignKey = reference.foreignKey
+        require(foreignKey != null && (foreignKey.deleteRule != null || foreignKey.updateRule != null)) { "$reference does not reference anything" }
+        return createFKey(foreignKey)
+    }
+
     fun createFKey(foreignKey: ForeignKeyConstraint): List<String> {
         val allFromColumnsBelongsToTheSameTable = foreignKey.from.all { it.table == foreignKey.fromTable }
         require(allFromColumnsBelongsToTheSameTable) { "not all referencing columns of $foreignKey belong to the same table " }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -823,7 +823,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         onDelete: ReferenceOption? = null,
         onUpdate: ReferenceOption? = null,
         fkName: String? = null
-    ): Column<T?> = Column<T>(this, name, refColumn.columnType.cloneAsBaseType()).references(refColumn, onDelete, onUpdate, fkName).nullable()
+    ): Column<T?> = reference(name, refColumn, onDelete, onUpdate, fkName).nullable()
 
     /**
      * Creates a column with the specified [name] with an optional reference to the [refColumn] column with [onDelete], [onUpdate], and [fkName] options.
@@ -846,10 +846,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         onDelete: ReferenceOption? = null,
         onUpdate: ReferenceOption? = null,
         fkName: String? = null
-    ): Column<E?> {
-        val entityIdColumn = entityId(name, (refColumn.columnType as EntityIDColumnType<T>).idColumn) as Column<E>
-        return entityIdColumn.references(refColumn, onDelete, onUpdate, fkName).nullable()
-    }
+    ): Column<E?> = reference(name, refColumn, onDelete, onUpdate, fkName).nullable()
 
     /**
      * Creates a column with the specified [name] with an optional reference to the `id` column in [foreign] table with [onDelete], [onUpdate], and [fkName] options.
@@ -870,7 +867,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         onDelete: ReferenceOption? = null,
         onUpdate: ReferenceOption? = null,
         fkName: String? = null
-    ): Column<EntityID<T>?> = entityId(name, foreign).references(foreign.id, onDelete, onUpdate, fkName).nullable()
+    ): Column<EntityID<T>?> = reference(name, foreign, onDelete, onUpdate, fkName).nullable()
 
     // Miscellaneous
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -957,6 +957,10 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         onDelete: ReferenceOption? = null,
         name: String? = null
     ) {
+        require(from.size == target.columns.size) {
+            val fkName = if (name != null) " ($name)" else ""
+            "Foreign key$fkName has ${from.size} columns, while referenced primary key (${target.name}) has ${target.columns.size}"
+        }
         _foreignKeys.add(ForeignKeyConstraint(from.zip(target.columns).toMap(), onUpdate, onDelete, name))
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -709,7 +709,9 @@ abstract class VendorDialect(
         fillConstraintCacheForTables(tablesToLoad)
         tables.forEach { table ->
             columnConstraintsCache[table.nameInDatabaseCase()].orEmpty().forEach {
-                constraints.getOrPut(it.from.table to it.from) { arrayListOf() }.add(it)
+                it.from.forEach { fromColumn ->
+                    constraints.getOrPut(table to fromColumn) { arrayListOf() }.add(it)
+                }
             }
         }
         return constraints

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -6,6 +6,8 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.nio.ByteBuffer
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.collections.HashMap
+import kotlin.collections.LinkedHashSet
 
 /**
  * Provides definitions for all the supported SQL data types.
@@ -578,8 +580,8 @@ interface DatabaseDialect {
     /** Returns a map with the column metadata of all the defined columns in each of the specified [tables]. */
     fun tableColumns(vararg tables: Table): Map<Table, List<ColumnMetadata>> = emptyMap()
 
-    /** Returns a map with the foreign key constraints of all the defined columns in each of the specified [tables]. */
-    fun columnConstraints(vararg tables: Table): Map<Pair<Table, Column<*>>, List<ForeignKeyConstraint>> = emptyMap()
+    /** Returns a map with the foreign key constraints of all the defined columns sets in each of the specified [tables]. */
+    fun columnConstraints(vararg tables: Table): Map<Pair<Table, LinkedHashSet<Column<*>>>, List<ForeignKeyConstraint>> = emptyMap()
 
     /** Returns a map with all the defined indices in each of the specified [tables]. */
     fun existingIndices(vararg tables: Table): Map<Table, List<Index>> = emptyMap()
@@ -701,17 +703,15 @@ abstract class VendorDialect(
     override fun tableColumns(vararg tables: Table): Map<Table, List<ColumnMetadata>> =
         TransactionManager.current().connection.metadata { columns(*tables) }
 
-    override fun columnConstraints(vararg tables: Table): Map<Pair<Table, Column<*>>, List<ForeignKeyConstraint>> {
-        val constraints = HashMap<Pair<Table, Column<*>>, MutableList<ForeignKeyConstraint>>()
+    override fun columnConstraints(vararg tables: Table): Map<Pair<Table, LinkedHashSet<Column<*>>>, List<ForeignKeyConstraint>> {
+        val constraints = HashMap<Pair<Table, LinkedHashSet<Column<*>>>, MutableList<ForeignKeyConstraint>>()
 
         val tablesToLoad = tables.filter { !columnConstraintsCache.containsKey(it.nameInDatabaseCase()) }
 
         fillConstraintCacheForTables(tablesToLoad)
         tables.forEach { table ->
             columnConstraintsCache[table.nameInDatabaseCase()].orEmpty().forEach {
-                it.from.forEach { fromColumn ->
-                    constraints.getOrPut(table to fromColumn) { arrayListOf() }.add(it)
-                }
+                constraints.getOrPut(table to it.from) { arrayListOf() }.add(it)
             }
         }
         return constraints

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -727,7 +727,7 @@ abstract class VendorDialect(
     protected fun String.quoteIdentifierWhenWrongCaseOrNecessary(tr: Transaction): String =
         tr.db.identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(this)
 
-    protected val columnConstraintsCache: MutableMap<String, List<ForeignKeyConstraint>> = ConcurrentHashMap()
+    protected val columnConstraintsCache: MutableMap<String, Collection<ForeignKeyConstraint>> = ConcurrentHashMap()
 
     protected open fun fillConstraintCacheForTables(tables: List<Table>): Unit =
         columnConstraintsCache.putAll(TransactionManager.current().db.metadata { tableConstraints(tables) })

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -241,7 +241,11 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                     onDelete = constraintDeleteRule,
                     name = constraintName
                 )
-            }.filterNotNull()
+            }
+                .filterNotNull()
+                .groupBy { it.fkName }
+                .values
+                .map { it.reduce(ForeignKeyConstraint::plus) }
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -752,4 +752,146 @@ class DDLTests : DatabaseTestsBase() {
     object TableFromSchemeTwo : IntIdTable("two.test") {
         val reference = reference("testOne", TableFromSchemeOne)
     }
+
+    @Test
+    fun testCompositeFKReferencingUniqueIndex() {
+        val TableA = object : Table("TableA") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+
+            init {
+                uniqueIndex(idA, idB)
+            }
+        }
+
+        val TableB = object : Table("TableB") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            val idC = integer("id_c")
+            override val primaryKey = PrimaryKey(idA, idB, idC)
+
+            init {
+                foreignKey(idA to TableA.idA, idB to TableA.idB)
+            }
+        }
+
+        withTables(excludeSettings = listOf(TestDB.SQLITE), TableA, TableB) {
+            TableA.insert {
+                it[idA] = 1
+                it[idB] = 2
+            }
+
+            TableB.insert {
+                it[idA] = 1
+                it[idB] = 2
+                it[idC] = 3
+            }
+
+            assertFailAndRollback("check violation composite foreign key constraint (insert key into child table not present in parent table)") {
+                TableB.insert {
+                    it[idA] = 1
+                    it[idB] = 1
+                    it[idC] = 3
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testCompositeFKReferencingPrimaryKey() {
+        val TableA = object : Table("TableA") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            override val primaryKey = PrimaryKey(idA, idB)
+        }
+
+        val TableB = object : Table("TableB") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            val idC = integer("id_c")
+            override val primaryKey = PrimaryKey(idA, idB, idC)
+
+            init {
+                foreignKey(idA, idB, target = TableA.primaryKey)
+            }
+        }
+
+        withTables(excludeSettings = listOf(TestDB.SQLITE), TableA, TableB) {
+            TableA.insert {
+                it[idA] = 1
+                it[idB] = 2
+            }
+
+            TableB.insert {
+                it[idA] = 1
+                it[idB] = 2
+                it[idC] = 3
+            }
+
+            assertFailAndRollback("check violation composite foreign key constraint (insert key into child table not present in parent table)") {
+                TableB.insert {
+                    it[idA] = 1
+                    it[idB] = 1
+                    it[idC] = 3
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testMultipleFK() {
+        val TableA = object : Table("TableA") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            override val primaryKey = PrimaryKey(idA, idB)
+        }
+
+        val TableC = object : Table("TableC") {
+            val idC = integer("id_c").uniqueIndex()
+        }
+
+        val TableB = object : Table("TableB") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            val idC = integer("id_c") references TableC.idC
+            override val primaryKey = PrimaryKey(idA, idB, idC)
+
+            init {
+                foreignKey(idA, idB, target = TableA.primaryKey)
+            }
+        }
+
+        withTables(excludeSettings = listOf(TestDB.SQLITE), TableA, TableB, TableC) {
+            TableA.insert {
+                it[idA] = 1
+                it[idB] = 2
+            }
+
+            TableC.insert {
+                it[idC] = 3
+            }
+
+            TableB.insert {
+                it[idA] = 1
+                it[idB] = 2
+                it[idC] = 3
+            }
+
+            assertFailAndRollback("check violation composite foreign key constraint (insert key into child table not present in parent table)") {
+                TableB.insert {
+                    it[idA] = 1
+                    it[idB] = 1
+                    it[idC] = 3
+                }
+            }
+
+            assertFailAndRollback("check violation foreign key constraint (insert key into child table not present in parent table)") {
+                TableB.insert {
+                    it[idA] = 1
+                    it[idB] = 2
+                    it[idC] = 1
+                }
+            }
+        }
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -497,4 +497,27 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             }
         }
     }
+
+    object CompositePrimaryKeyTable : Table("H2_COMPOSITE_PRIMARY_KEY") {
+        val idA = varchar("id_a", 255)
+        val idB = varchar("id_b", 255)
+        override val primaryKey = PrimaryKey(idA, idB)
+    }
+
+    object CompositeForeignKeyTable : Table("H2_COMPOSITE_FOREIGN_KEY") {
+        val idA = varchar("id_a", 255)
+        val idB = varchar("id_b", 255)
+
+        init {
+            foreignKey(idA, idB, target = CompositePrimaryKeyTable.primaryKey)
+        }
+    }
+
+    @Test
+    fun testCreateCompositePrimaryKeyTableAndCompositeForeignKeyTableMultipleTimes() {
+        withTables(CompositePrimaryKeyTable, CompositeForeignKeyTable) {
+            SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+        }
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -434,7 +434,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testCreateTableWithReferenceMutipleTimes() {
+    @Test fun testCreateTableWithReferenceMultipleTimes() {
         withTables(PlayerTable, SessionsTable) {
             SchemaUtils.createMissingTablesAndColumns(PlayerTable, SessionsTable)
             SchemaUtils.createMissingTablesAndColumns(PlayerTable, SessionsTable)

--- a/spring-transaction/src/test/kotlin/org.jetbrains.exposed.spring/SpringCoroutineTest.kt
+++ b/spring-transaction/src/test/kotlin/org.jetbrains.exposed.spring/SpringCoroutineTest.kt
@@ -26,6 +26,7 @@ open class SpringCoroutineTest : SpringTransactionTestBase() {
 
     @RepeatableTest(times = 5)
     @Test @Transactional @Commit
+    // Is this test flaky?
     open fun testNestedCoroutineTransaction() {
         try {
             SchemaUtils.create(Testing)


### PR DESCRIPTION
This PR closes #511 (and its duplicate #1234).

From the DSL point of view, there was added a new method for the `Table` class (`foreignKey`), supposed to be called in `init`
block.

It has two overloads, allowing two ways for defining composite foreign keys:
1. listing pairs of the column to column references (set of referenced columns must form an explicit unique constraint)
2. listing columns set referencing primary key:

```
val TableC = object : Table("TableB") {
    val idA1 = integer("id_a1")
    val idA2 = integer("id_a2")
    val idB1 = integer("id_b1")
    val idB2 = integer("id_b2")

    init {
        foreignKey(idA1 to TableA.idA1, idA2 to TableA.idA2)
        foreignKey(idB1, idB2, target = TableB.primaryKey) // foreignKey(idB1 to TableB.idB1, idB2 to TableB.idB2) is also possible
    }
}

val TableA = object : Table("TableA") {
    val idA1 = integer("id_a1")
    val idA2 = integer("id_a2")

    init {
        uniqueIndex(idA1, idA2)
    }
}
val TableB = object : Table("TableB") {
    val idB1 = integer("id_b1")
    val idB2 = integer("id_b2")
    override val primaryKey = PrimaryKey(idB1, idB2)
}
```