### PR TITLE
Improve initialization performance

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -123,6 +123,21 @@ class Column<T>(
         }
     }
 
+
+    /**
+     * Returns a copy of this column, but with the given column type.
+     */
+    fun withColumnType(columnType: IColumnType) = Column<T>(
+        table = this.table,
+        name = this.name,
+        columnType = columnType
+    ).also{
+        it.foreignKey = this.foreignKey
+        it.defaultValueFun = this.defaultValueFun
+        it.dbDefaultValue = this.dbDefaultValue
+    }
+
+
     override fun compareTo(other: Column<*>): Int = comparator.compare(this, other)
 
     override fun equals(other: Any?): Boolean {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1034,7 +1034,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     private fun <T> Column<T>.cloneWithAutoInc(idSeqName: String?): Column<T> = when (columnType) {
         is AutoIncColumnType -> this
         is ColumnType -> {
-            this@cloneWithAutoInc.clone(mapOf(Column<T>::columnType to AutoIncColumnType(columnType, idSeqName, "${tableName}_${name}_seq")))
+            this.withColumnType(AutoIncColumnType(columnType, idSeqName, "${tableName}_${name}_seq"))
         }
         else -> error("Unsupported column type for auto-increment $columnType")
     }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/IntEntity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/IntEntity.kt
@@ -5,4 +5,8 @@ import org.jetbrains.exposed.dao.id.IdTable
 
 abstract class IntEntity(id: EntityID<Int>) : Entity<Int>(id)
 
-abstract class IntEntityClass<out E : IntEntity>(table: IdTable<Int>, entityType: Class<E>? = null) : EntityClass<Int, E>(table, entityType)
+abstract class IntEntityClass<out E : IntEntity> constructor(
+    table: IdTable<Int>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<Int>) -> E)? = null
+) : EntityClass<Int, E>(table, entityType, entityCtor)

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/LongEntity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/LongEntity.kt
@@ -5,4 +5,8 @@ import org.jetbrains.exposed.dao.id.IdTable
 
 abstract class LongEntity(id: EntityID<Long>) : Entity<Long>(id)
 
-abstract class LongEntityClass<out E : LongEntity>(table: IdTable<Long>, entityType: Class<E>? = null) : EntityClass<Long, E>(table, entityType)
+abstract class LongEntityClass<out E : LongEntity>(
+    table: IdTable<Long>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<Long>) -> E)? = null
+) : EntityClass<Long, E>(table, entityType, entityCtor)

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/UUIDEntity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/UUIDEntity.kt
@@ -6,4 +6,8 @@ import java.util.*
 
 abstract class UUIDEntity(id: EntityID<UUID>) : Entity<UUID>(id)
 
-abstract class UUIDEntityClass<out E : UUIDEntity>(table: IdTable<UUID>, entityType: Class<E>? = null) : EntityClass<UUID, E>(table, entityType)
+abstract class UUIDEntityClass<out E : UUIDEntity>(
+    table: IdTable<UUID>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<UUID>) -> E)? = null
+) : EntityClass<UUID, E>(table, entityType, entityCtor)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -17,9 +17,9 @@ import org.junit.Test
 import java.sql.Connection
 import java.util.*
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 object EntityTestsData {
 
@@ -1295,6 +1295,27 @@ class EntityTests : DatabaseTestsBase() {
             assertEquals("Parent Category", post.parent?.category?.title)
             assertEquals("Parent Category", post.optCategory?.title)
             assertEquals("Child Category", post.category?.title)
+        }
+    }
+
+    @Test fun `test explicit entity constructor`() {
+        var createBoardCalled = false
+        fun createBoard(id: EntityID<Int>): Board {
+            createBoardCalled = true
+            return Board(id)
+        }
+        val boardEntityClass = object : IntEntityClass<Board>(Boards, entityCtor = ::createBoard) { }
+
+        withTables(Boards) {
+            val board = boardEntityClass.new {
+                name = "Test Board"
+            }
+
+            assertEquals("Test Board", board.name)
+            assertTrue(
+                createBoardCalled,
+                "Expected createBoardCalled to be called"
+            )
         }
     }
 }


### PR DESCRIPTION
This PR replaces reflection with regular code in two places:

1.  Cloning a `Column` to replace its type with auto-increment.
2. `EntityClass.createInstance`

On my computer it brings down the time to run this code for the 1st time from ~750ms to ~300ms:
```
     Database.connect("jdbc:h2:mem:test", driver = "org.h2.Driver")
     transaction{
            addLogger(StdOutSqlLogger)
            City.new { name = "St. Petersburg" }
            println("Cities: ${City.all().toList()}")
        }
```

Fixes #1453