### PR TITLE
UPDATE...RETURNING support

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -230,6 +230,17 @@ fun Join.update(where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null, limit: 
     return query.execute(TransactionManager.current())!!
 }
 
+fun <T : Table> T.updateReturning(
+    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    limit: Int? = null,
+    returning: FieldSet,
+    body: T.(UpdateReturningStatement) -> Unit
+): Iterator<ResultRow> {
+    val query = UpdateReturningStatement(this, limit, where?.let { SqlExpressionBuilder.it() }, returning)
+    body(query)
+    return query.execute(TransactionManager.current())!!
+}
+
 /**
  * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.tableExists02
  */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.statements.api
 
 import org.jetbrains.exposed.sql.IColumnType
+import org.jetbrains.exposed.sql.ResultRow
 import java.io.InputStream
 import java.sql.ResultSet
 
@@ -21,6 +22,8 @@ interface PreparedStatementApi {
     fun executeQuery(): ResultSet
 
     fun executeUpdate(): Int
+
+    fun executeUpdateReturning(): ResultSet
 
     val resultSet: ResultSet?
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -400,6 +400,7 @@ abstract class FunctionProvider {
      * @param columnsAndValues Pairs of column to update and values to update with.
      * @param limit Maximum number of rows to update.
      * @param where Condition that decides the rows to update.
+     * @param returning Updated Column/Fiels to return.
      * @param transaction Transaction where the operation is executed.
      */
     open fun update(
@@ -407,6 +408,7 @@ abstract class FunctionProvider {
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
+        returning: FieldSet?,
         transaction: Transaction
     ): String = with(QueryBuilder(true)) {
         +"UPDATE "
@@ -422,6 +424,11 @@ abstract class FunctionProvider {
             +it
         }
         limit?.let { +" LIMIT $it" }
+
+        returning?.let {
+            +" RETURNING "
+            returning.realFields.appendTo { +it }
+        }
         toString()
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -54,6 +54,20 @@ internal object H2FunctionProvider : FunctionProvider() {
     }
 
     override fun update(
+        target: Table,
+        columnsAndValues: List<Pair<Column<*>, Any?>>,
+        limit: Int?,
+        where: Op<Boolean>?,
+        returning: FieldSet?,
+        transaction: Transaction
+    ): String {
+        if (returning != null) {
+            transaction.throwUnsupportedException("H2 doesn't support RETURNING in UPDATE clause.")
+        }
+        return super.update(target, columnsAndValues, limit, where, returning, transaction)
+    }
+
+    override fun update(
         targets: Join,
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -6,6 +6,8 @@ import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.append
 
 internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
+    override val vendor = "MariaDB"
+
     override fun nextVal(seq: Sequence, builder: QueryBuilder) = builder {
         append("NEXTVAL(", seq.identifier, ")")
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -133,9 +133,10 @@ internal object OracleFunctionProvider : FunctionProvider() {
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
+        returning: FieldSet?,
         transaction: Transaction
     ): String {
-        val def = super.update(target, columnsAndValues, null, where, transaction)
+        val def = super.update(target, columnsAndValues, null, where, returning, transaction)
         return when {
             limit != null && where != null -> "$def AND ROWNUM <= $limit"
             limit != null -> "$def WHERE ROWNUM <= $limit"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -115,12 +115,13 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
+        returning: FieldSet?,
         transaction: Transaction
     ): String {
         if (limit != null) {
             transaction.throwUnsupportedException("PostgreSQL doesn't support LIMIT in UPDATE clause.")
         }
-        return super.update(target, columnsAndValues, limit, where, transaction)
+        return super.update(target, columnsAndValues, limit, where, returning, transaction)
     }
 
     override fun update(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -109,9 +109,13 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
+        returning: FieldSet?,
         transaction: Transaction
     ): String {
-        val def = super.update(target, columnsAndValues, null, where, transaction)
+        if (returning != null) {
+            transaction.throwUnsupportedException("SQLServer doesn't support RETURNING in UPDATE clause.")
+        }
+        val def = super.update(target, columnsAndValues, null, where, returning, transaction)
         return if (limit != null) def.replaceFirst("UPDATE", "UPDATE TOP($limit)") else def
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -103,12 +103,13 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
         where: Op<Boolean>?,
+        returning: FieldSet?,
         transaction: Transaction
     ): String {
         if (!ENABLE_UPDATE_DELETE_LIMIT && limit != null) {
             transaction.throwUnsupportedException("SQLite doesn't support LIMIT in UPDATE clause.")
         }
-        return super.update(target, columnsAndValues, limit, where, transaction)
+        return super.update(target, columnsAndValues, limit, where, returning, transaction)
     }
 
     override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.dao.flushCache
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.javatime.*
 import org.jetbrains.exposed.sql.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.sql.statements.BatchInsertStatement
@@ -343,6 +344,35 @@ class DefaultsTest : DatabaseTestsBase() {
             assertEqualDateTime(nonDefaultDate, result2[foo.defaultDateTime])
         }
     }
+//
+//    @Test
+//    fun testDefaultExpressions03() {
+//        val foo = object : IntIdTable("foo") {
+//            val name = text("name")
+//            val defaultDateTime = datetime("defaultDateTime").defaultExpression(CurrentTimestamp())
+//        }
+//
+//        val nonDefaultDate = LocalDate.of(2000, 1, 1).atStartOfDay()
+//
+//        withTables(foo) {
+//            val id = foo.insertAndGetId {
+//                it[foo.name] = "bar"
+//                it[foo.defaultDateTime] = nonDefaultDate
+//            }
+//
+//            val result = foo.select { foo.id eq id }.single()
+//
+//            assertEquals("bar", result[foo.name])
+//            assertEqualDateTime(nonDefaultDate, result[foo.defaultDateTime])
+//
+//            val result2 = foo.updateReturning({ foo.id eq id }, null, foo) {
+//                it[foo.name] = "baz"
+//            }.asSequence().toList()
+//
+//            assertEquals("baz", result2[0][foo.name])
+//            assertEqualDateTime(nonDefaultDate, result2[0][foo.defaultDateTime])
+//        }
+//    }
 
     @Test
     fun testBetweenFunction() {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
@@ -24,6 +24,7 @@ class JdbcPreparedStatementImpl(val statement: PreparedStatement, val wasGenerat
     override fun executeQuery(): ResultSet = statement.executeQuery()
 
     override fun executeUpdate(): Int = statement.executeUpdate()
+    override fun executeUpdateReturning(): ResultSet = statement.executeQuery()
 
     override fun set(index: Int, value: Any) {
         statement.setObject(index, value)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
@@ -157,7 +157,7 @@ class UpdateReturningTests : DatabaseTestsBase() {
             val address = encryptedVarchar("address", 100, Algorithms.BLOW_FISH("key"))
         }
 
-        withTables(stringTable) {
+        withTables(notSupportReturning, stringTable) {
             val id = stringTable.insertAndGetId {
                 it[name] = "TestName"
                 it[city] = "TestCity".toByteArray()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
@@ -23,7 +23,7 @@ class UpdateReturningTests : DatabaseTestsBase() {
         exclude
     }
     private val notSupportReturning by lazy {
-        val exclude = arrayListOf(TestDB.H2, TestDB.MARIADB, TestDB.SQLSERVER, TestDB.MYSQL, TestDB.H2_MYSQL, TestDB.H2_MARIADB)
+        val exclude = arrayListOf(TestDB.H2, TestDB.MARIADB, TestDB.SQLSERVER, TestDB.MYSQL, TestDB.H2_MYSQL, TestDB.H2_MARIADB, TestDB.H2_SQLSERVER, TestDB.H2_PSQL, TestDB.H2_ORACLE)
         if (!SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT) {
             exclude.add(TestDB.SQLITE)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
@@ -23,7 +23,7 @@ class UpdateReturningTests : DatabaseTestsBase() {
         exclude
     }
     private val notSupportReturning by lazy {
-        val exclude = arrayListOf(TestDB.H2, TestDB.MARIADB, TestDB.SQLSERVER, TestDB.MYSQL, TestDB.H2_MYSQL)
+        val exclude = arrayListOf(TestDB.H2, TestDB.MARIADB, TestDB.SQLSERVER, TestDB.MYSQL, TestDB.H2_MYSQL, H2_MARIADB)
         if (!SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT) {
             exclude.add(TestDB.SQLITE)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
@@ -1,0 +1,181 @@
+package org.jetbrains.exposed.sql.tests.shared.dml
+
+import org.jetbrains.exposed.crypt.Algorithms
+import org.jetbrains.exposed.crypt.encryptedBinary
+import org.jetbrains.exposed.crypt.encryptedVarchar
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.vendors.SQLiteDialect
+import org.junit.Test
+import java.lang.IllegalArgumentException
+
+class UpdateReturningTests : DatabaseTestsBase() {
+    private val notSupportLimit by lazy {
+        val exclude = arrayListOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.H2_PSQL)
+        if (!SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT) {
+            exclude.add(TestDB.SQLITE)
+        }
+        exclude
+    }
+    private val notSupportReturning by lazy {
+        val exclude = arrayListOf(TestDB.H2, TestDB.MARIADB, TestDB.SQLSERVER, TestDB.MYSQL, TestDB.H2_MYSQL)
+        if (!SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT) {
+            exclude.add(TestDB.SQLITE)
+        }
+        exclude
+    }
+
+    @Test
+    fun testUpdateReturning01() {
+        withCitiesAndUsers(exclude = notSupportReturning) { _, users, _ ->
+            val alexId = "alex"
+            val alexName = users.slice(users.name).select { users.id.eq(alexId) }.first()[users.name]
+            assertEquals("Alex", alexName)
+
+            val newName = "Alexey"
+            val alexNewName = users.updateReturning({ users.id.eq(alexId) }, null, users) {
+                it[users.name] = newName
+            }.asSequence().toList().first()[users.name]
+
+            assertEquals(newName, alexNewName)
+        }
+    }
+
+    @Test
+    fun testUpdateWithLimit01() {
+        withCitiesAndUsers(exclude = notSupportLimit + notSupportReturning) { _, users, _ ->
+            val aNames = users.slice(users.name).select { users.id like "a%" }.map { it[users.name] }
+            assertEquals(2, aNames.size)
+
+            users.updateReturning({ users.id like "a%" }, 1, users) {
+                it[users.id] = "NewName"
+            }
+
+            val unchanged = users.slice(users.name).select { users.id like "a%" }.count()
+            val changed = users.slice(users.name).select { users.id eq "NewName" }.count()
+            assertEquals(1, unchanged)
+            assertEquals(1, changed)
+        }
+    }
+
+    @Test
+    fun testUpdateWithLimit02() {
+        val dialects = TestDB.values().toList() - notSupportLimit - notSupportReturning
+        withCitiesAndUsers(dialects) { _, users, _ ->
+            expectException<UnsupportedByDialectException> {
+                users.updateReturning({ users.id like "a%" }, 1, users) {
+                    it[users.id] = "NewName"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testUpdateWithReturning01() {
+        val dialects = TestDB.values().toList() - notSupportLimit
+        withCitiesAndUsers(dialects) { _, users, _ ->
+            expectException<UnsupportedByDialectException> {
+                users.updateReturning({ users.id like "a%" }, 1, users) {
+                    it[users.id] = "NewName"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testUpdateWithJoin01() {
+        withCitiesAndUsers(exclude = listOf(TestDB.SQLITE)) { _, users, userData ->
+            val join = users.innerJoin(userData)
+            join.update {
+                it[userData.comment] = users.name
+                it[userData.value] = 123
+            }
+
+            join.selectAll().forEach {
+                assertEquals(it[users.name], it[userData.comment])
+                assertEquals(123, it[userData.value])
+            }
+        }
+    }
+    @Test
+    fun testUpdateWithJoin02() {
+        withCitiesAndUsers(exclude = TestDB.allH2TestDB + TestDB.SQLITE) { cities, users, userData ->
+            val join = cities.innerJoin(users).innerJoin(userData)
+            join.update {
+                it[userData.comment] = users.name
+                it[userData.value] = 123
+            }
+
+            join.selectAll().forEach {
+                assertEquals(it[users.name], it[userData.comment])
+                assertEquals(123, it[userData.value])
+            }
+        }
+    }
+
+    @Test
+    fun `test that column length checked in update `() {
+        val stringTable = object : IntIdTable("StringTable") {
+            val name = varchar("name", 10)
+        }
+
+        withTables(stringTable) {
+            stringTable.insert {
+                it[name] = "TestName"
+            }
+
+            val veryLongString = "1".repeat(255)
+            expectException<IllegalArgumentException> {
+                stringTable.updateReturning({ stringTable.name eq "TestName" }, null, stringTable) {
+                    it[name] = veryLongString
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test update fails with empty body`() {
+        withCitiesAndUsers { cities, _, _ ->
+            expectException<IllegalArgumentException> {
+                cities.updateReturning(where = { cities.id.isNull() }, null, cities) {
+                    // empty
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `update encryptedColumnType`() {
+        val stringTable = object : IntIdTable("StringTable") {
+            val name = encryptedVarchar("name", 100, Algorithms.AES_256_PBE_GCM("passwd", "12345678"))
+            val city = encryptedBinary("city", 100, Algorithms.AES_256_PBE_CBC("passwd", "12345678"))
+            val address = encryptedVarchar("address", 100, Algorithms.BLOW_FISH("key"))
+        }
+
+        withTables(stringTable) {
+            val id = stringTable.insertAndGetId {
+                it[name] = "TestName"
+                it[city] = "TestCity".toByteArray()
+                it[address] = "TestAddress"
+            }
+
+            val updatedName = "TestName2"
+            val updatedCity = "TestCity2"
+            val updatedAddress = "TestAddress2"
+            stringTable.updateReturning({ stringTable.id eq id }, null, stringTable) {
+                it[name] = updatedName
+                it[city] = updatedCity.toByteArray()
+                it[address] = updatedAddress
+            }
+
+            assertEquals(updatedName, stringTable.select { stringTable.id eq id }.single()[stringTable.name])
+            assertEquals(updatedCity, String(stringTable.select { stringTable.id eq id }.single()[stringTable.city]))
+            assertEquals(updatedAddress, stringTable.select { stringTable.id eq id }.single()[stringTable.address])
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateReturningTests.kt
@@ -23,7 +23,7 @@ class UpdateReturningTests : DatabaseTestsBase() {
         exclude
     }
     private val notSupportReturning by lazy {
-        val exclude = arrayListOf(TestDB.H2, TestDB.MARIADB, TestDB.SQLSERVER, TestDB.MYSQL, TestDB.H2_MYSQL, H2_MARIADB)
+        val exclude = arrayListOf(TestDB.H2, TestDB.MARIADB, TestDB.SQLSERVER, TestDB.MYSQL, TestDB.H2_MYSQL, TestDB.H2_MARIADB)
         if (!SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT) {
             exclude.add(TestDB.SQLITE)
         }


### PR DESCRIPTION
issue link: https://github.com/JetBrains/Exposed/issues/351

Known problems:
1. Should it be a different API `updateReturning` or should I pile it on the existing `update` somehow?
2. About 1/2 of the supported platforms do not support this feature. In the current implementation if you try to use it with an incompatible platform you'll get a runtime error. It seems like that is happening all over the project though so I'm not sure if it must be fixed for this PR.