### PR TITLE
fix: EXPOSED-36 LocalDate comparison in SQLite

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -93,6 +93,9 @@ abstract class DataTypeProvider {
     /** Time type for storing time without a time zone. */
     open fun timeType(): String = "TIME"
 
+    /** Data type for storing date without time or a time zone. */
+    open fun dateType(): String = "DATE"
+
     // Boolean type
 
     /** Data type for storing boolean values. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -15,6 +15,7 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun floatType(): String = "SINGLE"
     override fun binaryType(): String = "BLOB"
     override fun dateTimeType(): String = "TEXT"
+    override fun dateType(): String = "TEXT"
     override fun booleanToStatementString(bool: Boolean) = if (bool) "1" else "0"
 }
 

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -54,7 +54,7 @@ internal val LocalDate.millis get() = atStartOfDay(ZoneId.systemDefault()).toEpo
 class JavaLocalDateColumnType : ColumnType(), IDateColumnType {
     override val hasTimePart: Boolean = false
 
-    override fun sqlType(): String = "DATE"
+    override fun sqlType(): String = currentDialect.dataTypeProvider.dateType()
 
     override fun nonNullValueToString(value: Any): String {
         val instant = when (value) {

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -81,8 +81,9 @@ class JavaLocalDateColumnType : ColumnType(), IDateColumnType {
         else -> LocalDate.parse(value.toString())
     }
 
-    override fun notNullValueToDB(value: Any) = when (value) {
-        is LocalDate -> java.sql.Date(value.millis)
+    override fun notNullValueToDB(value: Any) = when {
+        value is LocalDate && currentDialect is SQLiteDialect -> DEFAULT_DATE_STRING_FORMATTER.format(value)
+        value is LocalDate -> java.sql.Date(value.millis)
         else -> value
     }
 

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -2,6 +2,9 @@ package org.jetbrains.exposed
 
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.javatime.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
@@ -125,6 +128,101 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             val minTsnExpr = TestTable.tsn.min()
             val minNullableTimestamp = TestTable.slice(minTsnExpr).selectAll().single()[minTsnExpr]
             assertEqualDateTime(now, minNullableTimestamp)
+        }
+    }
+
+    @Test
+    fun testSQLiteDateFieldRegression01() {
+        val (tableName, columnName) = "test_table" to "date_col"
+        val testTable = object : IntIdTable(tableName) {
+            val dateCol = date(columnName).defaultExpression(CurrentDate)
+        }
+
+        withDb(TestDB.SQLITE) {
+            // force table creation using old numeric date column instead of new text column
+            val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "$columnName NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+            try {
+                exec(createStatement)
+                testTable.insert { }
+
+                val year = testTable.dateCol.year()
+                val month = testTable.dateCol.month()
+                val day = testTable.dateCol.day()
+
+                val result1 = testTable.slice(year, month, day).selectAll().single()
+                assertEquals(today.year, result1[year])
+                assertEquals(today.monthValue, result1[month])
+                assertEquals(today.dayOfMonth, result1[day])
+
+                val lastDayOfMonth = CustomDateFunction(
+                    "date",
+                    testTable.dateCol,
+                    stringLiteral("start of month"),
+                    stringLiteral("+1 month"),
+                    stringLiteral("-1 day")
+                )
+                val nextMonth = LocalDate.of(today.year, today.monthValue, 1).plusMonths(1)
+                val expectedLastDayOfMonth = nextMonth.minusDays(1)
+
+                val result2 = testTable.slice(lastDayOfMonth).selectAll().single()
+                assertEquals(expectedLastDayOfMonth, result2[lastDayOfMonth])
+            } finally {
+                SchemaUtils.drop(testTable)
+            }
+        }
+    }
+
+    @Test
+    fun testSQLiteDateFieldRegression02() {
+        val (tableName, eventColumn, dateColumn) = Triple("test_table", "event", "date_col")
+        val testTable = object : IntIdTable(tableName) {
+            val event = varchar(eventColumn, 32)
+            val defaultDate = date(dateColumn).defaultExpression(CurrentDate)
+        }
+
+        withDb(TestDB.SQLITE) {
+            // force table creation using old numeric date column instead of new text column
+            val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "$eventColumn VARCHAR(32) NOT NULL, $dateColumn NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+            try {
+                exec(createStatement)
+                val eventAId = testTable.insertAndGetId {
+                    it[event] = "A"
+                    it[defaultDate] = LocalDate.of(2000, 12, 25)
+                }
+                val eventBId = testTable.insertAndGetId {
+                    it[event] = "B"
+                }
+
+                val inYear2000 = testTable.defaultDate.castTo<String>(TextColumnType()) like "2000%"
+                assertEquals(1, testTable.select { inYear2000 }.count())
+
+                val todayResult1 = testTable.select { testTable.defaultDate eq today }.single()
+                assertEquals(eventBId, todayResult1[testTable.id])
+
+                testTable.update({ testTable.id eq eventAId }) {
+                    it[testTable.defaultDate] = today
+                }
+
+                val todayResult2 = testTable.select { testTable.defaultDate eq today }.count()
+                assertEquals(2, todayResult2)
+
+                val twoYearsAgo = today.minusYears(2)
+                val twoYearsInFuture = today.plusYears(2)
+                val isWithinTwoYears = testTable.defaultDate.between(twoYearsAgo, twoYearsInFuture)
+                assertEquals(2, testTable.select { isWithinTwoYears }.count())
+
+                val yesterday = today.minusDays(1)
+
+                testTable.deleteWhere {
+                    testTable.defaultDate.day() eq dateParam(yesterday).day()
+                }
+
+                assertEquals(2, testTable.selectAll().count())
+            } finally {
+                SchemaUtils.drop(testTable)
+            }
         }
     }
 

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -141,7 +141,7 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
         withDb(TestDB.SQLITE) {
             // force table creation using old numeric date column instead of new text column
             val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-                "$columnName NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+                "$columnName DATE DEFAULT (CURRENT_DATE) NOT NULL);"
             try {
                 exec(createStatement)
                 testTable.insert { }
@@ -184,7 +184,7 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
         withDb(TestDB.SQLITE) {
             // force table creation using old numeric date column instead of new text column
             val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-                "$eventColumn VARCHAR(32) NOT NULL, $dateColumn NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+                "$eventColumn VARCHAR(32) NOT NULL, $dateColumn DATE DEFAULT (CURRENT_DATE) NOT NULL);"
             try {
                 exec(createStatement)
                 val eventAId = testTable.insertAndGetId {

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -127,6 +127,42 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             assertEqualDateTime(now, minNullableTimestamp)
         }
     }
+
+    @Test
+    fun testLocalDateComparison() {
+        val testTable = object : Table("test_table") {
+            val created = date("created")
+            val deleted = date("deleted")
+        }
+
+        withTables(testTable) {
+            val mayTheFourth = LocalDate.of(2023, 5, 4)
+            testTable.insert {
+                it[created] = mayTheFourth
+                it[deleted] = mayTheFourth
+            }
+            testTable.insert {
+                it[created] = mayTheFourth
+                it[deleted] = mayTheFourth.plusDays(1L)
+            }
+
+            val sameDateResult = testTable.select { testTable.created eq testTable.deleted }.toList()
+            assertEquals(1, sameDateResult.size)
+            assertEquals(mayTheFourth, sameDateResult.single()[testTable.deleted])
+
+            val sameMonthResult = testTable.select { testTable.created.month() eq testTable.deleted.month() }.toList()
+            assertEquals(2, sameMonthResult.size)
+
+            val year2023 = if (currentDialectTest is PostgreSQLDialect) {
+                // PostgreSQL requires explicit type cast to resolve function date_part
+                dateParam(mayTheFourth).castTo<LocalDate>(JavaLocalDateColumnType()).year()
+            } else {
+                dateParam(mayTheFourth).year()
+            }
+            val createdIn2023 = testTable.select { testTable.created.year() eq year2023 }.toList()
+            assertEquals(2, createdIn2023.size)
+        }
+    }
 }
 
 fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
@@ -30,7 +30,11 @@ private fun dateTimeWithFractionFormat(fraction: Int): DateTimeFormatter {
 
 class DateColumnType(val time: Boolean) : ColumnType(), IDateColumnType {
     override val hasTimePart: Boolean = time
-    override fun sqlType(): String = if (time) currentDialect.dataTypeProvider.dateTimeType() else "DATE"
+    override fun sqlType(): String = if (time) {
+        currentDialect.dataTypeProvider.dateTimeType()
+    } else {
+        currentDialect.dataTypeProvider.dateType()
+    }
 
     override fun nonNullValueToString(value: Any): String {
         if (value is String) return value
@@ -94,6 +98,7 @@ class DateColumnType(val time: Boolean) : ColumnType(), IDateColumnType {
     override fun notNullValueToDB(value: Any): Any = when {
         value is DateTime && time && currentDialect is SQLiteDialect -> SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.print(value)
         value is DateTime && time -> java.sql.Timestamp(value.millis)
+        value is DateTime && currentDialect is SQLiteDialect -> DEFAULT_DATE_STRING_FORMATTER.print(value)
         value is DateTime -> java.sql.Date(value.millis)
         else -> value
     }

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
@@ -123,3 +123,6 @@ fun dateTimeLiteral(value: DateTime): LiteralOp<DateTime> = LiteralOp(DateColumn
 
 fun CustomDateTimeFunction(functionName: String, vararg params: Expression<*>) =
     CustomFunction<DateTime?>(functionName, DateColumnType(true), *params)
+
+fun CustomDateFunction(functionName: String, vararg params: Expression<*>) =
+    CustomFunction<DateTime?>(functionName, DateColumnType(false), *params)

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -2,17 +2,18 @@ package org.jetbrains.exposed
 
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.jodatime.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-import org.junit.Assert
 import org.junit.Test
-import java.math.BigDecimal
-import java.math.RoundingMode
 import kotlin.test.assertEquals
 
 open class JodaTimeBaseTest : DatabaseTestsBase() {
@@ -43,6 +44,137 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
             assertEquals(now.hourOfDay, insertedHour)
             assertEquals(now.minuteOfHour, insertedMinute)
             assertEquals(now.secondOfMinute, insertedSecond)
+        }
+    }
+
+    @Test
+    fun testSQLiteDateFieldRegression01() {
+        val (tableName, columnName) = "test_table" to "date_col"
+        val testTable = object : IntIdTable(tableName) {
+            val dateCol = date(columnName).defaultExpression(CurrentDate)
+        }
+
+        withDb(TestDB.SQLITE) {
+            // force table creation using old numeric date column instead of new text column
+            val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "$columnName DATE DEFAULT (CURRENT_DATE) NOT NULL);"
+            try {
+                exec(createStatement)
+                testTable.insert { }
+
+                val year = testTable.dateCol.year()
+                val month = testTable.dateCol.month()
+                val day = testTable.dateCol.day()
+
+                val result1 = testTable.slice(year, month, day).selectAll().single()
+                assertEquals(today.year, result1[year])
+                assertEquals(today.monthOfYear, result1[month])
+                assertEquals(today.dayOfMonth, result1[day])
+
+                val lastDayOfMonth = CustomDateFunction(
+                    "date",
+                    testTable.dateCol,
+                    stringLiteral("start of month"),
+                    stringLiteral("+1 month"),
+                    stringLiteral("-1 day")
+                )
+                val nextMonth = DateTime.parse("${today.year}-${today.monthOfYear}-01").plusMonths(1)
+                val expectedLastDayOfMonth = nextMonth.minusDays(1)
+
+                val result2 = testTable.slice(lastDayOfMonth).selectAll().single()
+                assertEquals(expectedLastDayOfMonth, result2[lastDayOfMonth])
+            } finally {
+                SchemaUtils.drop(testTable)
+            }
+        }
+    }
+
+    @Test
+    fun testSQLiteDateFieldRegression02() {
+        val (tableName, eventColumn, dateColumn) = Triple("test_table", "event", "date_col")
+        val testTable = object : IntIdTable(tableName) {
+            val event = varchar(eventColumn, 32)
+            val defaultDate = date(dateColumn).defaultExpression(CurrentDate)
+        }
+
+        withDb(TestDB.SQLITE) {
+            // force table creation using old numeric date column instead of new text column
+            val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "$eventColumn VARCHAR(32) NOT NULL, $dateColumn DATE DEFAULT (CURRENT_DATE) NOT NULL);"
+            try {
+                exec(createStatement)
+                val eventAId = testTable.insertAndGetId {
+                    it[event] = "A"
+                    it[defaultDate] = DateTime.parse("2000-12-25")
+                }
+                val eventBId = testTable.insertAndGetId {
+                    it[event] = "B"
+                }
+
+                val inYear2000 = testTable.defaultDate.castTo<String>(TextColumnType()) like "2000%"
+                assertEquals(1, testTable.select { inYear2000 }.count())
+
+                val todayResult1 = testTable.select { testTable.defaultDate eq today }.single()
+                assertEquals(eventBId, todayResult1[testTable.id])
+
+                testTable.update({ testTable.id eq eventAId }) {
+                    it[testTable.defaultDate] = today
+                }
+
+                val todayResult2 = testTable.select { testTable.defaultDate eq today }.count()
+                assertEquals(2, todayResult2)
+
+                val twoYearsAgo = today.minusYears(2)
+                val twoYearsInFuture = today.plusYears(2)
+                val isWithinTwoYears = testTable.defaultDate.between(twoYearsAgo, twoYearsInFuture)
+                assertEquals(2, testTable.select { isWithinTwoYears }.count())
+
+                val yesterday = today.minusDays(1)
+
+                testTable.deleteWhere {
+                    testTable.defaultDate.day() eq dateParam(yesterday).day()
+                }
+
+                assertEquals(2, testTable.selectAll().count())
+            } finally {
+                SchemaUtils.drop(testTable)
+            }
+        }
+    }
+
+    @Test
+    fun testLocalDateComparison() {
+        val testTable = object : Table("test_table") {
+            val created = date("created")
+            val deleted = date("deleted")
+        }
+
+        withTables(testTable) {
+            val mayTheFourth = DateTime.parse("2023-05-04")
+            testTable.insert {
+                it[created] = mayTheFourth
+                it[deleted] = mayTheFourth
+            }
+            testTable.insert {
+                it[created] = mayTheFourth
+                it[deleted] = mayTheFourth.plusDays(1)
+            }
+
+            val sameDateResult = testTable.select { testTable.created eq testTable.deleted }.toList()
+            assertEquals(1, sameDateResult.size)
+            assertEquals(mayTheFourth, sameDateResult.single()[testTable.deleted])
+
+            val sameMonthResult = testTable.select { testTable.created.month() eq testTable.deleted.month() }.toList()
+            assertEquals(2, sameMonthResult.size)
+
+            val year2023 = if (currentDialectTest is PostgreSQLDialect) {
+                // PostgreSQL requires explicit type cast to resolve function date_part
+                dateParam(mayTheFourth).castTo<DateTime>(DateColumnType(false)).year()
+            } else {
+                dateParam(mayTheFourth).year()
+            }
+            val createdIn2023 = testTable.select { testTable.created.year() eq year2023 }.toList()
+            assertEquals(2, createdIn2023.size)
         }
     }
 }

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -66,7 +66,7 @@ private val LocalDate.millis get() = this.atStartOfDayIn(TimeZone.currentSystemD
 class KotlinLocalDateColumnType : ColumnType(), IDateColumnType {
     override val hasTimePart: Boolean = false
 
-    override fun sqlType(): String = "DATE"
+    override fun sqlType(): String = currentDialect.dataTypeProvider.dateType()
 
     override fun nonNullValueToString(value: Any): String {
         val instant = when (value) {

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -93,8 +93,9 @@ class KotlinLocalDateColumnType : ColumnType(), IDateColumnType {
         else -> LocalDate.parse(value.toString())
     }
 
-    override fun notNullValueToDB(value: Any) = when (value) {
-        is LocalDate -> java.sql.Date(value.millis)
+    override fun notNullValueToDB(value: Any) = when {
+        value is LocalDate && currentDialect is SQLiteDialect -> DEFAULT_DATE_STRING_FORMATTER.format(value.toJavaLocalDate())
+        value is LocalDate -> java.sql.Date(value.millis)
         else -> value
     }
 

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -136,7 +136,7 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
         withDb(TestDB.SQLITE) {
             // force table creation using old numeric date column instead of new text column
             val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-                "$columnName NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+                "$columnName DATE DEFAULT (CURRENT_DATE) NOT NULL);"
             try {
                 exec(createStatement)
                 testTable.insert { }
@@ -179,7 +179,7 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
         withDb(TestDB.SQLITE) {
             // force table creation using old numeric date column instead of new text column
             val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-                "$eventColumn VARCHAR(32) NOT NULL, $dateColumn NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+                "$eventColumn VARCHAR(32) NOT NULL, $dateColumn DATE DEFAULT (CURRENT_DATE) NOT NULL);"
             try {
                 exec(createStatement)
                 val eventAId = testTable.insertAndGetId {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -3,6 +3,9 @@ package org.jetbrains.exposed.sql.kotlin.datetime
 import kotlinx.datetime.*
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -120,6 +123,101 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
             val minTsnExpr = TestTable.tsn.min()
             val minNullableTimestamp = TestTable.slice(minTsnExpr).selectAll().single()[minTsnExpr]
             assertEqualDateTime(now, minNullableTimestamp)
+        }
+    }
+
+    @Test
+    fun testSQLiteDateFieldRegression01() {
+        val (tableName, columnName) = "test_table" to "date_col"
+        val testTable = object : IntIdTable(tableName) {
+            val dateCol = date(columnName).defaultExpression(CurrentDate)
+        }
+
+        withDb(TestDB.SQLITE) {
+            // force table creation using old numeric date column instead of new text column
+            val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "$columnName NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+            try {
+                exec(createStatement)
+                testTable.insert { }
+
+                val year = testTable.dateCol.year()
+                val month = testTable.dateCol.month()
+                val day = testTable.dateCol.day()
+
+                val result1 = testTable.slice(year, month, day).selectAll().single()
+                assertEquals(today.year, result1[year])
+                assertEquals(today.monthNumber, result1[month])
+                assertEquals(today.dayOfMonth, result1[day])
+
+                val lastDayOfMonth = CustomDateFunction(
+                    "date",
+                    testTable.dateCol,
+                    stringLiteral("start of month"),
+                    stringLiteral("+1 month"),
+                    stringLiteral("-1 day")
+                )
+                val nextMonth = LocalDate(today.year, today.monthNumber, 1).plus(1, DateTimeUnit.MONTH)
+                val expectedLastDayOfMonth = nextMonth.minus(1, DateTimeUnit.DAY)
+
+                val result2 = testTable.slice(lastDayOfMonth).selectAll().single()
+                assertEquals(expectedLastDayOfMonth, result2[lastDayOfMonth])
+            } finally {
+                SchemaUtils.drop(testTable)
+            }
+        }
+    }
+
+    @Test
+    fun testSQLiteDateFieldRegression02() {
+        val (tableName, eventColumn, dateColumn) = Triple("test_table", "event", "date_col")
+        val testTable = object : IntIdTable(tableName) {
+            val event = varchar(eventColumn, 32)
+            val defaultDate = date(dateColumn).defaultExpression(CurrentDate)
+        }
+
+        withDb(TestDB.SQLITE) {
+            // force table creation using old numeric date column instead of new text column
+            val createStatement = "CREATE TABLE IF NOT EXISTS $tableName (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "$eventColumn VARCHAR(32) NOT NULL, $dateColumn NUMERIC DEFAULT (CURRENT_DATE) NOT NULL);"
+            try {
+                exec(createStatement)
+                val eventAId = testTable.insertAndGetId {
+                    it[event] = "A"
+                    it[defaultDate] = LocalDate(2000, 12, 25)
+                }
+                val eventBId = testTable.insertAndGetId {
+                    it[event] = "B"
+                }
+
+                val inYear2000 = testTable.defaultDate.castTo<String>(TextColumnType()) like "2000%"
+                assertEquals(1, testTable.select { inYear2000 }.count())
+
+                val todayResult1 = testTable.select { testTable.defaultDate eq today }.single()
+                assertEquals(eventBId, todayResult1[testTable.id])
+
+                testTable.update({ testTable.id eq eventAId }) {
+                    it[testTable.defaultDate] = today
+                }
+
+                val todayResult2 = testTable.select { testTable.defaultDate eq today }.count()
+                assertEquals(2, todayResult2)
+
+                val twoYearsAgo = today.minus(2, DateTimeUnit.YEAR)
+                val twoYearsInFuture = today.plus(2, DateTimeUnit.YEAR)
+                val isWithinTwoYears = testTable.defaultDate.between(twoYearsAgo, twoYearsInFuture)
+                assertEquals(2, testTable.select { isWithinTwoYears }.count())
+
+                val yesterday = today.minus(1, DateTimeUnit.DAY)
+
+                testTable.deleteWhere {
+                    testTable.defaultDate.day() eq dateParam(yesterday).day()
+                }
+
+                assertEquals(2, testTable.selectAll().count())
+            } finally {
+                SchemaUtils.drop(testTable)
+            }
         }
     }
 


### PR DESCRIPTION
`LocalDate` value was being passed to database as `java.sql.Date`, stored as a 13-digit integer because the object represents **milliseconds** since 1970-01-01. Date datatype in SQLite passed to date functions as an integer must be of a specific format, 10 digits, to represent the number of **seconds** since 1970.

Conversion to a recognizable format could be achieved by changing the dialect's date functions, like `year()` e.g.:
```STRFTIME('%Y', date_column / 1000, 'unixepoch')```
But this would break cases where the same date functions are used for `LocalDateTime` values.

Date value is instead passed to database as a string, since [multiple formats](https://www.sqlite.org/lang_datefunc.html#time_values) are recognized for comparison.

To match this changed format, `LocalDate` column representation was also switched to TEXT , one of [3 supported storage types](https://www.sqlite.org/datatype3.html#date_and_time_datatype).

Initially, `DateColumnType` was set as DATE for all databases. SQLite does not have a date-specific column and would instead assign the type as NUMERIC, based on [type affinity](https://www.sqlite.org/datatype3.html#affinity_name_examples), with numbers representing seconds since 1970-01-01.