### PR TITLE
Disable `-XX:MaxPermSize` flag if the JDK version is Java 8 or higher

### DIFF
--- a/exposed-java-time/build.gradle.kts
+++ b/exposed-java-time/build.gradle.kts
@@ -33,7 +33,8 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 //}
 
 tasks.withType<Test>().configureEach {
-    jvmArgs = listOf("-XX:MaxPermSize=256m")
+    if (JavaVersion.VERSION_1_8 > JavaVersion.current())
+        jvmArgs = listOf("-XX:MaxPermSize=256m")
     testLogging {
         events.addAll(listOf(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED))
         showStandardStreams = true

--- a/exposed-kotlin-datetime/build.gradle.kts
+++ b/exposed-kotlin-datetime/build.gradle.kts
@@ -30,7 +30,8 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 }
 
 tasks.withType<Test>().configureEach {
-    jvmArgs = listOf("-XX:MaxPermSize=256m")
+    if (JavaVersion.VERSION_1_8 > JavaVersion.current())
+        jvmArgs = listOf("-XX:MaxPermSize=256m")
     testLogging {
         events.addAll(listOf(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED))
         showStandardStreams = true

--- a/exposed-spring-boot-starter/build.gradle.kts
+++ b/exposed-spring-boot-starter/build.gradle.kts
@@ -24,7 +24,8 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-    jvmArgs = listOf("-XX:MaxPermSize=256m")
+    if (JavaVersion.VERSION_1_8 > JavaVersion.current())
+        jvmArgs = listOf("-XX:MaxPermSize=256m")
 
     testLogging {
         events.addAll(listOf(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED))

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -35,7 +35,8 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-    jvmArgs = listOf("-XX:MaxPermSize=256m")
+    if (JavaVersion.VERSION_1_8 > JavaVersion.current())
+        jvmArgs = listOf("-XX:MaxPermSize=256m")
     testLogging {
         events.addAll(listOf(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED))
         showStandardStreams = true

--- a/spring-transaction/build.gradle.kts
+++ b/spring-transaction/build.gradle.kts
@@ -32,7 +32,8 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-    jvmArgs = listOf("-XX:MaxPermSize=256m")
+    if (JavaVersion.VERSION_1_8 > JavaVersion.current())
+        jvmArgs = listOf("-XX:MaxPermSize=256m")
     testLogging {
         events.addAll(listOf(TestLogEvent.PASSED, TestLogEvent.FAILED, TestLogEvent.SKIPPED))
         showStandardStreams = true


### PR DESCRIPTION
You can't compile Exposed with Java 17 because it fails with the following error.
```
Unrecognized VM option 'MaxPermSize=256m'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
Process 'Gradle Test Executor 122' finished with non-zero exit value 1
org.gradle.process.internal.ExecException: Process 'Gradle Test Executor 122' finished with non-zero exit value 1
        at org.gradle.process.internal.DefaultExecHandle$ExecResultImpl.assertNormalExitValue(DefaultExecHandle.java:414)
        at org.gradle.process.internal.worker.DefaultWorkerProcess.onProcessStop(DefaultWorkerProcess.java:141)
        at org.gradle.process.internal.worker.DefaultWorkerProcess.access$000(DefaultWorkerProcess.java:42)
        at org.gradle.process.internal.worker.DefaultWorkerProcess$1.executionFinished(DefaultWorkerProcess.java:94)
        at jdk.internal.reflect.GeneratedMethodAccessor1204.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.event.AbstractBroadcastDispatch.dispatch(AbstractBroadcastDispatch.java:43)
        at org.gradle.internal.event.BroadcastDispatch$SingletonDispatch.dispatch(BroadcastDispatch.java:245)
        at org.gradle.internal.event.BroadcastDispatch$SingletonDispatch.dispatch(BroadcastDispatch.java:157)
        at org.gradle.internal.event.ListenerBroadcast.dispatch(ListenerBroadcast.java:141)
        at org.gradle.internal.event.ListenerBroadcast.dispatch(ListenerBroadcast.java:37)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
        at jdk.proxy1/jdk.proxy1.$Proxy169.executionFinished(Unknown Source)
        at org.gradle.process.internal.DefaultExecHandle.setEndStateInfo(DefaultExecHandle.java:221)
        at org.gradle.process.internal.DefaultExecHandle.finished(DefaultExecHandle.java:354)
        at org.gradle.process.internal.ExecHandleRunner.completed(ExecHandleRunner.java:110)
        at org.gradle.process.internal.ExecHandleRunner.run(ExecHandleRunner.java:84)
        at org.gradle.internal.operations.CurrentBuildOperationPreservingRunnable.run(CurrentBuildOperationPreservingRunnable.java:42)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

`-XX:MaxPermSize` was deprecated in Java 8 and subsequently removed in newer versions, so to avoid this error we will check if the version is Java 8 or higher and, if it is, we won't apply the JVM flag.

The flag was already pointed out by @naftalmm in https://github.com/JetBrains/Exposed/pull/1409 so I made a PR to disable the flag altogether, this was a pain when I was trying to test my changes in Exposed and I always needed to comment out the flag to ran the tests. 😭 