### PR TITLE
EXPOSED-21 Primary key constraint not created

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -43,7 +43,8 @@ class Column<T>(
 
     fun nameInDatabaseCase(): String = name.inProperCase()
 
-    private val isLastColumnInPK: Boolean get() = table.primaryKey?.columns?.last() == this
+    private val isLastColumnInPK: Boolean
+        get() = this == table.primaryKey?.columns?.last()
 
     internal val isPrimaryConstraintWillBeDefined: Boolean get() = when {
         currentDialect is SQLiteDialect && columnType.isAutoInc -> false
@@ -75,7 +76,7 @@ class Column<T>(
         return listOf("ALTER TABLE ${tr.identity(table)} DROP COLUMN ${tr.identity(this)}")
     }
 
-    internal fun isOneColumnPK(): Boolean = table.primaryKey?.columns?.singleOrNull() == this
+    internal fun isOneColumnPK(): Boolean = this == table.primaryKey?.columns?.singleOrNull()
 
     /** Returns the SQL representation of this column. */
     fun descriptionDdl(modify: Boolean = false): String = buildString {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -213,13 +213,12 @@ class EntityIDColumnType<T : Comparable<T>>(val idColumn: Column<T>) : ColumnTyp
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
 
-        other as EntityIDColumnType<*>
-
-        if (idColumn != other.idColumn) return false
-
-        return true
+        return when (other) {
+            is EntityIDColumnType<*> -> idColumn == other.idColumn
+            is IColumnType -> idColumn.columnType == other
+            else -> false
+        }
     }
 
     override fun hashCode(): Int = 31 * super.hashCode() + idColumn.hashCode()


### PR DESCRIPTION
Adjust equals() method in EntityIDColumnType.

IdTable creates a column of EntityIDColumnType to replace the original when .entityId() is invoked. PrimaryKey() accepts arguments that can either be the former or the original column of non-EntityIDColumnType. This results in a failure to adequately compare column types when resolving a column's description of its primary key constraint.

Both isOneColumnPK() and isLastColumnInPK() are also adjusted so that equals() is invoked by the EntityIDColumnType (if present). This covers the potential case when an IdTable may be created with a single primary key column that has a user-defined name.

An extra test is added to cover testing of ddl involving a single primary key column in a Table. Existing related tests only cover Tables created with composite keys or single primary keys with a defined name constraint.