### PR TITLE
use TRANSACTION_READ_COMMITTED transaction level for sqlserver dialect

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -211,6 +211,7 @@ class Database private constructor(
                 is SQLiteDialect -> Connection.TRANSACTION_SERIALIZABLE
                 is OracleDialect -> Connection.TRANSACTION_READ_COMMITTED
                 is PostgreSQLDialect -> Connection.TRANSACTION_READ_COMMITTED
+                is SQLServerDialect -> Connection.TRANSACTION_READ_COMMITTED
                 else -> DEFAULT_ISOLATION_LEVEL
             }
 


### PR DESCRIPTION
Solution for #1406

After checking the latest changes, I see that `getDefaultIsolationLevel` is deprecated. We are using version `0.32.1` where `DatabaseConfig` was not implemented (: