### PR TITLE
Add Transaction to lifecycle hooks for #1530

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -72,8 +72,8 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
         }
         transactionImpl.commit()
         userdata.clear()
-        globalInterceptors.forEach { it.afterCommit() }
-        interceptors.forEach { it.afterCommit() }
+        globalInterceptors.forEach { it.afterCommit(this) }
+        interceptors.forEach { it.afterCommit(this) }
         userdata.putAll(dataToStore)
     }
 
@@ -81,8 +81,8 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
         globalInterceptors.forEach { it.beforeRollback(this) }
         interceptors.forEach { it.beforeRollback(this) }
         transactionImpl.rollback()
-        globalInterceptors.forEach { it.afterRollback() }
-        interceptors.forEach { it.afterRollback() }
+        globalInterceptors.forEach { it.afterRollback(this) }
+        interceptors.forEach { it.afterRollback(this) }
         userdata.clear()
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/StatementInterceptor.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/StatementInterceptor.kt
@@ -9,10 +9,10 @@ interface StatementInterceptor {
     fun afterExecution(transaction: Transaction, contexts: List<StatementContext>, executedStatement: PreparedStatementApi) {}
 
     fun beforeCommit(transaction: Transaction) {}
-    fun afterCommit() {}
+    fun afterCommit(transaction: Transaction) {}
 
     fun beforeRollback(transaction: Transaction) {}
-    fun afterRollback() {}
+    fun afterRollback(transaction: Transaction) {}
 
     fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> = emptyMap()
 }


### PR DESCRIPTION
Adding transaction to lifecycle hooks to support #1530.

Note:
- This is a breaking change to the `StatementInterceptor` interface