### PR TITLE
chore: Add to exception descriptive message indicating required autoCommit status for create/drop database

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -294,17 +294,13 @@ object SchemaUtils {
                 val createStatements = databases.flatMap { listOf(currentDialect.createDatabase(it)) }
                 execStatements(inBatch, createStatements)
             }
-        } catch (e: ExposedSQLException) {
+        } catch (exception: ExposedSQLException) {
             if (currentDialect.requiresAutoCommitOnCreateDrop && !transaction.connection.autoCommit) {
-                throw ExposedSQLException(
-                    cause = Exception(
-                        "${currentDialect.name} requires autoCommit to be enabled for CREATE DATABASE",
-                        e.cause
-                    ),
-                    e.contexts,
-                    transaction
+                throw IllegalStateException(
+                    "${currentDialect.name} requires autoCommit to be enabled for CREATE DATABASE",
+                    exception
                 )
-            } else throw e
+            } else throw exception
         }
     }
 
@@ -325,17 +321,13 @@ object SchemaUtils {
                 val createStatements = databases.flatMap { listOf(currentDialect.dropDatabase(it)) }
                 execStatements(inBatch, createStatements)
             }
-        } catch (e: ExposedSQLException) {
+        } catch (exception: ExposedSQLException) {
             if (currentDialect.requiresAutoCommitOnCreateDrop && !transaction.connection.autoCommit) {
-                throw ExposedSQLException(
-                    cause = Exception(
-                        "${currentDialect.name} requires autoCommit to be enabled for DROP DATABASE",
-                        e.cause
-                    ),
-                    e.contexts,
-                    transaction
+                throw IllegalStateException(
+                    "${currentDialect.name} requires autoCommit to be enabled for DROP DATABASE",
+                    exception
                 )
-            } else throw e
+            } else throw exception
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -281,6 +281,10 @@ object SchemaUtils {
      *
      * @param databases the names of the databases
      * @param inBatch flag to perform database creation in a single batch
+     *
+     * For PostgreSQL, calls to this function should be preceded by connection.autoCommit = true,
+     * and followed by connection.autoCommit = false.
+     * @see org.jetbrains.exposed.sql.tests.shared.ddl.CreateDatabaseTest
      */
     fun createDatabase(vararg databases: String, inBatch: Boolean = false) {
         with(TransactionManager.current()) {
@@ -294,6 +298,10 @@ object SchemaUtils {
      *
      * @param databases the names of the databases
      * @param inBatch flag to perform database creation in a single batch
+     *
+     * For PostgreSQL, calls to this function should be preceded by connection.autoCommit = true,
+     * and followed by connection.autoCommit = false.
+     * @see org.jetbrains.exposed.sql.tests.shared.ddl.CreateDatabaseTest
      */
     fun dropDatabase(vararg databases: String, inBatch: Boolean = false) {
         with(TransactionManager.current()) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -623,6 +623,9 @@ interface DatabaseDialect {
 
     val likePatternSpecialChars: Map<Char, Char?> get() = defaultLikePatternSpecialChars
 
+    /** Returns true if autoCommit should be enabled to create/drop database */
+    val requiresAutoCommitOnCreateDrop: Boolean get() = false
+
     /** Returns the name of the current database. */
     fun getDatabase(): String
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -213,6 +213,8 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
 open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProvider, PostgreSQLFunctionProvider) {
     override val supportsOrderByNullsFirstLast: Boolean = true
 
+    override val requiresAutoCommitOnCreateDrop: Boolean = true
+
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
     override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> = listOf(buildString {
@@ -258,5 +260,7 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
  * The driver accepts basic URLs in the following format : jdbc:pgsql://localhost:5432/db
  */
 open class PostgreSQLNGDialect : PostgreSQLDialect() {
+    override val requiresAutoCommitOnCreateDrop: Boolean = true
+
     companion object : DialectNameProvider("pgsql")
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.exposed.sql.tests.shared.ddl
 
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.junit.Test
@@ -11,7 +11,7 @@ class CreateDatabaseTest : DatabaseTestsBase() {
     @Test
     fun `create database test`() {
         // PostgreSQL will be tested in the next test function
-        withDb(excludeSettings = listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.H2_PSQL)) {
+        withDb(excludeSettings = listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
             val dbName = "jetbrains"
             try {
                 SchemaUtils.dropDatabase(dbName)
@@ -26,7 +26,7 @@ class CreateDatabaseTest : DatabaseTestsBase() {
     @Test
     fun `create database test in postgreSQL`() {
         // PostgreSQL needs auto commit to be "ON" to allow create database statement
-        withDb(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.H2_PSQL)) {
+        withDb(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
             connection.autoCommit = true
             val dbName = "jetbrains"
             SchemaUtils.createDatabase(dbName)


### PR DESCRIPTION
Simply added a more informative message in the exception thrown when `autoCommit` needs to be `true`