### PR TITLE
Fix check constraint-2

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -168,8 +168,8 @@ interface ISqlExpressionBuilder {
     infix fun <T> ExpressionWithColumnType<T>.neq(other: T): Op<Boolean> = if (other == null) isNotNull() else NeqOp(this, wrap(other))
 
     /** Checks if this expression is not equals to some [other] expression. */
-    infix fun <T, S1 : T?, S2 : T?> Expression<in S1>.neq(other: Expression<in S2>): Op<Boolean> = when {
-        other.equals(Op.NULL) -> isNotNull()
+    infix fun <T, S1 : T?, S2 : T?> Expression<in S1>.neq(other: Expression<in S2>): Op<Boolean> = when (other as Expression<*>) {
+        is Op.NULL -> isNotNull()
         else -> NeqOp(this, other)
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -27,7 +27,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
     }
 
     open operator fun <S> set(column: Column<S>, value: S) {
-        require(column.columnType.nullable || (value != null && value != Op.NULL)) {
+        require(column.columnType.nullable || (value != null && value !is Op.NULL)) {
             "Trying to set null to not nullable column $column"
         }
 
@@ -43,7 +43,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
 
     @JvmName("setWithEntityIdExpression")
     operator fun <S : Any?, ID : EntityID<S>, E : Expression<S>> set(column: Column<ID>, value: E) {
-        require(column.columnType.nullable || value != Op.NULL) {
+        require(column.columnType.nullable || value !is Op.NULL) {
             "Trying to set null to not nullable column $column"
         }
         checkThatExpressionWasNotSetInPreviousBatch(column)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -699,6 +699,19 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testCheckConstraint04() {
+        object : Table("test") {
+            val testColumn: Column<Int?> = integer("test_column").nullable()
+
+            init {
+                check("test_constraint") {
+                    testColumn.isNotNull() neq Op.TRUE
+                }
+            }
+        }
+    }
+
     internal enum class Foo { Bar, Baz }
 
     class PGEnum<T : Enum<T>>(enumTypeName: String, enumValue: T?) : PGobject() {


### PR DESCRIPTION
As @m-burst mentioned in https://github.com/JetBrains/Exposed/pull/1417 conversation, the same problem could arise in another place. This PR fixes it in the same manner as https://github.com/JetBrains/Exposed/pull/1417.

Also, it applies the same fix in `UpdateBuilder` class for checks that the value which is set to non-nullable column is not null. Although these checks are done in methods, which are intended to be called inside a transaction (so it's shouldn't lead to `IllegalStateException` in runtime), this fix still makes sense from the performance point of view (type check should be faster than `equals` method call)