### PR TITLE
Fix argument value error when use expression in mysql replace statement

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -82,7 +82,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
     override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
         val builder = QueryBuilder(true)
         val columns = data.joinToString { transaction.identity(it.first) }
-        val values = builder.apply { data.appendTo { registerArgument(it.first.columnType, it.second) } }.toString()
+        val values = builder.apply { data.appendTo { registerArgument(it.first, it.second) } }.toString()
         return "REPLACE INTO ${transaction.identity(table)} ($columns) VALUES ($values)"
     }
 


### PR DESCRIPTION
Fix raise `java.sql.SQLException` when use expression in mysql replace statement.

``` kotlin
import org.jetbrains.exposed.sql.*
import org.jetbrains.exposed.sql.transactions.transaction
import org.junit.jupiter.api.Test

object Users : Table() {
    val id = integer("id").autoIncrement()
    val name = varchar("name", length = 50).uniqueIndex()
    val cityId = integer("city_id").references(Cities.id).nullable()

    override val primaryKey = PrimaryKey(id)
}

object Cities : Table() {
    val id = integer("id").autoIncrement()
    val name = varchar("name", 50).uniqueIndex()

    override val primaryKey = PrimaryKey(id)
}

fun main() {
    Database.connect(url = "jdbc:mysql://localhost:3306/exposed_test", driver = "com.mysql.cj.jdbc.Driver", user = "<USERNAME>", password = "<PASSWORD>")

    transaction {
        addLogger(StdOutSqlLogger)

        SchemaUtils.create(Cities, Users)

        val munichId = Cities.insert {
            it[name] = "Munich"
        } get Cities.id

        Users.insert {
            it[name] = "Eugene"
            it[cityId] = wrapAsExpression(Cities.slice(Cities.id).select { Cities.name eq "Munich" })
        }

        Users.replace {
            it[name] = stringLiteral("Eugene")
            it[cityId] = munichId
        } // org.jetbrains.exposed.exceptions.ExposedSQLException: java.sql.SQLException: Subquery returns more than 1 row

        Users.replace {
            it[name] = "Eugene"
            it[cityId] = wrapAsExpression(Cities.slice(Cities.id).select { Cities.name eq "Munich" })
        } // org.jetbrains.exposed.exceptions.ExposedSQLException: java.sql.SQLException: Incorrect integer value: 'Munich' for column 'city_id' at row 1

        SchemaUtils.drop(Cities, Users)
    }
}
```