### PR TITLE
fix: EXPOSED-27 Id is not in record set

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
@@ -14,87 +14,86 @@ class ResultRow(
     /**
      * Retrieves value of a given expression on this row.
      *
-     * @param c expression to evaluate
+     * @param expression expression to evaluate
      * @throws IllegalStateException if expression is not in record set or if result value is uninitialized
      *
      * @see [getOrNull] to get null in the cases an exception would be thrown
      */
-    operator fun <T> get(c: Expression<T>): T {
-        if (c in lookUpCache) return lookUpCache[c] as T
+    operator fun <T> get(expression: Expression<T>): T {
+        if (expression in lookUpCache) return lookUpCache[expression] as T
 
-        val d = getRaw(c)
+        val d = getRaw(expression)
 
-        if (d == null && c is Column<*> && c.dbDefaultValue != null && !c.columnType.nullable) {
+        if (d == null && expression is Column<*> && expression.dbDefaultValue != null && !expression.columnType.nullable) {
             exposedLogger.warn(
-                "Column ${TransactionManager.current().fullIdentity(c)} is marked as not null, " +
+                "Column ${TransactionManager.current().fullIdentity(expression)} is marked as not null, " +
                     "has default db value, but returns null. Possible have to re-read it from DB."
             )
         }
 
         val result = database?.dialect?.let {
             withDialect(it) {
-                rawToColumnValue(d, c)
+                rawToColumnValue(d, expression)
             }
-        } ?: rawToColumnValue(d, c)
-        lookUpCache[c] = result
+        } ?: rawToColumnValue(d, expression)
+        lookUpCache[expression] = result
         return result
     }
 
-    operator fun <T> set(c: Expression<out T>, value: T) {
-        setInternal(c, value)
-        lookUpCache.remove(c)
+    operator fun <T> set(expression: Expression<out T>, value: T) {
+        setInternal(expression, value)
+        lookUpCache.remove(expression)
     }
 
-    private fun <T> setInternal(c: Expression<out T>, value: T) {
-        val index = getExpressionIndex(c)
+    private fun <T> setInternal(expression: Expression<out T>, value: T) {
+        val index = getExpressionIndex(expression)
         data[index] = value
     }
 
-    fun <T> hasValue(c: Expression<T>): Boolean = fieldIndex[c]?.let { data[it] != NotInitializedValue } ?: false
+    fun <T> hasValue(expression: Expression<T>): Boolean = fieldIndex[expression]?.let { data[it] != NotInitializedValue } ?: false
 
-    fun <T> getOrNull(c: Expression<T>): T? = if (hasValue(c)) get(c) else null
+    fun <T> getOrNull(expression: Expression<T>): T? = if (hasValue(expression)) get(expression) else null
 
     @Suppress("UNCHECKED_CAST")
-    private fun <T> rawToColumnValue(raw: T?, c: Expression<T>): T {
+    private fun <T> rawToColumnValue(raw: T?, expression: Expression<T>): T {
         return when {
             raw == null -> null
-            raw == NotInitializedValue -> error("$c is not initialized yet")
-            c is ExpressionAlias<T> && c.delegate is ExpressionWithColumnType<T> -> c.delegate.columnType.valueFromDB(raw)
-            c is ExpressionWithColumnType<T> -> c.columnType.valueFromDB(raw)
-            c is Op.OpBoolean -> BooleanColumnType.INSTANCE.valueFromDB(raw)
+            raw == NotInitializedValue -> error("$expression is not initialized yet")
+            expression is ExpressionAlias<T> && expression.delegate is ExpressionWithColumnType<T> -> expression.delegate.columnType.valueFromDB(raw)
+            expression is ExpressionWithColumnType<T> -> expression.columnType.valueFromDB(raw)
+            expression is Op.OpBoolean -> BooleanColumnType.INSTANCE.valueFromDB(raw)
             else -> raw
         } as T
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun <T> getRaw(c: Expression<T>): T? {
-        if (c is CompositeColumn<T>) {
-            val rawParts = c.getRealColumns().associateWith { getRaw(it) }
-            return c.restoreValueFromParts(rawParts)
+    private fun <T> getRaw(expression: Expression<T>): T? {
+        if (expression is CompositeColumn<T>) {
+            val rawParts = expression.getRealColumns().associateWith { getRaw(it) }
+            return expression.restoreValueFromParts(rawParts)
         }
 
-        val index = getExpressionIndex(c)
+        val index = getExpressionIndex(expression)
         return data[index] as T?
     }
 
     /**
      * Retrieves the index of a given expression in the [fieldIndex] map.
      *
-     * @param c expression for which to get the index
+     * @param expression expression for which to get the index
      * @throws IllegalStateException if expression is not in record set
      */
-    private fun <T> getExpressionIndex(c: Expression<T>): Int {
-        return fieldIndex[c]
-            ?: ((c as? Column<*>)?.columnType as? EntityIDColumnType<*>)?.let { fieldIndex[it.idColumn] }
+    private fun <T> getExpressionIndex(expression: Expression<T>): Int {
+        return fieldIndex[expression]
             ?: fieldIndex.keys.firstOrNull { exp ->
                 when (exp) {
                     // exp is Column<*> && exp.table is Alias<*> -> exp.table.delegate == c
-                    is Column<*> -> (exp.columnType as? EntityIDColumnType<*>)?.idColumn == c
-                    is ExpressionAlias<*> -> exp.delegate == c
+                    is Column<*> -> (exp.columnType as? EntityIDColumnType<*>)?.idColumn == expression
+                    is ExpressionAlias<*> -> exp.delegate == expression
                     else -> false
                 }
-            }?.let { fieldIndex[it] }
-            ?: error("$c is not in record set")
+            }?.let { exp -> fieldIndex[exp] }
+            ?: error("$expression is not in record set")
     }
 
     override fun toString(): String =

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -1319,4 +1319,28 @@ class EntityTests : DatabaseTestsBase() {
             )
         }
     }
+
+    object RequestsTable : IdTable<String>() {
+        val requestId: Column<String> = varchar("requestId", 256)
+        override val primaryKey = PrimaryKey(requestId)
+        override val id: Column<EntityID<String>> = requestId.entityId()
+    }
+
+    class Request(id: EntityID<String>) : Entity<String>(id) {
+        companion object : EntityClass<String, Request>(RequestsTable)
+
+        var requestId by RequestsTable.requestId
+    }
+
+    @Test
+    fun testSelectFromStringIdTableWithPrimaryKeyByColumn() {
+        withTables(RequestsTable) {
+            Request.new {
+                requestId = "123"
+            }
+
+            val count = Request.all().count()
+            assertEquals(1, count)
+        }
+    }
 }


### PR DESCRIPTION
In the `setInternal` function in `ResultRow`, the expression `c` could not be found in the `fieldIndex` map because the column comparison fails because of a type mismatch between EntityIDColumnType and VarCharColumnType.

Paired with @bog-walk 🙌🏼