### PR TITLE
feat: EXPOSED-32 Support string function CHAR_LENGTH

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -68,6 +68,15 @@ class Random(
 // String Functions
 
 /**
+ * Represents an SQL function that returns the length of [expr], measured in characters, or `null` if [expr] is null.
+ */
+class CharLength<T : String?>(
+    val expr: Expression<T>
+) : Function<Int?>(IntegerColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.charLength(expr, queryBuilder)
+}
+
+/**
  * Represents an SQL function that converts [expr] to lower case.
  */
 class LowerCase<T : String?>(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -16,6 +16,9 @@ import kotlin.internal.LowPriorityInOverloadResolution
 
 // String Functions
 
+/** Returns the length of this string expression, measured in characters, or `null` if this expression is null. */
+fun <T : String?> Expression<T>.charLength(): CharLength<T> = CharLength(this)
+
 /** Converts this string expression to lower case. */
 fun <T : String?> Expression<T>.lowerCase(): LowerCase<T> = LowerCase(this)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -150,6 +150,16 @@ abstract class FunctionProvider {
     // String functions
 
     /**
+     * SQL function that returns the length of [expr], measured in characters, or `null` if [expr] is null.
+     *
+     * @param expr String expression to count characters in.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
+    open fun <T : String?> charLength(expr: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("CHAR_LENGTH(", expr, ")")
+    }
+
+    /**
      * SQL function that extracts a substring from the specified string expression.
      *
      * @param expr The expression to extract the substring from.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -55,6 +55,10 @@ internal object OracleFunctionProvider : FunctionProvider() {
      */
     override fun random(seed: Int?): String = "dbms_random.value"
 
+    override fun <T : String?> charLength(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("LENGTH(", expr, ")")
+    }
+
     override fun <T : String?> substring(
         expr: Expression<T>,
         start: Expression<Int>,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -57,6 +57,10 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
 
     override fun random(seed: Int?): String = if (seed != null) "RAND($seed)" else "RAND(CHECKSUM(NEWID()))"
 
+    override fun <T : String?> charLength(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("LEN(", expr, ")")
+    }
+
     override fun <T : String?> groupConcat(expr: GroupConcat<T>, queryBuilder: QueryBuilder) {
         val tr = TransactionManager.current()
         return when {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -19,6 +19,10 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
 }
 
 internal object SQLiteFunctionProvider : FunctionProvider() {
+    override fun <T : String?> charLength(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("LENGTH(", expr, ")")
+    }
+
     override fun <T : String?> substring(
         expr: Expression<T>,
         start: Expression<Int>,

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -4,7 +4,6 @@ import org.jetbrains.exposed.crypt.Algorithms
 import org.jetbrains.exposed.crypt.Encryptor
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.concat
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
@@ -20,6 +19,7 @@ import org.jetbrains.exposed.sql.vendors.h2Mode
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class FunctionsTests : DatabaseTestsBase() {
 
@@ -259,20 +259,46 @@ class FunctionsTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testLengthWithCount01() {
-        class LengthFunction<T : ExpressionWithColumnType<String>>(val exp: T) : Function<Int>(IntegerColumnType()) {
-            override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-                if (currentDialectTest is SQLServerDialect) append("LEN(", exp, ')')
-                else append("LENGTH(", exp, ')')
-            }
-        }
+    fun testCharLengthWithSum() {
         withCitiesAndUsers { cities, _, _ ->
-            val sumOfLength = LengthFunction(cities.name).sum()
+            val sumOfLength = CharLength(cities.name).sum()
             val expectedValue = cities.selectAll().sumOf { it[cities.name].length }
 
             val results = cities.slice(sumOfLength).selectAll().toList()
             assertEquals(1, results.size)
             assertEquals(expectedValue, results.single()[sumOfLength])
+        }
+    }
+
+    @Test
+    fun testCharLengthWithEdgeCaseStrings() {
+        val testTable = object : Table("test_table") {
+            val nullString = varchar("null_string", 32).nullable()
+            val emptyString = varchar("empty_string", 32).nullable()
+        }
+
+        withTables(testTable) {
+            testTable.insert {
+                it[nullString] = null
+                it[emptyString] = ""
+            }
+            val helloWorld = "こんにちは世界" // each character is a 3-byte character
+
+            val nullLength = testTable.nullString.charLength()
+            val emptyLength = testTable.emptyString.charLength()
+            val multiByteLength = CharLength(stringLiteral(helloWorld))
+
+            // Oracle treats empty strings as null
+            val isOracleDialect = currentDialectTest is OracleDialect ||
+                currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+            val expectedEmpty = if (isOracleDialect) null else 0
+            // char_length should return single-character count, not total byte count
+            val expectedMultibyte = helloWorld.length
+
+            val result = testTable.slice(nullLength, emptyLength, multiByteLength).selectAll().single()
+            assertNull(result[nullLength])
+            assertEquals(expectedEmpty, result[emptyLength])
+            assertEquals(expectedMultibyte, result[multiByteLength])
         }
     }
 


### PR DESCRIPTION
Rationale for:

- Function Name: Opted to use `CharLength` instead of `Length` to follow the ANSI SQL standards, even though all dialects support a function with a variation on the name 'length'. Also, `LENGTH()` specifically returns the length of the string measured in bytes in MySQL and MariaDB, whereas all versions of `CHAR_LENGTH()` return the expected single-character count.

- Expression Type: The function only accepts string expressions, so an explicit cast is required if a number needs to be provided to the function. Of the supported databases, only MySQL, MariaDB, and Sqlite support a numerical value argument for implicit casting by the database.

Partial fix for [#1059](https://github.com/JetBrains/Exposed/issues/1059)