### PR TITLE
feat: EXPOSED-45 Support single statement UPSERT

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -3,6 +3,16 @@ package org.jetbrains.exposed.sql.statements
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.vendors.*
 
+/**
+ * Represents the SQL command that either inserts a new row into a table, or updates the existing row if insertion would violate a unique constraint.
+ *
+ * @param table Table to either insert values into or update values from.
+ * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
+ * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
+ * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
+ * If left null, all columns will be updated with the values provided for the insert.
+ * @param where Condition that determines which rows to update, if a unique violation is found. This clause may not be supported by all vendors.
+ */
 open class UpsertStatement<Key : Any>(
     table: Table,
     vararg val keys: Column<*>,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.exposed.sql.statements
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.vendors.*
+
+open class UpsertStatement<Key : Any>(
+    table: Table,
+    vararg val keys: Column<*>,
+    val onUpdate: List<Pair<Column<*>, Expression<*>>>?,
+    val where: Op<Boolean>?
+) : InsertStatement<Key>(table) {
+
+    override fun prepareSQL(transaction: Transaction): String {
+        val functionProvider = when (val dialect = transaction.db.dialect) {
+            is H2Dialect -> when (dialect.h2Mode) {
+                H2Dialect.H2CompatibilityMode.MariaDB, H2Dialect.H2CompatibilityMode.MySQL -> MysqlFunctionProvider()
+                else -> H2FunctionProvider
+            }
+            else -> dialect.functionProvider
+        }
+        return functionProvider.upsert(table, arguments!!.first(), onUpdate, where, transaction, *keys)
+    }
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -504,6 +504,132 @@ abstract class FunctionProvider {
     ): String = transaction.throwUnsupportedException("There's no generic SQL for REPLACE. There must be vendor specific implementation.")
 
     /**
+     * Returns the SQL command that either inserts a new row into a table, or updates the existing row if insertion would violate a unique constraint.
+     *
+     * **Note:** Vendors that do not support this operation directly implement the standard MERGE USING command.
+     *
+     * @param table Table to either insert values into or update values from.
+     * @param data Pairs of columns to use for insert or update and values to insert or update.
+     * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
+     * @param where Condition that determines which rows to update, if a unique violation is found.
+     * @param transaction Transaction where the operation is executed.
+     */
+    open fun upsert(
+        table: Table,
+        data: List<Pair<Column<*>, Any?>>,
+        onUpdate: List<Pair<Column<*>, Expression<*>>>?,
+        where: Op<Boolean>?,
+        transaction: Transaction,
+        vararg keys: Column<*>
+    ): String {
+        if (where != null) {
+            transaction.throwUnsupportedException("MERGE implementation of UPSERT doesn't support single WHERE clause")
+        }
+        val keyColumns = getKeyColumnsForUpsert(table, *keys)
+        if (keyColumns.isNullOrEmpty()) {
+            transaction.throwUnsupportedException("UPSERT requires a unique key or constraint as a conflict target")
+        }
+
+        val dataColumns = data.unzip().first
+        val autoIncColumn = table.autoIncColumn
+        val nextValExpression = autoIncColumn?.autoIncColumnType?.nextValExpression
+        val dataColumnsWithoutAutoInc = autoIncColumn?.let { dataColumns - autoIncColumn } ?: dataColumns
+        val updateColumns = dataColumns.filter { it !in keyColumns }
+
+        return with(QueryBuilder(true)) {
+            +"MERGE INTO "
+            table.describe(transaction, this)
+            +" T USING "
+            data.appendTo(prefix = "(VALUES (", postfix = ")") { (column, value) ->
+                registerArgument(column, value)
+            }
+            dataColumns.appendTo(prefix = ") S(", postfix = ")") { column ->
+                append(transaction.identity(column))
+            }
+
+            +" ON "
+            keyColumns.appendTo(separator = " AND ", prefix = "(", postfix = ")") { column ->
+                val columnName = transaction.identity(column)
+                append("T.$columnName=S.$columnName")
+            }
+
+            +" WHEN MATCHED THEN"
+            appendUpdateToUpsertClause(table, updateColumns, onUpdate, transaction, isAliasNeeded = true)
+
+            +" WHEN NOT MATCHED THEN INSERT "
+            dataColumnsWithoutAutoInc.appendTo(prefix = "(") { column ->
+                append(transaction.identity(column))
+            }
+            nextValExpression?.let {
+                append(", ${transaction.identity(autoIncColumn)}")
+            }
+            dataColumnsWithoutAutoInc.appendTo(prefix = ") VALUES(") { column ->
+                append("S.${transaction.identity(column)}")
+            }
+            nextValExpression?.let {
+                append(", $it")
+            }
+            +")"
+            toString()
+        }
+    }
+
+    /**
+     * Returns the columns to be used in the conflict condition of an upsert statement.
+     */
+    protected fun getKeyColumnsForUpsert(table: Table, vararg keys: Column<*>): List<Column<*>>? {
+        return keys.toList().ifEmpty {
+            table.primaryKey?.columns?.toList() ?: table.indices.firstOrNull { it.unique }?.columns
+        }
+    }
+
+    /**
+     * Appends the complete default SQL insert (no ignore) command to [this] QueryBuilder.
+     */
+    protected fun QueryBuilder.appendInsertToUpsertClause(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction) {
+        val valuesSql = if (data.isEmpty()) {
+            ""
+        } else {
+            data.appendTo(QueryBuilder(true), prefix = "VALUES (", postfix = ")") { (column, value) ->
+                registerArgument(column, value)
+            }.toString()
+        }
+        val insertStatement = insert(false, table, data.unzip().first, valuesSql, transaction)
+
+        +insertStatement
+    }
+
+    /**
+     * Appends an SQL update command for a derived table (with or without alias identifiers) to [this] QueryBuilder.
+     */
+    protected fun QueryBuilder.appendUpdateToUpsertClause(
+        table: Table,
+        updateColumns: List<Column<*>>,
+        onUpdate: List<Pair<Column<*>, Expression<*>>>?,
+        transaction: Transaction,
+        isAliasNeeded: Boolean
+    ) {
+        +" UPDATE SET "
+        onUpdate?.appendTo { (columnToUpdate, updateExpression) ->
+            if (isAliasNeeded) {
+                val aliasExpression = updateExpression.toString().replace(transaction.identity(table), "T")
+                append("T.${transaction.identity(columnToUpdate)}=${aliasExpression}")
+            } else {
+                append("${transaction.identity(columnToUpdate)}=${updateExpression}")
+            }
+        } ?: run {
+            updateColumns.appendTo { column ->
+                val columnName = transaction.identity(column)
+                if (isAliasNeeded) {
+                    append("T.$columnName=S.$columnName")
+                } else {
+                    append("$columnName=EXCLUDED.$columnName")
+                }
+            }
+        }
+    }
+
+    /**
      * Returns the SQL command that deletes one or more rows of a table.
      *
      * **Note:** The `ignore` parameter is not supported by all vendors, please check the documentation.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.vendors
 
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
+import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.math.BigDecimal
@@ -142,6 +143,49 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         }
         limit?.let { +" LIMIT $it" }
         toString()
+    }
+
+    override fun upsert(
+        table: Table,
+        data: List<Pair<Column<*>, Any?>>,
+        onUpdate: List<Pair<Column<*>, Expression<*>>>?,
+        where: Op<Boolean>?,
+        transaction: Transaction,
+        vararg keys: Column<*>
+    ): String {
+        if (keys.isNotEmpty()) {
+            transaction.throwUnsupportedException("MySQL doesn't support specifying conflict keys in UPSERT clause")
+        }
+        if (where != null) {
+            transaction.throwUnsupportedException("MySQL doesn't support WHERE in UPSERT clause")
+        }
+
+        val isAliasSupported = when (val dialect = transaction.db.dialect) {
+            is MysqlDialect -> dialect !is MariaDBDialect && dialect.isMysql8
+            else -> false  // H2_MySQL mode also uses this function provider & requires older version
+        }
+
+        return with(QueryBuilder(true)) {
+            appendInsertToUpsertClause(table, data, transaction)
+            if (isAliasSupported) {
+                +" AS NEW"
+            }
+
+            +" ON DUPLICATE KEY UPDATE "
+            onUpdate?.appendTo { (columnToUpdate, updateExpression) ->
+                append("${transaction.identity(columnToUpdate)}=${updateExpression}")
+            } ?: run {
+                data.unzip().first.appendTo { column ->
+                    val columnName = transaction.identity(column)
+                    if (isAliasSupported) {
+                        append("$columnName=NEW.$columnName")
+                    } else {
+                        append("$columnName=VALUES($columnName)")
+                    }
+                }
+            }
+            toString()
+        }
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -162,6 +162,18 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         toString()
     }
 
+    override fun upsert(
+        table: Table,
+        data: List<Pair<Column<*>, Any?>>,
+        onUpdate: List<Pair<Column<*>, Expression<*>>>?,
+        where: Op<Boolean>?,
+        transaction: Transaction,
+        vararg keys: Column<*>
+    ): String {
+        // SQLSERVER MERGE statement must be terminated by a semi-colon (;)
+        return super.upsert(table, data, onUpdate, where, transaction, *keys) + ";"
+    }
+
     override fun delete(ignore: Boolean, table: Table, where: String?, limit: Int?, transaction: Transaction): String {
         val def = super.delete(ignore, table, where, null, transaction)
         return if (limit != null) def.replaceFirst("DELETE", "DELETE TOP($limit)") else def

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -11,6 +11,7 @@ import org.junit.Assume
 import org.junit.AssumptionViolatedException
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.containers.PostgreSQLContainer
+import java.math.BigDecimal
 import java.sql.Connection
 import java.sql.SQLException
 import java.time.Duration
@@ -281,6 +282,12 @@ abstract class DatabaseTestsBase {
         "IF NOT EXISTS "
     } else {
         ""
+    }
+
+    fun Transaction.excludingH2Version1(dbSettings: TestDB, statement: Transaction.(TestDB) -> Unit) {
+        if (dbSettings !in TestDB.allH2TestDB || db.isVersionCovers(BigDecimal("2.0"))) {
+            statement(dbSettings)
+        }
     }
 
     protected fun prepareSchemaForTest(schemaName: String) : Schema {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
@@ -1,0 +1,348 @@
+package org.jetbrains.exposed.sql.tests.shared.dml
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.concat
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.less
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.minus
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
+import org.jetbrains.exposed.sql.tests.*
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.junit.Test
+
+class UpsertTests : DatabaseTestsBase() {
+    // these DB require key columns from ON clause to be included in the derived source table (USING clause)
+    private val upsertViaMergeDB = listOf(TestDB.SQLSERVER, TestDB.ORACLE) + TestDB.allH2TestDB - TestDB.H2_MYSQL
+
+    private val mySqlLikeDB = listOf(TestDB.MYSQL, TestDB.H2_MYSQL, TestDB.MARIADB, TestDB.H2_MARIADB)
+
+    @Test
+    fun testUpsertWithPKConflict() {
+        val tester = object : Table("tester") {
+            val id = integer("id").autoIncrement()
+            val name = varchar("name", 64)
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester) {
+            val id1 = tester.insert {
+                it[name] = "A"
+            } get tester.id
+
+            tester.upsert {
+                if (currentTestDB in upsertViaMergeDB) it[id] = 2
+                it[name] = "B"
+            }
+            tester.upsert {
+                it[id] = id1
+                it[name] = "C"
+            }
+
+            assertEquals(2, tester.selectAll().count())
+            val updatedResult = tester.select { tester.id eq id1 }.single()
+            assertEquals("C", updatedResult[tester.name])
+        }
+    }
+
+    @Test
+    fun testUpsertWithCompositePKConflict() {
+        val tester = object : Table("tester") {
+            val idA = integer("id_a")
+            val idB = integer("id_b")
+            val name = varchar("name", 64)
+
+            override val primaryKey = PrimaryKey(idA, idB)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester) {
+            val insertStmt = tester.insert {
+                it[idA] = 1
+                it[idB] = 1
+                it[name] = "A"
+            }
+
+            tester.upsert {  // insert because only 1 constraint is equal
+                it[idA] = 7
+                it[idB] = insertStmt get tester.idB
+                it[name] = "B"
+            }
+            tester.upsert {  // insert because both constraints differ
+                it[idA] = 99
+                it[idB] = 99
+                it[name] = "C"
+            }
+            tester.upsert {  // update because both constraints match
+                it[idA] = insertStmt get tester.idA
+                it[idB] = insertStmt get tester.idB
+                it[name] = "D"
+            }
+
+            assertEquals(3, tester.selectAll().count())
+            val updatedResult = tester.select { tester.idA eq insertStmt[tester.idA] }.single()
+            assertEquals("D", updatedResult[tester.name])
+        }
+    }
+
+    @Test
+    fun testUpsertWithUniqueIndexConflict() {
+        val tester = object : Table("tester") {
+            val name = varchar("name", 64).uniqueIndex()
+            val age = integer("age")
+        }
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester) {
+            val nameA = tester.upsert {
+                it[name] = "A"
+                it[age] = 10
+            } get tester.name
+            tester.upsert {
+                it[name] = "B"
+                it[age] = 10
+            }
+            tester.upsert {
+                it[name] = "A"
+                it[age] = 9
+            }
+
+            assertEquals(2, tester.selectAll().count())
+            val updatedResult = tester.select { tester.name eq nameA }.single()
+            assertEquals(9, updatedResult[tester.age])
+        }
+    }
+
+    @Test
+    fun testUpsertWithManualConflictKeys() {
+        val tester = object : Table("tester") {
+            val idA = integer("id_a").uniqueIndex()
+            val idB = integer("id_b").uniqueIndex()
+            val name = varchar("name", 64)
+        }
+
+        withTables(excludeSettings = mySqlLikeDB + TestDB.H2, tester) {
+            val oldIdA = tester.insert {
+                it[idA] = 1
+                it[idB] = 1
+                it[name] = "A"
+            } get tester.idA
+
+            val newIdB = tester.upsert(tester.idA) {
+                it[idA] = oldIdA
+                it[idB] = 2
+                it[name] = "B"
+            } get tester.idB
+            assertEquals("B", tester.selectAll().single()[tester.name])
+
+            val newIdA = tester.upsert(tester.idB) {
+                it[idA] = 99
+                it[idB] = newIdB
+                it[name] = "C"
+            } get tester.idA
+            assertEquals("C", tester.selectAll().single()[tester.name])
+
+            if (currentTestDB in upsertViaMergeDB) {
+                // passes since these DB use 'AND' within ON clause (other DB require single uniqueness constraint)
+                tester.upsert(tester.idA, tester.idB) {
+                    it[idA] = newIdA
+                    it[idB] = newIdB
+                    it[name] = "D"
+                }
+
+                val result = tester.selectAll().single()
+                assertEquals(newIdA, result[tester.idA])
+                assertEquals(newIdB, result[tester.idB])
+                assertEquals("D", result[tester.name])
+            }
+        }
+    }
+
+    @Test
+    fun testUpsertWithNoUniqueConstraints() {
+        val tester = object : Table("tester") {
+            val name = varchar("name", 64)
+        }
+
+        val okWithNoUniquenessDB = mySqlLikeDB + listOf(TestDB.SQLITE)
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester) {
+            if (currentTestDB in okWithNoUniquenessDB) {
+                tester.upsert {
+                    it[name] = "A"
+                }
+                assertEquals(1, tester.selectAll().count())
+            } else {
+                expectException<UnsupportedByDialectException> {
+                    tester.upsert {
+                        it[name] = "A"
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testUpsertWithManualUpdateAssignment() {
+        val tester = object : Table("tester") {
+            val word = varchar("word", 256).uniqueIndex()
+            val count = integer("count").default(1)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester) {
+            val testWord = "Test"
+            val incrementCount = listOf(tester.count to tester.count.plus(1))
+
+            repeat(3) {
+                tester.upsert(onUpdate = incrementCount) {
+                    it[word] = testWord
+                }
+            }
+
+            assertEquals(3, tester.selectAll().single()[tester.count])
+        }
+    }
+
+    @Test
+    fun testUpsertWithMultipleManualUpdates() {
+        val tester = object : Table("tester") {
+            val item = varchar("item", 64).uniqueIndex()
+            val amount = integer("amount").default(25)
+            val gains = integer("gains").default(100)
+            val losses = integer("losses").default(100)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester) {
+            val itemA = tester.upsert {
+                it[item] = "Item A"
+            } get tester.item
+
+            val adjustGainAndLoss = listOf(
+                tester.gains to tester.gains.plus(tester.amount),
+                tester.losses to tester.losses.minus(tester.amount)
+            )
+            tester.upsert(onUpdate = adjustGainAndLoss) {
+                it[item] = "Item B"
+                it[gains] = 200
+                it[losses] = 0
+            }
+
+            val insertResult = tester.select { tester.item neq itemA }.single()
+            assertEquals(200, insertResult[tester.gains])
+            assertEquals(0, insertResult[tester.losses])
+
+            tester.upsert(onUpdate = adjustGainAndLoss) {
+                it[item] = itemA
+                it[gains] = 200
+                it[losses] = 0
+            }
+
+            val updateResult = tester.select { tester.item eq itemA }.single()
+            assertEquals(125, updateResult[tester.gains])
+            assertEquals(75, updateResult[tester.losses])
+        }
+    }
+
+    @Test
+    fun testUpsertWithColumnExpressions() {
+        val defaultPhrase = "Phrase"
+        val tester = object : Table("tester") {
+            val word = varchar("word", 256).uniqueIndex()
+            val phrase = varchar("phrase", 256).defaultExpression(stringParam(defaultPhrase))
+        }
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester) {
+            val testWord = "Test"
+            tester.upsert {  // default expression in insert
+                it[word] = testWord
+            }
+            assertEquals("Phrase", tester.selectAll().single()[tester.phrase])
+
+            val phraseConcat = concat(" - ", listOf(tester.word, tester.phrase))
+            tester.upsert(onUpdate = listOf(tester.phrase to phraseConcat)) {  // expression in update
+                it[word] = testWord
+            }
+            assertEquals("$testWord - $defaultPhrase", tester.selectAll().single()[tester.phrase])
+
+            tester.upsert {  // provided expression in insert
+                it[word] = "$testWord 2"
+                it[phrase] = concat(stringLiteral("foo"), stringLiteral("bar"))
+            }
+            assertEquals("foobar", tester.select { tester.word eq "$testWord 2" }.single()[tester.phrase])
+        }
+    }
+
+    @Test
+    fun testUpsertWithWhere() {
+        val tester = object : IntIdTable("tester") {
+            val name = varchar("name", 64).uniqueIndex()
+            val address = varchar("address", 256)
+            val age = integer("age")
+        }
+
+        withTables(excludeSettings = mySqlLikeDB + upsertViaMergeDB + TestDB.H2, tester) {
+            val id1 = tester.insertAndGetId {
+                it[name] = "A"
+                it[address] = "Place A"
+                it[age] = 10
+            }
+            val unchanged = tester.insert {
+                it[name] = "B"
+                it[address] = "Place B"
+                it[age] = 50
+            }
+
+            val ageTooLow = tester.age less intLiteral(15)
+            val updatedAge = tester.upsert(tester.name, where = { ageTooLow }) {
+                it[name] = "A"
+                it[address] = "Address A"
+                it[age] = 20
+            } get tester.age
+
+            tester.upsert(tester.name, where = { ageTooLow }) {
+                it[name] = "B"
+                it[address] = "Address B"
+                it[age] = 20
+            }
+
+            assertEquals(2, tester.selectAll().count())
+            val unchangedResult = tester.select { tester.id eq unchanged[tester.id] }.single()
+            assertEquals(unchanged[tester.address], unchangedResult[tester.address])
+            val updatedResult = tester.select { tester.id eq id1 }.single()
+            assertEquals(updatedAge, updatedResult[tester.age])
+        }
+    }
+
+    @Test
+    fun testUpsertWithSubQuery() {
+        val tester1 = object : IntIdTable("tester_1") {
+            val name = varchar("name", 32)
+        }
+        val tester2 = object : IntIdTable("tester_2") {
+            val name = varchar("name", 32)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.H2), tester1, tester2) {
+            val id1 = tester1.insertAndGetId {
+                it[name] = "foo"
+            }
+            val id2 = tester1.insertAndGetId {
+                it[name] = "bar"
+            }
+
+            val query1 = tester1.slice(tester1.name).select { tester1.id eq id1 }
+            val id3 = tester2.upsert {
+                if (currentTestDB in upsertViaMergeDB) it[id] = 1
+                it[name] = query1
+            } get tester2.id
+            assertEquals("foo", tester2.selectAll().single()[tester2.name])
+
+            val query2 = tester1.slice(tester1.name).select { tester1.id eq id2 }
+            tester2.upsert {
+                it[id] = id3
+                it[name] = query2
+            }
+            assertEquals("bar", tester2.selectAll().single()[tester2.name])
+        }
+    }
+}


### PR DESCRIPTION
Add functionality for INSERT or UPDATE command.

MySQL, PostgreSQL, and SQLite use their own specific implementations, while the other dialects use the standard MERGE USING statement with aliases and a derived table.

Accepts **optional user-defined key columns** to determine the conflict condition. If none are provided, the primary key is used. If there is no primary key, the first unique index is used. If there are no unique indices, each dialect handles differently, but any documentation should probably strongly advise that keys are defined to avoid unexpected results.

Accepts an **optional WHERE clause**, as well as **user-defined update assignments** if update behaviour differs from insert behaviour. **Column expressions, defaults, and subqueries** are also enabled if the individual dialect allows them.

**Current caveats:**

1. Dialects that use MERGE require that the key used in the ON clause is present in the derived table. So if an `IntIdTable` is used e.g., usually the user doesn't have to manually specify the next id, but  `upsert` will fail unless the id is provided.

**Vendor-specific features not currently covered:**
- [SQLite] Should be able to chain multiple On CONFLICT causes together.
- [SQLite, PostgreSQL] User-defined update expressions & WHERE clause should be able to access insert values using `excluded.` identifier. Workaround is to reference the value that would have been inserted directly.
- [Oracle, SQLServer, H2] Technically do allow WHERE clause, but multiple and specific to either WHEN [NOT] MATCH THEN clause (Oracle differs in placement too).

**Plan**:
1. Submit a second PR for batch upsert, unless advised to push them together.
2. Submit a PR that addresses possible overlap with current implementation of REPLACE (at least in PostgreSQL) & update API docs (the 2 queries are very similar but not equivalent).
3. Add WHERE clause functionality to MERGE implementations.