### PR TITLE
Use getOrDefault instead of getValue in currentThreadManager

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -89,7 +89,7 @@ interface TransactionManager {
 
         internal val currentThreadManager = object : ThreadLocal<TransactionManager>() {
             override fun initialValue(): TransactionManager {
-                return defaultDatabase?.let { registeredDatabases.getValue(it) } ?: NotInitializedManager
+                return defaultDatabase?.let { registeredDatabases.getOrDefault(it, null) } ?: NotInitializedManager
             }
         }
 


### PR DESCRIPTION
Attempts to fix #1387.

I was unsure where to put the test since the `CoroutineTest` file didn't have a `Database` available.
Shall I put the test inside the `H2Tests` file?