### PR TITLE
introduce ForUpdateOption to be able to customize use particular for …

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -3,7 +3,6 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import org.jetbrains.exposed.sql.statements.api.ExposedDatabaseMetadata
-import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
 import org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManager
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
@@ -1,10 +1,12 @@
 package org.jetbrains.exposed.sql
 
+import org.jetbrains.exposed.sql.vendors.ForUpdateOption
+
 interface SizedIterable<out T> : Iterable<T> {
     fun limit(n: Int, offset: Long = 0): SizedIterable<T>
     fun count(): Long
     fun empty(): Boolean
-    fun forUpdate(): SizedIterable<T> = this
+    fun forUpdate(option: ForUpdateOption = ForUpdateOption.ForUpdate): SizedIterable<T> = this
     fun notForUpdate(): SizedIterable<T> = this
     fun copy(): SizedIterable<T>
     fun orderBy(vararg order: Pair<Expression<*>, SortOrder>): SizedIterable<T>
@@ -66,13 +68,13 @@ class LazySizedCollection<out T>(_delegate: SizedIterable<T>) : SizedIterable<T>
     override operator fun iterator() = wrapper.iterator()
     override fun count(): Long = _wrapper?.size?.toLong() ?: _count()
     override fun empty() = _wrapper?.isEmpty() ?: _empty()
-    override fun forUpdate(): SizedIterable<T> {
+    override fun forUpdate(option: ForUpdateOption): SizedIterable<T> {
         val localDelegate = delegate
         if (_wrapper != null && localDelegate is Query && localDelegate.hasCustomForUpdateState() && !localDelegate.isForUpdate()) {
             throw IllegalStateException("Impossible to change forUpdate state for loaded data")
         }
         if (_wrapper == null) {
-            delegate = delegate.forUpdate()
+            delegate = delegate.forUpdate(option)
         }
         return this
     }
@@ -118,7 +120,7 @@ infix fun <T, R> SizedIterable<T>.mapLazy(f: (T) -> R): SizedIterable<R> {
     val source = this
     return object : SizedIterable<R> {
         override fun limit(n: Int, offset: Long): SizedIterable<R> = source.copy().limit(n, offset).mapLazy(f)
-        override fun forUpdate(): SizedIterable<R> = source.copy().forUpdate().mapLazy(f)
+        override fun forUpdate(option: ForUpdateOption): SizedIterable<R> = source.copy().forUpdate(option).mapLazy(f)
         override fun notForUpdate(): SizedIterable<R> = source.copy().notForUpdate().mapLazy(f)
         override fun count(): Long = source.count()
         override fun empty(): Boolean = source.empty()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.sql.statements.Statement
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.sql.vendors.ForUpdateOption
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.sql.ResultSet
 import java.util.*
@@ -15,6 +16,11 @@ enum class SortOrder(val code: String) {
     DESC_NULLS_LAST(code = "DESC NULLS LAST")
 }
 
+private object NoForUpdateOption : ForUpdateOption {
+    override val querySuffix: String
+        get() = error("querySuffix should not be called for NoForUpdateOption object")
+}
+
 open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuery<Query>(set.source.targetTables()) {
     var distinct: Boolean = false
         protected set
@@ -25,7 +31,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     var having: Op<Boolean>? = null
         private set
 
-    private var forUpdate: Boolean? = null
+    private var forUpdate: ForUpdateOption? = null
 
     // private set
     var where: Op<Boolean>? = where
@@ -47,18 +53,18 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
         copy.forUpdate = forUpdate
     }
 
-    override fun forUpdate(): Query {
-        this.forUpdate = true
+    override fun forUpdate(option: ForUpdateOption): Query {
+        this.forUpdate = option
+        return this
+    }
+
+    override fun notForUpdate(): Query {
+        forUpdate = NoForUpdateOption
         return this
     }
 
     override fun withDistinct(value: Boolean): Query = apply {
         distinct = value
-    }
-
-    override fun notForUpdate(): Query {
-        forUpdate = false
-        return this
     }
 
     /**
@@ -92,7 +98,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     fun adjustHaving(body: Op<Boolean>?.() -> Op<Boolean>): Query = apply { having = having.body() }
 
     fun hasCustomForUpdateState() = forUpdate != null
-    fun isForUpdate() = (forUpdate ?: false) && currentDialect.supportsSelectForUpdate()
+    fun isForUpdate() = (forUpdate?.let { it !is NoForUpdateOption } ?: false) && currentDialect.supportsSelectForUpdate()
 
     override fun PreparedStatementApi.executeInternal(transaction: Transaction): ResultSet? {
         val fetchSize = this@Query.fetchSize ?: transaction.db.defaultFetchSize
@@ -151,7 +157,9 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
             }
 
             if (isForUpdate()) {
-                append(" FOR UPDATE")
+                forUpdate?.apply {
+                    append(" $querySuffix")
+                }
             }
         }
         return builder.toString()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -640,6 +640,14 @@ interface DatabaseDialect {
     }
 }
 
+interface ForUpdateOption {
+    companion object ForUpdate : ForUpdateOption {
+        override val querySuffix = "FOR UPDATE"
+    }
+    val querySuffix: String
+}
+
+
 /**
  * Base implementation of a vendor dialect
  */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -234,4 +234,12 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         /** MySQL dialect name */
         const val dialectName: String = "mysql"
     }
+
+    // check https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html for clarification
+    val LockInShareMod = object : ForUpdateOption {
+        override val querySuffix = "LOCK IN SHARE MODE"
+    }
+    val ForShare = object : ForUpdateOption {
+        override val querySuffix = "FOR SHARE"
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -250,6 +250,17 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
     companion object {
         /** PostgreSQL dialect name */
         const val dialectName: String = "postgresql"
+
+        // check https://www.postgresql.org/docs/12/explicit-locking.html#LOCKING-ROWS for clarification
+        val ForKeyShare = object : ForUpdateOption {
+            override val querySuffix = "FOR KEY SHARE"
+        }
+        val ForShare = object : ForUpdateOption {
+            override val querySuffix = "FOR SHARE"
+        }
+        val ForNoKeyUpdate = object : ForUpdateOption {
+            override val querySuffix = "FOR NO KEY UPDATE"
+        }
     }
 }
 
@@ -262,16 +273,15 @@ open class PostgreSQLNGDialect : PostgreSQLDialect() {
     companion object {
         /** PostgreSQL-NG dialect name */
         const val dialectName: String = "pgsql"
-    }
 
-    // check https://www.postgresql.org/docs/12/explicit-locking.html#LOCKING-ROWS for clarification
-    val ForKeyShare = object : ForUpdateOption {
-        override val querySuffix = "FOR KEY SHARE"
-    }
-    val ForShare = object : ForUpdateOption {
-        override val querySuffix = "FOR SHARE"
-    }
-    val ForNoKeyUpdate = object : ForUpdateOption {
-        override val querySuffix = "FOR NO KEY UPDATE"
+        val ForKeyShare = object : ForUpdateOption {
+            override val querySuffix = "FOR KEY SHARE"
+        }
+        val ForShare = object : ForUpdateOption {
+            override val querySuffix = "FOR SHARE"
+        }
+        val ForNoKeyUpdate = object : ForUpdateOption {
+            override val querySuffix = "FOR NO KEY UPDATE"
+        }
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -263,4 +263,15 @@ open class PostgreSQLNGDialect : PostgreSQLDialect() {
         /** PostgreSQL-NG dialect name */
         const val dialectName: String = "pgsql"
     }
+
+    // check https://www.postgresql.org/docs/12/explicit-locking.html#LOCKING-ROWS for clarification
+    val ForKeyShare = object : ForUpdateOption {
+        override val querySuffix = "FOR KEY SHARE"
+    }
+    val ForShare = object : ForUpdateOption {
+        override val querySuffix = "FOR SHARE"
+    }
+    val ForNoKeyUpdate = object : ForUpdateOption {
+        override val querySuffix = "FOR NO KEY UPDATE"
+    }
 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
@@ -4,13 +4,14 @@ import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.vendors.ForUpdateOption
 import kotlin.reflect.KProperty
 
 class View<out Target : Entity<*>> (val op: Op<Boolean>, val factory: EntityClass<*, Target>) : SizedIterable<Target> {
     override fun limit(n: Int, offset: Long): SizedIterable<Target> = factory.find(op).limit(n, offset)
     override fun count(): Long = factory.find(op).count()
     override fun empty(): Boolean = factory.find(op).empty()
-    override fun forUpdate(): SizedIterable<Target> = factory.find(op).forUpdate()
+    override fun forUpdate(option: ForUpdateOption): SizedIterable<Target> = factory.find(op).forUpdate(option)
     override fun notForUpdate(): SizedIterable<Target> = factory.find(op).notForUpdate()
 
     override operator fun iterator(): Iterator<Target> = factory.find(op).iterator()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
@@ -1,0 +1,68 @@
+package org.jetbrains.exposed.sql.tests.postgresql
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.RepeatableTestRule
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.vendors.ForUpdateOption
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class PostgresqlTests : DatabaseTestsBase() {
+    @get:Rule
+    val repeatRule = RepeatableTestRule()
+
+    private val table = object : IntIdTable() {
+        val name = varchar("name", 50)
+    }
+
+    @Test
+    fun `test for update options syntax`() {
+        val id = 1
+
+        fun Query.city() = map { it[table.name] }.single()
+
+        fun select(option: ForUpdateOption): String {
+            return table.select { table.id eq id }.forUpdate(option).city()
+        }
+
+        withDb(TestDB.POSTGRESQL) {
+            withTable {
+                val name = "name"
+                table.insert {
+                    it[table.id] = id
+                    it[table.name] = name
+                }
+                commit()
+
+                val defaultForUpdateRes = table.select { table.id eq id }.city()
+                val forUpdateRes = select(ForUpdateOption.ForUpdate)
+                val forShareRes = select(PostgreSQLDialect.ForShare)
+                val forKeyShareRes = select(PostgreSQLDialect.ForKeyShare)
+                val forNoKeyUpdateRes = select(PostgreSQLDialect.ForNoKeyUpdate)
+                val notForUpdateRes = table.select { table.id eq id }.notForUpdate().city()
+
+                assertEquals(name, defaultForUpdateRes)
+                assertEquals(name, forUpdateRes)
+                assertEquals(name, forShareRes)
+                assertEquals(name, forKeyShareRes)
+                assertEquals(name, forNoKeyUpdateRes)
+                assertEquals(name, notForUpdateRes)
+            }
+        }
+    }
+
+    private fun Transaction.withTable(statement: Transaction.() -> Unit) {
+        SchemaUtils.create(table)
+        try {
+            statement()
+            commit() // Need commit to persist data before drop tables
+        } finally {
+            SchemaUtils.drop(table)
+            commit()
+        }
+    }
+}


### PR DESCRIPTION
…update form.
There is a significant difference between different `for update` semantics  and it is desirable to support them. 
PG: https://www.postgresql.org/docs/12/explicit-locking.html#LOCKING-ROWS 
Mysql: https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html

All the honor goes to Gleb Leonov and Space team. 