### PR TITLE
JavaInstantColumnType: Adding ability to convert LocalDateTime to Instant

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -199,6 +199,7 @@ class JavaInstantColumnType : ColumnType(), IDateColumnType {
             is String -> return value
             is Instant -> value
             is java.sql.Timestamp -> value.toInstant()
+            is LocalDateTime -> value.atZone(ZoneId.systemDefault()).toInstant()
             else -> error("Unexpected value: $value of ${value::class.qualifiedName}")
         }
 


### PR DESCRIPTION
Adding missing conversion of `LocalDateTime` to `Instant`.