### PR TITLE
add partial index support (pg only)

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -193,6 +193,8 @@ data class CheckConstraint(
     }
 }
 
+typealias FilterCondition = (SqlExpressionBuilder.() -> Op<Boolean>)?
+
 /**
  * Represents an index.
  */
@@ -204,7 +206,9 @@ data class Index(
     /** Optional custom name for the index. */
     val customName: String? = null,
     /** Optional custom index type (e.g, BTREE or HASH) */
-    val indexType: String? = null
+    val indexType: String? = null,
+    /** Partial index filter condition */
+    val filterCondition: Op<Boolean>? = null
 ) : DdlAware {
     /** Table where the index is defined. */
     val table: Table
@@ -229,7 +233,7 @@ data class Index(
 
     override fun createStatement(): List<String> = listOf(currentDialect.createIndex(this))
     override fun modifyStatement(): List<String> = dropStatement() + createStatement()
-    override fun dropStatement(): List<String> = listOf(currentDialect.dropIndex(table.nameInDatabaseCase(), indexName))
+    override fun dropStatement(): List<String> = listOf(currentDialect.dropIndex(table.nameInDatabaseCase(), indexName, unique, filterCondition != null))
 
     /** Returns `true` if the [other] index has the same columns and uniqueness as this index, but a different name, `false` otherwise */
     fun onlyNameDiffer(other: Index): Boolean = indexName != other.indexName && columns == other.columns && unique == other.unique

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -806,7 +806,7 @@ interface DatabaseDialect {
     fun createIndex(index: Index): String
 
     /** Returns the SQL command that drops the specified [indexName] from the specified [tableName]. */
-    fun dropIndex(tableName: String, indexName: String): String
+    fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String
 
     /** Returns the SQL command that modifies the specified [column]. */
     fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String>
@@ -879,7 +879,6 @@ sealed class ForUpdateOption(open val querySuffix: String) {
 
         class ForUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR UPDATE", mode, *ofTables)
 
-
         open class ForNoKeyUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR NO KEY UPDATE", mode, *ofTables) {
             companion object : ForNoKeyUpdate()
         }
@@ -909,6 +908,9 @@ abstract class VendorDialect(
     override val dataTypeProvider: DataTypeProvider,
     override val functionProvider: FunctionProvider
 ) : DatabaseDialect {
+
+    protected val identifierManager
+        get() = TransactionManager.current().db.identifierManager
 
     abstract class DialectNameProvider(val dialectName: String)
 
@@ -1013,30 +1015,61 @@ abstract class VendorDialect(
         resetCaches()
     }
 
+    fun filterCondition(index: Index): String? {
+        return if (currentDialect is PostgreSQLDialect) {
+            index.filterCondition?.let {
+                QueryBuilder(false)
+                    .append(" WHERE ").append(it)
+                    .toString()
+            }
+        } else {
+            null
+        }
+    }
+
+    /**
+     * The uniquieness might be required for foreign constraints
+     *
+     * In postgresq (https://www.postgresql.org/docs/current/indexes-unique.html) Uniq means btree only.
+     * Unique constraints can not be partial
+     * Unique indexes can be partial
+     */
     override fun createIndex(index: Index): String {
         val t = TransactionManager.current()
         val quotedTableName = t.identity(index.table)
         val quotedIndexName = t.db.identifierManager.cutIfNecessaryAndQuote(index.indexName)
         val columnsList = index.columns.joinToString(prefix = "(", postfix = ")") { t.identity(it) }
+
+        val maybeFilterCondition = filterCondition(index) ?: ""
+
         return when {
-            index.unique -> {
+            // uniq and no filter -> constraint, the type is not supported
+            index.unique && maybeFilterCondition.isEmpty() -> {
                 "ALTER TABLE $quotedTableName ADD CONSTRAINT $quotedIndexName UNIQUE $columnsList"
             }
-            index.indexType != null -> {
-                createIndexWithType(name = quotedIndexName, table = quotedTableName, columns = columnsList, type = index.indexType)
+            // uniq and filter -> index only, the type is not supported
+            index.unique -> {
+                "CREATE UNIQUE INDEX $quotedIndexName ON $quotedTableName $columnsList$maybeFilterCondition"
             }
+            // type -> can't be uniq or constraint
+            index.indexType != null -> {
+                createIndexWithType(
+                    name = quotedIndexName, table = quotedTableName,
+                    columns = columnsList, type = index.indexType, filterCondition = maybeFilterCondition
+                )
+            }
+            // any other indexes. May be can be merged with `createIndexWithType`
             else -> {
-                "CREATE INDEX $quotedIndexName ON $quotedTableName $columnsList"
+                "CREATE INDEX $quotedIndexName ON $quotedTableName $columnsList$maybeFilterCondition"
             }
         }
     }
 
-    protected open fun createIndexWithType(name: String, table: String, columns: String, type: String): String {
-        return "CREATE INDEX $name ON $table $columns USING $type"
+    protected open fun createIndexWithType(name: String, table: String, columns: String, type: String, filterCondition: String): String {
+        return "CREATE INDEX $name ON $table $columns USING $type$filterCondition"
     }
 
-    override fun dropIndex(tableName: String, indexName: String): String {
-        val identifierManager = TransactionManager.current().db.identifierManager
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String {
         return "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT ${identifierManager.quoteIfNecessary(indexName)}"
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -276,7 +276,8 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         }
     }
 
-    override fun dropIndex(tableName: String, indexName: String): String = "ALTER TABLE $tableName DROP INDEX $indexName"
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String =
+        "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
 
     override fun setSchema(schema: Schema): String = "USE ${schema.identifier}"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -167,7 +167,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         }
         toString()
     }
-    
+
     override fun upsert(
         table: Table,
         data: List<Pair<Column<*>, Any?>>,
@@ -256,8 +256,16 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
 
     override fun setSchema(schema: Schema): String = "SET search_path TO ${schema.identifier}"
 
-    override fun createIndexWithType(name: String, table: String, columns: String, type: String): String {
-        return "CREATE INDEX $name ON $table USING $type $columns"
+    override fun createIndexWithType(name: String, table: String, columns: String, type: String, filterCondition: String): String {
+        return "CREATE INDEX $name ON $table USING $type $columns$filterCondition"
+    }
+
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String {
+        return if (isUnique && !isPartial) {
+            "ALTER TABLE IF EXISTS ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
+        } else {
+            "DROP INDEX IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
+        }
     }
 
     companion object : DialectNameProvider("postgresql")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -227,7 +227,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
         }
     }
 
-    override fun createIndexWithType(name: String, table: String, columns: String, type: String): String {
+    override fun createIndexWithType(name: String, table: String, columns: String, type: String, filterCondition: String): String {
         return "CREATE $type INDEX $name ON $table $columns"
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateIndexTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateIndexTests.kt
@@ -1,13 +1,12 @@
 package org.jetbrains.exposed.sql.tests.shared.ddl
 
-import org.jetbrains.exposed.sql.Schema
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.exists
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.junit.Test
 
 class CreateIndexTests : DatabaseTestsBase() {
@@ -81,6 +80,70 @@ class CreateIndexTests : DatabaseTestsBase() {
             assertEquals(false, TestTable.exists())
             SchemaUtils.createMissingTablesAndColumns(TestTable)
             assertEquals(true, TestTable.exists())
+        }
+    }
+
+
+    @Test
+    fun `test partial index`() {
+        val partialIndexTable = object : IntIdTable("PartialIndexTableTest") {
+            val name = varchar("name", 50)
+            val value = integer("value")
+            val anotherName = integer("anotherName")
+            val anotherValue = integer("anotherValue")
+            val flag = bool("flag")
+            init {
+                index("flag_index", columns = arrayOf(flag, name)) {
+                    flag eq true
+                }
+                index(columns = arrayOf(value, name)) {
+                    (name eq "aaa") and (value greaterEq 6)
+                }
+                uniqueIndex(columns = arrayOf(anotherValue))
+            }
+        }
+
+        withDb(TestDB.POSTGRESQL) {
+            SchemaUtils.createMissingTablesAndColumns(partialIndexTable)
+            assertTrue(partialIndexTable.exists())
+
+            // check that indexes are created and contain the proper filtering conditions
+            exec(
+                """SELECT indexname AS INDEX_NAME,
+                   substring(indexdef, strpos(indexdef, ' WHERE ') + 7) AS FILTER_CONDITION
+                   FROM pg_indexes
+                   WHERE tablename='partialindextabletest' AND indexname != 'partialindextabletest_pkey'
+                """.trimIndent()
+            ) {
+                var totalIndexCount = 0
+                while (it.next()) {
+                    totalIndexCount += 1
+                    val filter = it.getString("FILTER_CONDITION")
+
+                    when (it.getString("INDEX_NAME")) {
+                        "partialindextabletest_value_name" -> assertEquals(filter, "(((name)::text = 'aaa'::text) AND (value >= 6))")
+                        "flag_index" -> assertEquals(filter, "(flag = true)")
+                        "partialindextabletest_anothervalue_unique" -> assertTrue(filter.startsWith(" UNIQUE INDEX "))
+                    }
+                }
+                kotlin.test.assertEquals(totalIndexCount, 3, "Indexes expected to be created")
+            }
+
+            fun List<Column<*>>.names(): Set<String> { return map { identity(it) }.toSet() }
+            fun getIndexes(): List<Index> {
+                db.dialect.resetCaches()
+                return currentDialect.existingIndices(partialIndexTable)[partialIndexTable].orEmpty()
+            }
+
+            val dropIndex = Index(columns = listOf(partialIndexTable.value, partialIndexTable.name), unique = false).dropStatement().first()
+            kotlin.test.assertTrue(dropIndex.startsWith("DROP INDEX "), "Unique partial index must be created and dropped as index")
+            val dropUniqConstraint = Index(columns = listOf(partialIndexTable.anotherValue), unique = true).dropStatement().first()
+            kotlin.test.assertTrue(dropUniqConstraint.startsWith("ALTER TABLE "), "Unique index must be created and dropped as constraint")
+
+            execInBatch(listOf(dropUniqConstraint, dropIndex))
+
+            assertEquals(getIndexes().size, 1)
+            SchemaUtils.drop(partialIndexTable)
         }
     }
 }


### PR DESCRIPTION
**Limitation:**
- postgresql only is supported 
- `currentDialect.existingIndices` does not return the full filterCondition, just a placeholder to mark the index as a partial - the text to expression parser is not added. 

**How to Create :**
```kotlin
    object Test : Table("partialIndex") {
        val id = integer("id")
        val name = varchar("name", 128)
        init {
            index(columns = arrayOf(id, name)){
                (id greaterEq  3) and ( name.isNotNull() )
            }
        }
    }

```

**How to drop**
```kotlin
// Variant 1
// implies the table has just a single index
val index = currentDialect.existingIndices(partialIndexTable)[partialIndexTable].first()

// variant 2, if constraint 
val index = Index(columns = listOf(partialIndexTable.value, partialIndexTable.name), unique = false)
// variant 2, not constraint.
val index = Index(columns = listOf(partialIndexTable.value, partialIndexTable.name), unique = false){Op.TRUE} 

// and finally 
exec { index.dropStatement() } 
``` 

---

**Details user must be aware of**
There are three cases of indexed data in PG that we are interested in: Index, Unique Index, Unique Constraint. 
To create [unique] index we execute `CREATE [UNIQUE] INDEX `
To create Constraint, this form is used: `ALTER TABLE ...  ADD CONSTRAINT ...         UNIQUE (team, "member")`
The unique constraint always creates the unique index. 
This knowledge is important to understand the following invariants: 
- Unique constraints and indexes (remember, constraint always creates the index under the hood) can not specify index type, it is always B-tree. 
- Unique constraint can not be partial 
- Unique index can be partial. 

as a flow 
```
 if isUniq and notPartial -> Constraint
 If isUniq -> Unique Index, withType is ignored 
 if withType -> Index, isUniq ignored
 else -> Index
``` 

**Something to consider**

Unique Constraint is not mandatory to create referencing foreign key, contrary to a common disbelieve. However, according to PG doc, to is a constraint is a more idiomatic way. 

```sql
db=# create table master(id integer not null, name text ); 
CREATE TABLE
db=# create table detail (did integer not null, details text, mid integer references master(id)); 
ERROR:  there is no unique constraint matching given keys for referenced table "master"
db=# \d master 
               Table "public.master"
 Column |  Type   | Collation | Nullable | Default 
--------+---------+-----------+----------+---------
 id     | integer |           | not null | 
 name   | text    |           |          | 

db=# create unique index master_id_unique on master (id);
CREATE INDEX
db=# \d master
               Table "public.master"
 Column |  Type   | Collation | Nullable | Default 
--------+---------+-----------+----------+---------
 id     | integer |           | not null | 
 name   | text    |           |          | 
Indexes:
    "master_id_unique" UNIQUE, btree (id)

db=# create table detail (did integer not null, details text, mid integer references master(id));
CREATE TABLE
crcltdevdb=# \d detail 
               Table "public.detail"
 Column  |  Type   | Collation | Nullable | Default 
---------+---------+-----------+----------+---------
 did     | integer |           | not null | 
 details | text    |           |          | 
 mid     | integer |           |          | 
Foreign-key constraints:
    "detail_mid_fkey" FOREIGN KEY (mid) REFERENCES master(id)
``` 

Since Exposed resorted to the usage of unique constraint since it's inception, we can not completely switch to the Unique Indexes usage only. Additional reason to keep things slightly more complicated is that it will not break the backward compatibility with exposed. 