### PR TITLE
feat: Add findByIdAndUpdate functions to DAO API

### DIFF
--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -73,6 +73,28 @@ Update a value of a property similar to any property in a Kotlin class:
 movie.name = "Episode VIII – The Last Jedi"
 ```
 * Note: Exposed doesn't make an immediate update when you set a new value for Entity, it just stores it on the inner map. "Flushing" values to the database occurs at the end of the transaction or before next `select *` from the database.
+
+Search for an entity by its id and apply an update:
+```kotlin
+val updatedMovie = StarWarsFilm.findByIdAndUpdate(5) {
+    it.name = "Episode VIII – The Last Jedi"
+}
+```
+
+Search for a single entity by a query and apply an update:
+```kotlin
+val updatedMovie2 = StarWarsFilm.findSingleByAndUpdate(StarWarsFilms.name eq "The Last Jedi") {
+    it.name = "Episode VIII – The Last Jedi"
+}
+```
+
+Search for multiple entities by a query and apply an update to all entities:
+```kotlin
+val updatedMovies = StarWarsFilm.findManyByAndUpdate(StarWarsFilms.director eq "George Lucas") {
+    it.director = "Lucas, George"
+}
+```
+
 ### Delete
 ```kotlin
 movie.delete() 

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -88,13 +88,6 @@ val updatedMovie2 = StarWarsFilm.findSingleByAndUpdate(StarWarsFilms.name eq "Th
 }
 ```
 
-Search for multiple entities by a query and apply an update to all entities:
-```kotlin
-val updatedMovies = StarWarsFilm.findManyByAndUpdate(StarWarsFilms.director eq "George Lucas") {
-    it.director = "Lucas, George"
-}
-```
-
 ### Delete
 ```kotlin
 movie.delete() 

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -125,7 +125,6 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public final fun findById (Ljava/lang/Comparable;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun findById (Lorg/jetbrains/exposed/dao/id/EntityID;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun findByIdAndUpdate (Ljava/lang/Comparable;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
-	public final fun findManyByAndUpdate (Lorg/jetbrains/exposed/sql/Op;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun findSingleByAndUpdate (Lorg/jetbrains/exposed/sql/Op;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun findWithCacheCondition (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
 	public fun forEntityIds (Ljava/util/List;)Lorg/jetbrains/exposed/sql/SizedIterable;

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -124,6 +124,9 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public final fun find (Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun findById (Ljava/lang/Comparable;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun findById (Lorg/jetbrains/exposed/dao/id/EntityID;)Lorg/jetbrains/exposed/dao/Entity;
+	public final fun findByIdAndUpdate (Ljava/lang/Comparable;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
+	public final fun findManyByAndUpdate (Lorg/jetbrains/exposed/sql/Op;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public final fun findSingleByAndUpdate (Lorg/jetbrains/exposed/sql/Op;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun findWithCacheCondition (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
 	public fun forEntityIds (Ljava/util/List;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun forIds (Ljava/util/List;)Lorg/jetbrains/exposed/sql/SizedIterable;

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
@@ -107,21 +107,25 @@ class EntityCache(private val transaction: Transaction) {
     }
 
     private fun updateEntities(idTable: IdTable<*>) {
-        updates.remove(idTable)?.takeIf { it.isNotEmpty() }?.let {
-            val updatedEntities = HashSet<Entity<*>>()
-            val batch = EntityBatchUpdate(it.first().klass)
-            for (entity in it) {
-                if (entity.flush(batch)) {
-                    check(entity.klass !is ImmutableEntityClass<*, *>) { "Update on immutable entity ${entity.javaClass.simpleName} ${entity.id}" }
-                    updatedEntities.add(entity)
-                }
+        val update = updates.remove(idTable) ?: return
+        if (update.isEmpty()) return
+
+        val updatedEntities = HashSet<Entity<*>>()
+        val batch = EntityBatchUpdate(update.first().klass)
+
+        for (entity in update) {
+            if (entity.flush(batch)) {
+                check(entity.klass !is ImmutableEntityClass<*, *>) { "Update on immutable entity ${entity.javaClass.simpleName} ${entity.id}" }
+                updatedEntities.add(entity)
             }
-            executeAsPartOfEntityLifecycle {
-                batch.execute(transaction)
-            }
-            updatedEntities.forEach {
-                transaction.registerChange(it.klass, it.id, EntityChangeType.Updated)
-            }
+        }
+
+        executeAsPartOfEntityLifecycle {
+            batch.execute(transaction)
+        }
+
+        updatedEntities.forEach {
+            transaction.registerChange(it.klass, it.id, EntityChangeType.Updated)
         }
     }
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -68,6 +68,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @param block Lambda that contains entity updates
      *
      * @return The updated entity that conforms to this op or null if no entity was found.
+     * It also returns [null] if more than one entity conforms to the op.
      */
     fun findSingleByAndUpdate(op: Op<Boolean>, block: (it: T) -> Unit): T? {
         val result = find(op).forUpdate().singleOrNull() ?: return null
@@ -200,6 +201,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
                     }
                     column to value
                 }
+
                 exp is Column && exp.table == table -> null
                 else -> exp to value
             }
@@ -668,6 +670,7 @@ abstract class ImmutableCachedEntityClass<ID : Comparable<ID>, out T : Entity<ID
                     tr.getUserData(cacheLoadingState) != null -> {
                         return transactionCache // prevent recursive call to warmCache() in .all()
                     }
+
                     else -> {
                         tr.putUserData(cacheLoadingState, this)
                         super.all().toList() // force iteration to initialize lazy collection

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -23,6 +23,7 @@ import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 object EntityTestsData {
@@ -452,13 +453,16 @@ class EntityTests : DatabaseTestsBase() {
             val updatedItem = Item.findByIdAndUpdate(item.id.value) {
                 it.price = newPrice
             }
+
+            assertSame(updatedItem, item)
+
             assertNotNull(updatedItem)
             assertEquals(newPrice, updatedItem.price)
-            assertNull(Item.testCache(item.id))
+            assertNotNull(Item.testCache(item.id))
 
-            assertEquals(oldPrice, item.price)
-            item.refresh(flush = false)
             assertEquals(newPrice, item.price)
+            item.refresh(flush = false)
+            assertEquals(oldPrice, item.price)
             assertNotNull(Item.testCache(item.id))
         }
     }
@@ -478,54 +482,17 @@ class EntityTests : DatabaseTestsBase() {
             val updatedItem = Item.findSingleByAndUpdate(Items.name eq "Item A") {
                 it.price = newPrice
             }
+
+            assertSame(updatedItem, item)
+
             assertNotNull(updatedItem)
             assertEquals(newPrice, updatedItem.price)
-            assertNull(Item.testCache(item.id))
-
-            assertEquals(oldPrice, item.price)
-            item.refresh(flush = false)
-            assertEquals(newPrice, item.price)
             assertNotNull(Item.testCache(item.id))
-        }
-    }
 
-    @Test
-    fun testDaoFindManyByAndUpdate() {
-        withTables(Items) {
-            val itemA = Item.new {
-                name = "New item"
-                price = 20.0
-            }
-            assertEquals(20.0, itemA.price)
-            assertNotNull(Item.testCache(itemA.id))
-            val itemB = Item.new {
-                name = "New item"
-                price = 30.0
-            }
-            assertEquals(30.0, itemB.price)
-            assertNotNull(Item.testCache(itemB.id))
-
-            val newPrice = 50.0
-            val updatedItems = Item.findManyByAndUpdate(Items.name eq "New item") {
-                it.price = newPrice
-            }
-            assertEquals(2, updatedItems.count())
-            updatedItems.mapLazy {
-                assert(listOf(itemA.id.value, itemB.id.value).contains(it.id.value))
-                assertEquals(newPrice, it.price)
-                assertEquals("New item", it.name)
-            }
-
-            assertNull(Item.testCache(itemA.id))
-            assertNull(Item.testCache(itemB.id))
-            assertEquals(20.0, itemA.price)
-            assertEquals(30.0, itemB.price)
-            itemA.refresh(flush = false)
-            itemB.refresh(flush = false)
-            assertEquals(newPrice, itemA.price)
-            assertEquals(newPrice, itemB.price)
-            assertNotNull(Item.testCache(itemA.id))
-            assertNotNull(Item.testCache(itemB.id))
+            assertEquals(newPrice, item.price)
+            item.refresh(flush = false)
+            assertEquals(oldPrice, item.price)
+            assertNotNull(Item.testCache(item.id))
         }
     }
 


### PR DESCRIPTION
Currently there are no functions in the DAO api that directly allow updates. This change adds functions that allow direct updates in the EntityClass API. Usage guidelines are explained in the documentation updates.