### PR TITLE
Updated SpringBoot version to 3.0.4 to make exposed-spring-boot-start…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ subprojects {
     }
     tasks.withType<KotlinJvmCompile>().configureEach {
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = "17"
             apiVersion = "1.6"
             languageVersion = "1.6"
         }

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -21,8 +21,8 @@ object Versions {
     const val sqlserver = "9.4.1.jre8"
 
     /** Spring **/
-    const val springFramework = "5.3.22"
-    const val springBoot = "2.7.2"
+    const val springFramework = "6.0.6"
+    const val springBoot = "3.0.4"
 
     /** Test Dependencies **/
     const val testContainers = "1.16.3"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -3,7 +3,6 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.exposed.sql.statements.api.ExposedConnection
 import org.jetbrains.exposed.sql.statements.api.ExposedDatabaseMetadata
-import org.jetbrains.exposed.sql.transactions.DEFAULT_ISOLATION_LEVEL
 import org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManager
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
@@ -189,7 +188,8 @@ class Database private constructor(
                 explicitVendor = null,
                 config = databaseConfig,
                 getNewConnection = getNewConnection,
-                manager = manager)
+                manager = manager
+            )
         }
 
         fun connect(

--- a/exposed-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/exposed-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration
-org.springframework.boot.autoconfigure.EnableAutoConfiguration.exclude=\
-  org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration

--- a/exposed-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/exposed-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration
+org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration


### PR DESCRIPTION
- Updated Spring/SpringBoot dependencies to newest version.
-  Removed unused import.
- Changed registration of autoconfiguration files to SpringBoot 3 standard.