### PR TITLE
fix: EXPOSED-49 Replace statement defined as upsert statement

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -195,7 +195,12 @@ fun <Key : Comparable<Key>, T : IdTable<Key>> T.insertIgnoreAndGetId(body: T.(Up
     }
 
 /**
- * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testReplace01
+ * Represents the SQL command that either inserts a new row into a table, or deletes the existing row if insertion would violate a unique constraint,
+ * before inserting the new row.
+ *
+ * **Note:** This operation is not supported by all vendors, please check the documentation.
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReplaceTests.testReplace01
  */
 fun <T : Table> T.replace(body: T.(UpdateBuilder<*>) -> Unit): ReplaceStatement<Long> = ReplaceStatement<Long>(this).apply {
     body(this)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -195,12 +195,12 @@ fun <Key : Comparable<Key>, T : IdTable<Key>> T.insertIgnoreAndGetId(body: T.(Up
     }
 
 /**
- * Represents the SQL command that either inserts a new row into a table, or deletes the existing row if insertion would violate a unique constraint,
+ * Represents the SQL command that either inserts a new row into a table, or first deletes the existing row if insertion would violate a unique constraint,
  * before inserting the new row.
  *
  * **Note:** This operation is not supported by all vendors, please check the documentation.
  *
- * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReplaceTests.testReplace01
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReplaceTests.testReplaceWithExpression
  */
 fun <T : Table> T.replace(body: T.(UpdateBuilder<*>) -> Unit): ReplaceStatement<Long> = ReplaceStatement<Long>(this).apply {
     body(this)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -112,7 +112,15 @@ private fun <T : Table, E> T.batchInsert(
 }
 
 /**
- * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testBatchInsert01
+ * Represents the SQL command that either batch inserts new rows into a table, or, if insertions violate unique constraints,
+ * first deletes the existing rows before inserting new rows.
+ *
+ * **Note:** This operation is not supported by all vendors, please check the documentation.
+ *
+ * @param data Collection of values to use in replace.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReplaceTests.testBatchReplace01
  */
 fun <T : Table, E : Any> T.batchReplace(
     data: Iterable<E>,
@@ -120,12 +128,34 @@ fun <T : Table, E : Any> T.batchReplace(
     body: BatchReplaceStatement.(E) -> Unit
 ): List<ResultRow> = batchReplace(data.iterator(), shouldReturnGeneratedValues, body)
 
+/**
+ * Represents the SQL command that either batch inserts new rows into a table, or, if insertions violate unique constraints,
+ * first deletes the existing rows before inserting new rows.
+ *
+ * **Note:** This operation is not supported by all vendors, please check the documentation.
+ *
+ * @param data Sequence of values to use in replace.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReplaceTests.testBatchReplaceWithSequence
+ */
 fun <T : Table, E : Any> T.batchReplace(
     data: Sequence<E>,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchReplaceStatement.(E) -> Unit
 ): List<ResultRow> = batchReplace(data.iterator(), shouldReturnGeneratedValues, body)
 
+/**
+ * Represents the SQL command that either batch inserts new rows into a table, or, if insertions violate unique constraints,
+ * first deletes the existing rows before inserting new rows.
+ *
+ * **Note:** This operation is not supported by all vendors, please check the documentation.
+ *
+ * @param data Iterator over a collection of values to use in replace.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReplaceTests.testBatchReplace01
+ */
 private fun <T : Table, E> T.batchReplace(
     data: Iterator<E>,
     shouldReturnGeneratedValues: Boolean = true,
@@ -195,8 +225,8 @@ fun <Key : Comparable<Key>, T : IdTable<Key>> T.insertIgnoreAndGetId(body: T.(Up
     }
 
 /**
- * Represents the SQL command that either inserts a new row into a table, or first deletes the existing row if insertion would violate a unique constraint,
- * before inserting the new row.
+ * Represents the SQL command that either inserts a new row into a table, or, if insertion would violate a unique constraint,
+ * first deletes the existing row before inserting a new row.
  *
  * **Note:** This operation is not supported by all vendors, please check the documentation.
  *

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
@@ -1,22 +1,24 @@
 package org.jetbrains.exposed.sql.statements
 
+import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.vendors.H2Dialect
-import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
-import org.jetbrains.exposed.sql.vendors.h2Mode
+import org.jetbrains.exposed.sql.appendTo
 
 open class BatchReplaceStatement(
     table: Table,
     shouldReturnGeneratedValues: Boolean = true
 ) : BaseBatchInsertStatement(table, ignore = false, shouldReturnGeneratedValues) {
     override fun prepareSQL(transaction: Transaction): String {
-        val dialect = transaction.db.dialect
-        val functionProvider = when (dialect.h2Mode) {
-            // https://github.com/h2database/h2database/issues/2007
-            H2Dialect.H2CompatibilityMode.PostgreSQL -> H2FunctionProvider
-            else -> dialect.functionProvider
+        val values = arguments!!.first()
+        val valuesSql = if (values.isEmpty()) {
+            ""
+        } else {
+            values.appendTo(QueryBuilder(true), prefix = "VALUES (", postfix = ")") { (column, value) ->
+                registerArgument(column, value)
+            }.toString()
         }
-        return functionProvider.replace(table, arguments!!.first(), transaction)
+        val functionProvider = transaction.db.dialect.functionProvider
+        return functionProvider.replace(table, values.unzip().first, valuesSql, transaction)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
@@ -1,23 +1,23 @@
 package org.jetbrains.exposed.sql.statements
 
-import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.appendTo
 
+/**
+ * Represents the SQL command that either batch inserts new rows into a table, or, if insertions violate unique constraints,
+ * first deletes the existing rows before inserting new rows.
+ *
+ * @param table Table to either insert values into or delete values from then insert into.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ */
 open class BatchReplaceStatement(
     table: Table,
     shouldReturnGeneratedValues: Boolean = true
 ) : BaseBatchInsertStatement(table, ignore = false, shouldReturnGeneratedValues) {
     override fun prepareSQL(transaction: Transaction): String {
         val values = arguments!!.first()
-        val valuesSql = if (values.isEmpty()) {
-            ""
-        } else {
-            values.appendTo(QueryBuilder(true), prefix = "VALUES (", postfix = ")") { (column, value) ->
-                registerArgument(column, value)
-            }.toString()
-        }
+        val valuesSql = values.toSqlString()
         val functionProvider = transaction.db.dialect.functionProvider
         return functionProvider.replace(table, values.unzip().first, valuesSql, transaction)
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
@@ -2,6 +2,9 @@ package org.jetbrains.exposed.sql.statements
 
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider
+import org.jetbrains.exposed.sql.vendors.h2Mode
 
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or, if insertions violate unique constraints,
@@ -18,7 +21,11 @@ open class BatchReplaceStatement(
     override fun prepareSQL(transaction: Transaction): String {
         val values = arguments!!.first()
         val valuesSql = values.toSqlString()
-        val functionProvider = transaction.db.dialect.functionProvider
+        val dialect = transaction.db.dialect
+        val functionProvider = when (dialect.h2Mode) {
+            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider()
+            else -> dialect.functionProvider
+        }
         return functionProvider.replace(table, values.unzip().first, valuesSql, transaction)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
@@ -2,6 +2,9 @@ package org.jetbrains.exposed.sql.statements
 
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider
+import org.jetbrains.exposed.sql.vendors.h2Mode
 
 /**
  * Represents the SQL command that either inserts a new row into a table, or, if insertion would violate a unique constraint,
@@ -13,7 +16,11 @@ open class ReplaceStatement<Key : Any>(table: Table) : InsertStatement<Key>(tabl
     override fun prepareSQL(transaction: Transaction): String {
         val values = arguments!!.first()
         val valuesSql = values.toSqlString()
-        val functionProvider = transaction.db.dialect.functionProvider
+        val dialect = transaction.db.dialect
+        val functionProvider = when (dialect.h2Mode) {
+            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider()
+            else -> dialect.functionProvider
+        }
         return functionProvider.replace(table, values.unzip().first, valuesSql, transaction)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
@@ -1,19 +1,21 @@
 package org.jetbrains.exposed.sql.statements
 
+import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.vendors.H2Dialect
-import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
-import org.jetbrains.exposed.sql.vendors.h2Mode
+import org.jetbrains.exposed.sql.appendTo
 
 open class ReplaceStatement<Key : Any>(table: Table) : InsertStatement<Key>(table) {
     override fun prepareSQL(transaction: Transaction): String {
-        val dialect = transaction.db.dialect
-        val functionProvider = when (dialect.h2Mode) {
-            // https://github.com/h2database/h2database/issues/2007
-            H2Dialect.H2CompatibilityMode.PostgreSQL -> H2FunctionProvider
-            else -> dialect.functionProvider
+        val values = arguments!!.first()
+        val valuesSql = if (values.isEmpty()) {
+            ""
+        } else {
+            values.appendTo(QueryBuilder(true), prefix = "VALUES (", postfix = ")") { (column, value) ->
+                registerArgument(column, value)
+            }.toString()
         }
-        return functionProvider.replace(table, arguments!!.first(), transaction)
+        val functionProvider = transaction.db.dialect.functionProvider
+        return functionProvider.replace(table, values.unzip().first, valuesSql, transaction)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
@@ -1,20 +1,18 @@
 package org.jetbrains.exposed.sql.statements
 
-import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.appendTo
 
+/**
+ * Represents the SQL command that either inserts a new row into a table, or, if insertion would violate a unique constraint,
+ * first deletes the existing row before inserting a new row.
+ *
+ * @param table Table to either insert values into or delete values from then insert into.
+ */
 open class ReplaceStatement<Key : Any>(table: Table) : InsertStatement<Key>(table) {
     override fun prepareSQL(transaction: Transaction): String {
         val values = arguments!!.first()
-        val valuesSql = if (values.isEmpty()) {
-            ""
-        } else {
-            values.appendTo(QueryBuilder(true), prefix = "VALUES (", postfix = ")") { (column, value) ->
-                registerArgument(column, value)
-            }.toString()
-        }
+        val valuesSql = values.toSqlString()
         val functionProvider = transaction.db.dialect.functionProvider
         return functionProvider.replace(table, values.unzip().first, valuesSql, transaction)
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -496,13 +496,14 @@ abstract class FunctionProvider {
     }
 
     /**
-     * Represents the SQL command that either inserts a new row into a table, or first deletes the existing row if insertion would violate a unique constraint,
-     * before inserting the new row.
+     * Returns the SQL command that either inserts a new row into a table, or, if insertion would violate a unique constraint,
+     * first deletes the existing row before inserting a new row.
      *
      * **Note:** This operation is not supported by all vendors, please check the documentation.
      *
      * @param table Table to either insert values into or delete values from then insert into.
-     * @param data Pairs of column to replace and values to replace with.
+     * @param columns Columns to replace the values in.
+     * @param expression Expression with the values to use in replace.
      * @param transaction Transaction where the operation is executed.
      */
     open fun replace(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -496,7 +496,7 @@ abstract class FunctionProvider {
     }
 
     /**
-     * Represents the SQL command that either inserts a new row into a table, or deletes the existing row if insertion would violate a unique constraint,
+     * Represents the SQL command that either inserts a new row into a table, or first deletes the existing row if insertion would violate a unique constraint,
      * before inserting the new row.
      *
      * **Note:** This operation is not supported by all vendors, please check the documentation.
@@ -507,9 +507,10 @@ abstract class FunctionProvider {
      */
     open fun replace(
         table: Table,
-        data: List<Pair<Column<*>, Any?>>,
+        columns: List<Column<*>>,
+        expression: String,
         transaction: Transaction
-    ): String = transaction.throwUnsupportedException("There's no generic SQL for REPLACE. There must be vendor specific implementation.")
+    ): String = transaction.throwUnsupportedException("There's no generic SQL for REPLACE. There must be a vendor specific implementation.")
 
     /**
      * Returns the SQL command that either inserts a new row into a table, or updates the existing row if insertion would violate a unique constraint.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -496,12 +496,14 @@ abstract class FunctionProvider {
     }
 
     /**
-     * Returns the SQL command that insert a new row into a table, but if another row with the same primary/unique key already exists then it updates the values of that row instead.
-     * This operation is also known as "Insert or update".
+     * Represents the SQL command that either inserts a new row into a table, or deletes the existing row if insertion would violate a unique constraint,
+     * before inserting the new row.
      *
      * **Note:** This operation is not supported by all vendors, please check the documentation.
      *
+     * @param table Table to either insert values into or delete values from then insert into.
      * @param data Pairs of column to replace and values to replace with.
+     * @param transaction Transaction where the operation is executed.
      */
     open fun replace(
         table: Table,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -98,24 +98,6 @@ internal object H2FunctionProvider : FunctionProvider() {
         toString()
     }
 
-    override fun replace(
-        table: Table,
-        data: List<Pair<Column<*>, Any?>>,
-        transaction: Transaction
-    ): String {
-        if (data.isEmpty()) {
-            return ""
-        }
-
-        val columns = data.map { it.first }
-
-        val builder = QueryBuilder(true)
-
-        val sql = data.appendTo(builder, prefix = "VALUES (", postfix = ")") { (col, value) -> registerArgument(col, value) }.toString()
-
-        return super.insert(false, table, columns, sql, transaction).replaceFirst("INSERT", "MERGE")
-    }
-
     /**
      * Implementation of [FunctionProvider.locate]
      * Note: search is case-sensitive

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -96,11 +96,14 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
-        val builder = QueryBuilder(true)
-        val columns = data.joinToString { transaction.identity(it.first) }
-        val values = builder.apply { data.appendTo { registerArgument(it.first, it.second) } }.toString()
-        return "REPLACE INTO ${transaction.identity(table)} ($columns) VALUES ($values)"
+    override fun replace(
+        table: Table,
+        columns: List<Column<*>>,
+        expression: String,
+        transaction: Transaction
+    ): String {
+        val insertStatement = super.insert(false, table, columns, expression, transaction)
+        return insertStatement.replace("INSERT", "REPLACE")
     }
 
     private object CharColumnType : StringColumnType() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -167,33 +167,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         }
         toString()
     }
-
-    override fun replace(
-        table: Table,
-        data: List<Pair<Column<*>, Any?>>,
-        transaction: Transaction
-    ): String {
-        val builder = QueryBuilder(true)
-        val sql = if (data.isEmpty()) {
-            ""
-        } else {
-            data.appendTo(builder, prefix = "VALUES (", postfix = ")") { (col, value) -> registerArgument(col, value) }.toString()
-        }
-
-        val columns = data.map { it.first }
-
-        val def = super.insert(false, table, columns, sql, transaction)
-
-        val uniqueCols = table.primaryKey?.columns
-        if (uniqueCols.isNullOrEmpty()) {
-            transaction.throwUnsupportedException("PostgreSQL replace table must supply at least one primary key.")
-        }
-        val conflictKey = uniqueCols.joinToString { transaction.identity(it) }
-        return def + "ON CONFLICT ($conflictKey) DO UPDATE SET " + columns.joinToString {
-            "${transaction.identity(it)}=EXCLUDED.${transaction.identity(it)}"
-        }
-    }
-
+    
     override fun upsert(
         table: Table,
         data: List<Pair<Column<*>, Any?>>,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -129,11 +129,14 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         return super.update(target, columnsAndValues, limit, where, transaction)
     }
 
-    override fun replace(table: Table, data: List<Pair<Column<*>, Any?>>, transaction: Transaction): String {
-        val builder = QueryBuilder(true)
-        val columns = data.joinToString { transaction.identity(it.first) }
-        val values = builder.apply { data.appendTo { registerArgument(it.first, it.second) } }.toString()
-        return "INSERT OR REPLACE INTO ${transaction.identity(table)} ($columns) VALUES ($values)"
+    override fun replace(
+        table: Table,
+        columns: List<Column<*>>,
+        expression: String,
+        transaction: Transaction
+    ): String {
+        val insertStatement = super.insert(false, table, columns, expression, transaction)
+        return insertStatement.replace("INSERT", "INSERT OR REPLACE")
     }
 
     override fun upsert(

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
@@ -32,47 +32,16 @@ class H2Tests : DatabaseTestsBase() {
 
     @Test
     fun replaceAsInsertInH2() {
-        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2)) {
+        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2_MARIADB)) {
 
             SchemaUtils.drop(Testing)
             SchemaUtils.create(Testing)
             Testing.replace {
-                it[Testing.id] = 1
-                it[Testing.string] = "one"
+                it[id] = 1
+                it[string] = "one"
             }
 
             assertEquals("one", Testing.select { Testing.id.eq(1) }.single()[Testing.string])
-        }
-    }
-
-    @Test
-    fun replaceAsUpdateInH2() {
-        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2)) {
-
-            SchemaUtils.drop(Testing)
-            SchemaUtils.create(Testing)
-            Testing.insert {
-                it[Testing.id] = 1
-                it[Testing.string] = "one"
-            }
-
-            Testing.replace {
-                it[Testing.id] = 1
-                it[Testing.string] = "two"
-            }
-
-            assertEquals("two", Testing.select { Testing.id.eq(1) }.single()[Testing.string])
-        }
-    }
-
-    @Test
-    fun emptyReplace() {
-        withDb(listOf(TestDB.H2_MYSQL, TestDB.H2)) {
-
-            SchemaUtils.drop(Testing)
-            SchemaUtils.create(Testing)
-
-            Testing.replace {}
         }
     }
 
@@ -124,13 +93,6 @@ class H2Tests : DatabaseTestsBase() {
     object Testing : Table("H2_TESTING") {
         val id = integer("id").autoIncrement() // Column<Int>
         val string = varchar("string", 128)
-
-        override val primaryKey = PrimaryKey(id)
-    }
-
-    object RefTable : Table() {
-        val id = integer("id").autoIncrement() // Column<Int>
-        val ref = reference("test", Testing.id)
 
         override val primaryKey = PrimaryKey(id)
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -110,7 +110,7 @@ class ReplaceTests : DatabaseTestsBase() {
                 .select { cities.name inList listOf("Munich", "Prague", "St. Petersburg") }
                 .orderBy(cities.name).map { it[cities.id] }
 
-            // replace is implemented as deleted-then-insert on conflict, which breaks foreign key constraints,
+            // replace is implemented as delete-then-insert on conflict, which breaks foreign key constraints,
             // so this test will only work if those related rows are deleted.
             userData.deleteAll()
             users.deleteAll()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -11,7 +11,8 @@ import java.util.*
 
 class ReplaceTests : DatabaseTestsBase() {
 
-    private val replaceNotSupported = TestDB.values().toList() - listOf(TestDB.MYSQL, TestDB.MARIADB, TestDB.SQLITE)
+    private val mysqlLikeDialects = listOf(TestDB.MYSQL, TestDB.MARIADB, TestDB.H2_MYSQL, TestDB.H2_MARIADB)
+    private val replaceNotSupported = TestDB.values().toList() - mysqlLikeDialects - TestDB.SQLITE
 
     private object NewAuth : Table("new_auth") {
         val username = varchar("username", 16)
@@ -100,6 +101,21 @@ class ReplaceTests : DatabaseTestsBase() {
             }
 
             assertEquals("serverID1", NewAuth.selectAll().single()[NewAuth.serverID])
+        }
+    }
+
+    @Test
+    fun testEmptyReplace() {
+        val tester = object : Table("tester") {
+            val id = integer("id").autoIncrement()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(replaceNotSupported, tester) {
+            tester.replace { }
+
+            assertEquals(1, tester.selectAll().count())
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -128,7 +128,7 @@ class ReplaceTests : DatabaseTestsBase() {
 
             val cityNames = cities.slice(cities.name)
                 .select { cities.id inList cityUpdates.unzip().first }
-                .orderBy(cities.name).map { it[cities.name] }
+                .orderBy(cities.name).toCityNameList()
 
             assertEqualLists(cityUpdates.unzip().second, cityNames)
         }
@@ -146,7 +146,7 @@ class ReplaceTests : DatabaseTestsBase() {
                 this[Cities.name] = name
             }
 
-            val namesFromDB1 = Cities.selectAll().map { it[Cities.name] }
+            val namesFromDB1 = Cities.selectAll().toCityNameList()
             assertEquals(amountOfNames, namesFromDB1.size)
             assertEqualLists(names.unzip().second, namesFromDB1)
 
@@ -157,7 +157,7 @@ class ReplaceTests : DatabaseTestsBase() {
                 this[Cities.name] = name
             }
 
-            val namesFromDB2 = Cities.selectAll().map { it[Cities.name] }
+            val namesFromDB2 = Cities.selectAll().toCityNameList()
             assertEquals(amountOfNames, namesFromDB2.size)
             assertEqualLists(namesToReplace.unzip().second, namesFromDB2)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -5,62 +5,115 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
-import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.junit.Test
 import java.util.*
 
 class ReplaceTests : DatabaseTestsBase() {
 
-    private val notSupportsReplace = listOf(TestDB.ORACLE, TestDB.SQLSERVER, TestDB.H2_ORACLE, TestDB.H2_SQLSERVER)
+    private val replaceNotSupported = TestDB.values().toList() - listOf(TestDB.MYSQL, TestDB.MARIADB, TestDB.SQLITE)
 
-    // GitHub issue #98: Parameter index out of range when using Table.replace
+    private object NewAuth : Table("new_auth") {
+        val username = varchar("username", 16)
+        val session = binary("session", 64)
+        val timestamp = long("timestamp").default(0)
+        val serverID = varchar("serverID", 64).default("")
+
+        override val primaryKey = PrimaryKey(username)
+    }
+
     @Test
-    fun testReplace01() {
-        val NewAuth = object : Table("new_auth") {
-            val username = varchar("username", 16)
-            val session = binary("session", 64)
-            val timestamp = long("timestamp").default(0)
-            val serverID = varchar("serverID", 64).default("")
-
-            override val primaryKey = PrimaryKey(username)
-        }
-        withTables(notSupportsReplace, NewAuth) {
-            NewAuth.replace {
-                it[username] = "username"
-                it[session] = "session".toByteArray()
+    fun testReplaceWithPKConflict() {
+        withTables(replaceNotSupported, NewAuth) {
+            val (name1, session1) = "username" to "session"
+            NewAuth.replace {  // replace, like any insert, should accept defaults
+                it[username] = name1
+                it[session] = session1.toByteArray()
             }
+
+            val result1 = NewAuth.selectAll().single()
+            assertEquals(0, result1[NewAuth.timestamp])
+            assertTrue(result1[NewAuth.serverID].isEmpty())
+
+            val timeNow = System.currentTimeMillis()
+            val concatId = "$name1-$session1"
+            NewAuth.replace {
+                it[username] = name1
+                it[session] = session1.toByteArray()
+                it[timestamp] = timeNow
+                it[serverID] = concatId
+            }
+
+            val result2 = NewAuth.selectAll().single()
+            assertEquals(timeNow, result2[NewAuth.timestamp])
+            assertEquals(concatId, result2[NewAuth.serverID])
+        }
+    }
+
+    @Test
+    fun testReplaceWithCompositePKConflict() {
+        val tester = object : Table("test_table") {
+            val key1 = varchar("key_1", 16)
+            val key2 = varchar("key_2", 16)
+            val replaced = long("replaced").default(0)
+
+            override val primaryKey = PrimaryKey(key1, key2)
+        }
+
+        withTables(replaceNotSupported, tester) {
+            val (id1, id2) = "A" to "B"
+            tester.replace {
+                it[key1] = id1
+                it[key2] = id2
+            }
+
+            assertEquals(0, tester.selectAll().single()[tester.replaced])
+
+            val timeNow = System.currentTimeMillis()
+            tester.replace {// insert because only 1 constraint is equal
+                it[key1] = id1
+                it[key2] = "$id2 2"
+                it[replaced] = timeNow
+            }
+
+            assertEquals(2, tester.selectAll().count())
+            assertEquals(0, tester.select { tester.key2 eq id2 }.single()[tester.replaced])
+
+            tester.replace {  // delete & insert because both constraints match
+                it[key1] = id1
+                it[key2] = id2
+                it[replaced] = timeNow
+            }
+
+            assertEquals(2, tester.selectAll().count())
+            assertEquals(timeNow, tester.select { tester.key2 eq id2 }.single()[tester.replaced])
         }
     }
 
     @Test
     fun testReplaceWithExpression() {
-        val NewAuth = object : Table("new_auth") {
-            val username = varchar("username", 16)
-            val password = varchar("password", 64)
-            override val primaryKey = PrimaryKey(username)
-        }
-        withTables(notSupportsReplace, NewAuth) {
+        withTables(replaceNotSupported, NewAuth) {
             NewAuth.replace {
                 it[username] = "username"
-                it[password] = stringLiteral("  password1 ").trim()
+                it[session] = "session".toByteArray()
+                it[serverID] = stringLiteral("  serverID1 ").trim()
             }
+
+            assertEquals("serverID1", NewAuth.selectAll().single()[NewAuth.serverID])
         }
     }
 
     @Test
     fun testBatchReplace01() {
-        withCitiesAndUsers(notSupportsReplace) { cities, users, userData ->
-            val (munichId, pragueId, saintPetersburgId) = cities.slice(cities.id).select {
-                cities.name inList listOf("Munich", "Prague", "St. Petersburg")
-            }.orderBy(cities.name).map { it[cities.id] }
+        withCitiesAndUsers(replaceNotSupported) { cities, users, userData ->
+            val (munichId, pragueId, saintPetersburgId) = cities.slice(cities.id)
+                .select { cities.name inList listOf("Munich", "Prague", "St. Petersburg") }
+                .orderBy(cities.name).map { it[cities.id] }
 
-            // MySQL replace is implemented as deleted-then-insert, which breaks foreign key constraints,
+            // replace is implemented as deleted-then-insert on conflict, which breaks foreign key constraints,
             // so this test will only work if those related rows are deleted.
-            if (currentDialect is MysqlDialect) {
-                userData.deleteAll()
-                users.deleteAll()
-            }
+            userData.deleteAll()
+            users.deleteAll()
 
             val cityUpdates = listOf(
                 munichId to "München",
@@ -74,18 +127,19 @@ class ReplaceTests : DatabaseTestsBase() {
             }
 
             val cityNames = cities.slice(cities.name)
-                .select { cities.id inList listOf(munichId, pragueId, saintPetersburgId) }
+                .select { cities.id inList cityUpdates.unzip().first }
                 .orderBy(cities.name).map { it[cities.name] }
 
-            assertEqualLists(listOf("München", "Prague", "Saint Petersburg"), cityNames)
+            assertEqualLists(cityUpdates.unzip().second, cityNames)
         }
     }
 
     @Test
-    fun `batchReplace using a sequence should work`() {
+    fun testBatchReplaceWithSequence() {
         val Cities = DMLTestsData.Cities
-        withTables(notSupportsReplace, Cities) {
-            val names = List(25) { index -> index + 1 to UUID.randomUUID().toString() }.asSequence()
+        withTables(replaceNotSupported, Cities) {
+            val amountOfNames = 25
+            val names = List(amountOfNames) { index -> index + 1 to UUID.randomUUID().toString() }.asSequence()
 
             Cities.batchReplace(names) { (index, name) ->
                 this[Cities.id] = index
@@ -93,10 +147,10 @@ class ReplaceTests : DatabaseTestsBase() {
             }
 
             val namesFromDB1 = Cities.selectAll().map { it[Cities.name] }
-            assertEquals(25, namesFromDB1.size)
-            assertEqualLists(names.map { it.second }.toList(), namesFromDB1)
+            assertEquals(amountOfNames, namesFromDB1.size)
+            assertEqualLists(names.unzip().second, namesFromDB1)
 
-            val namesToReplace = List(25) { index -> index + 1 to UUID.randomUUID().toString() }.asSequence()
+            val namesToReplace = List(amountOfNames) { index -> index + 1 to UUID.randomUUID().toString() }.asSequence()
 
             Cities.batchReplace(namesToReplace) { (index, name) ->
                 this[Cities.id] = index
@@ -104,18 +158,17 @@ class ReplaceTests : DatabaseTestsBase() {
             }
 
             val namesFromDB2 = Cities.selectAll().map { it[Cities.name] }
-
-            assertEquals(25, namesFromDB2.size)
-            assertEqualLists(namesToReplace.map { it.second }.toList(), namesFromDB2)
+            assertEquals(amountOfNames, namesFromDB2.size)
+            assertEqualLists(namesToReplace.unzip().second, namesFromDB2)
         }
     }
 
     @Test
-    fun `batchInserting using empty sequence should work`() {
+    fun testBatchReplaceWithEmptySequence() {
         val Cities = DMLTestsData.Cities
         withTables(Cities) {
             val names = emptySequence<String>()
-            Cities.batchInsert(names) { name -> this[Cities.name] = name }
+            Cities.batchReplace(names) { name -> this[Cities.name] = name }
 
             val batchesSize = Cities.selectAll().count()
 


### PR DESCRIPTION
KDocs stated that `replace()` inserts a new row or updates the existing row if a unique constraint conflict is found, which is equivalent to an upsert command. They have been edited to state that REPLACE performs an "insert or delete then insert" command, as per the dialects that actually support it ([MySQL](https://dev.mysql.com/doc/refman/8.0/en/replace.html), [SQLite](https://www.sqlite.org/lang_conflict.html)).

Classes `ReplaceStatement` and `BatchReplaceStatement` refactored since supported vendors use syntax very similar to INSERT statement. Duplicate code from `InsertStatement`'s `prepareSql()` extracted to a protected helper function so that it can also be used in the 2 replace classes.

Test suites refactored to better test for expected "insert or delete then insert" behavior. 1 unused test table was deleted from `H2Tests.kt`.

BREAKING CHANGE:
- [H2, PostgreSQL] These dialect overrides have been removed as both were implementing an "insert or update" command. Attempting to use `replace()` with these dialects will now throw `UnsupportedByDialectException`. The out-of-the-box `upsert()` should be used instead [#1743](https://github.com/JetBrains/Exposed/pull/1743).