### PR TITLE
fix: EXPOSED-29 Cannot set nullable composite column in InsertStatement

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -28,7 +28,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
     }
 
     @LowPriorityInOverloadResolution
-    open operator fun < S> set(column: Column<S>, value: S) {
+    open operator fun <S> set(column: Column<S>, value: S) {
         require(column.columnType.nullable || (value != null && value !is Op.NULL)) {
             "Trying to set null to not nullable column $column"
         }
@@ -66,7 +66,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
 
     open operator fun <S> set(column: Column<S>, value: Query) = update(column, wrapAsExpression(value))
 
-    open operator fun <S : Any> set(column: CompositeColumn<S>, value: S) {
+    open operator fun <S> set(column: CompositeColumn<S>, value: S) {
         column.getRealColumnsWithValues(value).forEach { (realColumn, itsValue) -> set(realColumn as Column<Any?>, itsValue) }
     }
 

--- a/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyTests.kt
+++ b/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyTests.kt
@@ -78,6 +78,24 @@ open class MoneyBaseTest : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testNullableCompositeColumnInsertAndSelect() {
+        val table = object : IntIdTable("Table") {
+            val composite_money = compositeMoney(8, AMOUNT_SCALE, "composite_money").nullable()
+        }
+
+        withTables(table) {
+            val id = table.insertAndGetId {
+                it[composite_money] = null
+            }
+
+            val resultRow = table.select { table.id.eq(id) }.single()
+            val result = resultRow[table.composite_money]
+
+            assertEquals(null, result)
+        }
+    }
+
     private fun testInsertedAndSelect(toInsert: Money?) {
         withTables(Account) {
             val accountID = Account.insertAndGetId {


### PR DESCRIPTION
Remove the upper bound generic constraint for the function `set(column: CompositeColumn<S>, value: S)`

https://kotlinlang.org/docs/generics.html#upper-bounds:~:text=The%20default%20upper%20bound%20(if%20there%20was%20none%20specified)%20is%20Any%3F