### PR TITLE
chore: add detekt IntelliJ plugin configuration to detekt.xml

### DIFF
--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="DetektProjectConfiguration">
-    <enableDetekt>true</enableDetekt>
-    <enableFormatting>true</enableFormatting>
-    <buildUponDefaultConfig>true</buildUponDefaultConfig>
-    <configPaths>$PROJECT_DIR$/detekt.yml</configPaths>
-  </component>
+    <component name="DetektProjectConfiguration">
+        <enableDetekt>true</enableDetekt>
+        <enableFormatting>true</enableFormatting>
+        <buildUponDefaultConfig>true</buildUponDefaultConfig>
+        <configPaths>$PROJECT_DIR$/detekt.yml</configPaths>
+    </component>
+
+    <component name="DetektPluginSettings">
+        <enableDetekt>true</enableDetekt>
+        <enableFormatting>true</enableFormatting>
+        <buildUponDefaultConfig>true</buildUponDefaultConfig>
+        <configPaths>$PROJECT_DIR$/detekt.yml</configPaths>
+    </component>
 </project>


### PR DESCRIPTION
This change makes the warnings that appear in the IDE based on rules set in the `detekt.yml` config file. The steps to do it were Settings -> Tools -> detekt -> + Add configuration file -> Choose detekt.yml. This automatically adds a component called "DetektPluginSettings" in `detekt.xml`, which I modified further.

Thanks @bog-walk for catching this.