### PR TITLE
fix: EXPOSED-28 Update with join fails on H2 in MySql mode

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -63,6 +63,9 @@ internal object H2FunctionProvider : FunctionProvider() {
         if (limit != null) {
             transaction.throwUnsupportedException("H2 doesn't support LIMIT in UPDATE with join clause.")
         }
+        if (where != null && (transaction.db.dialect as H2Dialect).h2Mode != H2Dialect.H2CompatibilityMode.Oracle) {
+            transaction.throwUnsupportedException("H2 doesn't support WHERE in UPDATE with join clause.")
+        }
         val tableToUpdate = columnsAndValues.map { it.first.table }.distinct().singleOrNull()
             ?: transaction.throwUnsupportedException("H2 supports a join updates with a single table columns to update.")
         val joinPart = targets.joinParts.singleOrNull()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -16,6 +16,9 @@ internal object H2DataTypeProvider : DataTypeProvider() {
 }
 
 internal object H2FunctionProvider : FunctionProvider() {
+    private val DatabaseDialect.isH2Oracle: Boolean
+        get() = h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+
     override fun nextVal(seq: Sequence, builder: QueryBuilder) =
         when ((TransactionManager.current().db.dialect as H2Dialect).majorVersion) {
             H2Dialect.H2MajorVersion.One -> super.nextVal(seq, builder)
@@ -63,7 +66,7 @@ internal object H2FunctionProvider : FunctionProvider() {
         if (limit != null) {
             transaction.throwUnsupportedException("H2 doesn't support LIMIT in UPDATE with join clause.")
         }
-        if (where != null && (transaction.db.dialect as H2Dialect).h2Mode != H2Dialect.H2CompatibilityMode.Oracle) {
+        if (where != null && !transaction.db.dialect.isH2Oracle) {
             transaction.throwUnsupportedException("H2 doesn't support WHERE in UPDATE with join clause.")
         }
         val tableToUpdate = columnsAndValues.map { it.first.table }.distinct().singleOrNull()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
@@ -113,7 +113,8 @@ class UpdateTests : DatabaseTestsBase() {
 
         val supportWhere = TestDB.values().toList() - TestDB.allH2TestDB - TestDB.SQLITE + TestDB.H2_ORACLE
 
-        withTables(parent, child) { testingDb ->
+        withDb { testingDb ->
+            SchemaUtils.create(parent, child)
             val pId = parent.insertAndGetId { it[foo] = "foo" }
             child.insert {
                 it[bar] = "zip"
@@ -136,6 +137,7 @@ class UpdateTests : DatabaseTestsBase() {
                     }
                 }
             }
+            SchemaUtils.drop(parent, child)
         }
     }
 


### PR DESCRIPTION
`update()` with join in  `H2FunctionProvider` allows a WHERE clause to be appended to the query, even though the H2 [MERGE INTO](https://www.h2database.com/html/commands.html#merge_into) command supports WHERE minimally. So if a compatibility mode does not support WHERE in merge, the driver throws an unclear `JdbcSQLSyntaxErrorException`.

[Documentation](https://www.h2database.com/html/features.html#compatibility_modes) and tests show that the only H2 mode to support WHERE clause is Oracle mode.

This catches all unsupported cases and throws an `UnsupportedByDialectException` with a more informative message.