### PR TITLE
migrate pg tests to testcontainer module

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -26,5 +26,4 @@ object Versions {
 
     /** Test Dependencies **/
     const val testContainers = "1.16.3"
-    const val otjPgEmbedded = "0.13.4"
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -200,7 +200,7 @@ class Database private constructor(
             databaseConfig: DatabaseConfig? = null,
             manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it) }
         ): Database {
-            Class.forName(driver).newInstance()
+            Class.forName(driver).getDeclaredConstructor().newInstance()
             val dialectName = getDialectName(url) ?: error("Can't resolve dialect for connection: $url")
             return doConnect(dialectName, databaseConfig, { DriverManager.getConnection(url, user, password) }, setupConnection, manager)
         }

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-debug", Versions.kotlinCoroutines)
 
     implementation("org.testcontainers", "mysql", Versions.testContainers)
-    implementation("com.opentable.components", "otj-pg-embedded", Versions.otjPgEmbedded)
+    implementation("org.testcontainers", "postgresql", Versions.testContainers)
     testCompileOnly("org.postgresql", "postgresql", Versions.postgre)
     testCompileOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
     compileOnly("com.h2database", "h2", Versions.h2)

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.sql.tests
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import org.h2.engine.Mode
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
@@ -9,7 +8,9 @@ import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.junit.Assume
 import org.junit.AssumptionViolatedException
 import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.containers.PostgreSQLContainer
 import java.sql.Connection
+import java.time.Duration
 import java.util.*
 import kotlin.concurrent.thread
 import kotlin.reflect.KMutableProperty1
@@ -123,12 +124,32 @@ enum class TestDB(
 
 private val registeredOnShutdown = HashSet<TestDB>()
 
+internal class SpecifiedPGContainer(val image: String) : PostgreSQLContainer<SpecifiedPGContainer>(image) {
+    fun exposeFixedPort(hostPort: Int, containerPort: Int): SpecifiedPGContainer {
+        super.addFixedExposedPort(hostPort, containerPort)
+        return this
+    }
+
+}
+
 private val postgresSQLProcess by lazy {
-    EmbeddedPostgres.builder()
-        .setPgBinaryResolver { system, _ ->
-            EmbeddedPostgres::class.java.getResourceAsStream("/postgresql-$system-x86_64.txz")
+    SpecifiedPGContainer(image ="postgres:13.8-alpine")
+        .withUsername("postgres")
+        .withPassword("")
+        .withStartupTimeout(Duration.ofSeconds(60))
+        .withEnv("POSTGRES_HOST_AUTH_METHOD", "trust")
+        .exposeFixedPort(hostPort = 12346, containerPort = 5432)
+        .apply {
+            listOf(
+                "timezone=UTC",
+                "synchronous_commit=off",
+                "max_connections=300",
+                "fsync=off"
+            ).forEach{
+                setCommand("postgres", "-c", it)
+            }
+            start()
         }
-        .setPort(12346).start()
 }
 
 // MySQLContainer has to be extended, otherwise it leads to Kotlin compiler issues: https://github.com/testcontainers/testcontainers-java/issues/318


### PR DESCRIPTION
Fix pg embedded test segfaults 

```
/➜  src  file /PG-578c3302bce806451b07e3a73d8438d1/bin/postgres -v
/PG-578c3302bce806451b07e3a73d8438d1/bin/postgres: Mach-O universal binary with 2 architectures: [i386:Mach-O executable i386
- Mach-O executable i386] [x86_64]
/PG-578c3302bce806451b07e3a73d8438d1/bin/postgres (for architecture i386):	Mach-O executable i386
/PG-578c3302bce806451b07e3a73d8438d1/bin/postgres (for architecture x86_64):	Mach-O 64-bit executable x86_64
➜  src   /PG-578c3302bce806451b07e3a73d8438d1/bin/postgres -v
[1]    81714 segmentation fault   -v
``` 