### PR TITLE
feat: EXPOSED-47 Add support for SET DEFAULT reference option

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -117,11 +117,17 @@ data class ForeignKeyConstraint(
             }
             append("FOREIGN KEY ($fromColumns) REFERENCES $targetTableName($targetColumns)")
             if (deleteRule != ReferenceOption.NO_ACTION) {
-                append(" ON DELETE $deleteRule")
+                if (deleteRule == ReferenceOption.SET_DEFAULT && (currentDialect as? MysqlDialect)?.isMysql8 == false) {
+                    exposedLogger.warn("This MySQL version doesn't support FOREIGN KEY with SET DEFAULT reference option with ON DELETE clause. Please check your $fromTableName table.")
+                } else {
+                    append(" ON DELETE $deleteRule")
+                }
             }
             if (updateRule != ReferenceOption.NO_ACTION) {
                 if (currentDialect is OracleDialect || currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
                     exposedLogger.warn("Oracle doesn't support FOREIGN KEY with ON UPDATE clause. Please check your $fromTableName table.")
+                } else if (updateRule == ReferenceOption.SET_DEFAULT && (currentDialect as? MysqlDialect)?.isMysql8 == false) {
+                    exposedLogger.warn("This MySQL version doesn't support FOREIGN KEY with SET DEFAULT reference option with ON UPDATE clause. Please check your $fromTableName table.")
                 } else {
                     append(" ON UPDATE $updateRule")
                 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -29,7 +29,8 @@ enum class ReferenceOption {
     CASCADE,
     SET_NULL,
     RESTRICT,
-    NO_ACTION;
+    NO_ACTION,
+    SET_DEFAULT;
 
     override fun toString(): String = name.replace("_", " ")
 
@@ -40,6 +41,7 @@ enum class ReferenceOption {
             DatabaseMetaData.importedKeySetNull -> SET_NULL
             DatabaseMetaData.importedKeyRestrict -> RESTRICT
             DatabaseMetaData.importedKeyNoAction -> NO_ACTION
+            DatabaseMetaData.importedKeySetDefault -> SET_DEFAULT
             else -> currentDialect.defaultReferenceOption
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -125,12 +125,12 @@ data class ForeignKeyConstraint(
             if (deleteRule != ReferenceOption.NO_ACTION) {
                 if (deleteRule == ReferenceOption.SET_DEFAULT) {
                     when (currentDialect) {
-                        is MysqlDialect -> exposedLogger.warn(
-                            "MySQL doesn't support FOREIGN KEY with SET DEFAULT reference option with ON DELETE clause. " +
-                                "Please check your $fromTableName table."
-                        )
                         is MariaDBDialect -> exposedLogger.warn(
                             "MariaDB doesn't support FOREIGN KEY with SET DEFAULT reference option with ON DELETE clause. " +
+                                "Please check your $fromTableName table."
+                        )
+                        is MysqlDialect -> exposedLogger.warn(
+                            "MySQL doesn't support FOREIGN KEY with SET DEFAULT reference option with ON DELETE clause. " +
                                 "Please check your $fromTableName table."
                         )
                         else -> append(" ON DELETE $deleteRule")
@@ -144,15 +144,14 @@ data class ForeignKeyConstraint(
                     exposedLogger.warn("Oracle doesn't support FOREIGN KEY with ON UPDATE clause. Please check your $fromTableName table.")
                 } else if (updateRule == ReferenceOption.SET_DEFAULT) {
                     when (currentDialect) {
+                        is MariaDBDialect -> exposedLogger.warn(
+                            "MariaDB doesn't support FOREIGN KEY with SET DEFAULT reference option with ON UPDATE clause. " +
+                                "Please check your $fromTableName table."
+                        )
                         is MysqlDialect -> exposedLogger.warn(
                             "MySQL doesn't support FOREIGN KEY with SET DEFAULT reference option with ON UPDATE clause. " +
                                 "Please check your $fromTableName table."
                         )
-                        is MariaDBDialect ->
-                            exposedLogger.warn(
-                                "MariaDB doesn't support FOREIGN KEY with SET DEFAULT reference option with ON UPDATE clause. " +
-                                    "Please check your $fromTableName table."
-                            )
                         else -> append(" ON UPDATE $updateRule")
                     }
                 } else {

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -46,7 +46,7 @@ enum class TestDB(
     H2_PSQL({ "jdbc:h2:mem:psql;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1" }, "org.h2.Driver"),
     H2_ORACLE({ "jdbc:h2:mem:oracle;MODE=Oracle;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1" }, "org.h2.Driver"),
     H2_SQLSERVER({ "jdbc:h2:mem:sqlserver;MODE=MSSQLServer;DB_CLOSE_DELAY=-1" }, "org.h2.Driver"),
-    SQLITE({ "jdbc:sqlite:file:test?foreign_keys=on&mode=memory&cache=shared" }, "org.sqlite.JDBC"),
+    SQLITE({ "jdbc:sqlite:file:test?mode=memory&cache=shared" }, "org.sqlite.JDBC"),
     MYSQL(
         connection = {
             if (runTestContainersMySQL()) {

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -46,7 +46,7 @@ enum class TestDB(
     H2_PSQL({ "jdbc:h2:mem:psql;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1" }, "org.h2.Driver"),
     H2_ORACLE({ "jdbc:h2:mem:oracle;MODE=Oracle;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1" }, "org.h2.Driver"),
     H2_SQLSERVER({ "jdbc:h2:mem:sqlserver;MODE=MSSQLServer;DB_CLOSE_DELAY=-1" }, "org.h2.Driver"),
-    SQLITE({ "jdbc:sqlite:file:test?mode=memory&cache=shared" }, "org.sqlite.JDBC"),
+    SQLITE({ "jdbc:sqlite:file:test?foreign_keys=on&mode=memory&cache=shared" }, "org.sqlite.JDBC"),
     MYSQL(
         connection = {
             if (runTestContainersMySQL()) {

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/shared/ForeignKeyTables.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/shared/ForeignKeyTables.kt
@@ -1,0 +1,27 @@
+package org.jetbrains.exposed.sql.tests.shared
+
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.Table
+
+object Category : Table("Category") {
+    val id = integer("id")
+    val name = varchar(name = "name", length = 20)
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+const val DEFAULT_CATEGORY_ID = 0
+
+object Item : Table("Item") {
+    val id = integer("id")
+    val name = varchar(name = "name", length = 20)
+    val categoryId = integer("categoryId")
+        .default(DEFAULT_CATEGORY_ID)
+        .references(
+            Category.id,
+            onDelete = ReferenceOption.SET_DEFAULT,
+            onUpdate = ReferenceOption.NO_ACTION
+        )
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
@@ -1,0 +1,73 @@
+package org.jetbrains.exposed.sql.tests.sqlite
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.Category
+import org.jetbrains.exposed.sql.tests.shared.DEFAULT_CATEGORY_ID
+import org.jetbrains.exposed.sql.tests.shared.Item
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Assume
+import org.junit.Test
+
+class ForeignKeyConstraintTests : DatabaseTestsBase() {
+
+    @Test
+    fun `test ON DELETE SET DEFAULT for databases that support it without SQLite`() {
+        withDb(excludeSettings = listOf(TestDB.MARIADB, TestDB.MYSQL, TestDB.SQLITE)) {
+            testOnDeleteSetDefault()
+        }
+    }
+
+    @Test
+    fun `test ON DELETE SET DEFAULT for SQLite`() {
+        Assume.assumeTrue(TestDB.SQLITE in TestDB.enabledInTests())
+
+        transaction(Database.connect("jdbc:sqlite:file:test?mode=memory&cache=shared&foreign_keys=on", user = "root", driver = "org.sqlite.JDBC")) {
+            testOnDeleteSetDefault()
+        }
+    }
+
+    private fun Transaction.testOnDeleteSetDefault() {
+        SchemaUtils.create(Category, Item)
+
+        Category.insert {
+            it[id] = DEFAULT_CATEGORY_ID
+            it[name] = "Default"
+        }
+
+        val saladsId = 1
+        Category.insert {
+            it[id] = saladsId
+            it[name] = "Salads"
+        }
+
+        val tabboulehId = 0
+        Item.insert {
+            it[id] = tabboulehId
+            it[name] = "Tabbouleh"
+            it[categoryId] = saladsId
+        }
+
+        assertEquals(
+            saladsId,
+            Item.select { Item.id eq tabboulehId }.single().also {
+                println("SELECT result = $it")
+            }[Item.categoryId]
+        )
+
+        Category.deleteWhere { id eq saladsId }
+
+        assertEquals(
+            DEFAULT_CATEGORY_ID,
+            Item.select { Item.id eq tabboulehId }.single()[Item.categoryId]
+        )
+    }
+}


### PR DESCRIPTION
The `SET_DEFAULT` reference option is not supported in:

-  [MySQL 5.1.49](https://github.com/JetBrains/Exposed/blob/f0308188e0911f8f623b6b55f4998e59a5459963/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt#L15) according to this [manual](http://download.nust.na/pub6/mysql/doc/refman/5.1/en/innodb-foreign-key-constraints.html) since it is not mentioned as one of the possible reference options
- in [MariaDB](https://mariadb.com/kb/en/foreign-keys/#:~:text=The%20SET%20DEFAULT%20action%20is%20not%20supported.) ([Stack Overflow](https://stackoverflow.com/a/30585123/11310485))

The way I handled this is the same way the `ON UPDATE` clause was handled for Oracle.

In SQLite, [foreign key constraints are disabled by default](https://www.sqlite.org/releaselog/3_6_19.html#:~:text=Foreign%20key%20constraints%20are%20disabled%20by%20default.). To enable it in Exposed, add `?foreign_keys=on` to the connection URL when calling Database.connect. So a separate test was created for that.