### PR TITLE
fix: EXPOSED-64 Fix Detekt SpreadOperator warnings

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -47,7 +47,3 @@ complexity:
 naming:
     ConstructorParameterNaming:
         active: false
-
-performance:
-    SpreadOperator:
-        active: false

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -37,6 +37,6 @@ open class BatchUpsertStatement(
             }
             else -> dialect.functionProvider
         }
-        return functionProvider.upsert(table, arguments!!.first(), onUpdate, null, transaction, *keys)
+        return functionProvider.upsert(table, arguments!!.first(), onUpdate, null, transaction, keys = keys)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -28,6 +28,6 @@ open class UpsertStatement<Key : Any>(
             }
             else -> dialect.functionProvider
         }
-        return functionProvider.upsert(table, arguments!!.first(), onUpdate, where, transaction, *keys)
+        return functionProvider.upsert(table, arguments!!.first(), onUpdate, where, transaction, keys = keys)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -927,17 +927,17 @@ sealed class ForUpdateOption(open val querySuffix: String) {
             final override val querySuffix: String = preparedQuerySuffix
         }
 
-        class ForUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR UPDATE", mode, *ofTables)
+        class ForUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR UPDATE", mode, ofTables = ofTables)
 
-        open class ForNoKeyUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR NO KEY UPDATE", mode, *ofTables) {
+        open class ForNoKeyUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR NO KEY UPDATE", mode, ofTables = ofTables) {
             companion object : ForNoKeyUpdate()
         }
 
-        open class ForShare(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR SHARE", mode, *ofTables) {
+        open class ForShare(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR SHARE", mode, ofTables = ofTables) {
             companion object : ForShare()
         }
 
-        open class ForKeyShare(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR KEY SHARE", mode, *ofTables) {
+        open class ForKeyShare(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR KEY SHARE", mode, ofTables = ofTables) {
             companion object : ForKeyShare()
         }
     }


### PR DESCRIPTION
Replace spread operators with named arguments in code that was producing warnings on build.

Note that, while this removes warnings, analyzed bytecode still shows that a copy of the array is being made.
See issue https://youtrack.jetbrains.com/issue/KT-17043