### PR TITLE
Use VARCHAR2 column for VarCharColumnType when on Oracle

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -592,8 +592,10 @@ open class VarCharColumnType(
     val colLength: Int = 255,
     collate: String? = null
 ) : StringColumnType(collate) {
+    open fun preciseType() = currentDialect.dataTypeProvider.varcharType(colLength)
+
     override fun sqlType(): String = buildString {
-        append("VARCHAR($colLength)")
+        append(preciseType())
         if (collate != null) {
             append(" COLLATE ${escape(collate)}")
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -55,6 +55,9 @@ abstract class DataTypeProvider {
 
     // Character types
 
+    /** Character type for storing strings of variable length up to a maximum. */
+    open fun varcharType(colLength: Int): String = "VARCHAR($colLength)"
+
     /** Character type for storing strings of variable length.
      * Some database (postgresql) use the same data type name to provide virtually _unlimited_ length. */
     open fun textType(): String = "TEXT"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -13,6 +13,7 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun longType(): String = "NUMBER(19)"
     override fun longAutoincType(): String = "NUMBER(19)"
     override fun ulongType(): String = "NUMBER(20)"
+    override fun varcharType(colLength: Int): String = "VARCHAR2($colLength CHAR)"
     override fun textType(): String = "CLOB"
     override fun mediumTextType(): String = textType()
     override fun largeTextType(): String = textType()


### PR DESCRIPTION
Fixes  #1628 

In Oracle, the `VARCHAR` type is reserved and has the potential to change in the future. `VARCHAR2` should be used instead since it won't change. I also added the `CHAR` specification so that the column length always corresponds to characters instead of bytes or characters depending on the `NLS_LENGTH_SEMANTICS` database setting.