### PR TITLE
Add read-only transaction parameters

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -3,7 +3,6 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import org.jetbrains.exposed.sql.statements.api.ExposedDatabaseMetadata
-import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
 import org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManager
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ConnectionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ConnectionApi.kt
@@ -6,7 +6,7 @@ interface ExposedConnection<OriginalConnection : Any> {
     fun rollback()
     fun close()
     var autoCommit: Boolean
-    var isReadOnly: Boolean
+    var readOnly: Boolean
     var transactionIsolation: Int
     val connection: OriginalConnection
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ConnectionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ConnectionApi.kt
@@ -6,6 +6,7 @@ interface ExposedConnection<OriginalConnection : Any> {
     fun rollback()
     fun close()
     var autoCommit: Boolean
+    var isReadOnly: Boolean
     var transactionIsolation: Int
     val connection: OriginalConnection
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -12,7 +12,8 @@ import org.jetbrains.exposed.sql.statements.api.ExposedSavepoint
 import java.sql.SQLException
 
 class ThreadLocalTransactionManager(
-    private val db: Database
+    private val db: Database,
+    private val setupTxConnection: ((ExposedConnection<*>, TransactionInterface) -> Unit)? = null
 ) : TransactionManager {
     @Volatile
     override var defaultRepetitionAttempts: Int = db.config.defaultRepetitionAttempts
@@ -32,14 +33,19 @@ class ThreadLocalTransactionManager(
         @TestOnly
         set
 
+    @Volatile
+    override var defaultReadOnly: Boolean = DEFAULT_READ_ONLY
+
     val threadLocal = ThreadLocal<Transaction>()
 
-    override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction =
+    override fun newTransaction(isolation: Int, readOnly: Boolean, outerTransaction: Transaction?): Transaction =
         (
             outerTransaction?.takeIf { !db.useNestedTransactions } ?: Transaction(
                 ThreadLocalTransaction(
                     db = db,
+                    readOnly = outerTransaction?.readOnly ?: readOnly,
                     transactionIsolation = outerTransaction?.transactionIsolation ?: isolation,
+                    setupTxConnection = setupTxConnection,
                     threadLocal = threadLocal,
                     outerTransaction = outerTransaction
                 )
@@ -60,15 +66,23 @@ class ThreadLocalTransactionManager(
 
     private class ThreadLocalTransaction(
         override val db: Database,
+        private val setupTxConnection: ((ExposedConnection<*>, TransactionInterface) -> Unit)?,
         override val transactionIsolation: Int,
+        override val readOnly: Boolean,
         val threadLocal: ThreadLocal<Transaction>,
         override val outerTransaction: Transaction?
     ) : TransactionInterface {
 
         private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) {
             outerTransaction?.connection ?: db.connector().apply {
-                autoCommit = false
-                transactionIsolation = this@ThreadLocalTransaction.transactionIsolation
+                setupTxConnection?.invoke(this, this@ThreadLocalTransaction) ?: run {
+                    // The order of `setReadOnly` and `setAutoCommit` is important.
+                    // Some drivers start a transaction right after `setAutoCommit(false)`,
+                    // which makes `setReadOnly` throw an exception if it is called after `setAutoCommit`
+                    isReadOnly = outerTransaction?.readOnly ?: this@ThreadLocalTransaction.readOnly
+                    transactionIsolation = this@ThreadLocalTransaction.transactionIsolation
+                    autoCommit = false
+                }
             }
         }
         override val connection: ExposedConnection<*>
@@ -129,16 +143,26 @@ class ThreadLocalTransactionManager(
 }
 
 fun <T> transaction(db: Database? = null, statement: Transaction.() -> T): T =
-    transaction(db.transactionManager.defaultIsolationLevel, db.transactionManager.defaultRepetitionAttempts, db, statement)
+    transaction(
+        db.transactionManager.defaultIsolationLevel,
+        db.transactionManager.defaultRepetitionAttempts,
+        db.transactionManager.defaultReadOnly,
+        db, statement)
 
-fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Database? = null, statement: Transaction.() -> T): T =
+fun <T> transaction(
+    transactionIsolation: Int,
+    repetitionAttempts: Int,
+    readOnly: Boolean = false,
+    db: Database? = null,
+    statement: Transaction.() -> T
+): T =
     keepAndRestoreTransactionRefAfterRun(db) {
         val outer = TransactionManager.currentOrNull()
 
         if (outer != null && (db == null || outer.db == db)) {
             val outerManager = outer.db.transactionManager
 
-            val transaction = outerManager.newTransaction(transactionIsolation, outer)
+            val transaction = outerManager.newTransaction(transactionIsolation, readOnly, outer)
             try {
                 transaction.statement().also {
                     if (outer.db.useNestedTransactions) {
@@ -162,13 +186,14 @@ fun <T> transaction(transactionIsolation: Int, repetitionAttempts: Int, db: Data
                 } finally {
                     TransactionManager.resetCurrent(currentManager)
                 }
-            } ?: inTopLevelTransaction(transactionIsolation, repetitionAttempts, db, null, statement)
+            } ?: inTopLevelTransaction(transactionIsolation, repetitionAttempts, readOnly, db, null, statement)
         }
     }
 
 fun <T> inTopLevelTransaction(
     transactionIsolation: Int,
     repetitionAttempts: Int,
+    readOnly: Boolean = false,
     db: Database? = null,
     outerTransaction: Transaction? = null,
     statement: Transaction.() -> T
@@ -181,7 +206,7 @@ fun <T> inTopLevelTransaction(
 
         while (true) {
             db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
-            val transaction = db.transactionManager.newTransaction(transactionIsolation, outerTransaction)
+            val transaction = db.transactionManager.newTransaction(transactionIsolation, readOnly, outerTransaction)
 
             @Suppress("TooGenericExceptionCaught")
             try {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -76,10 +76,11 @@ class ThreadLocalTransactionManager(
         private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) {
             outerTransaction?.connection ?: db.connector().apply {
                 setupTxConnection?.invoke(this, this@ThreadLocalTransaction) ?: run {
+                    this.connection
                     // The order of `setReadOnly` and `setAutoCommit` is important.
                     // Some drivers start a transaction right after `setAutoCommit(false)`,
                     // which makes `setReadOnly` throw an exception if it is called after `setAutoCommit`
-                    isReadOnly = outerTransaction?.readOnly ?: this@ThreadLocalTransaction.readOnly
+                    readOnly = this@ThreadLocalTransaction.readOnly
                     transactionIsolation = this@ThreadLocalTransaction.transactionIsolation
                     autoCommit = false
                 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -76,7 +76,6 @@ class ThreadLocalTransactionManager(
         private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) {
             outerTransaction?.connection ?: db.connector().apply {
                 setupTxConnection?.invoke(this, this@ThreadLocalTransaction) ?: run {
-                    this.connection
                     // The order of `setReadOnly` and `setAutoCommit` is important.
                     // Some drivers start a transaction right after `setAutoCommit(false)`,
                     // which makes `setReadOnly` throw an exception if it is called after `setAutoCommit`

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -16,6 +16,8 @@ interface TransactionInterface {
 
     val transactionIsolation: Int
 
+    val readOnly: Boolean
+
     val outerTransaction: Transaction?
 
     fun commit()
@@ -28,12 +30,16 @@ interface TransactionInterface {
 @Deprecated("There is no single default level for all databases, please don't use that constant")
 const val DEFAULT_ISOLATION_LEVEL = Connection.TRANSACTION_REPEATABLE_READ
 
+const val DEFAULT_READ_ONLY = false
+
 private object NotInitializedManager : TransactionManager {
     override var defaultIsolationLevel: Int = -1
 
+    override var defaultReadOnly: Boolean = DEFAULT_READ_ONLY
+
     override var defaultRepetitionAttempts: Int = -1
 
-    override fun newTransaction(isolation: Int, outerTransaction: Transaction?): Transaction =
+    override fun newTransaction(isolation: Int, readOnly: Boolean, outerTransaction: Transaction?): Transaction =
         error("Please call Database.connect() before using this code")
 
     override fun currentOrNull(): Transaction = error("Please call Database.connect() before using this code")
@@ -47,9 +53,13 @@ interface TransactionManager {
 
     var defaultIsolationLevel: Int
 
+    var defaultReadOnly: Boolean
+
     var defaultRepetitionAttempts: Int
 
-    fun newTransaction(isolation: Int = defaultIsolationLevel, outerTransaction: Transaction? = null): Transaction
+    fun newTransaction(isolation: Int = defaultIsolationLevel,
+                       readOnly: Boolean = defaultReadOnly,
+                       outerTransaction: Transaction? = null): Transaction
 
     fun currentOrNull(): Transaction?
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -40,7 +40,7 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
         get() = connection.autoCommit
         set(value) { connection.autoCommit = value }
 
-    override var isReadOnly: Boolean
+    override var readOnly: Boolean
         get() = connection.isReadOnly
         set(value) {
             connection.isReadOnly = value

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -40,6 +40,12 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
         get() = connection.autoCommit
         set(value) { connection.autoCommit = value }
 
+    override var isReadOnly: Boolean
+        get() = connection.isReadOnly
+        set(value) {
+            connection.isReadOnly = value
+        }
+
     override var transactionIsolation: Int = -1
         get() {
             if (field == -1) {

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -72,7 +72,7 @@ enum class TestDB(
         beforeConnection = {
             Locale.setDefault(Locale.ENGLISH)
             val tmp = Database.connect(ORACLE.connection(), user = "sys as sysdba", password = "Oracle18", driver = ORACLE.driver)
-            transaction(Connection.TRANSACTION_READ_COMMITTED, 1, tmp) {
+            transaction(Connection.TRANSACTION_READ_COMMITTED, 1, db  = tmp) {
                 try {
                     exec("DROP USER ExposedTest CASCADE")
                 } catch (e: Exception) { // ignore

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
@@ -190,7 +190,7 @@ class MultiDatabaseEntityTest {
                 b2Reread.y = null
             }
         }
-        inTopLevelTransaction(Connection.TRANSACTION_READ_COMMITTED, 1, db1) {
+        inTopLevelTransaction(Connection.TRANSACTION_READ_COMMITTED, 1, db = db1) {
             assertNull(EntityTestsData.BEntity.testCache(db1b1.id))
             val b1Reread = EntityTestsData.BEntity[db1b1.id]
             assertEquals(db1b1.id, b1Reread.id)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -56,7 +56,7 @@ class ConnectionTimeoutTest : DatabaseTestsBase() {
         val db = Database.connect(datasource = datasource)
 
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 42, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, 42, db = db) {
                 exec("SELECT 1;")
                 // NO OP
             }
@@ -119,7 +119,7 @@ class ConnectionExceptions {
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db = db) {
                 this.exec("BROKEN_SQL_THAT_CAUSES_EXCEPTION()")
             }
             fail("Should have thrown an exception")
@@ -153,7 +153,7 @@ class ConnectionExceptions {
         val wrappingDataSource = WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db = db) {
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")
@@ -177,7 +177,7 @@ class ConnectionExceptions {
         val wrappingDataSource = ConnectionExceptions.WrappingDataSource(TestDB.H2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
         try {
-            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db) {
+            transaction(Connection.TRANSACTION_SERIALIZABLE, 5, db = db) {
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")
@@ -256,6 +256,19 @@ class ThreadLocalManagerTest : DatabaseTestsBase() {
             SchemaUtils.drop(DMLTestsData.Cities)
         }
         assertEquals(secondThreadTm, db2.transactionManager)
+    }
+
+    @Test
+    fun testReadOnly() {
+        withTables(excludeSettings = listOf(TestDB.SQLITE, TestDB.H2, TestDB.H2_MYSQL), RollbackTable) {
+            println(it.db?.dialect)
+            val t = assertFails {
+                inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, 1, true) {
+                    RollbackTable.insert { it[value] = "random-something" }
+                }
+            }
+            t.message?.run { assertTrue(contains("read-only")) } ?: fail("message should not be null")
+        }
     }
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -575,7 +575,7 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     private fun <T> newTransaction(statement: Transaction.() -> T) =
-        inTopLevelTransaction(TransactionManager.manager.defaultIsolationLevel, 1, null, null, statement)
+        inTopLevelTransaction(TransactionManager.manager.defaultIsolationLevel, 1, false, null, null, statement)
 
     @Test fun sharingEntityBetweenTransactions() {
         withTables(Humans) {


### PR DESCRIPTION
Some of the database vendors allows to minimize resource impact by specifying that the transaction will not add any changes to the data. 
This MR attempts to add that parameter,