### PR TITLE
Fix creation of composite primary key in schema

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -419,7 +419,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         /** Returns the columns that compose the primary key. */
         val columns: Array<Column<*>>,
         /** Returns the name of the primary key. */
-        val name: String = "pk_$tableName"
+        val name: String = "pk_$tableNameWithoutScheme"
     ) {
         constructor(firstColumn: Column<*>, vararg columns: Column<*>, name: String = "pk_$tableNameWithoutScheme") :
             this(arrayOf(firstColumn, *columns), name)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -407,7 +407,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     // Primary keys
 
-    internal fun isCustomPKNameDefined(): Boolean = primaryKey?.let { it.name != "pk_$tableName" } == true
+    internal fun isCustomPKNameDefined(): Boolean = primaryKey?.let { it.name != "pk_$tableNameWithoutScheme" } == true
 
     /**
      * Represents a primary key composed by the specified [columns], and with the specified [name].
@@ -421,7 +421,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         /** Returns the name of the primary key. */
         val name: String = "pk_$tableName"
     ) {
-        constructor(firstColumn: Column<*>, vararg columns: Column<*>, name: String = "pk_$tableName") :
+        constructor(firstColumn: Column<*>, vararg columns: Column<*>, name: String = "pk_$tableNameWithoutScheme") :
             this(arrayOf(firstColumn, *columns), name)
 
         init {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -934,14 +934,22 @@ class DDLTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(idA, idB)
         }
 
+        val tableB = object : Table("test.table_b") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            override val primaryKey = PrimaryKey(arrayOf(idA, idB))
+        }
+
         withSchemas(excludeSettings = listOf(TestDB.SQLITE), schemas = arrayOf(one)) {
-            SchemaUtils.create(tableA)
+            SchemaUtils.create(tableA, tableB)
             tableA.insert { it[idA] = 1; it[idB] = 1 }
+            tableB.insert { it[idA] = 1; it[idB] = 1 }
 
             assertEquals(1, tableA.selectAll().count())
+            assertEquals(1, tableB.selectAll().count())
 
             if (currentDialectTest is SQLServerDialect) {
-                SchemaUtils.drop(tableA)
+                SchemaUtils.drop(tableA, tableB)
             }
 
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -924,4 +924,27 @@ class DDLTests : DatabaseTestsBase() {
             }
         }
     }
+
+    @Test
+    fun createTableWithCompositePrimaryKeyAndSchema() {
+        val one = Schema("test")
+        val tableA = object : Table("test.table_a") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            override val primaryKey = PrimaryKey(idA, idB)
+        }
+
+        withSchemas(excludeSettings = listOf(TestDB.SQLITE), schemas = arrayOf(one)) {
+            SchemaUtils.create(tableA)
+            tableA.insert { it[idA] = 1; it[idB] = 1 }
+
+            assertEquals(1, tableA.selectAll().count())
+
+            if (currentDialectTest is SQLServerDialect) {
+                SchemaUtils.drop(tableA)
+            }
+
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/JetBrains/Exposed/issues/1496 by creating the primary key constraint name without including schema name