### PR TITLE
make clientDefault extend <T> instead of <T : Any>

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -699,7 +699,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     }
 
     /** Sets the default value for this column in the client side. */
-    fun <T : Any> Column<T>.clientDefault(defaultValue: () -> T): Column<T> = apply {
+    fun <T> Column<T>.clientDefault(defaultValue: () -> T): Column<T> = apply {
         dbDefaultValue = null
         defaultValueFun = defaultValue
     }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -22,6 +22,9 @@ import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
@@ -55,6 +58,32 @@ class DefaultsTest : DatabaseTestsBase() {
         override fun hashCode(): Int = id.value.hashCode()
 
         companion object : IntEntityClass<DBDefault>(TableWithDBDefault)
+    }
+
+    @Test
+    fun testCanUseClientDefaultOnNullableColumn() {
+        val defaultValue: Int? = null
+        val table = object : IntIdTable() {
+            val clientDefault = integer("clientDefault").nullable().clientDefault { defaultValue }
+        }
+        val returnedDefault = table.clientDefault.defaultValueFun?.invoke()
+
+        assertTrue(table.clientDefault.columnType.nullable, "Expected clientDefault columnType to be nullable")
+        assertNotNull(table.clientDefault.defaultValueFun, "Expected clientDefault column to have a default value fun, but was null")
+        assertEquals(defaultValue, returnedDefault, "Expected clientDefault to return $defaultValue, but was $returnedDefault")
+    }
+
+    @Test
+    fun testCanSetNullableColumnToUseClientDefault() {
+        val defaultValue = 123
+        val table = object : IntIdTable() {
+            val clientDefault = integer("clientDefault").clientDefault { defaultValue }.nullable()
+        }
+        val returnedDefault = table.clientDefault.defaultValueFun?.invoke()
+
+        assertTrue(table.clientDefault.columnType.nullable, "Expected clientDefault columnType to be nullable")
+        assertNotNull(table.clientDefault.defaultValueFun, "Expected clientDefault column to have a default value fun, but was null")
+        assertEquals(defaultValue, returnedDefault, "Expected clientDefault to return $defaultValue, but was $returnedDefault")
     }
 
     @Test


### PR DESCRIPTION
See issue #1612 

Due to `fun <T : Any> Column<T>.clientDefault` requiring `T : Any`, this function is not usable with nullable columns. As discussed in the above issue, this PR removes this requirement and doesn't seem to break anything.

Running the `:exposed-tests:test` I get 2319 passed, 333 ignored, no failed. I assume that those 333 are supposed to be ignored as nothing except the function signature has been changed.