### PR TITLE
Allow setting null value for nullable CompositeColumn via set operator

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -55,7 +55,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
 
     open operator fun <S> set(column: Column<S>, value: Query) = update(column, wrapAsExpression(value))
 
-    open operator fun <S : Any> set(column: CompositeColumn<S>, value: S) {
+    open operator fun <S> set(column: CompositeColumn<S>, value: S) {
         column.getRealColumnsWithValues(value).forEach { (realColumn, itsValue) -> set(realColumn as Column<Any?>, itsValue) }
     }
 

--- a/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyDefaultsTest.kt
+++ b/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyDefaultsTest.kt
@@ -6,9 +6,11 @@ import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.flushCache
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.update
 import org.junit.Test
 import java.math.BigDecimal
 import kotlin.test.assertNull
@@ -92,6 +94,10 @@ class MoneyDefaultsTest : DatabaseTestsBase() {
             db1.refresh(flush = true)
             assertEquals(money, db1.t1)
             assertEquals(TableWithDBDefault.defaultValue, db1.t1)
+            TableWithDBDefault.update {
+                it[t2] = null
+            }
+            assertNull(TableWithDBDefault.selectAll().single()[TableWithDBDefault.t2])
         }
     }
 }


### PR DESCRIPTION
Relax excessive generic type limitation for `UpdateBuilder.set(column: CompositeColumn<S>, value: S)`, which was introduced in 0.37.1