### PR TITLE
feat: EXPOSED-68 Add more json/json(b) column functions

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -873,6 +873,7 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public abstract fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public abstract fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public abstract fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public abstract fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public abstract fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public abstract fun less (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/LessOp;
@@ -969,7 +970,9 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public static fun isNotNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public static fun isNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public static fun jsonContains (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public static fun jsonContains (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
+	public static synthetic fun jsonContains$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public static synthetic fun jsonContains$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public static fun jsonExists (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public static synthetic fun jsonExists$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonExists;
@@ -1845,6 +1848,7 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public fun less (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/LessOp;
@@ -1940,6 +1944,7 @@ public class org/jetbrains/exposed/sql/SqlExpressionBuilderClass : org/jetbrains
 	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
 	public fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public fun less (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/LessOp;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -873,6 +873,8 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public abstract fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public abstract fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public abstract fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
+	public abstract fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public abstract fun less (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/LessOp;
 	public abstract fun less (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
 	public abstract fun lessEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
@@ -967,6 +969,10 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public static fun isNotNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public static fun isNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public static fun jsonContains (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
+	public static synthetic fun jsonContains$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonContains;
+	public static fun jsonExists (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
+	public static synthetic fun jsonExists$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public static fun less (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/LessOp;
 	public static fun less (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
 	public static fun lessEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
@@ -1137,9 +1143,28 @@ public class org/jetbrains/exposed/sql/JsonColumnType : org/jetbrains/exposed/sq
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class org/jetbrains/exposed/sql/JsonExtract : org/jetbrains/exposed/sql/Function {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/IColumnType;)V
+public final class org/jetbrains/exposed/sql/JsonContains : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getCandidate ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getTarget ()Lorg/jetbrains/exposed/sql/Expression;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/JsonExists : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;)V
 	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public final fun getOptional ()Ljava/lang/String;
+	public final fun getPath ()[Ljava/lang/String;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/JsonExtract : org/jetbrains/exposed/sql/Function {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public final fun getPath ()[Ljava/lang/String;
 	public final fun getToScalar ()Z
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
@@ -1820,6 +1845,8 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
+	public fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public fun less (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/LessOp;
 	public fun less (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
 	public fun lessEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
@@ -1913,6 +1940,8 @@ public class org/jetbrains/exposed/sql/SqlExpressionBuilderClass : org/jetbrains
 	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
+	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
+	public fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public fun less (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/LessOp;
 	public fun less (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
 	public fun lessEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/LessOp;
@@ -3156,7 +3185,9 @@ public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	public fun groupConcat (Lorg/jetbrains/exposed/sql/GroupConcat;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun hour (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun insert (ZLorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
-	public fun jsonExtract (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/QueryBuilder;)V
+	public fun jsonContains (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+	public fun jsonExists (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+	public fun jsonExtract (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun locate (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)V
 	public fun match (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/FunctionProvider$MatchMode;)Lorg/jetbrains/exposed/sql/Op;
 	public static synthetic fun match$default (Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/FunctionProvider$MatchMode;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -312,10 +312,12 @@ class JsonExtract<T>(
     vararg val path: String,
     /** Returns whether the extracted result should be a scalar or text value; if `false`, result will be a JSON object. */
     val toScalar: Boolean,
+    /** Returns the column type of [expression] to check, if casting to JSONB is required. */
+    val jsonType: IColumnType,
     columnType: IColumnType
 ) : Function<T>(columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) =
-        currentDialect.functionProvider.jsonExtract(expression, path = path, toScalar, queryBuilder)
+        currentDialect.functionProvider.jsonExtract(expression, path = path, toScalar, jsonType, queryBuilder)
 }
 
 // Sequence Manipulation Functions

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -547,6 +547,42 @@ class RegexpOp<T : String?>(
     }
 }
 
+// JSON Conditions
+
+/**
+ * Represents an SQL operator that checks whether a [candidate] expression is contained within a JSON [target].
+ */
+class JsonContains(
+    /** Returns the JSON expression being searched. */
+    val target: Expression<*>,
+    /** Returns the expression being searched for in [target]. */
+    val candidate: Expression<*>,
+    /** Returns an optional String representing JSON path/keys that match specific fields to search for [candidate]. */
+    val path: String?,
+    /** Returns the column type of [target] to check, if casting to JSONB is required. */
+    val jsonType: IColumnType
+) : Op<Boolean>(), ComplexExpression, Op.OpBoolean {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
+        currentDialect.functionProvider.jsonContains(target, candidate, path, jsonType, queryBuilder)
+}
+
+/**
+ * Represents an SQL operator that checks whether data exists within a JSON [expression] at the specified [path].
+ */
+class JsonExists(
+    /** Returns the JSON expression being checked. */
+    val expression: Expression<*>,
+    /** Returns the array of Strings representing JSON path/keys that match fields to check for existing data. */
+    vararg val path: String,
+    /** Returns an optional String representing any vendor-specific clause or argument. */
+    val optional: String?,
+    /** Returns the column type of [expression] to check, if casting to JSONB is required. */
+    val jsonType: IColumnType
+) : Op<Boolean>(), ComplexExpression, Op.OpBoolean {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
+        currentDialect.functionProvider.jsonExists(expression, path = path, optional, jsonType, queryBuilder)
+}
+
 // Subquery Expressions
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -539,6 +539,16 @@ interface ISqlExpressionBuilder {
         JsonContains(this, candidate, path, columnType)
 
     /**
+     * Checks whether a [candidate] value is contained within [this] JSON expression.
+     *
+     * @param candidate Value to search for in [this] JSON expression.
+     * @param path String representing JSON path/keys that match specific fields to search for [candidate].
+     * **Note:** Optional [path] argument is not supported by all vendors; please check the documentation.
+     */
+    fun <T> ExpressionWithColumnType<*>.jsonContains(candidate: T, path: String? = null): JsonContains =
+        JsonContains(this, asLiteral(candidate), path, columnType)
+
+    /**
      * Checks whether data exists within [this] JSON expression at the specified [path].
      *
      * @param path String(s) representing JSON path/keys that match fields to check for existing data.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -104,6 +104,7 @@ fun <T : Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> =
  * Returns the extracted data from a JSON object at the specified [path], either as a JSON representation or as a scalar value.
  *
  * @param path String(s) representing JSON path/keys that match fields to be extracted.
+ * If none are provided, the root context item `'$'` will be used by default.
  * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
  * @param toScalar If `true`, the extracted result is a scalar or text value; otherwise, it is a JSON object.
  */
@@ -122,7 +123,7 @@ inline fun <reified T : Any> ExpressionWithColumnType<*>.jsonExtract(vararg path
             JsonColumnType({ Json.Default.encodeToString(serializer<T>(), it) }, { Json.Default.decodeFromString(serializer<T>(), it) })
         }
     }
-    return JsonExtract(this, path = path, toScalar, columnType)
+    return JsonExtract(this, path = path, toScalar, this.columnType, columnType)
 }
 
 // Sequence Manipulation Functions
@@ -524,6 +525,30 @@ interface ISqlExpressionBuilder {
         pattern: Expression<String>,
         caseSensitive: Boolean = true
     ): RegexpOp<T> = RegexpOp(this, pattern, caseSensitive)
+
+    // JSON Conditions
+
+    /**
+     * Checks whether a [candidate] expression is contained within [this] JSON expression.
+     *
+     * @param candidate Expression to search for in [this] JSON expression.
+     * @param path String representing JSON path/keys that match specific fields to search for [candidate].
+     * **Note:** Optional [path] argument is not supported by all vendors; please check the documentation.
+     */
+    fun ExpressionWithColumnType<*>.jsonContains(candidate: Expression<*>, path: String? = null): JsonContains =
+        JsonContains(this, candidate, path, columnType)
+
+    /**
+     * Checks whether data exists within [this] JSON expression at the specified [path].
+     *
+     * @param path String(s) representing JSON path/keys that match fields to check for existing data.
+     * If none are provided, the root context item `'$'` will be used by default.
+     * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
+     * @param optional String representing any optional vendor-specific clause or argument.
+     * **Note:** [optional] function arguments are not supported by all vendors; please check the documentation.
+     */
+    fun ExpressionWithColumnType<*>.jsonExists(vararg path: String, optional: String? = null): JsonExists =
+        JsonExists(this, path = path, optional, columnType)
 
     // Conditional Expressions
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -444,19 +444,65 @@ abstract class FunctionProvider {
      * SQL function that extracts data from a JSON object at the specified [path], either as a JSON representation or as a scalar value.
      *
      * @param expression Expression from which to extract JSON subcomponents matched by [path].
-     * @param path String(s) representing JSON path/key(s) that matches fields to be extracted.
+     * @param path String(s) representing JSON path/keys that match fields to be extracted.
      * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
      * @param toScalar If `true`, the extracted result is a scalar or text value; otherwise, it is a JSON object.
+     * @param jsonType Column type of [expression] to check, if casting to JSONB is required.
      * @param queryBuilder Query builder to append the SQL function to.
      */
     open fun <T> jsonExtract(
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
+        jsonType: IColumnType,
         queryBuilder: QueryBuilder
     ) {
         throw UnsupportedByDialectException(
             "There's no generic SQL for JSON_EXTRACT. There must be a vendor specific implementation", currentDialect
+        )
+    }
+
+    /**
+     * SQL function that checks whether a [candidate] expression is contained within a JSON [target].
+     *
+     * @param target JSON expression being searched.
+     * @param candidate Expression to search for in [target].
+     * @param path String representing JSON path/keys that match specific fields to search for [candidate].
+     * **Note:** A [path] argument is not supported by all vendors; please check the documentation.
+     * @param jsonType Column type of [target] to check, if casting to JSONB is required.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
+    open fun jsonContains(
+        target: Expression<*>,
+        candidate: Expression<*>,
+        path: String?,
+        jsonType: IColumnType,
+        queryBuilder: QueryBuilder
+    ) {
+        throw UnsupportedByDialectException(
+            "There's no generic SQL for JSON_CONTAINS. There must be a vendor specific implementation", currentDialect
+        )
+    }
+
+    /**
+     * SQL function that checks whether data exists within a JSON [expression] at the specified [path].
+     *
+     * @param expression JSON expression being checked.
+     * @param path String(s) representing JSON path/keys that match fields to check for existing data.
+     * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
+     * @param optional String representing any optional vendor-specific clause or argument.
+     * @param jsonType Column type of [expression] to check, if casting to JSONB is required.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
+    open fun jsonExists(
+        expression: Expression<*>,
+        vararg path: String,
+        optional: String?,
+        jsonType: IColumnType,
+        queryBuilder: QueryBuilder
+    ) {
+        throw UnsupportedByDialectException(
+            "There's no generic SQL for JSON_EXISTS. There must be a vendor specific implementation", currentDialect
         )
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -134,9 +134,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
     ) {
         val oneOrAll = optional?.lowercase()
         if (oneOrAll != "one" && oneOrAll != "all") {
-            TransactionManager.current().throwUnsupportedException(
-                "MySQL requires a single optional argument: 'one' or 'all'; please check the documentation"
-            )
+            TransactionManager.current().throwUnsupportedException("MySQL requires a single optional argument: 'one' or 'all'")
         }
         queryBuilder {
             append("JSON_CONTAINS_PATH(", expression, ", ")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -102,12 +102,48 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
+        jsonType: IColumnType,
         queryBuilder: QueryBuilder
     ) = queryBuilder {
         if (toScalar) append("JSON_UNQUOTE(")
         append("JSON_EXTRACT(", expression, ", ")
-        path.appendTo { +"\"$.$it\"" }
+        path.ifEmpty { arrayOf("") }.appendTo { +"\"$$it\"" }
         append(")${if (toScalar) ")" else ""}")
+    }
+
+    override fun jsonContains(
+        target: Expression<*>,
+        candidate: Expression<*>,
+        path: String?,
+        jsonType: IColumnType,
+        queryBuilder: QueryBuilder
+    ) = queryBuilder {
+        append("JSON_CONTAINS(", target, ", ", candidate)
+        path?.let {
+            append(", '$$it'")
+        }
+        append(")")
+    }
+
+    override fun jsonExists(
+        expression: Expression<*>,
+        vararg path: String,
+        optional: String?,
+        jsonType: IColumnType,
+        queryBuilder: QueryBuilder
+    ) {
+        val oneOrAll = optional?.lowercase()
+        if (oneOrAll != "one" && oneOrAll != "all") {
+            TransactionManager.current().throwUnsupportedException(
+                "MySQL requires a single optional argument: 'one' or 'all'; please check the documentation"
+            )
+        }
+        queryBuilder {
+            append("JSON_CONTAINS_PATH(", expression, ", ")
+            append("'$oneOrAll', ")
+            path.ifEmpty { arrayOf("") }.appendTo { +"'$$it'" }
+            append(")")
+        }
     }
 
     override fun replace(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -156,9 +156,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {
-            TransactionManager.current().throwUnsupportedException(
-                "Oracle does not support multi-argument JSON paths; please check the documentation"
-            )
+            TransactionManager.current().throwUnsupportedException("Oracle does not support multiple JSON path arguments")
         }
         queryBuilder {
             append(if (toScalar) "JSON_VALUE" else "JSON_QUERY")
@@ -176,9 +174,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {
-            TransactionManager.current().throwUnsupportedException(
-                "Oracle does not support multi-argument JSON paths; please check the documentation"
-            )
+            TransactionManager.current().throwUnsupportedException("Oracle does not support multiple JSON path arguments")
         }
         queryBuilder {
             append("JSON_EXISTS(", expression, ", ")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -152,12 +152,42 @@ internal object OracleFunctionProvider : FunctionProvider() {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
+        jsonType: IColumnType,
         queryBuilder: QueryBuilder
-    ) = queryBuilder {
-        append(if (toScalar) "JSON_VALUE" else "JSON_QUERY")
-        append("(", expression, ", ")
-        path.appendTo { +"'$.$it'" }
-        append(")")
+    ) {
+        if (path.size > 1) {
+            TransactionManager.current().throwUnsupportedException(
+                "Oracle does not support multi-argument JSON paths; please check the documentation"
+            )
+        }
+        queryBuilder {
+            append(if (toScalar) "JSON_VALUE" else "JSON_QUERY")
+            append("(", expression, ", ")
+            append("'$", path.firstOrNull() ?: "", "'")
+            append(")")
+        }
+    }
+
+    override fun jsonExists(
+        expression: Expression<*>,
+        vararg path: String,
+        optional: String?,
+        jsonType: IColumnType,
+        queryBuilder: QueryBuilder
+    ) {
+        if (path.size > 1) {
+            TransactionManager.current().throwUnsupportedException(
+                "Oracle does not support multi-argument JSON paths; please check the documentation"
+            )
+        }
+        queryBuilder {
+            append("JSON_EXISTS(", expression, ", ")
+            append("'$", path.firstOrNull() ?: "", "'")
+            optional?.let {
+                append(" $it")
+            }
+            append(")")
+        }
     }
 
     override fun update(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -133,11 +133,9 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ) {
         path?.let {
-            TransactionManager.current().throwUnsupportedException(
-                "PostgreSQL containment operator does not support a JSON path argument."
-            )
+            TransactionManager.current().throwUnsupportedException("PostgreSQL does not support a JSON path argument")
         }
-        val isNotJsonB = jsonType.sqlType() != "JSONB"
+        val isNotJsonB = jsonType !is JsonBColumnType<*>
         queryBuilder {
             append(target)
             if (isNotJsonB) append("::jsonb")
@@ -154,11 +152,9 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {
-            TransactionManager.current().throwUnsupportedException(
-                "PostgreSQL does not support multi-argument JSON paths; please check the documentation"
-            )
+            TransactionManager.current().throwUnsupportedException("PostgreSQL does not support multiple JSON path arguments")
         }
-        val isNotJsonB = jsonType.sqlType() != "JSONB"
+        val isNotJsonB = jsonType !is JsonBColumnType<*>
         queryBuilder {
             append("JSONB_PATH_EXISTS(")
             if (isNotJsonB) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -143,9 +143,7 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {
-            TransactionManager.current().throwUnsupportedException(
-                "SQLServer does not support multi-argument JSON paths; please check the documentation"
-            )
+            TransactionManager.current().throwUnsupportedException("SQLServer does not support multiple JSON path arguments")
         }
         queryBuilder {
             append(if (toScalar) "JSON_VALUE" else "JSON_QUERY")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -149,10 +149,10 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
     ) {
         val transaction = TransactionManager.current()
         if (path.size > 1) {
-            transaction.throwUnsupportedException("SQLite does not support multi-argument JSON paths; please check the documentation")
+            transaction.throwUnsupportedException("SQLite does not support multiple JSON path arguments")
         }
         optional?.let {
-            transaction.throwUnsupportedException("SQLite only supports an optional path argument; please check the documentation")
+            transaction.throwUnsupportedException("SQLite does not support optional arguments other than a path argument")
         }
         queryBuilder {
             append("JSON_TYPE(", expression, ", ")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
@@ -130,7 +130,7 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
                 it[jsonBColumn] = data1.copy(user = alphaTeamUser)
             }
 
-            val userIsInactive = tester.jsonBColumn.jsonContains(stringLiteral("{\"active\":false}"))
+            val userIsInactive = tester.jsonBColumn.jsonContains("{\"active\":false}")
             assertEquals(0, tester.select { userIsInactive }.count())
 
             val alphaTeamUserAsJson = "{\"user\":${Json.Default.encodeToString(alphaTeamUser)}}"
@@ -139,7 +139,7 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
             // test target contains candidate at specified path
             if (currentTestDB in TestDB.mySqlRelatedDB) {
-                userIsInAlphaTeam = tester.jsonBColumn.jsonContains(stringLiteral("\"Alpha\""), ".user.team")
+                userIsInAlphaTeam = tester.jsonBColumn.jsonContains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.slice(tester.id).select { userIsInAlphaTeam }
                 assertEquals(newId, alphaTeamUsers.single()[tester.id])
             }
@@ -157,7 +157,7 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
             val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments (or an empty string)
+            // test data at path root '$' exists by providing no path arguments
             val hasAnyData = tester.jsonBColumn.jsonExists(optional = optional)
             assertEquals(2, tester.select { hasAnyData }.count())
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
@@ -1,9 +1,17 @@
 package org.jetbrains.exposed.sql.tests.shared.types
 
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonContains
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonExists
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.currentTestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.junit.Test
 
 class JsonBColumnTypeTests : DatabaseTestsBase() {
@@ -37,6 +45,45 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testSelectWithSliceExtract() {
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, user1, data1 ->
+            val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
+            val isActive = tester.jsonBColumn.jsonExtract<Boolean>("${pathPrefix}active", toScalar = false)
+            val result1 = tester.slice(isActive).selectAll().singleOrNull()
+            assertEquals(data1.active, result1?.get(isActive))
+
+            val storedUser = tester.jsonBColumn.jsonExtract<User>("${pathPrefix}user", toScalar = false)
+            val result2 = tester.slice(storedUser).selectAll().singleOrNull()
+            assertEquals(user1, result2?.get(storedUser))
+
+            val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "name") else arrayOf(".user.name")
+            val username = tester.jsonBColumn.jsonExtract<String>(*path)
+            val result3 = tester.slice(username).selectAll().singleOrNull()
+            assertEquals(user1.name, result3?.get(username))
+        }
+    }
+
+    @Test
+    fun testSelectWhereWithExtract() {
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, data1 ->
+            val newId = tester.insertAndGetId {
+                it[jsonBColumn] = data1.copy(logins = 1000)
+            }
+
+            // Postgres requires type casting to compare jsonb field as integer value in DB ???
+            val logins = if (currentDialectTest is PostgreSQLDialect) {
+                tester.jsonBColumn.jsonExtract<Int>("logins").castTo(IntegerColumnType())
+            } else {
+                tester.jsonBColumn.jsonExtract<Int>(".logins")
+            }
+            val tooManyLogins = logins greaterEq 1000
+
+            val result = tester.slice(tester.id).select { tooManyLogins }.singleOrNull()
+            assertEquals(newId, result?.get(tester.id))
+        }
+    }
+
+    @Test
     fun testDAOFunctionsWithJsonBColumn() {
         val dataTable = JsonTestsData.JsonBTable
         val dataEntity = JsonTestsData.JsonBEntity
@@ -59,7 +106,78 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
                 assertEquals(updatedUser, dataEntity.all().single().jsonBColumn)
 
+                if (testDb !in TestDB.allH2TestDB) {
+                    dataEntity.new { jsonBColumn = dataA }
+                    val loginCount = if (currentDialectTest is PostgreSQLDialect) {
+                        dataTable.jsonBColumn.jsonExtract<Int>("logins").castTo(IntegerColumnType())
+                    } else {
+                        dataTable.jsonBColumn.jsonExtract<Int>(".logins")
+                    }
+                    val frequentUser = dataEntity.find { loginCount greaterEq 50 }.single()
+                    assertEquals(updatedUser, frequentUser.jsonBColumn)
+                }
+
                 SchemaUtils.drop(dataTable)
+            }
+        }
+    }
+
+    @Test
+    fun testJsonContains() {
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, user1, data1 ->
+            val alphaTeamUser = user1.copy(team = "Alpha")
+            val newId = tester.insertAndGetId {
+                it[jsonBColumn] = data1.copy(user = alphaTeamUser)
+            }
+
+            val userIsInactive = tester.jsonBColumn.jsonContains(stringLiteral("{\"active\":false}"))
+            assertEquals(0, tester.select { userIsInactive }.count())
+
+            val alphaTeamUserAsJson = "{\"user\":${Json.Default.encodeToString(alphaTeamUser)}}"
+            var userIsInAlphaTeam = tester.jsonBColumn.jsonContains(stringLiteral(alphaTeamUserAsJson))
+            assertEquals(1, tester.select { userIsInAlphaTeam }.count())
+
+            // test target contains candidate at specified path
+            if (currentTestDB in TestDB.mySqlRelatedDB) {
+                userIsInAlphaTeam = tester.jsonBColumn.jsonContains(stringLiteral("\"Alpha\""), ".user.team")
+                val alphaTeamUsers = tester.slice(tester.id).select { userIsInAlphaTeam }
+                assertEquals(newId, alphaTeamUsers.single()[tester.id])
+            }
+        }
+    }
+
+    @Test
+    fun testJsonExists() {
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, data1 ->
+            val maximumLogins = 1000
+            val teamA = "A"
+            val newId = tester.insertAndGetId {
+                it[jsonBColumn] = data1.copy(user = data1.user.copy(team = teamA), logins = maximumLogins)
+            }
+
+            val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
+
+            // test data at path root '$' exists by providing no path arguments (or an empty string)
+            val hasAnyData = tester.jsonBColumn.jsonExists(optional = optional)
+            assertEquals(2, tester.select { hasAnyData }.count())
+
+            val hasFakeKey = tester.jsonBColumn.jsonExists(".fakeKey", optional = optional)
+            assertEquals(0, tester.select { hasFakeKey }.count())
+
+            val hasLogins = tester.jsonBColumn.jsonExists(".logins", optional = optional)
+            assertEquals(2, tester.select { hasLogins }.count())
+
+            // test data at path exists with filter condition & optional arguments
+            if (currentDialectTest is PostgreSQLDialect) {
+                val filterPath = ".logins ? (@ == $maximumLogins)"
+                val hasMaxLogins = tester.jsonBColumn.jsonExists(filterPath)
+                val usersWithMaxLogin = tester.slice(tester.id).select { hasMaxLogins }
+                assertEquals(newId, usersWithMaxLogin.single()[tester.id])
+
+                val (jsonPath, optionalArg) = ".user.team ? (@ == \$team)" to "{\"team\":\"$teamA\"}"
+                val isOnTeamA = tester.jsonBColumn.jsonExists(jsonPath, optional = optionalArg)
+                val usersOnTeamA = tester.slice(tester.id).select { isOnTeamA }
+                assertEquals(newId, usersOnTeamA.single()[tester.id])
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
@@ -153,8 +153,9 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
                 it[jsonColumn] = data1.copy(user = alphaTeamUser)
             }
 
-            val userIsInactive = tester.jsonColumn.jsonContains(stringLiteral("{\"active\":false}"))
-            assertEquals(0, tester.select { userIsInactive }.count())
+            val userIsInactive = tester.jsonColumn.jsonContains("{\"active\":false}")
+            val result = tester.select { userIsInactive }.toList()
+            assertEquals(0, result.size)
 
             val alphaTeamUserAsJson = "{\"user\":${Json.Default.encodeToString(alphaTeamUser)}}"
             var userIsInAlphaTeam = tester.jsonColumn.jsonContains(stringLiteral(alphaTeamUserAsJson))
@@ -162,7 +163,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
             // test target contains candidate at specified path
             if (currentTestDB in TestDB.mySqlRelatedDB) {
-                userIsInAlphaTeam = tester.jsonColumn.jsonContains(stringLiteral("\"Alpha\""), ".user.team")
+                userIsInAlphaTeam = tester.jsonColumn.jsonContains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.slice(tester.id).select { userIsInAlphaTeam }
                 assertEquals(newId, alphaTeamUsers.single()[tester.id])
             }
@@ -180,7 +181,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
             val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
 
-            // test data at path root '$' exists by providing no path arguments (or an empty string)
+            // test data at path root '$' exists by providing no path arguments
             val hasAnyData = tester.jsonColumn.jsonExists(optional = optional)
             assertEquals(2, tester.select { hasAnyData }.count())
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
@@ -1,12 +1,16 @@
 package org.jetbrains.exposed.sql.tests.shared.types
 
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonContains
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonExists
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.currentTestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.OracleDialect
@@ -45,17 +49,18 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
     @Test
     fun testSelectWithSliceExtract() {
         withJsonTable(exclude = TestDB.allH2TestDB) { tester, user1, data1 ->
+            val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
             // SQLServer & Oracle return null if extracted JSON is not scalar
             val requiresScalar = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
-            val isActive = tester.jsonColumn.jsonExtract<Boolean>("active", toScalar = requiresScalar)
+            val isActive = tester.jsonColumn.jsonExtract<Boolean>("${pathPrefix}active", toScalar = requiresScalar)
             val result1 = tester.slice(isActive).selectAll().singleOrNull()
             assertEquals(data1.active, result1?.get(isActive))
 
-            val storedUser = tester.jsonColumn.jsonExtract<User>("user", toScalar = false)
+            val storedUser = tester.jsonColumn.jsonExtract<User>("${pathPrefix}user", toScalar = false)
             val result2 = tester.slice(storedUser).selectAll().singleOrNull()
             assertEquals(user1, result2?.get(storedUser))
 
-            val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "name") else arrayOf("user.name")
+            val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "name") else arrayOf(".user.name")
             val username = tester.jsonColumn.jsonExtract<String>(*path)
             val result3 = tester.slice(username).selectAll().singleOrNull()
             assertEquals(user1.name, result3?.get(username))
@@ -73,7 +78,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
             val logins = if (currentDialectTest is PostgreSQLDialect) {
                 tester.jsonColumn.jsonExtract<Int>("logins").castTo(IntegerColumnType())
             } else {
-                tester.jsonColumn.jsonExtract<Int>("logins")
+                tester.jsonColumn.jsonExtract<Int>(".logins")
             }
             val tooManyLogins = logins greaterEq 1000
 
@@ -124,7 +129,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
                 if (testDb !in TestDB.allH2TestDB) {
                     dataEntity.new { jsonColumn = dataA }
-                    val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "team") else arrayOf("user.team")
+                    val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "team") else arrayOf(".user.team")
                     val userTeam = dataTable.jsonColumn.jsonExtract<String>(*path)
                     val userInTeamB = dataEntity.find { userTeam like "B%" }.single()
 
@@ -132,6 +137,79 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
                 }
 
                 SchemaUtils.drop(dataTable)
+            }
+        }
+    }
+
+    private val jsonContainsNotSupported = TestDB.values().toList() - listOf(
+        TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.MYSQL, TestDB.MARIADB
+    )
+
+    @Test
+    fun testJsonContains() {
+        withJsonTable(exclude = jsonContainsNotSupported) { tester, user1, data1 ->
+            val alphaTeamUser = user1.copy(team = "Alpha")
+            val newId = tester.insertAndGetId {
+                it[jsonColumn] = data1.copy(user = alphaTeamUser)
+            }
+
+            val userIsInactive = tester.jsonColumn.jsonContains(stringLiteral("{\"active\":false}"))
+            assertEquals(0, tester.select { userIsInactive }.count())
+
+            val alphaTeamUserAsJson = "{\"user\":${Json.Default.encodeToString(alphaTeamUser)}}"
+            var userIsInAlphaTeam = tester.jsonColumn.jsonContains(stringLiteral(alphaTeamUserAsJson))
+            assertEquals(1, tester.select { userIsInAlphaTeam }.count())
+
+            // test target contains candidate at specified path
+            if (currentTestDB in TestDB.mySqlRelatedDB) {
+                userIsInAlphaTeam = tester.jsonColumn.jsonContains(stringLiteral("\"Alpha\""), ".user.team")
+                val alphaTeamUsers = tester.slice(tester.id).select { userIsInAlphaTeam }
+                assertEquals(newId, alphaTeamUsers.single()[tester.id])
+            }
+        }
+    }
+
+    @Test
+    fun testJsonExists() {
+        withJsonTable(exclude = TestDB.allH2TestDB + TestDB.SQLSERVER) { tester, _, data1 ->
+            val maximumLogins = 1000
+            val teamA = "A"
+            val newId = tester.insertAndGetId {
+                it[jsonColumn] = data1.copy(user = data1.user.copy(team = teamA), logins = maximumLogins)
+            }
+
+            val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
+
+            // test data at path root '$' exists by providing no path arguments (or an empty string)
+            val hasAnyData = tester.jsonColumn.jsonExists(optional = optional)
+            assertEquals(2, tester.select { hasAnyData }.count())
+
+            val hasFakeKey = tester.jsonColumn.jsonExists(".fakeKey", optional = optional)
+            assertEquals(0, tester.select { hasFakeKey }.count())
+
+            val hasLogins = tester.jsonColumn.jsonExists(".logins", optional = optional)
+            assertEquals(2, tester.select { hasLogins }.count())
+
+            // test data at path exists with filter condition & optional arguments
+            val testDialect = currentDialectTest
+            if (testDialect is OracleDialect || testDialect is PostgreSQLDialect) {
+                val filterPath = if (testDialect is OracleDialect) {
+                    "?(@.logins == $maximumLogins)"
+                } else {
+                    ".logins ? (@ == $maximumLogins)"
+                }
+                val hasMaxLogins = tester.jsonColumn.jsonExists(filterPath)
+                val usersWithMaxLogin = tester.slice(tester.id).select { hasMaxLogins }
+                assertEquals(newId, usersWithMaxLogin.single()[tester.id])
+
+                val (jsonPath, optionalArg) = if (testDialect is OracleDialect) {
+                    "?(@.user.team == \$team)" to "PASSING '$teamA' AS \"team\""
+                } else {
+                    ".user.team ? (@ == \$team)" to "{\"team\":\"$teamA\"}"
+                }
+                val isOnTeamA = tester.jsonColumn.jsonExists(jsonPath, optional = optionalArg)
+                val usersOnTeamA = tester.slice(tester.id).select { isOnTeamA }
+                assertEquals(newId, usersOnTeamA.single()[tester.id])
             }
         }
     }


### PR DESCRIPTION
**Add** dialect overrides and unit tests for:
- `jsonContains()` -> Checks if the invoking JSON column expression contains the specific expression argument provided.
- `jsonExists()` -> Checks if any data exists at the specified path within the invoking JSON column expression. **Note:** SQLServer does have a relevant function but it is only available as of latest 2022 v16.x, while Exposed tests and supports 2017 v14.x.

**Fix** issues with `jsonExtract()`:
- [Postgres] Supports 2 variants, for either JSON or JSONB type, so a way to distinguish between the invoking column types needed to be added. This also allows casting since the 2 new functions only accept JSONB values.
- Some dialects were hard-coded with the prefix `'$.'`, but the root context item alone `'$'` is actually a valid JSON path, so the period was removed and tests adjusted.
- Refactored overrides to fail early if dialect-specific conditions are not met; for example, if too many path arguments or an unsupported optional argument are provided.

**Note:** H2 supports none of these functions.