### PR TITLE
Remove unnecessary proxy class

### DIFF
--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -152,11 +152,8 @@ private val postgresSQLProcess by lazy {
         }
 }
 
-// MySQLContainer has to be extended, otherwise it leads to Kotlin compiler issues: https://github.com/testcontainers/testcontainers-java/issues/318
-internal class SpecifiedMySQLContainer(val image: String) : MySQLContainer<SpecifiedMySQLContainer>(image)
-
 private val mySQLProcess by lazy {
-    SpecifiedMySQLContainer(image = "mysql:5")
+    MySQLContainer("mysql:5")
         .withDatabaseName("testdb")
         .withEnv("MYSQL_ROOT_PASSWORD", "test")
         .withExposedPorts().apply {


### PR DESCRIPTION
As described in testcontainers/testcontainers-java#318 Kotlin since `1.5.30` is [improved](https://kotlinlang.org/docs/whatsnew1530.html#improvements-to-type-inference-for-recursive-generic-types) type inference for recursive generic types and since `1.6` this improvement is [enabled by default](https://kotlinlang.org/docs/whatsnew16.html#improved-type-inference-for-recursive-generic-types).