### PR TITLE
add particular text lenght subtypes

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -622,8 +622,10 @@ open class VarCharColumnType(
  * [eagerLoading] means what content will be loaded immediately when data loaded from database.
  */
 open class TextColumnType(collate: String? = null, val eagerLoading: Boolean = false) : StringColumnType(collate) {
+    open fun preciseType() = currentDialect.dataTypeProvider.textType()
+
     override fun sqlType(): String = buildString {
-        append(currentDialect.dataTypeProvider.textType())
+        append(preciseType())
         if (collate != null) {
             append(" COLLATE ${escape(collate)}")
         }
@@ -636,6 +638,14 @@ open class TextColumnType(collate: String? = null, val eagerLoading: Boolean = f
         else
             value
     }
+}
+
+open class MediumTextColumnType(collate: String? = null, eagerLoading: Boolean = false) : TextColumnType(collate, eagerLoading) {
+    override fun preciseType(): String = currentDialect.dataTypeProvider.mediumTextType()
+}
+
+open class LargeTextColumnType(collate: String? = null, eagerLoading: Boolean = false) : TextColumnType(collate, eagerLoading) {
+    override fun preciseType(): String = currentDialect.dataTypeProvider.largeTextType()
 }
 
 // Binary columns

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -3,7 +3,6 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import org.jetbrains.exposed.sql.statements.api.ExposedDatabaseMetadata
-import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
 import org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManager
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -539,6 +539,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun text(name: String, collate: String? = null, eagerLoading: Boolean = false): Column<String> =
         registerColumn(name, TextColumnType(collate, eagerLoading))
 
+    fun mediumText(name: String, collate: String? = null, eagerLoading: Boolean = false): Column<String> =
+        registerColumn(name, MediumTextColumnType(collate, eagerLoading))
+    fun largeText(name: String, collate: String? = null, eagerLoading: Boolean = false): Column<String> =
+        registerColumn(name, LargeTextColumnType(collate, eagerLoading))
+
     // Binary columns
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -55,8 +55,15 @@ abstract class DataTypeProvider {
 
     // Character types
 
-    /** Character type for storing strings of variable and _unlimited_ length. */
+    /** Character type for storing strings of variable length.
+     * Some database (postgresql) use the same data type name to provide virtually _unlimited_ length. */
     open fun textType(): String = "TEXT"
+
+    /** Character type for storing strings of _medium_ length. */
+    open fun mediumTextType(): String = "TEXT"
+
+    /** Character type for storing strings of variable and _large_ length. */
+    open fun largeTextType(): String = "TEXT"
 
     // Binary data types
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -22,7 +22,14 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
 
     override fun ulongType(): String = "BIGINT UNSIGNED"
 
-    override fun textType(): String = "longtext"
+    override fun textType(): String = "text"
+    // override fun textType(): String = "longtext"
+
+    /** Character type for storing strings of variable and _unlimited_ length. */
+    override fun mediumTextType(): String = "MEDIUMTEXT"
+
+    /** Character type for storing strings of variable and _unlimited_ length. */
+    override fun largeTextType(): String = "LONGTEXT"
 
     override fun booleanFromStringToBoolean(value: String): Boolean = when(value) {
         "0" -> false

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -14,6 +14,8 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun longAutoincType(): String = "NUMBER(19)"
     override fun ulongType(): String = "NUMBER(20)"
     override fun textType(): String = "CLOB"
+    override fun mediumTextType(): String = textType()
+    override fun largeTextType(): String = textType()
     override fun timeType(): String = dateTimeType()
     override fun binaryType(): String {
         exposedLogger.error("Binary type is unsupported for Oracle. Please use blob column type instead.")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -16,7 +16,6 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
         exposedLogger.warn("The length of the binary column is not required.")
         return binaryType()
     }
-
     override fun blobType(): String = "bytea"
     override fun uuidToDB(value: UUID): Any = value
     override fun dateTimeType(): String = "TIMESTAMP"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -25,6 +25,8 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
      * https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-ver15
      */
     override fun textType(): String = "VARCHAR(MAX)"
+    override fun mediumTextType(): String = textType()
+    override fun largeTextType(): String = textType()
 
     override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {
         when (sortOrder) {


### PR DESCRIPTION
Distinct the particular text types. 
Current implementation uses `longtext` everywhere. It does make sense as most of the DB Engines keeps the reference and not the actual value. However that limits some scenarios relying on the exact "unlimited" text type length to discover externally indexable columns. 
In addition, in some scenarios appealing to the largest text possible introduced unwanted flexibility. 
Understandably, not every DB Engine make sense from this. To my best beliefs,  the ones who does are mysql (and compatible engines), Oracle, MSSql. 