### PR TITLE
test: Add json/jsonb array tests

### DIFF
--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -8,10 +8,12 @@ import org.jetbrains.exposed.sql.transactions.nullableTransactionScope
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.junit.Assume
 import org.junit.AssumptionViolatedException
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.containers.PostgreSQLContainer
+import java.math.BigDecimal
 import java.sql.Connection
 import java.sql.SQLException
 import java.time.Duration
@@ -290,6 +292,8 @@ abstract class DatabaseTestsBase {
             statement(dbSettings)
         }
     }
+
+    fun Transaction.isOldMySql(version: String = "8.0") = currentDialectTest is MysqlDialect && !db.isVersionCovers(BigDecimal(version))
 
     protected fun prepareSchemaForTest(schemaName: String) : Schema {
         return Schema(schemaName, defaultTablespace = "USERS", temporaryTablespace = "TEMP ", quota = "20M", on = "USERS")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -52,9 +52,8 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(id)
         }
 
-        withDb { dbSetting ->
-            val tooOldMysql = dbSetting == TestDB.MYSQL && !db.isVersionCovers(BigDecimal("5.6"))
-            if (!tooOldMysql) {
+        withDb {
+            if (!isOldMySql()) {
                 SchemaUtils.createMissingTablesAndColumns(TestTable)
                 assertTrue(TestTable.exists())
                 try {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -11,7 +11,6 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.statements.BatchInsertStatement
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
-import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
@@ -19,10 +18,8 @@ import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.entities.EntityTests
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.junit.Assume
 import org.junit.Test
-import java.math.BigDecimal
 import java.sql.SQLException
 import java.util.*
 import kotlin.test.assertEquals
@@ -381,8 +378,7 @@ class InsertTests : DatabaseTestsBase() {
         val emojis = "\uD83D\uDC68\uD83C\uDFFF\u200D\uD83D\uDC69\uD83C\uDFFF\u200D\uD83D\uDC67\uD83C\uDFFF\u200D\uD83D\uDC66\uD83C\uDFFF"
 
         withTables(TestDB.allH2TestDB + TestDB.SQLSERVER + TestDB.ORACLE, table) {
-            val isOldMySQL = currentDialectTest is MysqlDialect && db.isVersionCovers(BigDecimal("5.5"))
-            if (isOldMySQL) {
+            if (isOldMySql()) {
                 exec("ALTER TABLE ${table.nameInDatabaseCase()} DEFAULT CHARSET utf8mb4, MODIFY emoji VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
             }
             table.insert {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonContains
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonExists
@@ -11,6 +12,7 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.currentTestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.OracleDialect
@@ -212,6 +214,46 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
                 val usersOnTeamA = tester.slice(tester.id).select { isOnTeamA }
                 assertEquals(newId, usersOnTeamA.single()[tester.id])
             }
+        }
+    }
+
+    @Test
+    fun testJsonExtractWithArrays() {
+        withJsonArrays(exclude = TestDB.allH2TestDB) { tester, singleId, _ ->
+            val path1 = if (currentDialectTest is PostgreSQLDialect) arrayOf("users", "0", "team") else arrayOf(".users[0].team")
+            val firstIsOnTeamA = tester.groups.jsonExtract<String>(*path1) eq "Team A"
+            assertEquals(singleId, tester.select { firstIsOnTeamA }.single()[tester.id])
+
+            // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            val path2 = if (currentDialectTest is PostgreSQLDialect) "0" else "[0]"
+            val firstNumber = tester.numbers.jsonExtract<Int>(path2, toScalar = !isOldMySql())
+            assertEqualCollections(listOf(100, 3), tester.slice(firstNumber).selectAll().map { it[firstNumber] })
+        }
+    }
+
+    @Test
+    fun testJsonContainsWithArrays() {
+        withJsonArrays(exclude = jsonContainsNotSupported) { tester, _, tripleId ->
+            val hasSmallNumbers = tester.numbers.jsonContains("[3, 5]")
+            assertEquals(tripleId, tester.select { hasSmallNumbers }.single()[tester.id])
+
+            if (currentTestDB in TestDB.mySqlRelatedDB) {
+                val hasUserNameB = tester.groups.jsonContains("\"B\"", ".users[0].name")
+                assertEquals(tripleId, tester.select { hasUserNameB }.single()[tester.id])
+            }
+        }
+    }
+
+    @Test
+    fun testJsonExistsWithArrays() {
+        withJsonArrays(exclude = TestDB.allH2TestDB + TestDB.SQLSERVER) { tester, _, tripleId ->
+            val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
+
+            val hasMultipleUsers = tester.groups.jsonExists(".users[1]", optional = optional)
+            assertEquals(tripleId, tester.select { hasMultipleUsers }.single()[tester.id])
+
+            val hasAtLeast3Numbers = tester.numbers.jsonExists("[2]", optional = optional)
+            assertEquals(tripleId, tester.select { hasAtLeast3Numbers }.single()[tester.id])
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonTestsData.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonTestsData.kt
@@ -35,12 +35,12 @@ object JsonTestsData {
     }
 
     object JsonArrays : IntIdTable("j_arrays") {
-        val groups = json<UserGroup>("projects", Json.Default)
+        val groups = json<UserGroup>("groups", Json.Default)
         val numbers = json<IntArray>("numbers", Json.Default)
     }
 
     object JsonBArrays : IntIdTable("j_b_arrays") {
-        val groups = jsonb<UserGroup>("projects", Json.Default)
+        val groups = jsonb<UserGroup>("groups", Json.Default)
         val numbers = jsonb<IntArray>("numbers", Json.Default)
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonTestsData.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonTestsData.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 
@@ -31,6 +32,16 @@ object JsonTestsData {
         companion object : IntEntityClass<JsonBEntity>(JsonBTable)
 
         var jsonBColumn by JsonBTable.jsonBColumn
+    }
+
+    object JsonArrays : IntIdTable("j_arrays") {
+        val groups = json<UserGroup>("projects", Json.Default)
+        val numbers = json<IntArray>("numbers", Json.Default)
+    }
+
+    object JsonBArrays : IntIdTable("j_b_arrays") {
+        val groups = jsonb<UserGroup>("projects", Json.Default)
+        val numbers = jsonb<IntArray>("numbers", Json.Default)
     }
 }
 
@@ -78,8 +89,63 @@ fun DatabaseTestsBase.withJsonBTable(
     }
 }
 
+fun DatabaseTestsBase.withJsonArrays(
+    exclude: List<TestDB> = emptyList(),
+    statement: Transaction.(tester: JsonTestsData.JsonArrays, singleId: EntityID<Int>, tripleId: EntityID<Int>) -> Unit
+) {
+    val tester = JsonTestsData.JsonArrays
+
+    withDb(excludeSettings = exclude) { testDb ->
+        excludingH2Version1(testDb) {
+            SchemaUtils.create(tester)
+
+            val singleId = tester.insertAndGetId {
+                it[tester.groups] = UserGroup(listOf(User("A", "Team A")))
+                it[tester.numbers] = intArrayOf(100)
+            }
+            val tripleId = tester.insertAndGetId {
+                it[tester.groups] = UserGroup(List(3) { i -> User("${'B' + i}", "Team ${'B' + i}") })
+                it[tester.numbers] = intArrayOf(3, 4, 5)
+            }
+
+            statement(tester, singleId, tripleId)
+
+            SchemaUtils.drop(tester)
+        }
+    }
+}
+
+fun DatabaseTestsBase.withJsonBArrays(
+    exclude: List<TestDB> = emptyList(),
+    statement: Transaction.(tester: JsonTestsData.JsonBArrays, singleId: EntityID<Int>, tripleId: EntityID<Int>) -> Unit
+) {
+    val tester = JsonTestsData.JsonBArrays
+
+    withDb(excludeSettings = exclude) { testDb ->
+        excludingH2Version1(testDb) {
+            SchemaUtils.create(tester)
+
+            val singleId = tester.insertAndGetId {
+                it[tester.groups] = UserGroup(listOf(User("A", "Team A")))
+                it[tester.numbers] = intArrayOf(100)
+            }
+            val tripleId = tester.insertAndGetId {
+                it[tester.groups] = UserGroup(List(3) { i -> User("${'B' + i}", "Team ${'B' + i}") })
+                it[tester.numbers] = intArrayOf(3, 4, 5)
+            }
+
+            statement(tester, singleId, tripleId)
+
+            SchemaUtils.drop(tester)
+        }
+    }
+}
+
 @Serializable
 data class DataHolder(val user: User, val logins: Int, val active: Boolean, val team: String?)
 
 @Serializable
 data class User(val name: String, val team: String?)
+
+@Serializable
+data class UserGroup(val users: List<User>)


### PR DESCRIPTION
Add unit tests for JSON and JSONB functions using stored values that contain either a top-level JSON array (`'[1, 2, 3]'`) or an array nested in a JSON object (`'{"a":1,"b":[1, 2, 3]}'`).

Extract common conditional check for older versions of MySQL (and MariaDB) to `DatabaseTestsBase` class.