### PR TITLE
fix: EXPOSED-171 Switch from spring.factories to AutoConfiguration.imports (#1636)

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -21,6 +21,6 @@ object Versions {
     const val sqlserver = "9.4.1.jre8"
 
     /** Spring **/
-    const val springFramework = "5.3.29"
-    const val springBoot = "2.7.14"
+    const val springFramework = "6.0.11"
+    const val springBoot = "3.1.3"
 }

--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -50,13 +50,24 @@ Example:
 
 ```kotlin
 @Configuration
+@EnableAutoConfiguration(exclude = [DataSourceTransactionManagerAutoConfiguration::class])
 class ExposedConfig {
-  @Bean
-  fun databaseConfig() = DatabaseConfig {
-    useNestedTransactions = true
-  }
+    @Bean
+    fun databaseConfig() = DatabaseConfig {
+        useNestedTransactions = true
+    }
 }
 ```
+It is recommended that the `DataSourceTransactionManagerAutoConfiguration` class be excluded from auto-configuration, which can be done in a custom configuration, as shown above.
+
+Alternatively, the class can be disabled using the `exclude` attribute of `@SpringBootApplication`:
+
+```kotlin
+@SpringBootApplication(exclude = [DataSourceTransactionManagerAutoConfiguration::class])
+class MyApplication
+```
+
+See the [official documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.auto-configuration.disabling-specific) for more options to exclude auto-configuration classes.
 
 ## Automatic Schema Creation
 This starter will create the database schema if enabled automatically using any class that extends `org.jetbrains.exposed.sql.Table`

--- a/exposed-spring-boot-starter/build.gradle.kts
+++ b/exposed-spring-boot-starter/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 dependencies {
@@ -25,7 +25,7 @@ dependencies {
     testImplementation("org.springframework.boot", "spring-boot-starter-test", Versions.springBoot)
     // put in testImplementation so no hard dependency for those using the starter
     testImplementation("org.springframework.boot", "spring-boot-starter-webflux", Versions.springBoot)
-    testImplementation("com.h2database", "h2", Versions.h2)
+    testImplementation("com.h2database", "h2", Versions.h2_v2)
 }
 
 tasks.withType<Test>().configureEach {

--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
@@ -4,18 +4,16 @@ import org.jetbrains.exposed.spring.DatabaseInitializer
 import org.jetbrains.exposed.spring.SpringTransactionManager
 import org.jetbrains.exposed.sql.DatabaseConfig
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.AutoConfigureAfter
+import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import javax.sql.DataSource
 
-@Configuration
-@AutoConfigureAfter(DataSourceAutoConfiguration::class)
+@AutoConfiguration(after = [DataSourceAutoConfiguration::class])
 @EnableTransactionManagement
 open class ExposedAutoConfiguration(private val applicationContext: ApplicationContext) {
 

--- a/exposed-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/exposed-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration
-org.springframework.boot.autoconfigure.EnableAutoConfiguration.exclude=\
-  org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration

--- a/exposed-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/exposed-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration

--- a/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/Application.kt
+++ b/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/Application.kt
@@ -2,10 +2,11 @@ package org.jetbrains.exposed.spring
 
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
 import org.springframework.scheduling.annotation.EnableAsync
 
 @EnableAsync
-@SpringBootApplication
+@SpringBootApplication(exclude = [DataSourceTransactionManagerAutoConfiguration::class])
 open class Application {
 
     open fun main(args: Array<String>) {

--- a/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
+++ b/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.spring.autoconfigure
 
+import org.jetbrains.exposed.spring.Application
 import org.jetbrains.exposed.spring.DatabaseInitializer
 import org.jetbrains.exposed.spring.SpringTransactionManager
 import org.jetbrains.exposed.spring.tables.TestTable
@@ -9,9 +10,13 @@ import org.jetbrains.exposed.sql.selectAll
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
@@ -51,6 +56,18 @@ open class ExposedAutoConfigurationTest {
             expectedConfig.maxEntitiesToStoreInCachePerEntity,
             databaseConfig!!.maxEntitiesToStoreInCachePerEntity
         )
+    }
+
+    @Test
+    fun testClassExcludedFromAutoConfig() {
+        val contextRunner = ApplicationContextRunner().withConfiguration(
+            AutoConfigurations.of(Application::class.java)
+        )
+        contextRunner.run { context ->
+            assertThrows(NoSuchBeanDefinitionException::class.java) {
+                context.getBean(DataSourceTransactionManagerAutoConfiguration::class.java)
+            }
+        }
     }
 
     @TestConfiguration

--- a/spring-transaction/build.gradle.kts
+++ b/spring-transaction/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 dependencies {


### PR DESCRIPTION
Some documentation for reference:

- Change in auto-configuration files ([Spring Boot 3 Migration Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files))
- Change in test H2 version ([Spring Boot 3 Dependency](https://docs.spring.io/spring-boot/docs/3.0.x/reference/html/dependency-versions.html#appendix.dependency-versions))
- Recommended ways to exclude classes from auto-configuration ([Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.auto-configuration.disabling-specific))
- Testing auto-configuration using `ApplicationContextRunner` ([Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.developing-auto-configuration.testing))