### PR TITLE
Fix UInt value out of bounds

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -329,7 +329,7 @@ class UIntegerColumnType : ColumnType() {
         return when (value) {
             is UInt -> value
             is Int -> value.takeIf { it >= 0 }?.toUInt()
-            is Number -> value.toInt().takeIf { it >= 0 }?.toUInt()
+            is Number -> value.toLong().takeIf { it >= 0 && it < UInt.MAX_VALUE.toLong() }?.toUInt()
             is String -> value.toUInt()
             else -> error("Unexpected value of type Int: $value of ${value::class.qualifiedName}")
         } ?: error("negative value but type is UInt: $value")


### PR DESCRIPTION
Long.toInt will get a negative number if the value is greater than Int.MAX_VALUE
![image](https://user-images.githubusercontent.com/41381927/226825860-daae459b-fdac-425a-a962-0cd6dce8d60b.png)
