### PR TITLE
fix: Allow exec() transform block to return null if ResultSet is empty

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -180,7 +180,7 @@ open class Transaction(
         @Language("sql") stmt: String,
         args: Iterable<Pair<IColumnType, Any?>> = emptyList(),
         explicitStatementType: StatementType? = null,
-        transform: (ResultSet) -> T
+        transform: (ResultSet) -> T?
     ): T? {
         if (stmt.isEmpty()) return null
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionExecTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionExecTests.kt
@@ -149,11 +149,9 @@ class TransactionExecTests : DatabaseTestsBase() {
             assertNotNull(stringResult)
             assertEquals("Exposed", stringResult)
 
-            // no record exists for id = 999, but result set returns single nullable column due to subquery alias
+            // no record exists for id = 999, but result set returns single nullable column value due to subquery alias
             val dualExtra = if (testDb == TestDB.ORACLE) " FROM DUAL" else ""
-            val nullColumnResult = exec(
-                """SELECT (SELECT $title FROM $table WHERE $id = 999) AS sub$dualExtra"""
-            ) { rs ->
+            val nullColumnResult = exec("""SELECT (SELECT $title FROM $table WHERE $id = 999) AS sub$dualExtra""") { rs ->
                 rs.next()
                 rs.getString("sub")
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionExecTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionExecTests.kt
@@ -149,7 +149,7 @@ class TransactionExecTests : DatabaseTestsBase() {
             assertNotNull(stringResult)
             assertEquals("Exposed", stringResult)
 
-            // no record exists for id = 999, but result set returns single nullable column value due to subquery alias
+            // no record exists for id = 999, but result set returns single nullable value due to subquery alias
             val dualExtra = if (testDb == TestDB.ORACLE) " FROM DUAL" else ""
             val nullColumnResult = exec("""SELECT (SELECT $title FROM $table WHERE $id = 999) AS sub$dualExtra""") { rs ->
                 rs.next()


### PR DESCRIPTION
If the ResultSet contains no result, the user wants to return `null`. However, since `executeQuery()` returns a non-nullable ResultSet, the user is forced to return a non-null object, even if there is no result.

By allowing `transform` to return null, this is fixed.