### PR TITLE
fix: EXPOSED-80 Set repetition policy for suspended transactions

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3194,8 +3194,8 @@ public final class org/jetbrains/exposed/sql/transactions/experimental/Suspended
 	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun withSuspendTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun withSuspendTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun withSuspendTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun withSuspendTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ColumnMetadata {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3192,8 +3192,8 @@ public final class org/jetbrains/exposed/sql/transactions/TransactionStore : kot
 public final class org/jetbrains/exposed/sql/transactions/experimental/SuspendedKt {
 	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun suspendedTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun suspendedTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun suspendedTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun suspendedTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3123,11 +3123,11 @@ public final class org/jetbrains/exposed/sql/transactions/ThreadLocalTransaction
 }
 
 public final class org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManagerKt {
-	public static final fun inTopLevelTransaction (IIZLorg/jetbrains/exposed/sql/Database;Lorg/jetbrains/exposed/sql/Transaction;JJLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static synthetic fun inTopLevelTransaction$default (IIZLorg/jetbrains/exposed/sql/Database;Lorg/jetbrains/exposed/sql/Transaction;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun transaction (IIZLorg/jetbrains/exposed/sql/Database;JJLkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun inTopLevelTransaction (IZLorg/jetbrains/exposed/sql/Database;Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun inTopLevelTransaction$default (IZLorg/jetbrains/exposed/sql/Database;Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun transaction (IZLorg/jetbrains/exposed/sql/Database;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun transaction (Lorg/jetbrains/exposed/sql/Database;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static synthetic fun transaction$default (IIZLorg/jetbrains/exposed/sql/Database;JJLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun transaction$default (IZLorg/jetbrains/exposed/sql/Database;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun transaction$default (Lorg/jetbrains/exposed/sql/Database;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3192,10 +3192,10 @@ public final class org/jetbrains/exposed/sql/transactions/TransactionStore : kot
 public final class org/jetbrains/exposed/sql/transactions/experimental/SuspendedKt {
 	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun suspendedTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun suspendedTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun withSuspendTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun withSuspendTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ColumnMetadata {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3190,12 +3190,12 @@ public final class org/jetbrains/exposed/sql/transactions/TransactionStore : kot
 }
 
 public final class org/jetbrains/exposed/sql/transactions/experimental/SuspendedKt {
-	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun suspendedTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun suspendedTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ColumnMetadata {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2417,8 +2417,11 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 	public final fun getDebug ()Z
 	public final fun getDuration ()J
 	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxRepetitionDelay ()J
+	public final fun getMinRepetitionDelay ()J
 	public fun getOuterTransaction ()Lorg/jetbrains/exposed/sql/Transaction;
 	public fun getReadOnly ()Z
+	public final fun getRepetitionAttempts ()I
 	public final fun getStatementCount ()I
 	public final fun getStatementStats ()Ljava/util/HashMap;
 	public final fun getStatements ()Ljava/lang/StringBuilder;
@@ -2431,6 +2434,9 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 	public final fun setCurrentStatement (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
 	public final fun setDebug (Z)V
 	public final fun setDuration (J)V
+	public final fun setMaxRepetitionDelay (J)V
+	public final fun setMinRepetitionDelay (J)V
+	public final fun setRepetitionAttempts (I)V
 	public final fun setStatementCount (I)V
 	public final fun setWarnLongQueriesDuration (Ljava/lang/Long;)V
 	public final fun unregisterInterceptor (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;)Z
@@ -3190,10 +3196,10 @@ public final class org/jetbrains/exposed/sql/transactions/TransactionStore : kot
 }
 
 public final class org/jetbrains/exposed/sql/transactions/experimental/SuspendedKt {
-	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;IJJLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun withSuspendTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun withSuspendTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -34,30 +34,33 @@ class DatabaseConfig private constructor(
          */
         var defaultFetchSize: Int? = null,
         /**
-         * Default transaction isolation level. If not specified database-specific level will be used.
-         * Can be overridden on per-transaction level by specifying `transactionIsolation` parameter of `transaction` function.
+         * Default transaction isolation level. If not specified, the database-specific level will be used.
+         * This can be overridden on a per-transaction level by specifying the `transactionIsolation` parameter of
+         * the `transaction` function.
          * Check [Database.getDefaultIsolationLevel] for the database defaults.
          */
         var defaultIsolationLevel: Int = -1,
         /**
          * How many retries will be made inside any `transaction` block if SQLException happens.
-         * Can be overridden on per-transaction level by specifying `repetitionAttempts` property in `transaction` block.
+         * This can be overridden on a per-transaction level by specifying the `repetitionAttempts` property in a
+         * `transaction` block.
          * Default attempts are 3.
          */
         var defaultRepetitionAttempts: Int = 3,
         /**
          * The minimum number of milliseconds to wait before retrying a transaction if SQLException happens.
-         * Can be overridden on per-transaction level by specifying `minRepetitionDelay` property in `transaction` block.
+         * This can be overridden on a per-transaction level by specifying the `minRepetitionDelay` property in a
+         * `transaction` block.
          * Default minimum delay is 0.
          */
         var defaultMinRepetitionDelay: Long = 0,
         /**
          * The maximum number of milliseconds to wait before retrying a transaction if SQLException happens.
-         * Can be overridden on per-transaction level by specifying `maxRepetitionDelay` property in `transaction` block.
+         * This can be overridden on a per-transaction level by specifying the `maxRepetitionDelay` property in a
+         * `transaction` block.
          * Default maximum delay is 0.
          */
         var defaultMaxRepetitionDelay: Long = 0,
-
         /**
          * Should all connections/transactions be executed in read-only mode by default or not.
          * Default state is false.
@@ -66,25 +69,27 @@ class DatabaseConfig private constructor(
         /**
          * Threshold in milliseconds to log queries which exceed the threshold with WARN level.
          * No tracing enabled by default.
-         * Can be set on per-transaction level by setting [Transaction.warnLongQueriesDuration] field.
+         * This can be set on a per-transaction level by setting [Transaction.warnLongQueriesDuration] field.
          */
         var warnLongQueriesDuration: Long? = null,
         /**
          * Amount of entities to keep in an EntityCache per an Entity class.
          * Applicable only when `exposed-dao` module is used.
-         * Can be overridden on per-transaction basis via [EntityCache.maxEntitiesToStore].
+         * This can be overridden on a per-transaction basis via [EntityCache.maxEntitiesToStore].
          * All entities will be kept by default.
          */
         var maxEntitiesToStoreInCachePerEntity: Int = Int.MAX_VALUE,
         /**
-         * Turns on "mode" for Exposed DAO to store relations (after they were loaded)
-         * within the entity that will allow to access them outside the transaction.
+         * Turns on "mode" for Exposed DAO to store relations (after they were loaded) within the entity that will
+         * allow access to them outside the transaction.
          * Useful when [eager loading](https://github.com/JetBrains/Exposed/wiki/DAO#eager-loading) is used.
          */
         var keepLoadedReferencesOutOfTransaction: Boolean = false,
 
         /**
-         * Set the explicit dialect for a database. Can be useful when working with unsupported dialects which have the same behavior as the one that Exposed supports.
+         * Set the explicit dialect for a database.
+         * This can be useful when working with unsupported dialects which have the same behavior as the one that
+         * Exposed supports.
          */
         var explicitDialect: DatabaseDialect? = null,
 
@@ -95,7 +100,8 @@ class DatabaseConfig private constructor(
 
         /**
          * Log too much result sets opened in parallel.
-         * The error log will contain the stacktrace of the place in the code where new result set occurs, and it exceeds the threshold.
+         * The error log will contain the stacktrace of the place in the code where a new result set occurs, and it
+         * exceeds the threshold.
          * 0 value means no log needed.
          */
         var logTooMuchResultSetsThreshold: Int = 0,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -22,7 +22,7 @@ class DatabaseConfig private constructor(
 
     class Builder(
         /**
-         * SQLLogger to be used to log all SQL statements. [Slf4jSqlDebugLogger] by default
+         * SQLLogger to be used to log all SQL statements. [Slf4jSqlDebugLogger] by default.
          */
         var sqlLogger: SqlLogger? = null,
         /**
@@ -34,57 +34,57 @@ class DatabaseConfig private constructor(
          */
         var defaultFetchSize: Int? = null,
         /**
-         * Default transaction isolation level. If not specified database-specific level will be used
-         * Can be overridden on per-transaction level by specifying `transactionIsolation` parameter of `transaction` function
-         * Check [Database.getDefaultIsolationLevel] for the database defaults
+         * Default transaction isolation level. If not specified database-specific level will be used.
+         * Can be overridden on per-transaction level by specifying `transactionIsolation` parameter of `transaction` function.
+         * Check [Database.getDefaultIsolationLevel] for the database defaults.
          */
         var defaultIsolationLevel: Int = -1,
         /**
-         * How many retries will be made inside any `transaction` block if SQLException happens
-         * Can be overridden on per-transaction level by specifying `repetitionAttempts` parameter on call
-         * Default attempts are 3
+         * How many retries will be made inside any `transaction` block if SQLException happens.
+         * Can be overridden on per-transaction level by specifying `repetitionAttempts` property in `transaction` block.
+         * Default attempts are 3.
          */
         var defaultRepetitionAttempts: Int = 3,
         /**
-         * The minimum number of milliseconds to wait before retrying a transaction if SQLException happens
-         * Can be overridden on per-transaction level by specifying `minRepetitionDelay` parameter on call
-         * Default minimum delay is 0
+         * The minimum number of milliseconds to wait before retrying a transaction if SQLException happens.
+         * Can be overridden on per-transaction level by specifying `minRepetitionDelay` property in `transaction` block.
+         * Default minimum delay is 0.
          */
         var defaultMinRepetitionDelay: Long = 0,
         /**
-         * The maximum number of milliseconds to wait before retrying a transaction if SQLException happens
-         * Can be overridden on per-transaction level by specifying `maxRepetitionDelay` parameter on call
-         * Default maximum delay is 0
+         * The maximum number of milliseconds to wait before retrying a transaction if SQLException happens.
+         * Can be overridden on per-transaction level by specifying `maxRepetitionDelay` property in `transaction` block.
+         * Default maximum delay is 0.
          */
         var defaultMaxRepetitionDelay: Long = 0,
 
         /**
-         * Should all connections/transactions be executed in read-only mode by default or not
-         * Default state is false
+         * Should all connections/transactions be executed in read-only mode by default or not.
+         * Default state is false.
          */
         var defaultReadOnly: Boolean = false,
         /**
-         * Threshold in milliseconds to log queries which exceed the threshold with WARN level
-         * No tracing enabled by default
-         * Can be set on per-transaction level by setting [Transaction.warnLongQueriesDuration] field
+         * Threshold in milliseconds to log queries which exceed the threshold with WARN level.
+         * No tracing enabled by default.
+         * Can be set on per-transaction level by setting [Transaction.warnLongQueriesDuration] field.
          */
         var warnLongQueriesDuration: Long? = null,
         /**
-         * Amount of entities to keep in an EntityCache per an Entity class
-         * Applicable only when `exposed-dao` module is used
-         * Can be overridden on per-transaction basis via [EntityCache.maxEntitiesToStore]
-         * All entities will be kept by default
+         * Amount of entities to keep in an EntityCache per an Entity class.
+         * Applicable only when `exposed-dao` module is used.
+         * Can be overridden on per-transaction basis via [EntityCache.maxEntitiesToStore].
+         * All entities will be kept by default.
          */
         var maxEntitiesToStoreInCachePerEntity: Int = Int.MAX_VALUE,
         /**
          * Turns on "mode" for Exposed DAO to store relations (after they were loaded)
          * within the entity that will allow to access them outside the transaction.
-         * Useful when [eager loading](https://github.com/JetBrains/Exposed/wiki/DAO#eager-loading) is used
+         * Useful when [eager loading](https://github.com/JetBrains/Exposed/wiki/DAO#eager-loading) is used.
          */
         var keepLoadedReferencesOutOfTransaction: Boolean = false,
 
         /**
-         * Set the explicit dialect for a database. Can be useful when working with not supported dialects which have the same behavior as the one that Exposed supports
+         * Set the explicit dialect for a database. Can be useful when working with unsupported dialects which have the same behavior as the one that Exposed supports.
          */
         var explicitDialect: DatabaseDialect? = null,
 
@@ -96,7 +96,7 @@ class DatabaseConfig private constructor(
         /**
          * Log too much result sets opened in parallel.
          * The error log will contain the stacktrace of the place in the code where new result set occurs, and it exceeds the threshold.
-         * 0 value means no log needed
+         * 0 value means no log needed.
          */
         var logTooMuchResultSetsThreshold: Int = 0,
     )

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -33,7 +33,9 @@ open class UserDataHolder {
     fun <T : Any> getOrCreate(key: Key<T>, init: () -> T): T = userdata.getOrPut(key, init) as T
 }
 
-open class Transaction(private val transactionImpl: TransactionInterface) : UserDataHolder(), TransactionInterface by transactionImpl {
+open class Transaction(
+    private val transactionImpl: TransactionInterface
+) : UserDataHolder(), TransactionInterface by transactionImpl {
     final override val db: Database = transactionImpl.db
 
     var statementCount: Int = 0
@@ -43,8 +45,10 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
 
     /** The number of retries that will be made inside this `transaction` block if SQLException happens */
     var repetitionAttempts: Int = db.transactionManager.defaultRepetitionAttempts
+
     /** The minimum number of milliseconds to wait before retrying this `transaction` if SQLException happens */
     var minRepetitionDelay: Long = db.transactionManager.defaultMinRepetitionDelay
+
     /** The maximum number of milliseconds to wait before retrying this `transaction` if SQLException happens */
     var maxRepetitionDelay: Long = db.transactionManager.defaultMaxRepetitionDelay
 
@@ -100,7 +104,11 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
     @Suppress("MagicNumber")
     private fun describeStatement(delta: Long, stmt: String): String = "[${delta}ms] ${stmt.take(1024)}\n\n"
 
-    fun exec(@Language("sql") stmt: String, args: Iterable<Pair<IColumnType, Any?>> = emptyList(), explicitStatementType: StatementType? = null) =
+    fun exec(
+        @Language("sql") stmt: String,
+        args: Iterable<Pair<IColumnType, Any?>> = emptyList(),
+        explicitStatementType: StatementType? = null
+    ) =
         exec(stmt, args, explicitStatementType) { }
 
     fun <T : Any> exec(
@@ -200,13 +208,18 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
 
     internal fun getRetryInterval(): Long = if (repetitionAttempts > 0) {
         maxOf((maxRepetitionDelay - minRepetitionDelay) / (repetitionAttempts + 1), 1)
-    } else 0
+    } else {
+        0
+    }
 
     companion object {
         internal val globalInterceptors = arrayListOf<GlobalStatementInterceptor>()
 
         init {
-            ServiceLoader.load(GlobalStatementInterceptor::class.java, GlobalStatementInterceptor::class.java.classLoader).forEach {
+            ServiceLoader.load(
+                GlobalStatementInterceptor::class.java,
+                GlobalStatementInterceptor::class.java.classLoader
+            ).forEach {
                 globalInterceptors.add(it)
             }
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -39,6 +39,9 @@ open class Transaction(private val transactionImpl: TransactionInterface) : User
     var duration: Long = 0
     var warnLongQueriesDuration: Long? = db.config.warnLongQueriesDuration
     var debug = false
+    var repetitionAttempts: Int = 0
+    var minRepetitionDelay: Long = 0
+    var maxRepetitionDelay: Long = 0
     val id by lazy { UUID.randomUUID().toString() }
 
     // currently executing statement. Used to log error properly

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -158,21 +158,15 @@ class ThreadLocalTransactionManager(
 fun <T> transaction(db: Database? = null, statement: Transaction.() -> T): T =
     transaction(
         db.transactionManager.defaultIsolationLevel,
-        db.transactionManager.defaultRepetitionAttempts,
         db.transactionManager.defaultReadOnly,
         db,
-        db.transactionManager.defaultMinRepetitionDelay,
-        db.transactionManager.defaultMaxRepetitionDelay,
         statement
     )
 
 fun <T> transaction(
     transactionIsolation: Int,
-    repetitionAttempts: Int,
     readOnly: Boolean = false,
     db: Database? = null,
-    minRepetitionDelay: Long = 0,
-    maxRepetitionDelay: Long = 0,
     statement: Transaction.() -> T
 ): T =
     keepAndRestoreTransactionRefAfterRun(db) {
@@ -207,12 +201,9 @@ fun <T> transaction(
                 }
             } ?: inTopLevelTransaction(
                 transactionIsolation,
-                repetitionAttempts,
                 readOnly,
                 db,
                 null,
-                minRepetitionDelay,
-                maxRepetitionDelay,
                 statement
             )
         }
@@ -220,12 +211,9 @@ fun <T> transaction(
 
 fun <T> inTopLevelTransaction(
     transactionIsolation: Int,
-    repetitionAttempts: Int,
     readOnly: Boolean = false,
     db: Database? = null,
     outerTransaction: Transaction? = null,
-    minRepetitionDelay: Long = 0,
-    maxRepetitionDelay: Long = 0,
     statement: Transaction.() -> T
 ): T {
 
@@ -234,10 +222,8 @@ fun <T> inTopLevelTransaction(
 
         val outerManager = outerTransaction?.db.transactionManager.takeIf { it.currentOrNull() != null }
 
-        var intermediateDelay = minRepetitionDelay
-        var retryInterval = if (repetitionAttempts > 0) {
-             maxOf((maxRepetitionDelay - minRepetitionDelay) / (repetitionAttempts + 1), 1)
-        } else 0
+        var intermediateDelay: Long = 0
+        var retryInterval: Long? = null
 
         while (true) {
             db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
@@ -249,28 +235,33 @@ fun <T> inTopLevelTransaction(
                 val answer = transaction.statement()
                 transaction.commit()
                 return answer
-            } catch (e: SQLException) {
-                handleSQLException(e, transaction, repetitions)
+            } catch (cause: SQLException) {
+                handleSQLException(cause, transaction, repetitions)
                 repetitions++
-                if (repetitions >= repetitionAttempts) {
-                    throw e
+                if (repetitions >= transaction.repetitionAttempts) {
+                    throw cause
+                }
+
+                if (retryInterval == null) {
+                    retryInterval = transaction.getRetryInterval()
+                    intermediateDelay = transaction.minRepetitionDelay
                 }
                 // set delay value with an exponential backoff time period.
                 val delay = when {
-                    minRepetitionDelay < maxRepetitionDelay -> {
+                    transaction.minRepetitionDelay < transaction.maxRepetitionDelay -> {
                         intermediateDelay += retryInterval * repetitions
                         ThreadLocalRandom.current().nextLong(intermediateDelay, intermediateDelay + retryInterval)
                     }
-                    minRepetitionDelay == maxRepetitionDelay -> minRepetitionDelay
+                    transaction.minRepetitionDelay == transaction.maxRepetitionDelay -> transaction.minRepetitionDelay
                     else -> 0
                 }
                 exposedLogger.warn("Wait $delay milliseconds before retrying")
                 try {
                     Thread.sleep(delay)
-                } catch (e: InterruptedException) {
+                } catch (cause: InterruptedException) {
                   // Do nothing
                 }
-            } catch (e: Throwable) {
+            } catch (cause: Throwable) {
                 val currentStatement = transaction.currentStatement
                 transaction.rollbackLoggingException {
                     exposedLogger.warn(
@@ -278,7 +269,7 @@ fun <T> inTopLevelTransaction(
                         it
                     )
                 }
-                throw e
+                throw cause
             } finally {
                 TransactionManager.resetCurrent(outerManager)
                 closeStatementsAndConnection(transaction)
@@ -301,16 +292,16 @@ private fun <T> keepAndRestoreTransactionRefAfterRun(db: Database? = null, block
     }
 }
 
-internal fun handleSQLException(e: SQLException, transaction: Transaction, repetitions: Int) {
-    val exposedSQLException = e as? ExposedSQLException
+internal fun handleSQLException(cause: SQLException, transaction: Transaction, repetitions: Int) {
+    val exposedSQLException = cause as? ExposedSQLException
     val queriesToLog = exposedSQLException?.causedByQueries()?.joinToString(";\n") ?: "${transaction.currentStatement}"
-    val message = "Transaction attempt #$repetitions failed: ${e.message}. Statement(s): $queriesToLog"
+    val message = "Transaction attempt #$repetitions failed: ${cause.message}. Statement(s): $queriesToLog"
     exposedSQLException?.contexts?.forEach {
         transaction.interceptors.filterIsInstance<SqlLogger>().forEach { logger ->
             logger.log(it, transaction)
         }
     }
-    exposedLogger.warn(message, e)
+    exposedLogger.warn(message, cause)
     transaction.rollbackLoggingException { exposedLogger.warn("Transaction rollback failed: ${it.message}. See previous log line for statement", it) }
 }
 
@@ -323,8 +314,8 @@ internal fun closeStatementsAndConnection(transaction: Transaction) {
             transaction.currentStatement = null
         }
         transaction.closeExecutedStatements()
-    } catch (e: Exception) {
-        exposedLogger.warn("Statements close failed", e)
+    } catch (cause: Exception) {
+        exposedLogger.warn("Statements close failed", cause)
     }
     transaction.closeLoggingException { exposedLogger.warn("Transaction close failed: ${it.message}. Statement: $currentStatement", it) }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -102,9 +102,7 @@ class ThreadLocalTransactionManager(
             get() = connectionLazy.value
 
         private val useSavePoints = outerTransaction != null && db.useNestedTransactions
-        private var savepoint: ExposedSavepoint? = if (useSavePoints) {
-            connection.setSavepoint(savepointName)
-        } else null
+        private var savepoint: ExposedSavepoint? = if (useSavePoints) connection.setSavepoint(savepointName) else null
 
         override fun commit() {
             if (connectionLazy.isInitialized()) {
@@ -216,7 +214,6 @@ fun <T> inTopLevelTransaction(
     outerTransaction: Transaction? = null,
     statement: Transaction.() -> T
 ): T {
-
     fun run(): T {
         var repetitions = 0
 
@@ -259,7 +256,7 @@ fun <T> inTopLevelTransaction(
                 try {
                     Thread.sleep(delay)
                 } catch (cause: InterruptedException) {
-                  // Do nothing
+                    // Do nothing
                 }
             } catch (cause: Throwable) {
                 val currentStatement = transaction.currentStatement
@@ -302,7 +299,9 @@ internal fun handleSQLException(cause: SQLException, transaction: Transaction, r
         }
     }
     exposedLogger.warn(message, cause)
-    transaction.rollbackLoggingException { exposedLogger.warn("Transaction rollback failed: ${it.message}. See previous log line for statement", it) }
+    transaction.rollbackLoggingException {
+        exposedLogger.warn("Transaction rollback failed: ${it.message}. See previous log line for statement", it)
+    }
 }
 
 internal fun closeStatementsAndConnection(transaction: Transaction) {
@@ -317,5 +316,7 @@ internal fun closeStatementsAndConnection(transaction: Transaction) {
     } catch (cause: Exception) {
         exposedLogger.warn("Statements close failed", cause)
     }
-    transaction.closeLoggingException { exposedLogger.warn("Transaction close failed: ${it.message}. Statement: $currentStatement", it) }
+    transaction.closeLoggingException {
+        exposedLogger.warn("Transaction close failed: ${it.message}. Statement: $currentStatement", it)
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -162,4 +162,5 @@ internal inline fun TransactionInterface.closeLoggingException(log: (Exception) 
 }
 
 val Database?.transactionManager: TransactionManager
-    get() = TransactionManager.managerFor(this) ?: throw RuntimeException("database $this don't have any transaction manager")
+    get() = TransactionManager.managerFor(this)
+        ?: throw RuntimeException("database $this don't have any transaction manager")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionScope.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionScope.kt
@@ -13,7 +13,6 @@ class TransactionStore<T : Any>(val init: (Transaction.() -> T)? = null) : ReadW
 
     private val key = Key<T>()
 
-    @Suppress("UNCHECKED_CAST")
     override fun getValue(thisRef: Any?, property: KProperty<*>): T? {
         val currentOrNullTransaction = TransactionManager.currentOrNull()
         return currentOrNullTransaction?.getUserData(key)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
@@ -63,9 +63,15 @@ suspend fun <T> newSuspendedTransaction(
         suspendedTransactionAsyncInternal(true, repetitionAttempts, minRepetitionDelay, maxRepetitionDelay, statement).await()
     }
 
-suspend fun <T> Transaction.suspendedTransaction(context: CoroutineContext? = null, statement: suspend Transaction.() -> T): T =
+suspend fun <T> Transaction.suspendedTransaction(
+    context: CoroutineContext? = null,
+    repetitionAttempts: Int = 0,
+    minRepetitionDelay: Long = 0,
+    maxRepetitionDelay: Long = 0,
+    statement: suspend Transaction.() -> T
+): T =
     withTransactionScope(context, this, db = null, transactionIsolation = null) {
-        suspendedTransactionAsyncInternal(false, 0, 0, 0, statement).await()
+        suspendedTransactionAsyncInternal(false, repetitionAttempts, minRepetitionDelay, maxRepetitionDelay, statement).await()
     }
 
 suspend fun <T> suspendedTransactionAsync(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
@@ -20,12 +20,16 @@ import kotlin.coroutines.coroutineContext
 
 internal class TransactionContext(val manager: TransactionManager?, val transaction: Transaction?)
 
-internal class TransactionScope(internal val tx: Lazy<Transaction>, parent: CoroutineContext) : CoroutineScope, CoroutineContext.Element {
+internal class TransactionScope(
+    internal val tx: Lazy<Transaction>,
+    parent: CoroutineContext
+) : CoroutineScope, CoroutineContext.Element {
     private val baseScope = CoroutineScope(parent)
     override val coroutineContext get() = baseScope.coroutineContext + this
     override val key = Companion
 
-    internal fun holdsSameTransaction(transaction: Transaction?) = transaction != null && tx.isInitialized() && tx.value == transaction
+    internal fun holdsSameTransaction(transaction: Transaction?) =
+        transaction != null && tx.isInitialized() && tx.value == transaction
     companion object : CoroutineContext.Key<TransactionScope>
 }
 
@@ -73,7 +77,10 @@ suspend fun <T> newSuspendedTransaction(
  * The resulting `TransactionScope` is derived from the current `coroutineContext` if the latter already holds [this] `Transaction`;
  * otherwise, a new scope is created using [this] `Transaction` and a given coroutine [context].
  */
-suspend fun <T> Transaction.withSuspendTransaction(context: CoroutineContext? = null, statement: suspend Transaction.() -> T): T =
+suspend fun <T> Transaction.withSuspendTransaction(
+    context: CoroutineContext? = null,
+    statement: suspend Transaction.() -> T
+): T =
     withTransactionScope(context, this, db = null, transactionIsolation = null) {
         suspendedTransactionAsyncInternal(false, statement).await()
     }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -84,7 +84,8 @@ enum class TestDB(
         beforeConnection = {
             Locale.setDefault(Locale.ENGLISH)
             val tmp = Database.connect(ORACLE.connection(), user = "sys as sysdba", password = "Oracle18", driver = ORACLE.driver)
-            transaction(Connection.TRANSACTION_READ_COMMITTED, 1, db  = tmp) {
+            transaction(Connection.TRANSACTION_READ_COMMITTED, db  = tmp) {
+                repetitionAttempts = 1
                 try {
                     exec("DROP USER ExposedTest CASCADE")
                 } catch (e: Exception) { // ignore
@@ -205,7 +206,8 @@ abstract class DatabaseTestsBase {
 
         val database = dbSettings.db!!
         try {
-            transaction(database.transactionManager.defaultIsolationLevel, 1, db = database) {
+            transaction(database.transactionManager.defaultIsolationLevel, db = database) {
+                repetitionAttempts = 1
                 registerInterceptor(CurrentTestDBInterceptor)
                 currentTestDB = dbSettings
                 statement(dbSettings)
@@ -246,7 +248,8 @@ abstract class DatabaseTestsBase {
                         commit()
                     } catch (_: Exception) {
                         val database = testDB.db!!
-                        inTopLevelTransaction(database.transactionManager.defaultIsolationLevel, 1, db = database) {
+                        inTopLevelTransaction(database.transactionManager.defaultIsolationLevel, db = database) {
+                            repetitionAttempts = 1
                             SchemaUtils.drop(*tables)
                         }
                     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
@@ -190,7 +190,8 @@ class MultiDatabaseEntityTest {
                 b2Reread.y = null
             }
         }
-        inTopLevelTransaction(Connection.TRANSACTION_READ_COMMITTED, 1, db = db1) {
+        inTopLevelTransaction(Connection.TRANSACTION_READ_COMMITTED, db = db1) {
+            repetitionAttempts = 1
             assertNull(EntityTestsData.BEntity.testCache(db1b1.id))
             val b1Reread = EntityTestsData.BEntity[db1b1.id]
             assertEquals(db1b1.id, b1Reread.id)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseTest.kt
@@ -12,7 +12,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import org.jetbrains.exposed.sql.transactions.experimental.suspendedTransaction
+import org.jetbrains.exposed.sql.transactions.experimental.withSuspendTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.junit.After
@@ -192,7 +192,7 @@ class MultiDatabaseTest {
                 assertEquals(2L, DMLTestsData.Cities.selectAll().count())
                 assertEquals("city3", DMLTestsData.Cities.selectAll().last()[DMLTestsData.Cities.name])
 
-                tr1.suspendedTransaction {
+                tr1.withSuspendTransaction {
                     assertEquals(1L, DMLTestsData.Cities.selectAll().count())
                     DMLTestsData.Cities.insert {
                         it[DMLTestsData.Cities.name] = "city4"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
@@ -82,7 +82,7 @@ class CoroutineTests : DatabaseTestsBase() {
                 }
 
                 val insertJob = launch {
-                    newSuspendedTransaction(Dispatchers.Default, db = db, repetitionAttempts = 10) {
+                    newSuspendedTransaction(Dispatchers.Default, db = db, repetitionAttempts = 20) {
                         TestingUnique.insert { it[id] = originalId }
                         // throws JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation
                         // until original row is updated with a new id
@@ -92,7 +92,7 @@ class CoroutineTests : DatabaseTestsBase() {
                     }
                 }
                 val updateJob = launch {
-                    newSuspendedTransaction(Dispatchers.Default, db = db, repetitionAttempts = 10) {
+                    newSuspendedTransaction(Dispatchers.Default, db = db, repetitionAttempts = 20) {
                         TestingUnique.update({ TestingUnique.id eq originalId }) { it[id] = updatedId }
 
                         withSuspendTransaction {
@@ -159,13 +159,13 @@ class CoroutineTests : DatabaseTestsBase() {
                 }
 
                 val (insertResult, updateResult) = listOf(
-                    suspendedTransactionAsync(db = db, repetitionAttempts = 10) {
+                    suspendedTransactionAsync(db = db, repetitionAttempts = 20) {
                         TestingUnique.insert { it[id] = originalId }
                         // throws JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation
                         // until original row is updated with a new id
                         TestingUnique.selectAll().count()
                     },
-                    suspendedTransactionAsync(db = db, repetitionAttempts = 10) {
+                    suspendedTransactionAsync(db = db, repetitionAttempts = 20) {
                         TestingUnique.update({ TestingUnique.id eq originalId }) { it[id] = updatedId }
                         TestingUnique.selectAll().count()
                     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
@@ -13,7 +13,7 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.RepeatableTest
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import org.jetbrains.exposed.sql.transactions.experimental.suspendedTransaction
+import org.jetbrains.exposed.sql.transactions.experimental.withSuspendTransaction
 import org.jetbrains.exposed.sql.transactions.experimental.suspendedTransactionAsync
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Rule
@@ -31,6 +31,10 @@ class CoroutineTests : DatabaseTestsBase() {
 
     object Testing : IntIdTable("COROUTINE_TESTING")
 
+    object TestingUnique : Table("COROUTINE_UNIQUE") {
+        val id = integer("id").uniqueIndex()
+    }
+
     @Rule
     @JvmField
     val timeout = CoroutinesTimeout.seconds(60)
@@ -44,7 +48,7 @@ class CoroutineTests : DatabaseTestsBase() {
                     newSuspendedTransaction(db = db) {
                         Testing.insert {}
 
-                        suspendedTransaction {
+                        withSuspendTransaction {
                             assertEquals(1, Testing.select { Testing.id.eq(1) }.singleOrNull()?.getOrNull(Testing.id)?.value)
                         }
                     }
@@ -65,48 +69,47 @@ class CoroutineTests : DatabaseTestsBase() {
     }
 
     @Test @RepeatableTest(10)
-    fun testSuspendedTransactionWithRepetition() {
-        // SQLServer requires IDENTITY_INSERT flag to insert explicit value for identity column
-        withTables(excludeSettings = listOf(TestDB.SQLSERVER), Testing) {
+    fun testSuspendTransactionWithRepetition() {
+        withTables(TestingUnique) {
             val (originalId, updatedId) = 1 to 99
             val mainJob = GlobalScope.async(Dispatchers.Default) {
                 newSuspendedTransaction(Dispatchers.Default, db = db) {
-                    Testing.insert { it[id] = originalId }
+                    TestingUnique.insert { it[id] = originalId }
 
-                    suspendedTransaction {
-                        assertEquals(originalId, Testing.selectAll().singleOrNull()?.get(Testing.id)?.value)
+                    withSuspendTransaction {
+                        assertEquals(originalId, TestingUnique.selectAll().single()[TestingUnique.id])
                     }
                 }
 
                 val insertJob = launch {
                     newSuspendedTransaction(Dispatchers.Default, db = db, repetitionAttempts = 10) {
-                        Testing.insert { it[id] = originalId }
+                        TestingUnique.insert { it[id] = originalId }
                         // throws JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation
                         // until original row is updated with a new id
-                        suspendedTransaction {
-                            assertEquals(2, Testing.selectAll().count())
+                        withSuspendTransaction {
+                            assertEquals(2, TestingUnique.selectAll().count())
                         }
                     }
                 }
                 val updateJob = launch {
                     newSuspendedTransaction(Dispatchers.Default, db = db, repetitionAttempts = 10) {
-                        Testing.update({ Testing.id eq originalId }) { it[id] = updatedId }
+                        TestingUnique.update({ TestingUnique.id eq originalId }) { it[id] = updatedId }
 
-                        suspendedTransaction {
-                            assertEquals(updatedId, Testing.selectAll().singleOrNull()?.get(Testing.id)?.value)
+                        withSuspendTransaction {
+                            assertEquals(updatedId, TestingUnique.selectAll().single()[TestingUnique.id])
                         }
                     }
                 }
                 insertJob.join()
                 updateJob.join()
 
-                val result = newSuspendedTransaction(Dispatchers.Default, db = db) { Testing.selectAll().count() }
+                val result = newSuspendedTransaction(Dispatchers.Default, db = db) { TestingUnique.selectAll().count() }
                 kotlin.test.assertEquals(2, result, "Failing at end of mainJob")
             }
 
             while (!mainJob.isCompleted) Thread.sleep(100)
             mainJob.getCompletionExceptionOrNull()?.let { throw it }
-            assertEqualCollections(listOf(updatedId, originalId), Testing.selectAll().map { it[Testing.id].value })
+            assertEqualCollections(listOf(updatedId, originalId), TestingUnique.selectAll().map { it[TestingUnique.id] })
         }
     }
 
@@ -117,7 +120,7 @@ class CoroutineTests : DatabaseTestsBase() {
                 val launchResult = suspendedTransactionAsync(Dispatchers.IO, db = db) {
                     Testing.insert {}
 
-                    suspendedTransaction {
+                    withSuspendTransaction {
                         assertEquals(1, Testing.select { Testing.id.eq(1) }.singleOrNull()?.getOrNull(Testing.id)?.value)
                     }
                 }
@@ -143,29 +146,28 @@ class CoroutineTests : DatabaseTestsBase() {
     }
 
     @Test @RepeatableTest(10)
-    fun testSuspendedTransactionAsyncWithRepetition() {
-        // SQLServer requires IDENTITY_INSERT flag to insert explicit value for identity column
-        withTables(excludeSettings = listOf(TestDB.SQLSERVER, TestDB.SQLITE), Testing) {
+    fun testSuspendTransactionAsyncWithRepetition() {
+        withTables(excludeSettings = listOf(TestDB.SQLITE), TestingUnique) {
             val (originalId, updatedId) = 1 to 99
             val mainJob = GlobalScope.async(Dispatchers.Default) {
                 newSuspendedTransaction(Dispatchers.Default, db = db) {
-                    Testing.insert { it[id] = originalId }
+                    TestingUnique.insert { it[id] = originalId }
 
-                    suspendedTransaction {
-                        assertEquals(originalId, Testing.selectAll().singleOrNull()?.get(Testing.id)?.value)
+                    withSuspendTransaction {
+                        assertEquals(originalId, TestingUnique.selectAll().single()[TestingUnique.id])
                     }
                 }
 
                 val (insertResult, updateResult) = listOf(
                     suspendedTransactionAsync(db = db, repetitionAttempts = 10) {
-                        Testing.insert { it[id] = originalId }
+                        TestingUnique.insert { it[id] = originalId }
                         // throws JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation
                         // until original row is updated with a new id
-                        Testing.selectAll().count()
+                        TestingUnique.selectAll().count()
                     },
                     suspendedTransactionAsync(db = db, repetitionAttempts = 10) {
-                        Testing.update({ Testing.id eq originalId }) { it[id] = updatedId }
-                        Testing.selectAll().count()
+                        TestingUnique.update({ TestingUnique.id eq originalId }) { it[id] = updatedId }
+                        TestingUnique.selectAll().count()
                     }
                 ).awaitAll()
 
@@ -175,7 +177,7 @@ class CoroutineTests : DatabaseTestsBase() {
 
             while (!mainJob.isCompleted) Thread.sleep(100)
             mainJob.getCompletionExceptionOrNull()?.let { throw it }
-            assertEqualCollections(listOf(updatedId, originalId), Testing.selectAll().map { it[Testing.id].value })
+            assertEqualCollections(listOf(updatedId, originalId), TestingUnique.selectAll().map { it[TestingUnique.id] })
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
@@ -58,7 +58,8 @@ class NestedTransactionsTest : DatabaseTestsBase() {
             assertNotNull(TransactionManager.currentOrNull())
 
             try {
-                inTopLevelTransaction(this.transactionIsolation, 1) {
+                inTopLevelTransaction(this.transactionIsolation) {
+                    repetitionAttempts = 1
                     throw IllegalStateException("Should be rethrow")
                 }
             } catch (e: Exception) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -622,16 +622,18 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     private fun <T> newTransaction(statement: Transaction.() -> T) =
-        inTopLevelTransaction(TransactionManager.manager.defaultIsolationLevel, 1, false, null, null, 0, 0, statement)
+        inTopLevelTransaction(TransactionManager.manager.defaultIsolationLevel, false, null, null, statement)
 
     @Test fun sharingEntityBetweenTransactions() {
         withTables(Humans) {
             val human1 = newTransaction {
+                repetitionAttempts = 1
                 Human.new {
                     this.h = "foo"
                 }
             }
             newTransaction {
+                repetitionAttempts = 1
                 assertEquals(null, Human.testCache(human1.id))
                 assertEquals("foo", Humans.selectAll().single()[Humans.h])
                 human1.h = "bar"
@@ -640,6 +642,7 @@ class EntityTests : DatabaseTestsBase() {
             }
 
             newTransaction {
+                repetitionAttempts = 1
                 assertEquals("bar", Humans.selectAll().single()[Humans.h])
             }
         }
@@ -779,7 +782,7 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
                 School.all().with(School::region)
                 assertNotNull(School.testCache(school1.id))
                 assertNotNull(School.testCache(school2.id))
@@ -807,7 +810,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 School.find {
                     Schools.id eq school1.id
                 }.first().load(School::region)
@@ -848,7 +852,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 School.all().with(School::region, School::secondaryRegion)
                 assertNotNull(School.testCache(school1.id))
                 assertNotNull(School.testCache(school2.id))
@@ -879,7 +884,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 val school2 = School.find {
                     Schools.id eq school1.id
                 }.first().load(School::secondaryRegion)
@@ -939,7 +945,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 val cache = TransactionManager.current().entityCache
 
                 School.all().with(School::students)
@@ -980,7 +987,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 val cache = TransactionManager.current().entityCache
 
                 School.find { Schools.id eq school1.id }.first().load(School::students)
@@ -1025,7 +1033,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 School.all().with(School::students, Student::detentions)
                 val cache = TransactionManager.current().entityCache
 
@@ -1088,7 +1097,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 School.all().with(School::holidays)
                 val cache = TransactionManager.current().entityCache
 
@@ -1236,7 +1246,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 Student.all().with(Student::bio)
                 val cache = TransactionManager.current().entityCache
 
@@ -1280,7 +1291,8 @@ class EntityTests : DatabaseTestsBase() {
 
             commit()
 
-            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE, 1) {
+            inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
+                repetitionAttempts = 1
                 Student.all().first().load(Student::bio)
                 val cache = TransactionManager.current().entityCache
 


### PR DESCRIPTION
Refactor suspend transaction functions, `newSuspendedTransaction` and `suspendedTransactionAsync`, to implement a similar retry policy as regular `transaction` by introducing mutable properties to `Transaction` class:
- repetitionAttempts
- minRepetitionDelay
- maxRepetitionDelay

```kt
newSuspendedTransaction {
    repetitionAttempts = 10
    // statements
}
```

Rename `Transaction.suspendedTransaction()` to `Transaction.withSuspendTransaction()`.

To be consistent across both regular and suspend transactions, these repetition parameters have been removed from `transaction` in favor of using the same `Transaction` class properties. 
```kt
transaction {
    repetitionAttempts = 10
    // statements
}
```
**Note** that current behavior had an empty transaction block (with no set repetition arguments) using the default values set in `DatabaseConfig`, so this has been maintained even with the new setup.

Add unit tests:
- To simulate a constraint violation and concurrent update, which is only resolved by multiple statement retries.
- To test that `transaction` uses repetition values properly.

**Additional:**
- Rename nested function parameter from `_tx` to `currentTransaction`, in order to remove Detekt warning about `FunctionParameterNaming` starting with underscore.