### PR TITLE
Fix bool column behavior in Oracle queries

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -7,9 +7,9 @@ import org.jetbrains.exposed.sql.statements.DefaultValueMarker
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.MariaDBDialect
+import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.io.InputStream
-import java.lang.IllegalArgumentException
 import java.math.BigDecimal
 import java.math.MathContext
 import java.math.RoundingMode
@@ -781,6 +781,12 @@ class BooleanColumnType : ColumnType() {
     }
 
     override fun nonNullValueToString(value: Any): String = currentDialect.dataTypeProvider.booleanToStatementString(value as Boolean)
+
+    override fun notNullValueToDB(value: Any): Any = when {
+        value is Boolean && currentDialect is OracleDialect ->
+            nonNullValueToString(value)
+        else -> value
+    }
 
     companion object {
         internal val INSTANCE = BooleanColumnType()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/BooleanColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/BooleanColumnTypeTests.kt
@@ -1,0 +1,53 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class BooleanColumnTypeTests : DatabaseTestsBase() {
+    object BooleanTable : IntIdTable() {
+        val boolColumn = bool("boolColumn")
+    }
+
+    @Test
+    fun `true value`() {
+        withTables(BooleanTable) {
+            val id = BooleanTable.insertAndGetId {
+                it[boolColumn] = true
+            }
+
+            val result = BooleanTable.select { BooleanTable.id eq id }.singleOrNull()
+            assertEquals(true, result?.get(BooleanTable.boolColumn))
+        }
+    }
+
+    @Test
+    fun `false value`() {
+        withTables(BooleanTable) {
+            val id = BooleanTable.insertAndGetId {
+                it[boolColumn] = false
+            }
+
+            val result = BooleanTable.select { BooleanTable.id eq id }.singleOrNull()
+            assertEquals(false, result?.get(BooleanTable.boolColumn))
+        }
+    }
+
+    @Test
+    fun `bool in a condition`() {
+        withTables(BooleanTable) {
+            val idTrue = BooleanTable.insertAndGetId {
+                it[boolColumn] = true
+            }
+            BooleanTable.insertAndGetId {
+                it[boolColumn] = false
+            }
+
+            val resultTrue = BooleanTable.select { BooleanTable.boolColumn eq true }.singleOrNull()
+            assertEquals(idTrue, resultTrue?.get(BooleanTable.id))
+        }
+    }
+}


### PR DESCRIPTION
Fix how bool values are sent to Oracle DB. Previously `BooleanColumnType`
didn't do any conversion so real boolean value did reach JDBC and it has
been converted to numeric value of 0 or 1.

This behavior is not correct as bool columns in Exposed are CHAR(1) in Oracle.
We need to pass bool as a string instead of a number otherwise Oracle will not use
indexes when such column is used in WHERE clause.

Example:

    create table foo (boolColumn char(1));
    create index foo_idx on foo (boolColumn);

With numeric value:

    select 1 from foo where boolColumn = 1;    // results in full table scan (ignores foo_idx)

    --------------------------------------------------------------------------
    | Id  | Operation         | Name | Rows  | Bytes | Cost (%CPU)| Time     |
    --------------------------------------------------------------------------
    |   0 | SELECT STATEMENT  |      |     1 |     3 |     2   (0)| 00:00:01 |
    |*  1 |  TABLE ACCESS FULL| FOO  |     1 |     3 |     2   (0)| 00:00:01 |
    --------------------------------------------------------------------------

    Predicate Information (identified by operation id):
    ---------------------------------------------------

    "   1 - filter(TO_NUMBER(""BOOLCOLUMN"")=1)"

With string value:

    select 1 from foo where boolColumn = '1';  // correctly uses foo_idx

    ----------------------------------------------------------------------------
    | Id  | Operation        | Name    | Rows  | Bytes | Cost (%CPU)| Time     |
    ----------------------------------------------------------------------------
    |   0 | SELECT STATEMENT |         |     1 |     3 |     1   (0)| 00:00:01 |
    |*  1 |  INDEX RANGE SCAN| FOO_IDX |     1 |     3 |     1   (0)| 00:00:01 |
    ----------------------------------------------------------------------------

    Predicate Information (identified by operation id):
    ---------------------------------------------------

    "   1 - access(""BOOLCOLUMN""='1')"