### PR TITLE
deprecate: EXPOSED-84 Raise deprecation levels of API elements

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -448,10 +448,10 @@ public abstract class org/jetbrains/exposed/sql/CompositeColumn : org/jetbrains/
 public final class org/jetbrains/exposed/sql/CompositeSqlLogger : org/jetbrains/exposed/sql/SqlLogger, org/jetbrains/exposed/sql/statements/StatementInterceptor {
 	public fun <init> ()V
 	public final fun addLogger (Lorg/jetbrains/exposed/sql/SqlLogger;)V
-	public fun afterCommit ()V
+	public synthetic fun afterCommit ()V
 	public fun afterCommit (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public fun afterExecution (Lorg/jetbrains/exposed/sql/Transaction;Ljava/util/List;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
-	public fun afterRollback ()V
+	public synthetic fun afterRollback ()V
 	public fun afterRollback (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public fun afterStatementPrepared (Lorg/jetbrains/exposed/sql/Transaction;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
 	public fun beforeCommit (Lorg/jetbrains/exposed/sql/Transaction;)V

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -423,7 +423,6 @@ public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/expos
 
 public final class org/jetbrains/exposed/sql/ColumnTypeKt {
 	public static final fun getAutoIncColumnType (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/AutoIncColumnType;
-	public static final synthetic fun getAutoIncSeqName (Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;
 	public static final fun isAutoInc (Lorg/jetbrains/exposed/sql/IColumnType;)Z
 }
 
@@ -519,11 +518,9 @@ public final class org/jetbrains/exposed/sql/Database {
 
 public final class org/jetbrains/exposed/sql/Database$Companion {
 	public final fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Database;
-	public final synthetic fun connect (Ljavax/sql/ConnectionPoolDataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Database;
 	public final fun connect (Ljavax/sql/DataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Database;
 	public final fun connect (Lkotlin/jvm/functions/Function0;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Database;
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/sql/Database$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
-	public static synthetic fun connect$default (Lorg/jetbrains/exposed/sql/Database$Companion;Ljavax/sql/ConnectionPoolDataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/sql/Database$Companion;Ljavax/sql/DataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/sql/Database$Companion;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
 	public final fun connectPool (Ljavax/sql/ConnectionPoolDataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Database;
@@ -1680,7 +1677,7 @@ public final class org/jetbrains/exposed/sql/SchemaUtils {
 	public static synthetic fun create$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)V
 	public final fun createDatabase ([Ljava/lang/String;Z)V
 	public static synthetic fun createDatabase$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Ljava/lang/String;ZILjava/lang/Object;)V
-	public final fun createFKey (Lorg/jetbrains/exposed/sql/Column;)Ljava/util/List;
+	public final synthetic fun createFKey (Lorg/jetbrains/exposed/sql/Column;)Ljava/util/List;
 	public final fun createFKey (Lorg/jetbrains/exposed/sql/ForeignKeyConstraint;)Ljava/util/List;
 	public final fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/util/List;
 	public final fun createMissingTablesAndColumns ([Lorg/jetbrains/exposed/sql/Table;ZZ)V
@@ -2557,10 +2554,10 @@ public abstract interface class org/jetbrains/exposed/sql/statements/GlobalState
 }
 
 public final class org/jetbrains/exposed/sql/statements/GlobalStatementInterceptor$DefaultImpls {
-	public static fun afterCommit (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;)V
+	public static synthetic fun afterCommit (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;)V
 	public static fun afterCommit (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;)V
 	public static fun afterExecution (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;Ljava/util/List;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
-	public static fun afterRollback (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;)V
+	public static synthetic fun afterRollback (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;)V
 	public static fun afterRollback (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;)V
 	public static fun afterStatementPrepared (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
 	public static fun beforeCommit (Lorg/jetbrains/exposed/sql/statements/GlobalStatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;)V
@@ -2650,10 +2647,10 @@ public final class org/jetbrains/exposed/sql/statements/StatementGroup : java/la
 }
 
 public abstract interface class org/jetbrains/exposed/sql/statements/StatementInterceptor {
-	public abstract fun afterCommit ()V
+	public abstract synthetic fun afterCommit ()V
 	public abstract fun afterCommit (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public abstract fun afterExecution (Lorg/jetbrains/exposed/sql/Transaction;Ljava/util/List;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
-	public abstract fun afterRollback ()V
+	public abstract synthetic fun afterRollback ()V
 	public abstract fun afterRollback (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public abstract fun afterStatementPrepared (Lorg/jetbrains/exposed/sql/Transaction;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
 	public abstract fun beforeCommit (Lorg/jetbrains/exposed/sql/Transaction;)V
@@ -2663,10 +2660,10 @@ public abstract interface class org/jetbrains/exposed/sql/statements/StatementIn
 }
 
 public final class org/jetbrains/exposed/sql/statements/StatementInterceptor$DefaultImpls {
-	public static fun afterCommit (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;)V
+	public static synthetic fun afterCommit (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;)V
 	public static fun afterCommit (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;)V
 	public static fun afterExecution (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;Ljava/util/List;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
-	public static fun afterRollback (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;)V
+	public static synthetic fun afterRollback (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;)V
 	public static fun afterRollback (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;)V
 	public static fun afterStatementPrepared (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
 	public static fun beforeCommit (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;Lorg/jetbrains/exposed/sql/Transaction;)V

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1617,7 +1617,7 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun min (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Min;
 	public static final fun nextIntVal (Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/NextVal;
 	public static final fun nextLongVal (Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/NextVal;
-	public static final fun nextVal (Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/NextVal;
+	public static final synthetic fun nextVal (Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/NextVal;
 	public static final fun stdDevPop (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/StdDevPop;
 	public static synthetic fun stdDevPop$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;IILjava/lang/Object;)Lorg/jetbrains/exposed/sql/StdDevPop;
 	public static final fun stdDevSamp (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/StdDevSamp;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -162,14 +162,6 @@ val IColumnType.isAutoInc: Boolean get() = this is AutoIncColumnType || (this is
 val Column<*>.autoIncColumnType: AutoIncColumnType?
     get() = (columnType as? AutoIncColumnType) ?: (columnType as? EntityIDColumnType<*>)?.idColumn?.columnType as? AutoIncColumnType
 
-@Deprecated(
-    message = "Will be removed in upcoming releases. Please use [autoIncColumnType.autoincSeq] instead",
-    replaceWith = ReplaceWith("this.autoIncColumnType.autoincSeq"),
-    level = DeprecationLevel.HIDDEN
-)
-val Column<*>.autoIncSeqName: String?
-    get() = autoIncColumnType?.autoincSeq
-
 internal fun IColumnType.rawSqlType(): IColumnType = when {
     this is AutoIncColumnType -> delegate
     this is EntityIDColumnType<*> && idColumn.columnType is AutoIncColumnType -> idColumn.columnType.delegate

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -144,26 +144,6 @@ class Database private constructor(
             )
         }
 
-        @Deprecated(
-            level = DeprecationLevel.HIDDEN,
-            replaceWith = ReplaceWith("connectPool(datasource, setupConnection, manager)"),
-            message = "Use connectPool instead"
-        )
-        fun connect(
-            datasource: ConnectionPoolDataSource,
-            setupConnection: (Connection) -> Unit = {},
-            databaseConfig: DatabaseConfig? = null,
-            manager: (Database) -> TransactionManager = { ThreadLocalTransactionManager(it) }
-        ): Database {
-            return doConnect(
-                explicitVendor = null,
-                config = databaseConfig,
-                getNewConnection = { datasource.pooledConnection.connection!! },
-                setupConnection = setupConnection,
-                manager = manager
-            )
-        }
-
         fun connectPool(
             datasource: ConnectionPoolDataSource,
             setupConnection: (Connection) -> Unit = {},

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -525,10 +525,10 @@ class LikeEscapeOp(expr1: Expression<*>, expr2: Expression<*>, like: Boolean, va
     }
 }
 
-@Deprecated("Use LikeEscapeOp", replaceWith = ReplaceWith("LikeEscapeOp(expr1, expr2, true, null)"), level = DeprecationLevel.WARNING)
+@Deprecated("Use LikeEscapeOp", replaceWith = ReplaceWith("LikeEscapeOp(expr1, expr2, true, null)"), DeprecationLevel.ERROR)
 class LikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "LIKE")
 
-@Deprecated("Use LikeEscapeOp", replaceWith = ReplaceWith("LikeEscapeOp(expr1, expr2, false, null)"), level = DeprecationLevel.WARNING)
+@Deprecated("Use LikeEscapeOp", replaceWith = ReplaceWith("LikeEscapeOp(expr1, expr2, false, null)"), DeprecationLevel.ERROR)
 class NotLikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "NOT LIKE")
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -129,7 +129,7 @@ inline fun <reified T : Any> ExpressionWithColumnType<*>.jsonExtract(vararg path
 // Sequence Manipulation Functions
 
 /** Advances this sequence and returns the new value. */
-@Deprecated("please use [nextIntVal] or [nextLongVal] functions", ReplaceWith("nextIntVal()"), DeprecationLevel.ERROR)
+@Deprecated("Please use [nextIntVal] or [nextLongVal] functions", ReplaceWith("nextIntVal()"), DeprecationLevel.WARNING)
 fun Sequence.nextVal(): NextVal<Int> = nextIntVal()
 
 /** Advances this sequence and returns the new value. */
@@ -216,7 +216,7 @@ data class LikePattern(
     }
 }
 
-@Deprecated("Implement interface ISqlExpressionBuilder instead inherit this class", level = DeprecationLevel.ERROR)
+@Deprecated("Implement interface ISqlExpressionBuilder directly instead", level = DeprecationLevel.HIDDEN)
 open class SqlExpressionBuilderClass : ISqlExpressionBuilder
 
 @Suppress("INAPPLICABLE_JVM_NAME", "TooManyFunctions")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -129,7 +129,7 @@ inline fun <reified T : Any> ExpressionWithColumnType<*>.jsonExtract(vararg path
 // Sequence Manipulation Functions
 
 /** Advances this sequence and returns the new value. */
-@Deprecated("Please use [nextIntVal] or [nextLongVal] functions", ReplaceWith("nextIntVal()"), DeprecationLevel.WARNING)
+@Deprecated("Please use [nextIntVal] or [nextLongVal] functions", ReplaceWith("nextIntVal()"), DeprecationLevel.HIDDEN)
 fun Sequence.nextVal(): NextVal<Int> = nextIntVal()
 
 /** Advances this sequence and returns the new value. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -121,7 +121,7 @@ object SchemaUtils {
     @Deprecated(
         "Will be removed in upcoming releases. Please use overloaded version instead",
         ReplaceWith("createFKey(checkNotNull(reference.foreignKey) { \"${"$"}reference does not reference anything\" })"),
-        DeprecationLevel.ERROR
+        DeprecationLevel.HIDDEN
     )
     fun createFKey(reference: Column<*>): List<String> {
         val foreignKey = reference.foreignKey

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/StatementInterceptor.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/StatementInterceptor.kt
@@ -20,15 +20,13 @@ interface StatementInterceptor {
 
     fun beforeCommit(transaction: Transaction) {}
 
-    @Deprecated("using afterCommit with transaction", level = DeprecationLevel.ERROR)
-    // @Deprecated("using afterCommit with transaction", level = DeprecationLevel.HIDDEN) \\ next version, backward compatibility
+    @Deprecated("Use afterCommit() with a transaction", level = DeprecationLevel.HIDDEN)
     fun afterCommit() {}
     fun afterCommit(transaction: Transaction) {}
 
     fun beforeRollback(transaction: Transaction) {}
 
-    @Deprecated("using afterRollback with transaction", level = DeprecationLevel.ERROR)
-    // @Deprecated("using afterRollback with transaction", level = DeprecationLevel.HIDDEN) \\ next version, backward compatibility
+    @Deprecated("Use afterRollback() with a transaction", level = DeprecationLevel.HIDDEN)
     fun afterRollback() {}
     fun afterRollback(transaction: Transaction) {}
 

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -185,10 +185,10 @@ public final class org/jetbrains/exposed/dao/EntityHookKt {
 
 public final class org/jetbrains/exposed/dao/EntityLifecycleInterceptor : org/jetbrains/exposed/sql/statements/GlobalStatementInterceptor {
 	public fun <init> ()V
-	public fun afterCommit ()V
+	public synthetic fun afterCommit ()V
 	public fun afterCommit (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public fun afterExecution (Lorg/jetbrains/exposed/sql/Transaction;Ljava/util/List;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
-	public fun afterRollback ()V
+	public synthetic fun afterRollback ()V
 	public fun afterRollback (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public fun afterStatementPrepared (Lorg/jetbrains/exposed/sql/Transaction;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
 	public fun beforeCommit (Lorg/jetbrains/exposed/sql/Transaction;)V

--- a/exposed-java-time/api/exposed-java-time.api
+++ b/exposed-java-time/api/exposed-java-time.api
@@ -5,7 +5,7 @@ public final class org/jetbrains/exposed/sql/javatime/CurrentDate : org/jetbrain
 
 public final class org/jetbrains/exposed/sql/javatime/CurrentDateTime : org/jetbrains/exposed/sql/Function {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/javatime/CurrentDateTime;
-	public final fun invoke ()Lorg/jetbrains/exposed/sql/javatime/CurrentDateTime;
+	public final synthetic fun invoke ()Lorg/jetbrains/exposed/sql/javatime/CurrentDateTime;
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -31,10 +31,9 @@ object CurrentDateTime : Function<LocalDateTime>(JavaLocalDateTimeColumnType.INS
     }
 
     @Deprecated(
-        message = "This class is now a singleton, no need for its constructor call; " +
-            "this method is provided for backward-compatibility only, and will be removed in future releases",
+        message = "This class is now a singleton, no need for its constructor call",
         replaceWith = ReplaceWith("this"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.HIDDEN,
     )
     operator fun invoke() = this
 }

--- a/exposed-jodatime/api/exposed-jodatime.api
+++ b/exposed-jodatime/api/exposed-jodatime.api
@@ -5,7 +5,7 @@ public final class org/jetbrains/exposed/sql/jodatime/CurrentDate : org/jetbrain
 
 public final class org/jetbrains/exposed/sql/jodatime/CurrentDateTime : org/jetbrains/exposed/sql/Function {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/jodatime/CurrentDateTime;
-	public final fun invoke ()Lorg/jetbrains/exposed/sql/jodatime/CurrentDateTime;
+	public final synthetic fun invoke ()Lorg/jetbrains/exposed/sql/jodatime/CurrentDateTime;
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
@@ -22,10 +22,9 @@ object CurrentDateTime : Function<DateTime>(DateColumnType(true)) {
     }
 
     @Deprecated(
-        message = "This class is now a singleton, no need for its constructor call; " +
-            "this method is provided for backward-compatibility only, and will be removed in future releases",
+        message = "This class is now a singleton, no need for its constructor call",
         replaceWith = ReplaceWith("this"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.HIDDEN,
     )
     operator fun invoke() = this
 }

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -5,7 +5,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentDate : org/j
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime : org/jetbrains/exposed/sql/Function {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime;
-	public final fun invoke ()Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime;
+	public final synthetic fun invoke ()Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime;
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.jetbrains.exposed.sql.vendors.h2Mode
 import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
 
 internal class DateInternal(val expr: Expression<*>) : Function<LocalDate>(KotlinLocalDateColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("DATE(", expr, ")") }
@@ -47,10 +46,9 @@ object CurrentDateTime : Function<LocalDateTime>(KotlinLocalDateTimeColumnType.I
     }
 
     @Deprecated(
-        message = "This class is now a singleton, no need for its constructor call; " +
-            "this method is provided for backward-compatibility only, and will be removed in future releases",
+        message = "This class is now a singleton, no need for its constructor call",
         replaceWith = ReplaceWith("this"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.HIDDEN,
     )
     operator fun invoke() = this
 }


### PR DESCRIPTION
Raise levels of API `@Deprecated` annotations as per [gradual phase-out guidelines](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecated/#kotlin.Deprecated).
**Note**: All elements had most recent level change on last release (0.41.1 - November 2022), except `createFKey()`, which was last changed on 12/2021.

**Raise from WARNING to ERROR**:
- Op.kt classes: `LikeOp` and `NotLikeOp`

**Raise from ERROR to HIDDEN** (to preserve binary compatibility with previously compiled code):
- `CurrentDateTime` object's `invoke()` (in all 3 date-time modules)
- `StatementInterceptor` interface's `afterCommit()` and `afterRollback()`
- `SchemaUtils` object `createFKey()`
- SQLExpressionBuilder.kt `Sequence.nextVal()` and `SqlExpressionBuilderClass`

**Currently HIDDEN, now removed**:
- `Database` companion object's `connect()`
- ColumnType.kt property `autoIncSeqName`

**Deprecation level NOT changed**:
- `ExposedDatabaseMetadata` class [property](https://github.com/JetBrains/Exposed/blob/main/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt#L23) `currentScheme` is currently set at WARNING level, but is used fairly frequently throughout the codebase, so it cannot be raised to ERROR without an investigation into why.