### PR TITLE
test: Add jsonb datetime tests

### DIFF
--- a/exposed-java-time/build.gradle.kts
+++ b/exposed-java-time/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     kotlin("jvm") apply true
+    kotlin("plugin.serialization") apply true
     id("testWithDBs")
 }
 

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -1,5 +1,11 @@
 package org.jetbrains.exposed
 
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
@@ -10,6 +16,7 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.vendors.*
 import org.junit.Assert.fail
 import org.junit.Test
@@ -261,6 +268,42 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             assertEquals(2, createdIn2023.size)
         }
     }
+
+    @Test
+    fun testDateTimeAsJsonB() {
+        val tester = object : Table("tester") {
+            val created = datetime("created")
+            val modified = jsonb<ModifierData>("modified", Json.Default)
+        }
+
+        withTables(excludeSettings = TestDB.allH2TestDB + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
+            val dateTimeNow = LocalDateTime.now()
+            tester.insert {
+                it[created] = dateTimeNow.minusYears(1)
+                it[modified] = ModifierData(1, dateTimeNow)
+            }
+            tester.insert {
+                it[created] = dateTimeNow.plusYears(1)
+                it[modified] = ModifierData(2, dateTimeNow)
+            }
+
+            val prefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
+
+            // value extracted in same manner it is stored, a json string
+            val modifiedAsString = tester.modified.jsonExtract<String>("${prefix}timestamp")
+            val allModifiedAsString = tester.slice(modifiedAsString).selectAll()
+            assertTrue(allModifiedAsString.all { it[modifiedAsString] == dateTimeNow.toString() })
+
+            // PostgreSQL requires explicit type cast to timestamp for in-DB comparison
+            val dateModified = if (currentDialectTest is PostgreSQLDialect) {
+                tester.modified.jsonExtract<LocalDateTime>("${prefix}timestamp").castTo(JavaLocalDateTimeColumnType())
+            } else {
+                tester.modified.jsonExtract<LocalDateTime>("${prefix}timestamp")
+            }
+            val modifiedBeforeCreation = tester.select { dateModified less tester.created }.single()
+            assertEquals(2, modifiedBeforeCreation[tester.modified].userId)
+        }
+    }
 }
 
 fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {
@@ -336,4 +379,17 @@ val today: LocalDate = LocalDate.now()
 object CitiesTime : IntIdTable("CitiesTime") {
     val name = varchar("name", 50) // Column<String>
     val local_time = datetime("local_time").nullable() // Column<datetime>
+}
+
+@Serializable
+data class ModifierData(
+    val userId: Int,
+    @Serializable(with = DateTimeSerializer::class)
+    val timestamp: LocalDateTime
+)
+
+object DateTimeSerializer : KSerializer<LocalDateTime> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: LocalDateTime) = encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder): LocalDateTime = LocalDateTime.parse(decoder.decodeString())
 }

--- a/exposed-jodatime/build.gradle.kts
+++ b/exposed-jodatime/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
+    kotlin("plugin.serialization") apply true
     id("testWithDBs")
 }
 

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -1,5 +1,10 @@
 package org.jetbrains.exposed
 
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
@@ -10,6 +15,7 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.vendors.*
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -177,6 +183,42 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
             assertEquals(2, createdIn2023.size)
         }
     }
+
+    @Test
+    fun testDateTimeAsJsonB() {
+        val tester = object : Table("tester") {
+            val created = datetime("created")
+            val modified = jsonb<ModifierData>("modified", Json.Default)
+        }
+
+        withTables(excludeSettings = TestDB.allH2TestDB + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
+            val dateTimeNow = DateTime.now()
+            tester.insert {
+                it[created] = dateTimeNow.minusYears(1)
+                it[modified] = ModifierData(1, dateTimeNow)
+            }
+            tester.insert {
+                it[created] = dateTimeNow.plusYears(1)
+                it[modified] = ModifierData(2, dateTimeNow)
+            }
+
+            val prefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
+
+            // value extracted in same manner it is stored, a json string
+            val modifiedAsString = tester.modified.jsonExtract<String>("${prefix}timestamp")
+            val allModifiedAsString = tester.slice(modifiedAsString).selectAll()
+            assertTrue(allModifiedAsString.all { it[modifiedAsString] == dateTimeNow.toString() })
+
+            // PostgreSQL requires explicit type cast to timestamp for in-DB comparison
+            val dateModified = if (currentDialectTest is PostgreSQLDialect) {
+                tester.modified.jsonExtract<DateTime>("${prefix}timestamp").castTo(DateColumnType(true))
+            } else {
+                tester.modified.jsonExtract<DateTime>("${prefix}timestamp")
+            }
+            val modifiedBeforeCreation = tester.select { dateModified less tester.created }.single()
+            assertEquals(2, modifiedBeforeCreation[tester.modified].userId)
+        }
+    }
 }
 
 fun assertEqualDateTime(d1: DateTime?, d2: DateTime?) {
@@ -200,4 +242,17 @@ val today: DateTime = DateTime.now().withTimeAtStartOfDay()
 object CitiesTime : IntIdTable("CitiesTime") {
     val name = varchar("name", 50) // Column<String>
     val local_time = datetime("local_time").nullable() // Column<datetime>
+}
+
+@Serializable
+data class ModifierData(
+    val userId: Int,
+    @Serializable(with = DateTimeSerializer::class)
+    val timestamp: DateTime
+)
+
+object DateTimeSerializer : KSerializer<DateTime> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("DateTime", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: DateTime) = encoder.encodeString(value.toString())
+    override fun deserialize(decoder: Decoder): DateTime = DateTime.parse(decoder.decodeString())
 }

--- a/exposed-kotlin-datetime/build.gradle.kts
+++ b/exposed-kotlin-datetime/build.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     kotlin("jvm") apply true
+    kotlin("plugin.serialization") apply true
     id("testWithDBs")
 }
 


### PR DESCRIPTION
Add unit tests using JSON values that contain datetime strings, to check how extraction of values and value comparison is handled.

**Note:**
`java.time` and `org.joda.time` types do not have implicitly supported serializers from `kotlinx.serialization` library, unlike `kotlinx.datetime` types. This means a [custom serializer](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#serializing-3rd-party-classes) needs to be used, either specified on a property (as seen in the tests) or on an entire file. This also means that current implementation of `jsonExtract()` will not allow extraction as a JSON value (with `toScalar = false`) because the function uses the implicit type serializer `serializer<T>()` for datetime types.