### PR TITLE
fix: EXPOSED-48 Incorrect statistics aggregate functions

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -225,10 +225,16 @@ class Count(
  */
 class StdDevPop<T>(
     /** Returns the expression from which the population standard deviation is calculated. */
-    val expr: Expression<T>,
+    val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("STDDEV_POP(", expr, ")") }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        val functionProvider = when (currentDialect.h2Mode) {
+            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+            else -> currentDialect.functionProvider
+        }
+        functionProvider.stdDevPop(expression, this)
+    }
 }
 
 /**
@@ -237,10 +243,16 @@ class StdDevPop<T>(
  */
 class StdDevSamp<T>(
     /** Returns the expression from which the sample standard deviation is calculated. */
-    val expr: Expression<T>,
+    val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("STDDEV_SAMP(", expr, ")") }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        val functionProvider = when (currentDialect.h2Mode) {
+            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+            else -> currentDialect.functionProvider
+        }
+        functionProvider.stdDevSamp(expression, this)
+    }
 }
 
 /**
@@ -249,10 +261,16 @@ class StdDevSamp<T>(
  */
 class VarPop<T>(
     /** Returns the expression from which the population variance is calculated. */
-    val expr: Expression<T>,
+    val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("VAR_POP(", expr, ")") }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        val functionProvider = when (currentDialect.h2Mode) {
+            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+            else -> currentDialect.functionProvider
+        }
+        functionProvider.varPop(expression, this)
+    }
 }
 
 /**
@@ -261,10 +279,16 @@ class VarPop<T>(
  */
 class VarSamp<T>(
     /** Returns the expression from which the sample variance is calculated. */
-    val expr: Expression<T>,
+    val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("VAR_SAMP(", expr, ")") }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
+        val functionProvider = when (currentDialect.h2Mode) {
+            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+            else -> currentDialect.functionProvider
+        }
+        functionProvider.varSamp(expression, this)
+    }
 }
 
 // Sequence Manipulation Functions

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -228,12 +228,14 @@ class StdDevPop<T>(
     val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        val functionProvider = when (currentDialect.h2Mode) {
-            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
-            else -> currentDialect.functionProvider
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder {
+            val functionProvider = when (currentDialect.h2Mode) {
+                H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+                else -> currentDialect.functionProvider
+            }
+            functionProvider.stdDevPop(expression, this)
         }
-        functionProvider.stdDevPop(expression, this)
     }
 }
 
@@ -246,12 +248,14 @@ class StdDevSamp<T>(
     val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        val functionProvider = when (currentDialect.h2Mode) {
-            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
-            else -> currentDialect.functionProvider
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder {
+            val functionProvider = when (currentDialect.h2Mode) {
+                H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+                else -> currentDialect.functionProvider
+            }
+            functionProvider.stdDevSamp(expression, this)
         }
-        functionProvider.stdDevSamp(expression, this)
     }
 }
 
@@ -264,12 +268,14 @@ class VarPop<T>(
     val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        val functionProvider = when (currentDialect.h2Mode) {
-            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
-            else -> currentDialect.functionProvider
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder {
+            val functionProvider = when (currentDialect.h2Mode) {
+                H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+                else -> currentDialect.functionProvider
+            }
+            functionProvider.varPop(expression, this)
         }
-        functionProvider.varPop(expression, this)
     }
 }
 
