### PR TITLE
feat: EXPOSED-69 Extend json support to H2, Oracle (text) and DAO

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1129,6 +1129,7 @@ public class org/jetbrains/exposed/sql/JsonColumnType : org/jetbrains/exposed/sq
 	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public final fun getDeserialize ()Lkotlin/jvm/functions/Function1;
 	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/String;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.sql.vendors
 
 import org.intellij.lang.annotations.Language
-import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
@@ -15,8 +14,7 @@ internal object H2DataTypeProvider : DataTypeProvider() {
     override fun uuidType(): String = "UUID"
     override fun dateTimeType(): String = "DATETIME(9)"
 
-    override fun jsonType(): String =
-        throw UnsupportedByDialectException("This vendor does not support non-binary text JSON data type", currentDialect)
+    override fun jsonBType(): String = "JSON"
 
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
@@ -7,7 +7,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.junit.Test
 
 class JsonBColumnTypeTests : DatabaseTestsBase() {
-    private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER) + TestDB.allH2TestDB + TestDB.ORACLE
+    private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER) + TestDB.ORACLE
 
     @Test
     fun testInsertAndSelect() {
@@ -33,6 +33,34 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
             }
 
             assertEquals(updatedData, tester.selectAll().single()[tester.jsonBColumn])
+        }
+    }
+
+    @Test
+    fun testDAOFunctionsWithJsonBColumn() {
+        val dataTable = JsonTestsData.JsonBTable
+        val dataEntity = JsonTestsData.JsonBEntity
+
+        withDb(excludeSettings = binaryJsonNotSupportedDB) { testDb ->
+            excludingH2Version1(testDb) {
+                SchemaUtils.create(dataTable)
+
+                val dataA = DataHolder(User("Admin", "Alpha"), 10, true, null)
+                val newUser = dataEntity.new {
+                    jsonBColumn = dataA
+                }
+
+                assertEquals(dataA, dataEntity.findById(newUser.id)?.jsonBColumn)
+
+                val updatedUser = dataA.copy(logins = 99)
+                dataTable.update {
+                    it[jsonBColumn] = updatedUser
+                }
+
+                assertEquals(updatedUser, dataEntity.all().single().jsonBColumn)
+
+                SchemaUtils.drop(dataTable)
+            }
         }
     }
 }


### PR DESCRIPTION
**H2:**
H2 started supporting JSON data type (maps to `byte[]`) in [version 1.4.200](https://github.com/h2database/h2database/releases/tag/version-1.4.200) and Exposed tests use version 1.4.199. Since v1.4.2 was the final version before 2.0 release and [v1 is being phased out](https://youtrack.jetbrains.com/issue/EXPOSED-30/Phase-Out-Support-for-H2-Version-1.x), H2 v1 is excluded from tests (the test blocks were fixed to properly do this).

Extended support does not cover existing functions as H2 only supports [two json-constructing functions](https://www.h2database.com/html/functions.html#json_object).

**Oracle:**
Oracle started supporting JSON data type in native binary format [as of 21c](https://docs.oracle.com/en/database/oracle/oracle-database/21/adjsn/json-in-oracle-database.html#GUID-CBEDC779-39A3-43C9-AF38-861AE3FC0AEC), while Exposed currently tests [using 18c](https://github.com/JetBrains/Exposed/blob/main/buildScripts/docker/docker-compose-oracle.yml). [Documentation](https://docs.oracle.com/en/database/oracle/oracle-database/18/adjsn/overview-of-storage-and-management-of-JSON-data.html#GUID-26AB85D2-3277-451B-BFAA-9DD45355FCC7) recommends storing JSON data in text format using `VARCHAR2(4000)`, `VARCHAR2(32767)`, or `BLOB|CLOB`. Using `VARCHAR2(32767)` requires extending DB parameter `MAX_STRING_SIZE` for testing, so `VARCHAR2(4000)` has been chosen until users request otherwise.

Oracle has no [Boolean data type](https://docs.oracle.com/en/database/oracle/oracle-database/18/adjsn/function-JSON_VALUE.html#GUID-FD4E6FFA-8865-4682-B66A-79F77CBACD50), so functions that extract JSON booleans return a String representation instead. The current function to handle string booleans from DB was refactored to allow for more than numeric strings.

**DAO:**
When DAO entities are used, the DB sometimes returns data objects directly due to caching, so `valueFromDB()` was adjusted. Basic unit tests have also been added.