### PR TITLE
feat: EXPOSED-52 Support batch UPSERT

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -289,6 +289,9 @@ fun <T : Table> T.upsert(
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
  *
+ * **Note**: Unlike `upsert`, `batchUpsert` does not include a `where` parameter. Please log a feature request on
+ * [YouTrack](https://youtrack.jetbrains.com/newIssue?project=EXPOSED&c=Type%20Feature&draftId=25-4449790) if a use-case requires inclusion of a `where` clause.
+ *
  * @param data Collection of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
  * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
@@ -311,6 +314,9 @@ fun <T : Table, E : Any> T.batchUpsert(
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
  *
+ * **Note**: Unlike `upsert`, `batchUpsert` does not include a `where` parameter. Please log a feature request on
+ * [YouTrack](https://youtrack.jetbrains.com/newIssue?project=EXPOSED&c=Type%20Feature&draftId=25-4449790) if a use-case requires inclusion of a `where` clause.
+ *
  * @param data Sequence of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
  * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
@@ -332,6 +338,9 @@ fun <T : Table, E : Any> T.batchUpsert(
 
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
+ *
+ * **Note**: Unlike `upsert`, `batchUpsert` does not include a `where` parameter. Please log a feature request on
+ * [YouTrack](https://youtrack.jetbrains.com/newIssue?project=EXPOSED&c=Type%20Feature&draftId=25-4449790) if a use-case requires inclusion of a `where` clause.
  *
  * @param data Iterator over a collection of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -287,6 +287,68 @@ fun <T : Table> T.upsert(
 }
 
 /**
+ * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
+ *
+ * @param data Collection of values to use in replace.
+ * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
+ * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
+ * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
+ * If left null, all columns will be updated with the values provided for the insert.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.UpsertTests.testBatchUpsertWithNoConflict
+ */
+fun <T : Table, E : Any> T.batchUpsert(
+    data: Iterable<E>,
+    vararg keys: Column<*>,
+    onUpdate: List<Pair<Column<*>, Expression<*>>>? = null,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchUpsertStatement.(E) -> Unit
+): List<ResultRow> = batchUpsert(data.iterator(), *keys, onUpdate = onUpdate, shouldReturnGeneratedValues = shouldReturnGeneratedValues, body = body)
+
+/**
+ * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
+ *
+ * @param data Sequence of values to use in replace.
+ * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
+ * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
+ * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
+ * If left null, all columns will be updated with the values provided for the insert.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.UpsertTests.testBatchUpsertWithSequence
+ */
+fun <T : Table, E : Any> T.batchUpsert(
+    data: Sequence<E>,
+    vararg keys: Column<*>,
+    onUpdate: List<Pair<Column<*>, Expression<*>>>? = null,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchUpsertStatement.(E) -> Unit
+): List<ResultRow> = batchUpsert(data.iterator(), *keys, onUpdate = onUpdate, shouldReturnGeneratedValues = shouldReturnGeneratedValues, body = body)
+
+/**
+ * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
+ *
+ * @param data Iterator over a collection of values to use in replace.
+ * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
+ * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
+ * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
+ * If left null, all columns will be updated with the values provided for the insert.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.UpsertTests.testBatchUpsertWithNoConflict
+ */
+private fun <T : Table, E> T.batchUpsert(
+    data: Iterator<E>,
+    vararg keys: Column<*>,
+    onUpdate: List<Pair<Column<*>, Expression<*>>>? = null,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchUpsertStatement.(E) -> Unit
+): List<ResultRow> = executeBatch(data, body) {
+    BatchUpsertStatement(this, *keys, onUpdate = onUpdate, shouldReturnGeneratedValues = shouldReturnGeneratedValues)
+}
+
+/**
  * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.tableExists02
  */
 fun Table.exists(): Boolean = currentDialect.tableExists(this)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -289,7 +289,7 @@ fun <T : Table> T.upsert(
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
  *
- * @param data Collection of values to use in replace.
+ * @param data Collection of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
  * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
  * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
@@ -304,12 +304,14 @@ fun <T : Table, E : Any> T.batchUpsert(
     onUpdate: List<Pair<Column<*>, Expression<*>>>? = null,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchUpsertStatement.(E) -> Unit
-): List<ResultRow> = batchUpsert(data.iterator(), *keys, onUpdate = onUpdate, shouldReturnGeneratedValues = shouldReturnGeneratedValues, body = body)
+): List<ResultRow> {
+    return batchUpsert(data.iterator(), *keys, onUpdate = onUpdate, shouldReturnGeneratedValues = shouldReturnGeneratedValues, body = body)
+}
 
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
  *
- * @param data Sequence of values to use in replace.
+ * @param data Sequence of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
  * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
  * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
@@ -324,12 +326,14 @@ fun <T : Table, E : Any> T.batchUpsert(
     onUpdate: List<Pair<Column<*>, Expression<*>>>? = null,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchUpsertStatement.(E) -> Unit
-): List<ResultRow> = batchUpsert(data.iterator(), *keys, onUpdate = onUpdate, shouldReturnGeneratedValues = shouldReturnGeneratedValues, body = body)
+): List<ResultRow> {
+    return batchUpsert(data.iterator(), *keys, onUpdate = onUpdate, shouldReturnGeneratedValues = shouldReturnGeneratedValues, body = body)
+}
 
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
  *
- * @param data Iterator over a collection of values to use in replace.
+ * @param data Iterator over a collection of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
  * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
  * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -1,0 +1,39 @@
+package org.jetbrains.exposed.sql.statements
+
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
+import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider
+
+/**
+ * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
+ *
+ * @param table Table to either insert values into or update values from.
+ * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
+ * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
+ * @param onUpdate List of pairs of specific columns to update and the expressions to update them with.
+ * If left null, all columns will be updated with the values provided for the insert.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
+ * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ */
+open class BatchUpsertStatement(
+    table: Table,
+    vararg val keys: Column<*>,
+    val onUpdate: List<Pair<Column<*>, Expression<*>>>?,
+    shouldReturnGeneratedValues: Boolean = true
+) : BaseBatchInsertStatement(table, ignore = false, shouldReturnGeneratedValues) {
+
+    override fun prepareSQL(transaction: Transaction): String {
+        val functionProvider = when (val dialect = transaction.db.dialect) {
+            is H2Dialect -> when (dialect.h2Mode) {
+                H2Dialect.H2CompatibilityMode.MariaDB, H2Dialect.H2CompatibilityMode.MySQL -> MysqlFunctionProvider()
+                else -> H2FunctionProvider
+            }
+            else -> dialect.functionProvider
+        }
+        return functionProvider.upsert(table, arguments!!.first(), onUpdate, null, transaction, *keys)
+    }
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -11,6 +11,9 @@ import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider
 /**
  * Represents the SQL command that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
  *
+ * **Note**: Unlike `UpsertStatement`, `BatchUpsertStatement` does not include a `where` parameter. Please log a feature request
+ * on [YouTrack](https://youtrack.jetbrains.com/newIssue?project=EXPOSED&c=Type%20Feature&draftId=25-4449790) if a use-case requires inclusion of a `where` clause.
+ *
  * @param table Table to either insert values into or update values from.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
  * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
@@ -41,6 +41,16 @@ class EntityLifecycleInterceptor : GlobalStatementInterceptor {
                 }
             }
 
+            is UpsertStatement<*>, is BatchUpsertStatement -> {
+                transaction.flushCache()
+                transaction.entityCache.removeTablesReferrers(statement.targets, true)
+                if (!isExecutedWithinEntityLifecycle) {
+                    statement.targets.filterIsInstance<IdTable<*>>().forEach {
+                        transaction.entityCache.data[it]?.clear()
+                    }
+                }
+            }
+
             is InsertStatement<*> -> {
                 transaction.flushCache()
                 transaction.entityCache.removeTablesReferrers(listOf(statement.table), true)

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -123,6 +123,7 @@ enum class TestDB(
 
     companion object {
         val allH2TestDB = listOf(H2, H2_MYSQL, H2_PSQL, H2_MARIADB, H2_ORACLE, H2_SQLSERVER)
+        val mySqlRelatedDB = listOf(MYSQL, MARIADB, H2_MYSQL, H2_MARIADB)
         fun enabledInTests(): Set<TestDB> {
             val concreteDialects = System.getProperty("exposed.test.dialects", "")
                 .split(",")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.sql.tests.*
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.junit.Test
+import java.util.*
 
 // Upsert implementation does not support H2 version 1
 // https://youtrack.jetbrains.com/issue/EXPOSED-30/Phase-Out-Support-for-H2-Version-1.x
@@ -94,29 +95,24 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertWithUniqueIndexConflict() {
-        val tester = object : Table("tester") {
-            val name = varchar("name", 64).uniqueIndex()
-            val age = integer("age")
-        }
-
-        withTables(tester) { testDb ->
+        withTables(Words) { testDb ->
             excludingH2Version1(testDb) {
-                val nameA = tester.upsert {
-                    it[name] = "A"
-                    it[age] = 10
-                } get tester.name
-                tester.upsert {
-                    it[name] = "B"
-                    it[age] = 10
+                val wordA = Words.upsert {
+                    it[word] = "A"
+                    it[count] = 10
+                } get Words.word
+                Words.upsert {
+                    it[word] = "B"
+                    it[count] = 10
                 }
-                tester.upsert {
-                    it[name] = "A"
-                    it[age] = 9
+                Words.upsert {
+                    it[word] = wordA
+                    it[count] = 9
                 }
 
-                assertEquals(2, tester.selectAll().count())
-                val updatedResult = tester.select { tester.name eq nameA }.single()
-                assertEquals(9, updatedResult[tester.age])
+                assertEquals(2, Words.selectAll().count())
+                val updatedResult = Words.select { Words.word eq wordA }.single()
+                assertEquals(9, updatedResult[Words.count])
             }
         }
     }
@@ -196,23 +192,18 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertWithManualUpdateAssignment() {
-        val tester = object : Table("tester") {
-            val word = varchar("word", 256).uniqueIndex()
-            val count = integer("count").default(1)
-        }
-
-        withTables(tester) { testDb ->
+        withTables(Words) { testDb ->
             excludingH2Version1(testDb) {
                 val testWord = "Test"
-                val incrementCount = listOf(tester.count to tester.count.plus(1))
+                val incrementCount = listOf(Words.count to Words.count.plus(1))
 
                 repeat(3) {
-                    tester.upsert(onUpdate = incrementCount) {
+                    Words.upsert(onUpdate = incrementCount) {
                         it[word] = testWord
                     }
                 }
 
-                assertEquals(3, tester.selectAll().single()[tester.count])
+                assertEquals(3, Words.selectAll().single()[Words.count])
             }
         }
     }
@@ -364,5 +355,78 @@ class UpsertTests : DatabaseTestsBase() {
                 assertEquals("bar", tester2.selectAll().single()[tester2.name])
             }
         }
+    }
+
+    @Test
+    fun testBatchUpsertWithNoConflict() {
+        withTables(Words) { testDb ->
+            excludingH2Version1(testDb) {
+                val amountOfWords = 10
+                val allWords = List(amountOfWords) { i -> "Word ${'A' + i}" to amountOfWords * i + amountOfWords }
+
+                val generatedIds = Words.batchUpsert(allWords) { (word, count) ->
+                    this[Words.word] = word
+                    this[Words.count] = count
+                }
+
+                assertEquals(amountOfWords, generatedIds.size)
+            }
+        }
+    }
+
+    @Test
+    fun testBatchUpsertWithConflict() {
+        withTables(Words) { testDb ->
+            excludingH2Version1(testDb) {
+                val vowels = listOf("A", "E", "I", "O", "U")
+                val alphabet = ('A'..'Z').map { it.toString() }
+                val allLetters = alphabet + vowels
+                val incrementCount = listOf(Words.count to Words.count.plus(1))
+
+                Words.batchUpsert(allLetters, onUpdate = incrementCount) { letter ->
+                    this[Words.word] = letter
+                }
+
+                assertEquals(alphabet.size.toLong(), Words.selectAll().count())
+                Words.selectAll().forEach {
+                    val expectedCount = if (it[Words.word] in vowels) 2 else 1
+                    assertEquals(expectedCount, it[Words.count])
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testBatchUpsertWithSequence() {
+        withTables(Words) { testDb ->
+            excludingH2Version1(testDb) {
+                val amountOfWords = 25
+                val allWords = List(amountOfWords) { UUID.randomUUID().toString() }.asSequence()
+                Words.batchUpsert(allWords) { word -> this[Words.word] = word }
+
+                val batchesSize = Words.selectAll().count()
+
+                assertEquals(amountOfWords.toLong(), batchesSize)
+            }
+        }
+    }
+
+    @Test
+    fun testBatchUpsertWithEmptySequence() {
+        withTables(Words) { testDb ->
+            excludingH2Version1(testDb) {
+                val allWords = emptySequence<String>()
+                Words.batchUpsert(allWords) { word -> this[Words.word] = word }
+
+                val batchesSize = Words.selectAll().count()
+
+                assertEquals(0, batchesSize)
+            }
+        }
+    }
+
+    private object Words : Table("words") {
+        val word = varchar("name", 64).uniqueIndex()
+        val count = integer("count").default(1)
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -2,10 +2,7 @@ package org.jetbrains.exposed.sql.tests.shared.entities
 
 import org.jetbrains.exposed.dao.*
 import org.jetbrains.exposed.dao.exceptions.EntityNotFoundException
-import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
-import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.dao.id.*
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
@@ -17,10 +14,7 @@ import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
 import org.junit.Test
 import java.sql.Connection
 import java.util.*
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 object EntityTestsData {
 
@@ -371,6 +365,58 @@ class EntityTests : DatabaseTestsBase() {
             board2.refresh(flush = false)
             assertNotNull(Board.testCache(board2.id))
             assertEquals("relevant2", board2.name)
+        }
+    }
+
+    object Items : IntIdTable("items") {
+        val name = varchar("name", 255).uniqueIndex()
+        val price = double("price")
+    }
+
+    class Item(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<Item>(Items)
+        var name by Items.name
+        var price by Items.price
+    }
+
+    @Test
+    fun testCacheInvalidatedOnDSLUpsert() {
+        withTables(Items) { testDb ->
+            excludingH2Version1(testDb) {
+                val oldPrice = 20.0
+                val itemA = Item.new {
+                    name = "Item A"
+                    price = oldPrice
+                }
+                assertEquals(oldPrice, itemA.price)
+                assertNotNull(Item.testCache(itemA.id))
+
+                val newPrice = 50.0
+                val conflictKeys = if (testDb in TestDB.mySqlRelatedDB) emptyArray<Column<*>>() else arrayOf(Items.name)
+                Items.upsert(*conflictKeys) {
+                    it[name] = itemA.name
+                    it[price] = newPrice
+                }
+                assertEquals(oldPrice, itemA.price)
+                assertNull(Item.testCache(itemA.id))
+
+                itemA.refresh(flush = false)
+                assertEquals(newPrice, itemA.price)
+                assertNotNull(Item.testCache(itemA.id))
+
+                val newPricePlusExtra = 100.0
+                val newItems = List(5) { i -> "Item ${'A' + i}" to newPricePlusExtra }
+                Items.batchUpsert(newItems, *conflictKeys, shouldReturnGeneratedValues = false) { (name, price) ->
+                    this[Items.name] = name
+                    this[Items.price] = price
+                }
+                assertEquals(newPrice, itemA.price)
+                assertNull(Item.testCache(itemA.id))
+
+                itemA.refresh(flush = false)
+                assertEquals(newPricePlusExtra, itemA.price)
+                assertNotNull(Item.testCache(itemA.id))
+            }
         }
     }
 


### PR DESCRIPTION
Add support and tests for batch UPSERT query.

Extract an existing table object to use across multiple tests in `UpsertTests` suite.
Extract commonly-grouped collection of MySQL-specific `TestDB` to a companion object property, so they can be easily accessed across test files.

Edit `EntityLifecycleInterceptor` and add test for entity cache invalidation when DSL `(batch)upsert` used alongside DAO, as per issue [#914](https://github.com/JetBrains/Exposed/issues/914).