### PR TITLE
Allow to pass DatabaseConfig in SpringTransactionManager

### DIFF
--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
@@ -2,8 +2,10 @@ package org.jetbrains.exposed.spring.autoconfigure
 
 import org.jetbrains.exposed.spring.DatabaseInitializer
 import org.jetbrains.exposed.spring.SpringTransactionManager
+import org.jetbrains.exposed.sql.DatabaseConfig
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.context.ApplicationContext
@@ -24,7 +26,18 @@ open class ExposedAutoConfiguration(private val applicationContext: ApplicationC
     private var showSql: Boolean = false
 
     @Bean
-    open fun springTransactionManager(datasource: DataSource) = SpringTransactionManager(datasource, showSql)
+    open fun springTransactionManager(datasource: DataSource, databaseConfig: DatabaseConfig): SpringTransactionManager {
+        return SpringTransactionManager(datasource, databaseConfig, showSql)
+    }
+
+    /**
+     * Database config with default values
+     */
+    @Bean
+    @ConditionalOnMissingBean(DatabaseConfig::class)
+    open fun databaseConfig(): DatabaseConfig {
+        return DatabaseConfig {  }
+    }
 
     @Bean
     @ConditionalOnProperty("spring.exposed.generate-ddl", havingValue = "true", matchIfMissing = false)

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.spring
 
 import org.jetbrains.exposed.sql.DEFAULT_REPETITION_ATTEMPTS
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.addLogger
@@ -21,6 +22,7 @@ import javax.sql.DataSource
 
 class SpringTransactionManager(
     _dataSource: DataSource,
+    databaseConfig: DatabaseConfig,
     private val showSql: Boolean = false,
     @Volatile override var defaultRepetitionAttempts: Int = DEFAULT_REPETITION_ATTEMPTS
 ) : DataSourceTransactionManager(_dataSource), TransactionManager {
@@ -29,7 +31,10 @@ class SpringTransactionManager(
         this.isRollbackOnCommitFailure = true
     }
 
-    private val db = Database.connect(_dataSource) { this }
+    private val db = Database.connect(
+        datasource = _dataSource,
+        databaseConfig = databaseConfig
+    ) { this }
 
     @Volatile override var defaultIsolationLevel: Int = -1
         get() {

--- a/spring-transaction/src/test/kotlin/org.jetbrains.exposed.spring/SpringTransactionTestBase.kt
+++ b/spring-transaction/src/test/kotlin/org.jetbrains.exposed.spring/SpringTransactionTestBase.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.spring
 
+import org.jetbrains.exposed.sql.DatabaseConfig
 import org.junit.FixMethodOrder
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
@@ -25,7 +26,7 @@ open class TestConfig : TransactionManagementConfigurer {
     open fun ds(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName("embeddedTest").setType(EmbeddedDatabaseType.H2).build()
 
     @Bean
-    override fun annotationDrivenTransactionManager(): PlatformTransactionManager? = SpringTransactionManager(ds())
+    override fun annotationDrivenTransactionManager(): PlatformTransactionManager = SpringTransactionManager(ds(), DatabaseConfig {})
 
     @Bean
     open fun service(): Service = Service()


### PR DESCRIPTION
SpringTransactionManager does not allow to pass DatabaseConfig inside.