### PR TITLE
feat: EXPOSED-37 Support null-safe equality comparison

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -286,6 +286,26 @@ interface ISqlExpressionBuilder {
     /** Returns `true` if this expression is not null, `false` otherwise. */
     fun <T> Expression<T>.isNotNull(): IsNotNullOp = IsNotNullOp(this)
 
+    /** Checks if this expression is equal to some [t] value, with `null` treated as a comparable value */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.isNotDistinctFrom(t: T): IsNotDistinctFromOp = IsNotDistinctFromOp(this, wrap(t))
+
+    /** Checks if this expression is equal to some [other] expression, with `null` treated as a comparable value */
+    infix fun <T : Comparable<T>, S : T?> Expression<in S>.isNotDistinctFrom(other: Expression<in S>): IsNotDistinctFromOp = IsNotDistinctFromOp(this, other)
+
+    /** Checks if this expression is equal to some [t] value, with `null` treated as a comparable value */
+    @JvmName("isNotDistinctFromEntityID")
+    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.isNotDistinctFrom(t: T): IsNotDistinctFromOp = IsNotDistinctFromOp(this, wrap(t))
+
+    /** Checks if this expression is not equal to some [t] value, with `null` treated as a comparable value */
+    infix fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.isDistinctFrom(t: T): IsDistinctFromOp = IsDistinctFromOp(this, wrap(t))
+
+    /** Checks if this expression is not equal to some [other] expression, with `null` treated as a comparable value */
+    infix fun <T : Comparable<T>, S : T?> Expression<in S>.isDistinctFrom(other: Expression<in S>): IsDistinctFromOp = IsDistinctFromOp(this, other)
+
+    /** Checks if this expression is not equal to some [t] value, with `null` treated as a comparable value */
+    @JvmName("isDistinctFromEntityID")
+    infix fun <T : Comparable<T>> ExpressionWithColumnType<EntityID<T>>.isDistinctFrom(t: T): IsDistinctFromOp = IsDistinctFromOp(this, wrap(t))
+
     // Mathematical Operators
 
     /** Adds the [t] value to this expression. */


### PR DESCRIPTION
The normal 3-valued logic of SQL syntax means the result of `null == null` is UNKNOWN, which returns `null` instead of `true`.

Supporting null-safe comparison, using IS [NOT] DISTINCT FROM and its variants, allows 2 null values to be treated as equivalent. This limits the return value of the equality comparison to only 2 values: `true` or `false`.