### PR TITLE
Fix: PostgreSQLDialect.modifyColumn is not able to drop default values

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -222,7 +222,7 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
             column.dbDefaultValue?.let {
                 append(", ALTER COLUMN $colName SET DEFAULT ${PostgreSQLDataTypeProvider.processForDefaultValue(it)}")
             } ?: run {
-                ",  ALTER COLUMN $colName DROP DEFAULT"
+                append(",  ALTER COLUMN $colName DROP DEFAULT")
             }
         }
     })


### PR DESCRIPTION
Previously, `PostgreSQLDialect.modifyColumn` was not able to drop default values.