### PR TITLE
fix: Support Short type for BigDecimal conversion functions

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -490,6 +490,7 @@ class DecimalColumnType(
         }
         is Long -> value.toBigDecimal()
         is Int -> value.toBigDecimal()
+        is Short -> value.toBigDecimal()
         else -> error("Unexpected value of type Decimal: $value of ${value::class.qualifiedName}")
     }.setScale(scale, RoundingMode.HALF_EVEN)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -490,7 +490,7 @@ class DecimalColumnType(
         }
         is Long -> value.toBigDecimal()
         is Int -> value.toBigDecimal()
-        is Short -> value.toBigDecimal()
+        is Short -> value.toLong().toBigDecimal()
         else -> error("Unexpected value of type Decimal: $value of ${value::class.qualifiedName}")
     }.setScale(scale, RoundingMode.HALF_EVEN)
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
@@ -91,6 +91,29 @@ class H2Tests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testH2V1WithBigDecimalFunctionThatReturnsShort() {
+        val testTable = object : Table("test_table") {
+            val number = short("number")
+        }
+
+        withDb(TestDB.allH2TestDB) {
+            try {
+                SchemaUtils.create(testTable)
+
+                testTable.batchInsert(listOf<Short>(2, 4, 6, 8, 10)) { n ->
+                    this[testTable.number] = n
+                }
+
+                val average = testTable.number.avg()
+                val result = testTable.select(average).single()[average]
+                assertEquals("6.00".toBigDecimal(), result)
+            } finally {
+                SchemaUtils.drop(testTable)
+            }
+        }
+    }
+
     class WrappedTransactionManager(val transactionManager: TransactionManager) :
         TransactionManager by transactionManager
 


### PR DESCRIPTION
In case of avg aggregate functions for h2 db - it returns Short type and fail convert it to BigDecimal.

e.g. 
code example:
```kotlin
    (FilmCategories innerJoin Films).slice(FilmCategories.category, FilmCategories.film.count(), Films.length.avg()).selectAll()
        .groupBy(FilmCategories.category).forEach { row ->
            println(
                "Category: ${row[FilmCategories.category]}\n" +
                    "\tNumber of films: ${row[FilmCategories.film.count()]}\n" +
                    "\tAverage duration of films: ${row[Films.length.avg()]}",
            )
        }

```


SQL: 
```sql
SELECT FILM_CATEGORY.CATEGORY_ID, COUNT(FILM_CATEGORY.FILM_ID), AVG(FILM."LENGTH") FROM FILM_CATEGORY INNER JOIN FILM ON FILM.FILM_ID = FILM_CATEGORY.FILM_ID GROUP BY FILM_CATEGORY.CATEGORY_ID
```

Current error:
```
Exception in thread "main" java.lang.IllegalStateException: Unexpected value of type Decimal: 111 of kotlin.Short
	at org.jetbrains.exposed.sql.DecimalColumnType.valueFromDB(ColumnType.kt:447)
	at org.jetbrains.exposed.sql.DecimalColumnType.valueFromDB(ColumnType.kt:417)
	at org.jetbrains.exposed.sql.ResultRow.rawToColumnValue(ResultRow.kt:63)
	at org.jetbrains.exposed.sql.ResultRow.access$rawToColumnValue(ResultRow.kt:7)
	at org.jetbrains.exposed.sql.ResultRow$get$result$1$1.invoke(ResultRow.kt:36)
	at org.jetbrains.exposed.sql.vendors.DefaultKt.withDialect(Default.kt:886)
	at org.jetbrains.exposed.sql.ResultRow.get(ResultRow.kt:35)
	at ProblemsKt.task4(problems.kt:39)
	at MainKt$main$1.invoke(main.kt:32)
	at MainKt$main$1.invoke(main.kt:10)
```
