### PR TITLE
EntityClass#wramUpReferences should cache reference of referrer

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -383,7 +383,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
                 distinctRefIds.forEach { id ->
                     cache.getOrPutReferrers(id, refColumn) { result[id]?.let { SizedCollection(it) } ?: emptySized() }.also {
                         if (keepLoadedReferenceOutOfTransaction) {
-                            findById(id)?.storeReferenceInCache(refColumn, it)
+                            cache.data[id.table]?.get(id.value)?.storeReferenceInCache(refColumn, it)
                         }
                     }
                 }


### PR DESCRIPTION
Currently, trying to find `User` with id of `City`. Should update cache of `City`