@@ -282,12 +288,14 @@ class VarSamp<T>(
     val expression: Expression<T>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        val functionProvider = when (currentDialect.h2Mode) {
-            H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
-            else -> currentDialect.functionProvider
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder {
+            val functionProvider = when (currentDialect.h2Mode) {
+                H2Dialect.H2CompatibilityMode.SQLServer -> H2FunctionProvider
+                else -> currentDialect.functionProvider
+            }
+            functionProvider.varSamp(expression, this)
         }
-        functionProvider.varSamp(expression, this)
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -73,28 +73,28 @@ fun Column<*>.countDistinct(): Count = Count(this, true)
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Number?> ExpressionWithColumnType<T>.stdDevPop(scale: Int = 2): StdDevPop<T> = StdDevPop(this, scale)
+fun <T : Any?> ExpressionWithColumnType<T>.stdDevPop(scale: Int = 2): StdDevPop<T> = StdDevPop(this, scale)
 
 /**
  * Returns the sample standard deviation of the non-null input values, or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Number?> ExpressionWithColumnType<T>.stdDevSamp(scale: Int = 2): StdDevSamp<T> = StdDevSamp(this, scale)
+fun <T : Any?> ExpressionWithColumnType<T>.stdDevSamp(scale: Int = 2): StdDevSamp<T> = StdDevSamp(this, scale)
 
 /**
  * Returns the population variance of the non-null input values (square of the population standard deviation), or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Number?> ExpressionWithColumnType<T>.varPop(scale: Int = 2): VarPop<T> = VarPop(this, scale)
+fun <T : Any?> ExpressionWithColumnType<T>.varPop(scale: Int = 2): VarPop<T> = VarPop(this, scale)
 
 /**
  * Returns the sample variance of the non-null input values (square of the sample standard deviation), or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Number?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> = VarSamp(this, scale)
+fun <T : Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> = VarSamp(this, scale)
 
 // Sequence Manipulation Functions
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -73,28 +73,28 @@ fun Column<*>.countDistinct(): Count = Count(this, true)
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Any?> ExpressionWithColumnType<T>.stdDevPop(scale: Int = 2): StdDevPop<T> = StdDevPop(this, scale)
+fun <T : Number?> ExpressionWithColumnType<T>.stdDevPop(scale: Int = 2): StdDevPop<T> = StdDevPop(this, scale)
 
 /**
  * Returns the sample standard deviation of the non-null input values, or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Any?> ExpressionWithColumnType<T>.stdDevSamp(scale: Int = 2): StdDevSamp<T> = StdDevSamp(this, scale)
+fun <T : Number?> ExpressionWithColumnType<T>.stdDevSamp(scale: Int = 2): StdDevSamp<T> = StdDevSamp(this, scale)
 
 /**
  * Returns the population variance of the non-null input values (square of the population standard deviation), or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Any?> ExpressionWithColumnType<T>.varPop(scale: Int = 2): VarPop<T> = VarPop(this, scale)
+fun <T : Number?> ExpressionWithColumnType<T>.varPop(scale: Int = 2): VarPop<T> = VarPop(this, scale)
 
 /**
  * Returns the sample variance of the non-null input values (square of the sample standard deviation), or `null` if there are no non-null values.
  *
  * @param scale The scale of the decimal column expression returned.
  */
-fun <T : Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> = VarSamp(this, scale)
+fun <T : Number?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> = VarSamp(this, scale)
 
 // Sequence Manipulation Functions
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -385,18 +385,46 @@ abstract class FunctionProvider {
 
     // Aggregate Functions for Statistics
 
+    /**
+     * SQL function that returns the population standard deviation of the non-null input values,
+     * or `null` if there are no non-null values.
+     *
+     * @param expression Expression from which the population standard deviation is calculated.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
     open fun <T> stdDevPop(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("STDDEV_POP(", expression, ")")
     }
 
+    /**
+     * SQL function that returns the sample standard deviation of the non-null input values,
+     * or `null` if there are no non-null values.
+     *
+     * @param expression Expression from which the sample standard deviation is calculated.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
     open fun <T> stdDevSamp(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("STDDEV_SAMP(", expression, ")")
     }
 
+    /**
+     * SQL function that returns the population variance of the non-null input values (square of the population standard deviation),
+     * or `null` if there are no non-null values.
+     *
+     * @param expression Expression from which the population variance is calculated.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
     open fun <T> varPop(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("VAR_POP(", expression, ")")
     }
 
+    /**
+     * SQL function that returns the sample variance of the non-null input values (square of the sample standard deviation),
+     * or `null` if there are no non-null values.
+     *
+     * @param expression Expression from which the sample variance is calculated.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
     open fun <T> varSamp(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("VAR_SAMP(", expression, ")")
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -383,6 +383,24 @@ abstract class FunctionProvider {
         append("CAST(", expr, " AS ", type.sqlType(), ")")
     }
 
+    // Aggregate Functions for Statistics
+
+    open fun <T> stdDevPop(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("STDDEV_POP(", expression, ")")
+    }
+
+    open fun <T> stdDevSamp(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("STDDEV_SAMP(", expression, ")")
+    }
+
+    open fun <T> varPop(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("VAR_POP(", expression, ")")
+    }
+
+    open fun <T> varSamp(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("VAR_SAMP(", expression, ")")
+    }
+
     // Commands
     @Suppress("VariableNaming")
     open val DEFAULT_VALUE_EXPRESSION: String = "DEFAULT VALUES"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -118,6 +118,22 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         append("DATEPART(MINUTE, ", expr, ")")
     }
 
+    override fun <T> stdDevPop(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("STDEVP(", expression, ")")
+    }
+
+    override fun <T> stdDevSamp(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("STDEV(", expression, ")")
+    }
+
+    override fun <T> varPop(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("VARP(", expression, ")")
+    }
+
+    override fun <T> varSamp(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
+        append("VAR(", expression, ")")
+    }
+
     override fun update(
         target: Table,
         columnsAndValues: List<Pair<Column<*>, Any?>>,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -105,6 +105,28 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         append(")")
     }
 
+    private const val UNSUPPORTED_AGGREGATE = "SQLite doesn't provide built-in aggregate function"
+
+    override fun <T> stdDevPop(
+        expression: Expression<T>,
+        queryBuilder: QueryBuilder
+    ): Unit = TransactionManager.current().throwUnsupportedException("$UNSUPPORTED_AGGREGATE STDDEV_POP")
+
+    override fun <T> stdDevSamp(
+        expression: Expression<T>,
+        queryBuilder: QueryBuilder
+    ): Unit = TransactionManager.current().throwUnsupportedException("$UNSUPPORTED_AGGREGATE STDDEV_SAMP")
+
+    override fun <T> varPop(
+        expression: Expression<T>,
+        queryBuilder: QueryBuilder
+    ): Unit = TransactionManager.current().throwUnsupportedException("$UNSUPPORTED_AGGREGATE VAR_POP")
+
+    override fun <T> varSamp(
+        expression: Expression<T>,
+        queryBuilder: QueryBuilder
+    ): Unit = TransactionManager.current().throwUnsupportedException("$UNSUPPORTED_AGGREGATE VAR_SAMP")
+
     override fun insert(
         ignore: Boolean,
         table: Table,

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/StatisticsFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/StatisticsFunctionTests.kt
@@ -1,0 +1,79 @@
+package org.jetbrains.exposed.sql.tests.shared.functions
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.Function
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+import java.math.*
+
+class StatisticsFunctionTests : DatabaseTestsBase() {
+    @Test
+    fun testStdDevPop() {
+        withSampleTable {
+            val expectedStdDevPop = calculateStandardDeviation(isPopulation = true)
+            assertExpressionEqual(expectedStdDevPop, SampleTestTable.number.stdDevPop(scale))
+        }
+    }
+
+    @Test
+    fun testStdDevSamp() {
+        withSampleTable {
+            val expectedStdDevSamp = calculateStandardDeviation(isPopulation = false)
+            assertExpressionEqual(expectedStdDevSamp, SampleTestTable.number.stdDevSamp(scale))
+        }
+    }
+
+    @Test
+    fun testVarPop() {
+        withSampleTable {
+            val expectedVarPop = calculateVariance(isPopulation = true)
+            assertExpressionEqual(expectedVarPop, SampleTestTable.number.varPop(scale))
+        }
+    }
+
+    @Test
+    fun testVarSamp() {
+        withSampleTable {
+            val expectedVarSamp = calculateVariance(isPopulation = false)
+            assertExpressionEqual(expectedVarSamp, SampleTestTable.number.varSamp(scale))
+        }
+    }
+
+    private object SampleTestTable : Table("sample_table") {
+        val number = integer("number").nullable()
+    }
+    private val data: List<Int?> = listOf(4, null, 5, null, 6)
+    private val scale = 4
+
+    private fun withSampleTable(excludeDB: List<TestDB> = emptyList(), body: Transaction.(TestDB) -> Unit) {
+        // SQLite does not have any built-in statistics-specific aggregate functions
+        withTables(excludeSettings = excludeDB + TestDB.SQLITE, SampleTestTable) {
+            SampleTestTable.batchInsert(data) { num ->
+                this[SampleTestTable.number] = num
+            }
+            body(it)
+        }
+    }
+
+    private fun Transaction.assertExpressionEqual(expected: BigDecimal, expression: Function<BigDecimal?>) {
+        val result = SampleTestTable.slice(expression).selectAll().first()[expression]
+        assertEquals(expected, result?.setScale(expected.scale(), RoundingMode.HALF_EVEN))
+    }
+
+    private fun calculateStandardDeviation(isPopulation: Boolean): BigDecimal {
+        return calculateVariance(isPopulation).sqrt(MathContext(scale, RoundingMode.HALF_EVEN))
+    }
+
+    private fun calculateVariance(isPopulation: Boolean): BigDecimal {
+        val nonNullData = data.filterNotNull()
+        val mean = nonNullData.average()
+        val squaredSum = nonNullData.sumOf { n ->
+            val deviation = n - mean
+            deviation * deviation
+        }
+        val size = if (isPopulation) nonNullData.size else nonNullData.lastIndex
+        return (squaredSum / size).toBigDecimal(MathContext(scale))
+    }
+}


### PR DESCRIPTION
The aggregate functions for statistics were failing on:
- [SQLite] with `no such function` exception from DB. Now they fail early with an `UnsupportedByDialectException`.
- [SQL Server] because of unrecognized syntax. Now they use the correct function name.

Add a new test class for statistics aggregate functions.