### PR TITLE
Fix `ResultRow` creation

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
@@ -88,7 +88,8 @@ class ResultRow(
         fun create(rs: ResultSet, fieldsIndex: Map<Expression<*>, Int>): ResultRow {
             return ResultRow(fieldsIndex).apply {
                 fieldsIndex.forEach { (field, index) ->
-                    val value = (field as? Column<*>)?.columnType?.readObject(rs, index + 1) ?: rs.getObject(index + 1)
+                    val columnType = (field as? Column<*>)?.columnType
+                    val value = if (columnType != null) columnType.readObject(rs, index + 1) else rs.getObject(index + 1)
                     data[index] = value
                 }
             }


### PR DESCRIPTION
This PR not only fixes https://github.com/JetBrains/Exposed/issues/1435 (which is a rather specific use-case) but also improves performance of the `ResultRow.create` method if some fields of `ResultSet` are `NULL`.