### PR TITLE
Table aware deleteWhere 

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -3,7 +3,6 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import org.jetbrains.exposed.sql.statements.api.ExposedDatabaseMetadata
-import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
 import org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManager
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -53,11 +53,11 @@ fun FieldSet.selectAllBatched(
 /**
  * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testDelete01
  */
-fun Table.deleteWhere(limit: Int? = null, offset: Long? = null, op: SqlExpressionBuilder.() -> Op<Boolean>) =
-    DeleteStatement.where(TransactionManager.current(), this@deleteWhere, SqlExpressionBuilder.op(), false, limit, offset)
+fun <T : Table> T.deleteWhere(limit: Int? = null, offset: Long? = null, op: T.(ISqlExpressionBuilder) -> Op<Boolean>) =
+    DeleteStatement.where(TransactionManager.current(), this@deleteWhere, op(SqlExpressionBuilder), false, limit, offset)
 
-fun Table.deleteIgnoreWhere(limit: Int? = null, offset: Long? = null, op: SqlExpressionBuilder.() -> Op<Boolean>) =
-    DeleteStatement.where(TransactionManager.current(), this@deleteIgnoreWhere, SqlExpressionBuilder.op(), true, limit, offset)
+fun <T : Table> T.deleteIgnoreWhere(limit: Int? = null, offset: Long? = null, op: T.(ISqlExpressionBuilder) -> Op<Boolean>) =
+    DeleteStatement.where(TransactionManager.current(), this@deleteIgnoreWhere, op(SqlExpressionBuilder), true, limit, offset)
 
 /**
  * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testDelete01
@@ -136,7 +136,7 @@ private fun <T : Table, E> T.batchReplace(
     BatchReplaceStatement(this, shouldReturnGeneratedValues)
 }
 
-private fun <E, S: BaseBatchInsertStatement> executeBatch(
+private fun <E, S : BaseBatchInsertStatement> executeBatch(
     data: Iterator<E>,
     body: S.(E) -> Unit,
     newBatchStatement: () -> S
@@ -182,7 +182,7 @@ private fun <E, S: BaseBatchInsertStatement> executeBatch(
     return result
 }
 
-fun <T: Table> T.insertIgnore(body: T.(UpdateBuilder<*>)->Unit): InsertStatement<Long> = InsertStatement<Long>(this, isIgnore = true).apply {
+fun <T : Table> T.insertIgnore(body: T.(UpdateBuilder<*>) -> Unit): InsertStatement<Long> = InsertStatement<Long>(this, isIgnore = true).apply {
     body(this)
     execute(TransactionManager.current())
 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -243,9 +243,11 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
      */
     open fun delete() {
         val table = klass.table
-        TransactionManager.current().registerChange(klass, id, EntityChangeType.Removed)
+        // Capture reference to the field
+        val entityId = this.id
+        TransactionManager.current().registerChange(klass, entityId, EntityChangeType.Removed)
         executeAsPartOfEntityLifecycle {
-            table.deleteWhere { table.id eq id }
+            table.deleteWhere { table.id eq entityId }
         }
         klass.removeFromCache(this)
     }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.dao
 import org.jetbrains.exposed.dao.exceptions.EntityNotFoundException
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import kotlin.properties.Delegates
 import kotlin.reflect.KProperty

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
@@ -3,6 +3,8 @@ package org.jetbrains.exposed.dao
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/sql/SamplesSQL.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/sql/SamplesSQL.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.tests.demo.sql
 
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Assume

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNull
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -12,13 +13,11 @@ import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
-import org.jetbrains.exposed.sql.tests.shared.assertFalse
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.junit.Test
 import java.math.BigDecimal
-import java.sql.SQLException
 import java.util.*
 
 class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -39,6 +39,14 @@ class DeleteTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testDeleteTableInContext() {
+        withCitiesAndUsers { _, users, _ ->
+            // Now deleteWhere should bring the table it operates on into context
+            users.deleteWhere { name like "%thing" }
+        }
+    }
+
+    @Test
     fun testDeleteWithLimitAndOffset01() {
         withCitiesAndUsers(exclude = notSupportLimit) { _, _, userData ->
             userData.deleteWhere(limit = 1) { userData.value eq 20 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -40,9 +40,9 @@ class DeleteTests : DatabaseTestsBase() {
 
     @Test
     fun testDeleteTableInContext() {
-        withCitiesAndUsers { _, users, _ ->
-            // Now deleteWhere should bring the table it operates on into context
-            users.deleteWhere { name like "%thing" }
+        withCitiesAndUsers { _, users, userData ->
+            // Now deleteWhere and deleteIgnoreWhere should bring the table it operates on into context
+            users.deleteIgnoreWhere { name like "%thing" }
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
+import junit.framework.TestCase.assertNull
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -41,8 +42,18 @@ class DeleteTests : DatabaseTestsBase() {
     @Test
     fun testDeleteTableInContext() {
         withCitiesAndUsers { _, users, userData ->
+            userData.deleteAll()
+            val userDataExists = userData.selectAll().any()
+            assertEquals(false, userDataExists)
+
+            val smthId = users.slice(users.id).select { users.name.like("%thing") }.single()[users.id]
+            assertEquals("smth", smthId)
+
             // Now deleteWhere and deleteIgnoreWhere should bring the table it operates on into context
-            users.deleteIgnoreWhere { name like "%thing" }
+            users.deleteWhere { name like "%thing" }
+
+            val hasSmth = users.select { users.name.like("%thing") }.firstOrNull()
+            assertNull(hasSmth)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -7,11 +7,16 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
-import org.jetbrains.exposed.sql.tests.shared.*
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.entities.EntityTests
+import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.junit.Assume
@@ -20,7 +25,6 @@ import java.math.BigDecimal
 import java.sql.SQLException
 import java.util.*
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.fail

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB


### PR DESCRIPTION
This feature allows to omit table name from the where clause of delete queries.
Instead of:
https://github.com/JetBrains/Exposed/blob/bd5709f8e21983ffbe4b39f66b2412a73bb9c603/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt#L35

This now could be simplified to 
```kotlin
users.deleteWhere { name like "%thing" }
```
