### PR TITLE
Support combining nullable parameters in WHERE clause

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -116,6 +116,20 @@ infix fun Expression<Boolean>.or(op: Expression<Boolean>): Op<Boolean> = when {
     else -> OrOp(listOf(this, op))
 }
 
+/**
+ * Returns the result of performing a logical `and` operation between this expression and the [op] **if** [op] is not null.
+ * Otherwise, this expression will be returned.
+ */
+infix fun Op<Boolean>.andIfNotNull(op: Expression<Boolean>?): Op<Boolean> =
+    op?.let { this and it } ?: this
+
+/**
+ * Returns the result of performing a logical `or` operation between this expression and the [op] **if** [op] is not null.
+ * Otherwise, this expression will be returned.
+ */
+infix fun Op<Boolean>.orIfNotNull(op: Expression<Boolean>?): Op<Boolean> =
+    op?.let { this or it } ?: this
+
 /** Reduces this list to a single expression by performing an `and` operation between all the expressions in the list. */
 fun List<Op<Boolean>>.compoundAnd(): Op<Boolean> = reduce(Op<Boolean>::and)
 
@@ -133,6 +147,18 @@ inline fun Expression<Boolean>.andNot(op: SqlExpressionBuilder.() -> Op<Boolean>
 
 /** Returns the result of performing a logical `or` operation between this expression and the negate [op]. */
 inline fun Expression<Boolean>.orNot(op: SqlExpressionBuilder.() -> Op<Boolean>): Op<Boolean> = or(not(Op.build(op)))
+
+/**
+ * Returns the result of performing a logical `and` operation between this expression and the [op] **if** [op] is not null.
+ * Otherwise, this expression will be returned.
+ */
+inline fun Op<Boolean>.andIfNotNull(op: SqlExpressionBuilder.() -> Op<Boolean>?): Op<Boolean> = andIfNotNull(SqlExpressionBuilder.op())
+
+/**
+ * Returns the result of performing a logical `or` operation between this expression and the [op] **if** [op] is not null.
+ * Otherwise, this expression will be returned.
+ */
+inline fun Op<Boolean>.orIfNotNull(op: SqlExpressionBuilder.() -> Op<Boolean>?): Op<Boolean> = orIfNotNull(SqlExpressionBuilder.op())
 
 // Comparison Operators
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -405,6 +405,13 @@ class FunctionsTests : DatabaseTestsBase() {
             assertEquals("$secondOp OR $secondOp OR $secondOp OR $secondOp", (secondOp or secondOp or secondOp or secondOp).toString())
             assertEquals("($initialOp) OR ($initialOp) OR ($initialOp) OR ($initialOp)", (initialOp or (initialOp or initialOp) or initialOp).toString())
             assertEquals("($initialOp) OR ($secondOp AND $secondOp) OR ($initialOp)", (initialOp or (secondOp and secondOp) or initialOp).toString())
+            assertEquals("$initialOp", (initialOp orIfNotNull (null as Expression<Boolean>?)).toString())
+            assertEquals("$initialOp", (initialOp andIfNotNull (null as Op<Boolean>?)).toString())
+            assertEquals("($initialOp) AND ($initialOp)", (initialOp andIfNotNull (initialOp andIfNotNull (null as Op<Boolean>?))).toString())
+            assertEquals("($initialOp) AND ($initialOp)", (initialOp andIfNotNull (null as Op<Boolean>?) andIfNotNull initialOp).toString())
+            assertEquals("($initialOp) AND $secondOp", (initialOp andIfNotNull (secondOp andIfNotNull (null as Op<Boolean>?))).toString())
+            assertEquals( "(($initialOp) AND $secondOp) OR $secondOp", (initialOp andIfNotNull (secondOp andIfNotNull (null as Expression<Boolean>?)) orIfNotNull secondOp).toString())
+            assertEquals("($initialOp) AND ($initialOp)", (initialOp.andIfNotNull { initialOp }).toString())
         }
     }
 


### PR DESCRIPTION
This PR adds two functions(`andIfNotNull`, `orIfNotNull`) that allow to combine null condition with and/or in where clause.

A query statement is often composed with required and optional parameters. For optional parameters, we can add them to where clause with following syntax(from wiki):
```kotlin
val query = StarWarsFilms.selectAll()
directorName?.let {
    query.andWhere { StarWarsFilms.director eq it }
}
sequelId?.let {
    query.andWhere { StarWarsFilms.sequelId eq it }
}
```

With this PR the syntax can be simplified:
```kotlin
val query = StarWarsFilms.select {
    Op.TRUE andIfNotNull // No required parameters in this sample, a non-null condition is needed as beginning
        directorName?.let { StarWarsFilms.director eq it } andIfNotNull
        sequelId?.let { StarWarsFilms.sequelId eq it }
}
```