### PR TITLE
Fix method resolution ambiguity when passing null to eq/neq methods

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -154,10 +154,7 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is equals to some [t] value. */
-    infix fun <T : Comparable<T>, E : EntityID<T>?> ExpressionWithColumnType<E>.eq(t: T?): Op<Boolean> {
-        if (t == null) {
-            return isNull()
-        }
+    infix fun <T : Comparable<T>, E : EntityID<T>?> ExpressionWithColumnType<E>.eq(t: T): Op<Boolean> {
         @Suppress("UNCHECKED_CAST")
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
@@ -174,7 +171,12 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is not equals to some [t] value. */
-    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.neq(t: T?): Op<Boolean> = if (t == null) isNotNull() else NeqOp(this, wrap(t))
+    infix fun <T : Comparable<T>, E : EntityID<T>?> ExpressionWithColumnType<E>.neq(t: T): Op<Boolean> {
+        @Suppress("UNCHECKED_CAST")
+        val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
+        val entityID = EntityID(t, table)
+        return NeqOp(this, wrap(entityID))
+    }
 
     /** Checks if this expression is less than some [t] value. */
     infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.less(t: T): LessOp = LessOp(this, wrap(t))

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
@@ -81,11 +81,17 @@ class ConditionsTests : DatabaseTestsBase() {
             users.update {
                 it[users.cityId] = Op.nullOp()
             }
+            users.update {
+                it[users.cityId] = null
+            }
             val nullUsers1 = users.select { users.cityId.isNull() }.count()
             assertEquals(allUsers, nullUsers1)
 
             val nullUsers2 = users.select { users.cityId eq Op.nullOp() }.count()
             assertEquals(allUsers, nullUsers2)
+
+            val nullUsers3 = users.select { users.cityId eq null }.count()
+            assertEquals(allUsers, nullUsers3)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -233,9 +233,10 @@ class SelectTests : DatabaseTestsBase() {
             secondTable.insert { }
 
             assertEquals(2L, secondTable.selectAll().count())
-            val secondEntries = secondTable.select { secondTable.firstOpt eq firstId.value }.toList()
-
-            assertEquals(1, secondEntries.size)
+            assertEquals(1, secondTable.select { secondTable.firstOpt eq firstId.value }.toList().size)
+            assertEquals(0, secondTable.select { secondTable.firstOpt neq firstId.value }.toList().size)
+            assertEquals(1, secondTable.select { secondTable.firstOpt eq null }.count())
+            assertEquals(1, secondTable.select { secondTable.firstOpt neq null }.count())
         }
     }
 


### PR DESCRIPTION
This PR fixes https://github.com/JetBrains/Exposed/issues/1437 by making `fun <T : Comparable<T>, E : EntityID<T>?> ExpressionWithColumnType<E>.eq(t: T`~?~`)` overload accept only non-nullable arguments. Passing `null` to receivers of this type will be resolved to more general overload `<T> ExpressionWithColumnType<T>.eq(t: T)` having the same logic for processing of this value.
Also, this PR fixes the same problem for `neq` method and unifies their API and implementation.