### PR TITLE
Serialization API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out/
 build/
 classes/
 **/jetbrains.db
+

--- a/exposed-serialization/src/main/kotlin/org/jetbrains/exposed/serialization/DAOSerializer.kt
+++ b/exposed-serialization/src/main/kotlin/org/jetbrains/exposed/serialization/DAOSerializer.kt
@@ -1,0 +1,86 @@
+package org.jetbrains.exposed.serialization
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.jetbrains.exposed.dao.Entity
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+
+object DAOSerializer {
+
+    /**
+     * A disgusting, performance-heavy way to create a JsonPrimitive from a generic primitive.
+     * @param value A primitive type such as a Number, String, or null.
+     */
+    fun toElement(value: Any?): JsonPrimitive { // Horribly inefficient way of doing this (probably)
+        return if (value != null) {
+            val str = value.toString()
+            try {
+                JsonPrimitive(str.toInt())
+            } catch (notInt: NumberFormatException) {
+                try {
+                    JsonPrimitive(str.toFloat())
+                } catch (notFloat: NumberFormatException) {
+                    try {
+                        JsonPrimitive(str.toBooleanStrict())
+                    } catch (isString: IllegalArgumentException) {
+                        JsonPrimitive(str)
+                    }
+                }
+            }
+        } else JsonNull
+    }
+
+    /**
+     * Serialize a ResultRow.
+     * @param table The Table the row belongs to. Leave null to disable further serialization of referenced rows.
+     */
+    fun jsonify(row: ResultRow, table: Table? = null): JsonObject {
+        return buildJsonObject {
+            row.fieldIndex.keys.forEach { field ->
+                val value = row[field]
+                val name = field.toString().substringAfterLast('.')
+                if (table != null) {
+                    val refColumns = table.columns.filter { (it.name == name).and(it.referee != null) }
+                    if (refColumns.isNotEmpty()) {
+                        for (refCol in refColumns) {
+                            val referee = refCol.referee!!
+                            val referencedValue = referee.table.select {
+                                referee eq referee.asLiteral(value)
+                            }.first()
+                            put(name, jsonify(referencedValue))
+                        }
+                    } else put(name, toElement(value))
+                } else put(name, toElement(value)) // Should clean this up
+            }
+        }
+    }
+
+    /**
+     * Serialize a DAO entity, including its referenced rows.
+     */
+    fun jsonify(dao: Entity<Int>, recursion: Boolean = false): JsonObject {
+        val columns = dao.klass.dependsOnColumns
+        val values = dao.readValues
+        return buildJsonObject {
+            for (column in columns) {
+                val referee = column.referee
+                if (referee != null) {
+                    transaction {
+                        val referencedRow = referee.table.select {
+                            referee eq referee.asLiteral(values[column])
+                        }.single()
+                        if (recursion) put(column.name, jsonify(referencedRow, referee.table))
+                        else put(column.name, jsonify(referencedRow))
+                    }
+                } else {
+                    put(column.name, toElement(values[column]))
+                }
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ include("exposed-money")
 include("exposed-bom")
 include("exposed-kotlin-datetime")
 include("exposed-crypt")
+include("exposed-serialization")
 
 pluginManagement {
     plugins {


### PR DESCRIPTION
This is an experimental API to serialize DAO objects and ResultRows to JSON objects. Obviously not production-ready, but I'd like to gauge interest to see if it is worth pursuing this further.

Needless to say, there's much more work to be done, but I'd like to see if this is something that will be useful before I go full time on this. Future plans include:
- Automatic de/serialization to and from interfaces and classes (hugely useful for multiplatform/web applications), without the need for boilerplate code to implement it
- Performance enhancements (obviously)
- Allow developers to specify limits to reference column recursion (depth)

Please let me know if I should keep working on this. Thanks. 
