### PR TITLE
feat: EXPOSED-60 Support json/json(b) column types

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.gradle
 object Versions {
     const val kotlin = "1.7.21"
     const val kotlinCoroutines = "1.6.4"
+    const val kotlinxSerialization = "1.5.1"
 
     const val slf4j = "1.7.36"
     const val log4j2 = "2.17.2"

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1114,6 +1114,30 @@ public final class org/jetbrains/exposed/sql/JoinType : java/lang/Enum {
 	public static fun values ()[Lorg/jetbrains/exposed/sql/JoinType;
 }
 
+public final class org/jetbrains/exposed/sql/JsonBColumnType : org/jetbrains/exposed/sql/JsonColumnType {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun sqlType ()Ljava/lang/String;
+}
+
+public class org/jetbrains/exposed/sql/JsonColumnType : org/jetbrains/exposed/sql/ColumnType {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final fun getDeserialize ()Lkotlin/jvm/functions/Function1;
+	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/String;
+	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
+	public fun sqlType ()Ljava/lang/String;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/sql/JsonExtract : org/jetbrains/exposed/sql/Function {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getPath ()[Ljava/lang/String;
+	public final fun getToScalar ()Z
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
 public final class org/jetbrains/exposed/sql/Key {
 	public fun <init> ()V
 }
@@ -2051,6 +2075,8 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public fun innerJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public final fun integer (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public fun join (Lorg/jetbrains/exposed/sql/ColumnSet;Lorg/jetbrains/exposed/sql/JoinType;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Join;
+	public final fun json (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun jsonb (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun largeText (Ljava/lang/String;Ljava/lang/String;Z)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun largeText$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public fun leftJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
@@ -2911,6 +2937,8 @@ public abstract class org/jetbrains/exposed/sql/vendors/DataTypeProvider {
 	public abstract fun hexToDb (Ljava/lang/String;)Ljava/lang/String;
 	public fun integerAutoincType ()Ljava/lang/String;
 	public fun integerType ()Ljava/lang/String;
+	public fun jsonBType ()Ljava/lang/String;
+	public fun jsonType ()Ljava/lang/String;
 	public fun largeTextType ()Ljava/lang/String;
 	public fun longAutoincType ()Ljava/lang/String;
 	public fun longType ()Ljava/lang/String;
@@ -3113,6 +3141,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	public fun groupConcat (Lorg/jetbrains/exposed/sql/GroupConcat;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun hour (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun insert (ZLorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
+	public fun jsonExtract (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun locate (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)V
 	public fun match (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/FunctionProvider$MatchMode;)Lorg/jetbrains/exposed/sql/Op;
 	public static synthetic fun match$default (Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/FunctionProvider$MatchMode;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;

--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
+    kotlin("plugin.serialization") apply true
 }
 
 repositories {
@@ -12,5 +13,7 @@ dependencies {
     api(kotlin("stdlib"))
     api(kotlin("reflect"))
     api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", Versions.kotlinCoroutines)
+    api("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
+    api("org.postgresql", "postgresql", Versions.postgre)
     api("org.slf4j", "slf4j-api", "1.7.25")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -911,9 +911,12 @@ class EnumerationNameColumnType<T : Enum<T>>(
 
 // Serialization columns
 
-class JsonColumnType<T : Any>(
-    private val serialize: (T) -> String,
-    private val deserialize: (String) -> T
+/**
+ * Column for storing JSON in non-binary text format.
+ */
+open class JsonColumnType<T : Any>(
+    val serialize: (T) -> String,
+    val deserialize: (String) -> T
 ): ColumnType() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.jsonType()
 
@@ -946,6 +949,16 @@ class JsonColumnType<T : Any>(
         }
         super.setParameter(stmt, index, parameterValue)
     }
+}
+
+/**
+ * Column for storing JSON in binary format.
+ */
+class JsonBColumnType<T : Any>(
+    serialize: (T) -> String,
+    deserialize: (String) -> T
+): JsonColumnType<T>(serialize, deserialize) {
+    override fun sqlType(): String = currentDialect.dataTypeProvider.jsonBType()
 }
 
 // Date/Time columns

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -909,7 +909,7 @@ class EnumerationNameColumnType<T : Enum<T>>(
     }
 }
 
-// Serialization columns
+// JSON columns
 
 /**
  * Column for storing JSON data, either in non-binary text format or the vendor's default JSON type format.
@@ -935,7 +935,7 @@ open class JsonColumnType<T : Any>(
     override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
         val parameterValue = when (currentDialect) {
             is PostgreSQLDialect -> PGobject().apply {
-                type = currentDialect.dataTypeProvider.jsonType()
+                type = sqlType()
                 this.value = value as String?
             }
             else -> value
@@ -948,7 +948,9 @@ open class JsonColumnType<T : Any>(
  * Column for storing JSON data in binary format.
  */
 class JsonBColumnType<T : Any>(
+    /** Returns the function that encodes an object of type [T] to a JSON String. */
     serialize: (T) -> String,
+    /** Returns the function that decodes a JSON String to an object of type [T]. */
     deserialize: (String) -> T
 ) : JsonColumnType<T>(serialize, deserialize) {
     override fun sqlType(): String = currentDialect.dataTypeProvider.jsonBType()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -946,11 +946,12 @@ open class JsonColumnType<T : Any>(
 
 /**
  * Column for storing JSON data in binary format.
+ *
+ * @param serialize Function that encodes an object of type [T] to a JSON String
+ * @param deserialize Function that decodes a JSON String to an object of type [T]
  */
 class JsonBColumnType<T : Any>(
-    /** Returns the function that encodes an object of type [T] to a JSON String. */
     serialize: (T) -> String,
-    /** Returns the function that decodes a JSON String to an object of type [T]. */
     deserialize: (String) -> T
 ) : JsonColumnType<T>(serialize, deserialize) {
     override fun sqlType(): String = currentDialect.dataTypeProvider.jsonBType()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -299,6 +299,25 @@ class VarSamp<T>(
     }
 }
 
+// JSON Functions
+
+/**
+ * Represents an SQL function that returns extracted data from a JSON object at the specified [path],
+ * either as a JSON representation or as a scalar value.
+ */
+class JsonExtract<T>(
+    /** Returns the expression from which to extract JSON subcomponents matched by [path]. */
+    val expression: Expression<*>,
+    /** Returns array of Strings representing JSON path/keys that match fields to be extracted. */
+    vararg val path: String,
+    /** Returns whether the extracted result should be a scalar or text value; if `false`, result will be a JSON object. */
+    val toScalar: Boolean,
+    columnType: IColumnType
+) : Function<T>(columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
+        currentDialect.functionProvider.jsonExtract(expression, path = path, toScalar, queryBuilder)
+}
+
 // Sequence Manipulation Functions
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -117,6 +117,7 @@ inline fun <reified T : Any> ExpressionWithColumnType<*>.jsonExtract(vararg path
         Byte::class -> ByteColumnType()
         Double::class -> DoubleColumnType()
         Float::class -> FloatColumnType()
+        ByteArray::class -> BasicBinaryColumnType()
         else -> {
             JsonColumnType({ Json.Default.encodeToString(serializer<T>(), it) }, { Json.Default.decodeFromString(serializer<T>(), it) })
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.exposed.sql
 
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
@@ -653,6 +655,14 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
             override fun nonNullValueToString(value: Any): String = super.nonNullValueToString(notNullValueToDB(value))
         }
     )
+
+    // Serialization columns
+
+    fun <T : Any> json(name: String, stringify: (T) -> String, parse: (String) -> T): Column<T> =
+        registerColumn(name, JsonColumnType(stringify, parse))
+
+    fun <T : Any> json(name: String, actualJson: Json, kSerializer: KSerializer<T>): Column<T> =
+        json(name, { actualJson.encodeToString(kSerializer, it) }, { actualJson.decodeFromString(kSerializer, it) })
 
     // Auto-generated values
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -652,7 +652,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         }
     )
 
-    // Serialization columns
+    // JSON columns
 
     /**
      * Creates a column, with the specified [name], for storing JSON data.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.sql
 
-import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
@@ -674,12 +673,14 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * Creates a column, with the specified [name], for storing JSON in text format.
      *
      * @param name Name of the column
-     * @param jsonConfig Instance of the `Json` class.
-     * The default `Json` object is used if a configured instance is not provided.
-     * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
-     * Defaults to a generic serializer for type [T].
+     * @param jsonConfig Instance of the `Json` class. The default `Json` object is used if a configured instance is not provided.
+     * @param kSerializer Serializer responsible for the representation of a serial form of type [T]. Defaults to a generic serializer for type [T].
      */
-    inline fun <reified T : Any> json(name: String, jsonConfig: Json = Json, kSerializer: KSerializer<T> = serializer<T>()): Column<T> =
+    inline fun <reified T : Any> json(
+        name: String,
+        jsonConfig: Json = Json,
+        kSerializer: KSerializer<T> = serializer<T>()
+    ): Column<T> =
         json(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })
 
     /**
@@ -690,18 +691,21 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param deserialize Function that decodes a JSON string into a data object.
      */
     fun <T : Any> jsonb(name: String, serialize: (T) -> String, deserialize: (String) -> T): Column<T> =
-        registerColumn(name, JsonColumnType(serialize, deserialize))
+        registerColumn(name, JsonBColumnType(serialize, deserialize))
 
     /**
      * Creates a column, with the specified [name], for storing JSON in decomposed binary format.
      *
      * @param name Name of the column
-     * @param jsonConfig Instance of the `Json` class.
-     * The default `Json` object is used if a configured instance is not provided.
+     * @param jsonConfig Instance of the `Json` class. The default `Json` object is used if a configured instance is not provided.
      * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
      * Defaults to a generic serializer for type [T].
      */
-    inline fun <reified T : Any> jsonb(name: String, jsonConfig: Json = Json, kSerializer: KSerializer<T> = serializer<T>()): Column<T> =
+    inline fun <reified T : Any> jsonb(
+        name: String,
+        jsonConfig: Json = Json,
+        kSerializer: KSerializer<T> = serializer<T>()
+    ): Column<T> =
         jsonb(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })
 
     // Auto-generated values

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -107,14 +107,14 @@ abstract class DataTypeProvider {
     /** Returns the boolean value of the specified SQL [value]. */
     open fun booleanFromStringToBoolean(value: String): Boolean = value.toBoolean()
 
-    // Serialization types
+    // JSON types
 
     /** Data type for storing JSON in a non-binary text format. */
     open fun jsonType(): String = "JSON"
 
     /** Data type for storing JSON in a decomposed binary format. */
     open fun jsonBType(): String =
-        throw UnsupportedByDialectException("This vendor does not support binary JSONB data type", currentDialect)
+        throw UnsupportedByDialectException("This vendor does not support binary JSON data type", currentDialect)
 
     // Misc.
 
@@ -438,7 +438,7 @@ abstract class FunctionProvider {
         append("VAR_SAMP(", expression, ")")
     }
 
-    // Json Functions
+    // JSON Functions
 
     /**
      * SQL function that extracts data from a JSON object at the specified [path], either as a JSON representation or as a scalar value.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -107,6 +107,10 @@ abstract class DataTypeProvider {
     /** Returns the boolean value of the specified SQL [value]. */
     open fun booleanFromStringToBoolean(value: String): Boolean = value.toBoolean()
 
+    // Serialization types
+
+    open fun jsonType(): String = "JSON"
+
     // Misc.
 
     /** Returns the SQL representation of the specified expression, for it to be used as a column default value. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -440,9 +440,23 @@ abstract class FunctionProvider {
 
     // Json Functions
 
-    open fun <T> jsonExtractText(queryBuilder: QueryBuilder, expression: Expression<T>, vararg paths: String) = queryBuilder {
+    /**
+     * SQL function that extracts data from a JSON object at the specified [path], either as a JSON representation or as a scalar value.
+     *
+     * @param expression Expression from which to extract JSON subcomponents matched by [path].
+     * @param path String(s) representing JSON path/key(s) that matches fields to be extracted.
+     * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
+     * @param toScalar If `true`, the extracted result is a scalar or text value; otherwise, it is a JSON object.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
+    open fun <T> jsonExtract(
+        expression: Expression<T>,
+        vararg path: String,
+        toScalar: Boolean,
+        queryBuilder: QueryBuilder
+    ) {
         throw UnsupportedByDialectException(
-            "There's no generic SQL for JSON_EXTRACT_TEXT. There must be avvendor specific implementation", currentDialect
+            "There's no generic SQL for JSON_EXTRACT. There must be a vendor specific implementation", currentDialect
         )
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -113,7 +113,8 @@ abstract class DataTypeProvider {
     open fun jsonType(): String = "JSON"
 
     /** Data type for storing JSON in a decomposed binary format. */
-    open fun jsonBType(): String = "JSON"
+    open fun jsonBType(): String =
+        throw UnsupportedByDialectException("This vendor does not support binary JSONB data type", currentDialect)
 
     // Misc.
 
@@ -435,6 +436,14 @@ abstract class FunctionProvider {
      */
     open fun <T> varSamp(expression: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("VAR_SAMP(", expression, ")")
+    }
+
+    // Json Functions
+
+    open fun <T> jsonExtractText(queryBuilder: QueryBuilder, expression: Expression<T>, vararg paths: String) = queryBuilder {
+        throw UnsupportedByDialectException(
+            "There's no generic SQL for JSON_EXTRACT_TEXT. There must be avvendor specific implementation", currentDialect
+        )
     }
 
     // Commands

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -109,7 +109,11 @@ abstract class DataTypeProvider {
 
     // Serialization types
 
+    /** Data type for storing JSON in a non-binary text format. */
     open fun jsonType(): String = "JSON"
+
+    /** Data type for storing JSON in a decomposed binary format. */
+    open fun jsonBType(): String = "JSON"
 
     // Misc.
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.vendors
 
 import org.intellij.lang.annotations.Language
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
@@ -13,6 +14,12 @@ internal object H2DataTypeProvider : DataTypeProvider() {
 
     override fun uuidType(): String = "UUID"
     override fun dateTimeType(): String = "DATETIME(9)"
+
+    override fun jsonType(): String =
+        throw UnsupportedByDialectException("This vendor does not support non-binary JSON data type", currentDialect)
+
+    override fun jsonBType(): String = "JSON"
+
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -16,9 +16,10 @@ internal object H2DataTypeProvider : DataTypeProvider() {
     override fun dateTimeType(): String = "DATETIME(9)"
 
     override fun jsonType(): String =
-        throw UnsupportedByDialectException("This vendor does not support non-binary JSON data type", currentDialect)
+        throw UnsupportedByDialectException("This vendor does not support non-binary text JSON data type", currentDialect)
 
-    override fun jsonBType(): String = "JSON"
+    override fun jsonBType(): String =
+        throw UnsupportedByDialectException("This vendor does not support binary JSONB data type", currentDialect)
 
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -18,9 +18,6 @@ internal object H2DataTypeProvider : DataTypeProvider() {
     override fun jsonType(): String =
         throw UnsupportedByDialectException("This vendor does not support non-binary text JSON data type", currentDialect)
 
-    override fun jsonBType(): String =
-        throw UnsupportedByDialectException("This vendor does not support binary JSONB data type", currentDialect)
-
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -40,6 +40,8 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
     override fun jsonType(): String =
         throw UnsupportedByDialectException("This vendor does not support non-binary JSON data type", currentDialect)
 
+    override fun jsonBType(): String = "JSON"
+
     override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {
 
         when (sortOrder) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -37,9 +37,6 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
         else -> value.toBoolean()
     }
 
-    override fun jsonType(): String =
-        throw UnsupportedByDialectException("This vendor does not support non-binary JSON data type", currentDialect)
-
     override fun jsonBType(): String = "JSON"
 
     override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {
@@ -99,6 +96,18 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         } else {
             queryBuilder { append(expr1, " REGEXP ", pattern) }
         }
+    }
+
+    override fun <T> jsonExtract(
+        expression: Expression<T>,
+        vararg path: String,
+        toScalar: Boolean,
+        queryBuilder: QueryBuilder
+    ) = queryBuilder {
+        if (toScalar) append("JSON_UNQUOTE(")
+        append("JSON_EXTRACT(", expression, ", ")
+        path.appendTo { +"\"$.$it\"" }
+        append(")${if (toScalar) ")" else ""}")
     }
 
     override fun replace(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -37,6 +37,9 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
         else -> value.toBoolean()
     }
 
+    override fun jsonType(): String =
+        throw UnsupportedByDialectException("This vendor does not support non-binary JSON data type", currentDialect)
+
     override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {
 
         when (sortOrder) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -41,7 +41,10 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     }
 
     override fun jsonType(): String =
-        throw UnsupportedByDialectException("This vendor does not support non-binary JSON data type", currentDialect)
+        throw UnsupportedByDialectException("This vendor does not support non-binary text JSON data type", currentDialect)
+
+    override fun jsonBType(): String =
+        throw UnsupportedByDialectException("This vendor does not support binary JSONB data type", currentDialect)
 
     override fun processForDefaultValue(e: Expression<*>): String = when {
         e is LiteralOp<*> && (e.columnType as? IDateColumnType)?.hasTimePart == false -> "DATE ${super.processForDefaultValue(e)}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.sql.vendors
 
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
@@ -39,7 +40,8 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
         error("Unexpected value of type Boolean: $value")
     }
 
-    override fun jsonType(): String = "VARCHAR(32767)"
+    override fun jsonType(): String =
+        throw UnsupportedByDialectException("This vendor does not support non-binary JSON data type", currentDialect)
 
     override fun processForDefaultValue(e: Expression<*>): String = when {
         e is LiteralOp<*> && (e.columnType as? IDateColumnType)?.hasTimePart == false -> "DATE ${super.processForDefaultValue(e)}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -43,9 +43,6 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun jsonType(): String =
         throw UnsupportedByDialectException("This vendor does not support non-binary text JSON data type", currentDialect)
 
-    override fun jsonBType(): String =
-        throw UnsupportedByDialectException("This vendor does not support binary JSONB data type", currentDialect)
-
     override fun processForDefaultValue(e: Expression<*>): String = when {
         e is LiteralOp<*> && (e.columnType as? IDateColumnType)?.hasTimePart == false -> "DATE ${super.processForDefaultValue(e)}"
         e is LiteralOp<*> && e.columnType is IDateColumnType -> "TIMESTAMP ${super.processForDefaultValue(e)}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -39,6 +39,8 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
         error("Unexpected value of type Boolean: $value")
     }
 
+    override fun jsonType(): String = "VARCHAR(32767)"
+
     override fun processForDefaultValue(e: Expression<*>): String = when {
         e is LiteralOp<*> && (e.columnType as? IDateColumnType)?.hasTimePart == false -> "DATE ${super.processForDefaultValue(e)}"
         e is LiteralOp<*> && e.columnType is IDateColumnType -> "TIMESTAMP ${super.processForDefaultValue(e)}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -20,6 +20,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun uuidToDB(value: UUID): Any = value
     override fun dateTimeType(): String = "TIMESTAMP"
     override fun ubyteType(): String = "SMALLINT"
+    override fun jsonBType(): String = "JSONB"
     override fun hexToDb(hexString: String): String = """E'\\x$hexString'"""
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -20,7 +20,9 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun uuidToDB(value: UUID): Any = value
     override fun dateTimeType(): String = "TIMESTAMP"
     override fun ubyteType(): String = "SMALLINT"
+
     override fun jsonBType(): String = "JSONB"
+
     override fun hexToDb(hexString: String): String = """E'\\x$hexString'"""
 }
 
@@ -108,6 +110,19 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
     override fun <T> second(expr: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("Extract(SECOND FROM ")
         append(expr)
+        append(")")
+    }
+
+    override fun <T> jsonExtract(
+        expression: Expression<T>,
+        vararg path: String,
+        toScalar: Boolean,
+        queryBuilder: QueryBuilder
+    ) = queryBuilder {
+        append("JSON_EXTRACT_PATH")
+        if (toScalar) append("_TEXT")
+        append("(", expression, ", ")
+        path.appendTo { +"'$it'" }
         append(")")
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -20,9 +20,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun uuidToDB(value: UUID): Any = value
     override fun dateTimeType(): String = "TIMESTAMP"
     override fun ubyteType(): String = "SMALLINT"
-
     override fun jsonBType(): String = "JSONB"
-
     override fun hexToDb(hexString: String): String = """E'\\x$hexString'"""
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -27,7 +27,6 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
     override fun textType(): String = "VARCHAR(MAX)"
     override fun mediumTextType(): String = textType()
     override fun largeTextType(): String = textType()
-
     override fun jsonType(): String = "NVARCHAR(MAX)"
 
     override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -28,6 +28,8 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
     override fun mediumTextType(): String = textType()
     override fun largeTextType(): String = textType()
 
+    override fun jsonType(): String = "NVARCHAR(MAX)"
+
     override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {
         when (sortOrder) {
             SortOrder.ASC, SortOrder.DESC -> super.precessOrderByClause(queryBuilder, expression, sortOrder)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -136,6 +136,18 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         append("VAR(", expression, ")")
     }
 
+    override fun <T> jsonExtract(
+        expression: Expression<T>,
+        vararg path: String,
+        toScalar: Boolean,
+        queryBuilder: QueryBuilder
+    ) = queryBuilder {
+        append(if (toScalar) "JSON_VALUE" else "JSON_QUERY")
+        append("(", expression, ", ")
+        path.appendTo { +"'$.$it'" }
+        append(")")
+    }
+
     override fun update(
         target: Table,
         columnsAndValues: List<Pair<Column<*>, Any?>>,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -130,6 +130,17 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ): Unit = TransactionManager.current().throwUnsupportedException("$UNSUPPORTED_AGGREGATE VAR_SAMP")
 
+    override fun <T> jsonExtract(
+        expression: Expression<T>,
+        vararg path: String,
+        toScalar: Boolean,
+        queryBuilder: QueryBuilder
+    ) = queryBuilder {
+        append("JSON_EXTRACT(", expression, ", ")
+        path.appendTo { +"'$.$it'" }
+        append(")")
+    }
+
     override fun insert(
         ignore: Boolean,
         table: Table,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -17,9 +17,7 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun dateTimeType(): String = "TEXT"
     override fun dateType(): String = "TEXT"
     override fun booleanToStatementString(bool: Boolean) = if (bool) "1" else "0"
-
     override fun jsonType(): String = "TEXT"
-
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -17,6 +17,9 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun dateTimeType(): String = "TEXT"
     override fun dateType(): String = "TEXT"
     override fun booleanToStatementString(bool: Boolean) = if (bool) "1" else "0"
+
+    override fun jsonType(): String = "TEXT"
+
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }
 

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
+    kotlin("plugin.serialization") apply true
     id("testWithDBs")
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
@@ -1,0 +1,38 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class JsonBColumnTypeTests : DatabaseTestsBase() {
+    private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER) + TestDB.allH2TestDB + TestDB.ORACLE
+
+    @Test
+    fun testInsertAndSelect() {
+        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, _ ->
+            val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
+            val newId = tester.insertAndGetId {
+                it[jsonBColumn] = newData
+            }
+
+            val newResult = tester.select { tester.id eq newId }.singleOrNull()
+            assertEquals(newData, newResult?.get(tester.jsonBColumn))
+        }
+    }
+
+    @Test
+    fun testUpdate() {
+        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, data1 ->
+            assertEquals(data1, tester.selectAll().single()[tester.jsonBColumn])
+
+            val updatedData = data1.copy(active = false)
+            tester.update {
+                it[jsonBColumn] = updatedData
+            }
+
+            assertEquals(updatedData, tester.selectAll().single()[tester.jsonBColumn])
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
@@ -1,0 +1,114 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class JsonColumnTypeTests : DatabaseTestsBase() {
+    @Test
+    fun testInsertAndSelect() {
+        withDb {
+            addLogger(StdOutSqlLogger)
+            println(currentDialectTest.name)
+            try {
+                SchemaUtils.create(JsonTable)
+                val user1 = User("Admin", null)
+                val instance1 = DataHolder(user1, 10, true, null)
+                val id1 = JsonTable.insertAndGetId {
+                    it[jsonColumn] = instance1
+                }
+
+                val result = JsonTable.select { JsonTable.id eq id1 }.singleOrNull()
+                assertEquals(instance1, result?.get(JsonTable.jsonColumn))
+            } finally {
+                SchemaUtils.drop(JsonTable)
+            }
+        }
+    }
+
+    @Test
+    fun testUpdate() {
+        withDb {
+            addLogger(StdOutSqlLogger)
+            println(currentDialectTest.name)
+            try {
+                SchemaUtils.create(JsonTable)
+                val user1 = User("Admin", null)
+                val instance1 = DataHolder(user1, 10, true, null)
+                JsonTable.insert {
+                    it[jsonColumn] = instance1
+                }
+
+                assertEquals(instance1, JsonTable.selectAll().single()[JsonTable.jsonColumn])
+
+                val instance2 = instance1.copy(active = false)
+                JsonTable.update {
+                    it[jsonColumn] = instance2
+                }
+
+                assertEquals(instance2, JsonTable.selectAll().single()[JsonTable.jsonColumn])
+            } finally {
+                SchemaUtils.drop(JsonTable)
+            }
+        }
+    }
+
+    @Test
+    fun testSelectWithSlice() {
+        withDb {
+            addLogger(StdOutSqlLogger)
+            println(currentDialectTest.name)
+            try {
+                SchemaUtils.create(JsonTable)
+                val user1 = User("Admin", null)
+                val instance1 = DataHolder(user1, 10, true, null)
+                val id1 = JsonTable.insertAndGetId {
+                    it[jsonColumn] = instance1
+                }
+
+                //val isActive = JsonTable.jsonColumn.jsonColumnPath<Boolean>("active").alias("is_active")
+                //val result = JsonTable.slice(isActive).selectAll().singleOrNull()
+                //assertEquals(instance1.active, result?.get(isActive))
+            } finally {
+                SchemaUtils.drop(JsonTable)
+            }
+        }
+    }
+
+    // test containment
+    @Test
+    fun testSelectWhereJsonContains() {
+        withDb {
+            addLogger(StdOutSqlLogger)
+            println(currentDialectTest.name)
+            try {
+                SchemaUtils.create(JsonTable)
+                val user1 = User("Admin", null)
+                val instance1 = DataHolder(user1, 10, true, null)
+                val id1 = JsonTable.insertAndGetId {
+                    it[jsonColumn] = instance1
+                }
+                JsonTable.jsonColumn
+
+                //val result = JsonBTable.select { JsonBTable.jsonBColumn regexp "\"active\":true" }.singleOrNull()
+                //assertEquals(id1, result?.get(JsonBTable.id))
+            } finally {
+                SchemaUtils.drop(JsonTable)
+            }
+        }
+    }
+
+    private object JsonTable : IntIdTable("json_table") {
+        val jsonColumn = json("json_column", Json, DataHolder.serializer())
+    }
+
+    @Serializable
+    private data class DataHolder(val user: User, val logins: Int, val active: Boolean, val team: String?)
+    @Serializable
+    private data class User(val name: String, val team: String?)
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonTestsData.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonTestsData.kt
@@ -1,0 +1,61 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+
+object JsonTestsData {
+    object JsonTable : IntIdTable("j_table") {
+        val jsonColumn = json<DataHolder>("j_column", Json.Default)
+    }
+
+    object JsonBTable : IntIdTable("j_b_table") {
+        val jsonBColumn = jsonb<DataHolder>("j_b_column", Json.Default)
+    }
+}
+
+fun DatabaseTestsBase.withJsonTable(
+    exclude: List<TestDB> = emptyList(),
+    statement: Transaction.(tester: JsonTestsData.JsonTable, user1: User, data1: DataHolder) -> Unit
+) {
+    val tester = JsonTestsData.JsonTable
+
+    withTables(exclude, tester) { testDb ->
+        excludingH2Version1(testDb) {
+            val user1 = User("Admin", null)
+            val data1 = DataHolder(user1, 10, true, null)
+
+            tester.insert { it[jsonColumn] = data1 }
+
+            statement(tester, user1, data1)
+        }
+    }
+}
+
+fun DatabaseTestsBase.withJsonBTable(
+    exclude: List<TestDB> = emptyList(),
+    statement: Transaction.(tester: JsonTestsData.JsonBTable, user1: User, data1: DataHolder) -> Unit
+) {
+    val tester = JsonTestsData.JsonBTable
+
+    withTables(exclude, tester) { testDb ->
+        excludingH2Version1(testDb) {
+            val user1 = User("Admin", null)
+            val data1 = DataHolder(user1, 10, true, null)
+
+            tester.insert { it[jsonBColumn] = data1 }
+
+            statement(tester, user1, data1)
+        }
+    }
+}
+
+@Serializable
+data class DataHolder(val user: User, val logins: Int, val active: Boolean, val team: String?)
+
+@Serializable
+data class User(val name: String, val team: String?)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,5 +15,6 @@ include("exposed-crypt")
 pluginManagement {
     plugins {
         id("org.jetbrains.kotlin.jvm") version "1.8.22"
+        id("org.jetbrains.kotlin.plugin.serialization") version "1.7.21"
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,6 @@ include("exposed-crypt")
 pluginManagement {
     plugins {
         id("org.jetbrains.kotlin.jvm") version "1.8.22"
-        id("org.jetbrains.kotlin.plugin.serialization") version "1.7.21"
+        id("org.jetbrains.kotlin.plugin.serialization") version "1.8.22"
     }
 }


### PR DESCRIPTION
Add 2 new column types: `JsonColumnType` & `JsonBColumnType` that can be used 3 ways:
```
json("column_name", Json, Type.serializer()) // or custom serializer
json<Type>("column_name", Json)
json("column_name", customEncoder(), customDecoder())
```

Dialects store JSON differently, usually in text or binary format, but may not reflect this in the name of the data type. Some may not even support the JSON data type, but use it as an alias for another type (e.g. [MariaDB](https://mariadb.com/kb/en/json-data-type/) maps JSON to LONGTEXT and [H2](https://www.h2database.com/html/datatypes.html#json_type) maps to `byte[]`). To allow for this variability, the user's choice between `json()` and `jsonb()` can be flexible depending on dialect, e.g.:

- [PostgreSQL] `json()` -> JSON, `jsonb()` -> JSONB
- [MySQL] [Only supports binary format](https://dev.mysql.com/doc/refman/8.0/en/json.html) but default type is still JSON, so both column types map to JSON (i.e. using `json()` and `jsonb()` is equivalent).
- [SQLite] No JSON type but allows JSON functions on TEXT columns, so `json()` maps to TEXT, while `jsonb()` throws.

**Current caveats:**
- Oracle and H2 are not yet supported.
- Use in DAO not fully supported.
- Only 2 functions currently supported: using paths/keys to extract from stored JSON as a scalar value/text or as a JSON object.

**Next steps:**
1. Extend support to Oracle and H2 (will likely mean overrides in `JsonBColumnType`).
2. Add a few more functions (assess most-used/important/broad functions across dialects).
3. Test and extend fully to DAO, as well as potential edge cases: e.g. raw Json strings, Json arrays or nested arrays, if field identifiers need escape formatting, indexing +/- misuse as primary/foreign key?
4. Assess potential use case for extending current cast types, literals, and parameters to include Json type.