### PR TITLE
insertIgnoreAndGet must explicitly mark failed insert on conflicts

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -190,8 +190,10 @@ fun <T: Table> T.insertIgnore(body: T.(UpdateBuilder<*>)->Unit): InsertStatement
 fun <Key : Comparable<Key>, T : IdTable<Key>> T.insertIgnoreAndGetId(body: T.(UpdateBuilder<*>) -> Unit) =
     InsertStatement<EntityID<Key>>(this, isIgnore = true).run {
         body(this)
-        execute(TransactionManager.current())
-        getOrNull(id)
+        when (execute(TransactionManager.current())) {
+            null, 0 -> null
+            else -> getOrNull(id)
+        }
     }
 
 /**

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -80,6 +80,13 @@ class InsertTests : DatabaseTestsBase() {
             }
 
             assertEquals(null, idNull)
+
+            val shouldNotReturnProvidedIdOnConflict = idTable.insertIgnoreAndGetId {
+                it[idTable.id] = EntityID(100, idTable)
+                it[idTable.name] = "2"
+            }
+
+            assertEquals(null, shouldNotReturnProvidedIdOnConflict)
         }
     }
 


### PR DESCRIPTION
insertIgnoreAndGetId conceals the fact of failed insert by returning the provided values instead of `null`. The existing nullable result contract is not honored for PG / MySQL