### PR TITLE
Sum batch results for inserts

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -120,7 +120,7 @@ open class InsertStatement<Key : Any>(val table: Table, val isIgnore: Boolean = 
     }
 
     protected open fun PreparedStatementApi.execInsertFunction(): Pair<Int, ResultSet?> {
-        val inserted = if (arguments().count() > 1 || isAlwaysBatch) executeBatch().count() else executeUpdate()
+        val inserted = if (arguments().count() > 1 || isAlwaysBatch) executeBatch().sum() else executeUpdate()
         val rs = if (autoIncColumns.isNotEmpty()) {
             resultSet
         } else null


### PR DESCRIPTION
When executing a batch insert, the number of inserted rows is the sum of the batch rows instead of the count.

Making this distinction allows extensions of batch insert like
```kotlin
class MyBatchInsertStatement(
    table: Table,
) : BatchInsertStatement(table) {
    override fun prepareSQL(transaction: Transaction) = buildString {
        append(super.prepareSQL(transaction))
        append(" ON CONFLICT (id) DO NOTHING")
    }
}
```
where the return value of `execute` is still accurate.