### PR TITLE
Fix an error when updating an entity with a foreign key id (issue 880)

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -273,7 +273,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
                     }
                 }
             } else {
-                batch.addBatch(id)
+                batch.addBatch(this)
                 for ((c, v) in writeValues) {
                     batch[c] = v
                 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityBatchUpdate.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityBatchUpdate.kt
@@ -6,13 +6,13 @@ import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.statements.BatchUpdateStatement
 import java.util.*
 
-class EntityBatchUpdate(val klass: EntityClass<*, Entity<*>>) {
+class EntityBatchUpdate(private val klass: EntityClass<*, Entity<*>>) {
 
     private val data = ArrayList<Pair<EntityID<*>, SortedMap<Column<*>, Any?>>>()
 
-    fun addBatch(id: EntityID<*>) {
-        if (id.table != klass.table) error("Table from Entity ID ${id.table.tableName} differs from entity class ${klass.table.tableName}")
-        data.add(id to TreeMap())
+    fun addBatch(entity: Entity<*>) {
+        if (entity.klass != klass) error("Entity class${entity.klass} differs from expected entity class $klass")
+        data.add(entity.id to TreeMap())
     }
 
     operator fun set(column: Column<*>, value: Any?) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ForeignIdEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ForeignIdEntityTest.kt
@@ -1,0 +1,65 @@
+package org.jetbrains.exposed.sql.tests.shared.entities
+
+import org.jetbrains.exposed.dao.LongEntity
+import org.jetbrains.exposed.dao.LongEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertFalse
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Test
+
+/**
+ * A case when a table's primary key is a foreign key to some other table (ProjectConfigs.id -> Project.id)
+ */
+class ForeignIdEntityTest : DatabaseTestsBase() {
+
+    object Schema {
+
+        object Projects : LongIdTable() {
+            val name = varchar("name", 50)
+        }
+
+        object ProjectConfigs : IdTable<Long>() {
+            override val id = reference("id", Projects)
+            val setting = bool("setting")
+        }
+
+    }
+
+    class Project(id: EntityID<Long>) : LongEntity(id) {
+        companion object : LongEntityClass<Project>(Schema.Projects)
+
+        var name by Schema.Projects.name
+    }
+
+    class ProjectConfig(id: EntityID<Long>) : LongEntity(id) {
+        companion object : LongEntityClass<ProjectConfig>(Schema.ProjectConfigs)
+
+        var setting by Schema.ProjectConfigs.setting
+    }
+
+    @Test
+    fun foreignIdEntityUpdate() {
+        // reproducer for https://github.com/JetBrains/Exposed/issues/880
+        withTables(Schema.Projects, Schema.ProjectConfigs) {
+            db.useNestedTransactions = true
+
+            transaction {
+                val projectId = Project.new { name = "Space" }.id.value
+                ProjectConfig.new(projectId) { setting = true }
+            }
+
+            transaction {
+                ProjectConfig.all().first().setting = false
+            }
+
+            transaction {
+                assertFalse(ProjectConfig.all().first().setting)
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
Making sure that when we update an entity with an id which is a foreign key to another table, the assertion in `EntityBatchUpdate.addBatch()` allows this.

Closes #880