### PR TITLE
Add spring-boot 3 compatible registration file

### DIFF
--- a/exposed-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/exposed-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration


### PR DESCRIPTION
This adds file required for registration of autoconfiguration in spring-boot 3. 

Not sure what happens to do with the exclude from the spring.factories file.