### PR TITLE
fix: EXPOSED-23 H2 unsupported indexing behavior

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -221,8 +221,11 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
     override fun createIndex(index: Index): String {
-        if (index.columns.any { it.columnType is TextColumnType }) {
-            exposedLogger.warn("Index on ${index.table.tableName} for ${index.columns.joinToString { it.name }} can't be created in H2")
+        if (
+            (majorVersion == H2MajorVersion.One || h2Mode == H2CompatibilityMode.Oracle) &&
+            index.columns.any { it.columnType is TextColumnType }
+        ) {
+            exposedLogger.warn("Index on ${index.table.tableName} for ${index.columns.joinToString { it.name }} can't be created on CLOB in H2")
             return ""
         }
         if (index.indexType != null) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
@@ -14,6 +15,7 @@ import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.inProperCase
 import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
+import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
@@ -22,6 +24,7 @@ import org.postgresql.util.PGobject
 import java.util.*
 import kotlin.random.Random
 import kotlin.test.assertNotNull
+import kotlin.test.expect
 
 class DDLTests : DatabaseTestsBase() {
 
@@ -206,6 +209,33 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testPrimaryKeyOnTextColumnInH2() {
+        val testTable = object : Table("test_pk_table") {
+            val column1 = text("column_1")
+
+            override val primaryKey = PrimaryKey(column1)
+        }
+
+        withDb(TestDB.allH2TestDB) {
+            val h2Dialect = currentDialectTest as H2Dialect
+            val isOracleMode = h2Dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+            val singleColumnDescription = testTable.columns.single().descriptionDdl(false)
+
+            assertTrue(singleColumnDescription.contains("PRIMARY KEY"))
+
+            if (h2Dialect.isSecondVersion && !isOracleMode) {
+                expect(Unit) {
+                    SchemaUtils.create(testTable)
+                }
+            } else {
+                expectException<ExposedSQLException> {
+                    SchemaUtils.create(testTable)
+                }
+            }
+        }
+    }
+
     @Test fun testIndices01() {
         val t = object : Table("t1") {
             val id = integer("id")
@@ -246,6 +276,42 @@ class DDLTests : DatabaseTestsBase() {
                     "(${"lvalue".inProperCase()}, ${"rvalue".inProperCase()})",
                 a2
             )
+        }
+    }
+
+    @Test
+    fun testIndexOnTextColumnInH2() {
+        val testTable = object : Table("test_index_table") {
+            val column1 = text("column_1")
+
+            init {
+                index(isUnique = false, column1)
+            }
+        }
+
+        withDb(TestDB.allH2TestDB) {
+            val h2Dialect = currentDialectTest as H2Dialect
+            val isOracleMode = h2Dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+            val tableProperName = testTable.tableName.inProperCase()
+            val columnProperName = testTable.columns.single().name.inProperCase()
+            val indexProperName = "${tableProperName}_$columnProperName"
+
+            val indexStatement = SchemaUtils.createIndex(testTable.indices.single())
+
+            assertEquals(
+                "CREATE TABLE " + addIfNotExistsIfSupported() + tableProperName +
+                    " (" + testTable.columns.single().descriptionDdl(false) + ")",
+                testTable.ddl
+            )
+
+            if (h2Dialect.isSecondVersion && !isOracleMode) {
+                assertEquals(
+                    "CREATE INDEX $indexProperName ON $tableProperName ($columnProperName)",
+                    indexStatement
+                )
+            } else {
+                assertTrue(indexStatement.single().isEmpty())
+            }
         }
     }
 


### PR DESCRIPTION
Fix indexing behavior on text column in H2 v2.x

H2 version 1.x does not support indexing on `text` columns, with attempts to create a primary key throwing a `JdbcSQLFeatureNotSupportedException`, while `.uniqueIndex()` and `index()` log a warn & ignore the attempt.

H2 2.x supports indexing on `text` columns, except when in Oracle mode, because `text` maps to `clob`. Attempting to create a primary key in Oracle mode still throws an exception, but index can now be actually created by `.uniqueIndex()` and `index()` in all other modes.