### PR TITLE
fix some codes to not use platform type and expression style

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -79,8 +79,8 @@ class JavaLocalDateColumnType : ColumnType(), IDateColumnType {
         else -> LocalDate.parse(value.toString())
     }
 
-    override fun notNullValueToDB(value: Any) = when {
-        value is LocalDate -> java.sql.Date(value.millis)
+    override fun notNullValueToDB(value: Any) = when (value) {
+        is LocalDate -> java.sql.Date(value.millis)
         else -> value
     }
 

--- a/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyDefaultsTest.kt
+++ b/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyDefaultsTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertNull
 class MoneyDefaultsTest : DatabaseTestsBase() {
 
     object TableWithDBDefault : IntIdTable() {
-        val defaultValue = Money.of(BigDecimal.ONE, "USD")
+        val defaultValue: Money = Money.of(BigDecimal.ONE, "USD")
 
         var cIndex = 0
         val field = varchar("field", 100)

--- a/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
+++ b/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.spring.DatabaseInitializer
 import org.jetbrains.exposed.spring.SpringTransactionManager
 import org.jetbrains.exposed.spring.tables.TestTable
 import org.jetbrains.exposed.sql.DatabaseConfig
+import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.selectAll
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
@@ -117,5 +118,5 @@ open class AsyncExposedService {
     open fun allTestData() = TestTable.selectAll().toList()
 
     // you need to put open otherwise @Transactional is not applied since spring plugin not applied (similar to maven kotlin plugin)
-    open fun allTestDataAsync() = CompletableFuture.completedFuture(TestTable.selectAll().toList())
+    open fun allTestDataAsync(): CompletableFuture<List<ResultRow>> = CompletableFuture.completedFuture(TestTable.selectAll().toList())
 }


### PR DESCRIPTION
Hi i am Heli who using Exposed

First, changed some codes to not use the platform type. platform type requires unnecessary boilerplate(!!, let trick, ...) And open source is a guide to writing code.

so i think bad code examples should be deleted.

Second, change 'when' expression style

thanks. 🙇

--
There is no change that users can feel.

