### PR TITLE
Reduce `SHOW TRANSACTION ISOLATION LEVEL` in Postgres

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -40,7 +40,18 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
         get() = connection.autoCommit
         set(value) { connection.autoCommit = value }
 
-    override var transactionIsolation: Int = connection.transactionIsolation
+    override var transactionIsolation: Int = -1
+        get() {
+            if (field != -1) {
+                return field
+            }
+
+            return synchronized(this) {
+                val value = connection.transactionIsolation
+                field = value
+                value
+            }
+        }
         set(value) {
             if (field != value) {
                 connection.transactionIsolation = value


### PR DESCRIPTION
Currently, in Postgres + Spring Transaction setup, 
`SHOW TRANSACTION ISOLATION LEVEL` is executed every time a transaction is started, as shown in the image.

![スクリーンショット 2022-03-19 10 38 55](https://user-images.githubusercontent.com/5021900/159102022-9080c37a-dc6d-4231-8a24-57939503b43b.png)

So, I changed the initialization of `transactionIsolation` to be lazy.