### PR TITLE
Store client default value on first access

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -168,7 +168,8 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
     @Suppress("UNCHECKED_CAST", "USELESS_CAST")
     fun <T> Column<T>.lookup(): T = when {
         writeValues.containsKey(this as Column<out Any?>) -> writeValues[this as Column<out Any?>] as T
-        id._value == null && _readValues?.hasValue(this)?.not() ?: true -> defaultValueFun?.invoke() as T
+        id._value == null && _readValues?.hasValue(this)?.not() ?: true -> defaultValueFun?.invoke()
+            .also { writeValues[this as Column<Any?>] = it } as T
         columnType.nullable -> readValues[this]
         else -> readValues[this]!!
     }


### PR DESCRIPTION
For columns with `defaultValueFun`, `defaultValueFun` gets invoked on every value access until the entity being flushed to DB. This is problematic for non-deterministic `defaultValueFun` such as random key generation, since it returns different value for each access.

We can just store generated default value on first value access.