### PR TITLE
Expose info whether lazy collection is loaded

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
@@ -112,6 +112,8 @@ class LazySizedCollection<out T>(_delegate: SizedIterable<T>) : SizedIterable<T>
         delegate = delegate.orderBy(*order)
         return this
     }
+
+    fun isLoaded(): Boolean = _wrapper != null
 }
 
 infix fun <T, R> SizedIterable<T>.mapLazy(f: (T) -> R): SizedIterable<R> {


### PR DESCRIPTION
It would be nice to allow developer to know whether lazily loaded is already loaded. 

My use case is a simple mapping from DAO entity to dto. Currently I need to pass extra param, which tells the mapping function to skip certain attributes - to avoid extra loading or exception.

With this function I can easily check that:
```kotlin
val messages by DiscussionMessageEntity referrersOn DiscussionMessageTable.discussionId
...
val messageDtos = if ((messages as LazySizedCollection).isLoaded()) {
    messages.map { it.toDto() }
} else {
    listOf()
}
```