### PR TITLE
feat: Add spring mutli container support

### DIFF
--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
@@ -1,0 +1,226 @@
+package org.jetbrains.exposed.spring
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Assert
+import org.junit.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import org.springframework.transaction.annotation.Transactional
+import javax.sql.DataSource
+import kotlin.test.BeforeTest
+
+/**
+ * @author ivan@daangn.com
+ */
+open class SpringMultiContainerTransactionTest {
+
+    val orderContainer = AnnotationConfigApplicationContext(OrderConfig::class.java)
+    val paymentContainer = AnnotationConfigApplicationContext(PaymentConfig::class.java)
+
+    val orders: Orders = orderContainer.getBean(Orders::class.java)
+    val payments: Payments = paymentContainer.getBean(Payments::class.java)
+
+    @BeforeTest
+    open fun beforeTest() {
+        orders.init()
+        payments.init()
+    }
+
+    @Test
+    open fun test1() {
+        Assert.assertEquals(0, orders.findAll().size)
+        Assert.assertEquals(0, payments.findAll().size)
+    }
+
+    @Test
+    open fun test2() {
+        orders.create()
+        Assert.assertEquals(1, orders.findAll().size)
+        payments.create()
+        Assert.assertEquals(1, payments.findAll().size)
+    }
+
+    @Test
+    open fun test3() {
+        orders.databaseTemplate {
+            payments.create()
+            orders.create()
+            payments.create()
+        }
+        Assert.assertEquals(1, orders.findAll().size)
+        Assert.assertEquals(2, payments.findAll().size)
+    }
+
+    @Test
+    open fun test4() {
+        kotlin.runCatching {
+            orders.databaseTemplate {
+                orders.create()
+                payments.create()
+                throw Error()
+            }
+        }
+        Assert.assertEquals(0, orders.findAll().size)
+        Assert.assertEquals(1, payments.findAll().size)
+    }
+
+    @Test
+    open fun test5() {
+        kotlin.runCatching {
+            orders.databaseTemplate {
+                orders.create()
+                payments.databaseTemplate {
+                    payments.create()
+                    throw Error()
+                }
+            }
+        }
+        Assert.assertEquals(0, orders.findAll().size)
+        Assert.assertEquals(0, payments.findAll().size)
+    }
+
+    @Test
+    open fun test6() {
+        Assert.assertEquals(0, orders.findAllWithExposedTrxBlock().size)
+        Assert.assertEquals(0, payments.findAllWithExposedTrxBlock().size)
+    }
+
+    @Test
+    open fun test7() {
+        orders.createWithExposedTrxBlock()
+        Assert.assertEquals(1, orders.findAllWithExposedTrxBlock().size)
+        payments.createWithExposedTrxBlock()
+        Assert.assertEquals(1, payments.findAllWithExposedTrxBlock().size)
+    }
+
+    @Test
+    open fun test8() {
+        orders.databaseTemplate {
+            payments.createWithExposedTrxBlock()
+            orders.createWithExposedTrxBlock()
+            payments.createWithExposedTrxBlock()
+        }
+        Assert.assertEquals(1, orders.findAllWithExposedTrxBlock().size)
+        Assert.assertEquals(2, payments.findAllWithExposedTrxBlock().size)
+    }
+
+    @Test
+    open fun test9() {
+        kotlin.runCatching {
+            orders.databaseTemplate {
+                orders.createWithExposedTrxBlock()
+                payments.createWithExposedTrxBlock()
+                throw Error()
+            }
+        }
+        Assert.assertEquals(0, orders.findAllWithExposedTrxBlock().size)
+        Assert.assertEquals(1, payments.findAllWithExposedTrxBlock().size)
+    }
+
+    @Test
+    open fun test10() {
+        kotlin.runCatching {
+            orders.databaseTemplate {
+                orders.createWithExposedTrxBlock()
+                payments.databaseTemplate {
+                    payments.createWithExposedTrxBlock()
+                    throw Error()
+                }
+            }
+        }
+        Assert.assertEquals(0, orders.findAllWithExposedTrxBlock().size)
+        Assert.assertEquals(0, payments.findAllWithExposedTrxBlock().size)
+    }
+}
+
+@Configuration
+@EnableTransactionManagement(proxyTargetClass = true)
+open class OrderConfig {
+
+    @Bean
+    open fun dataSource(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName("embeddedTest1").setType(EmbeddedDatabaseType.H2).build()
+
+    @Bean
+    open fun transactionManager(dataSource: DataSource) = SpringTransactionManager(dataSource)
+
+    @Bean
+    open fun orders() = Orders()
+}
+
+@Transactional
+open class Orders {
+
+    open fun findAll() = Order.selectAll().map { it }
+
+    open fun findAllWithExposedTrxBlock() = transaction { findAll() }
+
+    open fun create() = Order.insertAndGetId {
+        it[buyer] = 123
+    }.value
+
+    open fun createWithExposedTrxBlock() = transaction { create() }
+
+    open fun init() {
+        SchemaUtils.create(Order)
+        Order.deleteAll()
+    }
+
+    open fun databaseTemplate(block: () -> Unit) {
+        block()
+    }
+}
+
+object Order : LongIdTable("orders") {
+    val buyer = long("buyer_id")
+}
+
+@Configuration
+@EnableTransactionManagement(proxyTargetClass = true)
+open class PaymentConfig {
+
+    @Bean
+    open fun dataSource(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName("embeddedTest2").setType(EmbeddedDatabaseType.H2).build()
+
+    @Bean
+    open fun transactionManager(dataSource: DataSource) = SpringTransactionManager(dataSource)
+
+    @Bean
+    open fun payments() = Payments()
+}
+
+@Transactional
+open class Payments {
+
+    open fun findAll() = Payment.selectAll().map { it }
+
+    open fun findAllWithExposedTrxBlock() = transaction { findAll() }
+
+    open fun create() = Payment.insertAndGetId {
+        it[state] = "state"
+    }.value
+
+    open fun createWithExposedTrxBlock() = transaction { create() }
+
+    open fun init() {
+        SchemaUtils.create(Payment)
+        Payment.deleteAll()
+    }
+
+    open fun databaseTemplate(block: () -> Unit) {
+        block()
+    }
+}
+
+object Payment : LongIdTable("payments") {
+    val state = varchar("state", 50)
+}

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
@@ -19,9 +19,6 @@ import org.springframework.transaction.annotation.Transactional
 import javax.sql.DataSource
 import kotlin.test.BeforeTest
 
-/**
- * @author ivan@daangn.com
- */
 open class SpringMultiContainerTransactionTest {
 
     val orderContainer = AnnotationConfigApplicationContext(OrderConfig::class.java)
@@ -67,7 +64,7 @@ open class SpringMultiContainerTransactionTest {
             orders.transaction {
                 orders.create()
                 payments.create()
-                throw Error()
+                throw SpringTransactionTestException()
             }
         }
         Assert.assertEquals(0, orders.findAll().size)
@@ -81,7 +78,7 @@ open class SpringMultiContainerTransactionTest {
                 orders.create()
                 payments.databaseTemplate {
                     payments.create()
-                    throw Error()
+                    throw SpringTransactionTestException()
                 }
             }
         }
@@ -120,7 +117,7 @@ open class SpringMultiContainerTransactionTest {
             orders.transaction {
                 orders.createWithExposedTrxBlock()
                 payments.createWithExposedTrxBlock()
-                throw Error()
+                throw SpringTransactionTestException()
             }
         }
         Assert.assertEquals(0, orders.findAllWithExposedTrxBlock().size)
@@ -134,7 +131,7 @@ open class SpringMultiContainerTransactionTest {
                 orders.createWithExposedTrxBlock()
                 payments.databaseTemplate {
                     payments.createWithExposedTrxBlock()
-                    throw Error()
+                    throw SpringTransactionTestException()
                 }
             }
         }
@@ -224,3 +221,5 @@ open class Payments {
 object Payment : LongIdTable("payments") {
     val state = varchar("state", 50)
 }
+
+private class SpringTransactionTestException() : Error()

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
@@ -222,4 +222,4 @@ object Payment : LongIdTable("payments") {
     val state = varchar("state", 50)
 }
 
-private class SpringTransactionTestException() : Error()
+private class SpringTransactionTestException : Error()

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringMultiContainerTransactionTest.kt
@@ -52,7 +52,7 @@ open class SpringMultiContainerTransactionTest {
 
     @Test
     open fun test3() {
-        orders.databaseTemplate {
+        orders.transaction {
             payments.create()
             orders.create()
             payments.create()
@@ -64,7 +64,7 @@ open class SpringMultiContainerTransactionTest {
     @Test
     open fun test4() {
         kotlin.runCatching {
-            orders.databaseTemplate {
+            orders.transaction {
                 orders.create()
                 payments.create()
                 throw Error()
@@ -77,7 +77,7 @@ open class SpringMultiContainerTransactionTest {
     @Test
     open fun test5() {
         kotlin.runCatching {
-            orders.databaseTemplate {
+            orders.transaction {
                 orders.create()
                 payments.databaseTemplate {
                     payments.create()
@@ -105,7 +105,7 @@ open class SpringMultiContainerTransactionTest {
 
     @Test
     open fun test8() {
-        orders.databaseTemplate {
+        orders.transaction {
             payments.createWithExposedTrxBlock()
             orders.createWithExposedTrxBlock()
             payments.createWithExposedTrxBlock()
@@ -117,7 +117,7 @@ open class SpringMultiContainerTransactionTest {
     @Test
     open fun test9() {
         kotlin.runCatching {
-            orders.databaseTemplate {
+            orders.transaction {
                 orders.createWithExposedTrxBlock()
                 payments.createWithExposedTrxBlock()
                 throw Error()
@@ -130,7 +130,7 @@ open class SpringMultiContainerTransactionTest {
     @Test
     open fun test10() {
         kotlin.runCatching {
-            orders.databaseTemplate {
+            orders.transaction {
                 orders.createWithExposedTrxBlock()
                 payments.databaseTemplate {
                     payments.createWithExposedTrxBlock()
@@ -162,20 +162,20 @@ open class Orders {
 
     open fun findAll() = Order.selectAll().map { it }
 
-    open fun findAllWithExposedTrxBlock() = transaction { findAll() }
+    open fun findAllWithExposedTrxBlock() = org.jetbrains.exposed.sql.transactions.transaction { findAll() }
 
     open fun create() = Order.insertAndGetId {
         it[buyer] = 123
     }.value
 
-    open fun createWithExposedTrxBlock() = transaction { create() }
+    open fun createWithExposedTrxBlock() = org.jetbrains.exposed.sql.transactions.transaction { create() }
 
     open fun init() {
         SchemaUtils.create(Order)
         Order.deleteAll()
     }
 
-    open fun databaseTemplate(block: () -> Unit) {
+    open fun transaction(block: () -> Unit) {
         block()
     }
 }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionEntityTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionEntityTest.kt
@@ -83,9 +83,6 @@ open class SpringTransactionEntityTest : SpringTransactionTestBase() {
     @Autowired
     lateinit var service: Service
 
-    @Autowired
-    lateinit var ds: EmbeddedDatabase
-
     @BeforeTest
     open fun beforeTest() {
         service.init()

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionEntityTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionEntityTest.kt
@@ -5,12 +5,16 @@ import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
 import org.springframework.test.annotation.Commit
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -39,6 +43,11 @@ class OrderDAO(id: EntityID<UUID>) : UUIDEntity(id) {
 @org.springframework.stereotype.Service
 @Transactional
 open class Service {
+
+    open fun init() {
+        SchemaUtils.create(CustomerTable, OrderTable)
+    }
+
     open fun createCustomer(name: String): CustomerDAO {
         return CustomerDAO.new {
             this.name = name
@@ -59,6 +68,14 @@ open class Service {
     open fun findOrderByProduct(product: String): OrderDAO? {
         return OrderDAO.find { OrderTable.product eq product }.singleOrNull()
     }
+
+    open fun transaction(block: () -> Unit) {
+        block()
+    }
+
+    open fun cleanUp() {
+        SchemaUtils.drop(CustomerTable, OrderTable)
+    }
 }
 
 open class SpringTransactionEntityTest : SpringTransactionTestBase() {
@@ -66,29 +83,39 @@ open class SpringTransactionEntityTest : SpringTransactionTestBase() {
     @Autowired
     lateinit var service: Service
 
-    @Test @Commit
-    open fun test01() {
-        transaction {
-            SchemaUtils.create(CustomerTable, OrderTable)
-        }
+    @Autowired
+    lateinit var ds: EmbeddedDatabase
 
+    @BeforeTest
+    open fun beforeTest() {
+        service.init()
+    }
+
+    @Test
+    @Commit
+    open fun test01() {
         val customer = service.createCustomer("Alice1")
         service.createOrder(customer, "Product1")
         val order = service.findOrderByProduct("Product1")
         assertNotNull(order)
-        transaction {
+        service.transaction {
             assertEquals("Alice1", order.customer.name)
         }
     }
 
-    @Test @Commit
+    @Test
+    @Commit
     fun test02() {
         service.doBoth("Bob", "Product2")
         val order = service.findOrderByProduct("Product2")
         assertNotNull(order)
-        transaction {
+        service.transaction {
             assertEquals("Bob", order.customer.name)
-            SchemaUtils.drop(CustomerTable, OrderTable)
         }
+    }
+
+    @AfterTest
+    fun afterTest() {
+        service.cleanUp()
     }
 }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionEntityTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionEntityTest.kt
@@ -5,11 +5,8 @@ import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.transactions.TransactionManager
-import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
 import org.springframework.test.annotation.Commit
 import org.springframework.transaction.annotation.Transactional
 import java.util.*


### PR DESCRIPTION
Our team has a monolithic architecture with multiple teams working on different domains in one codebase.

Each domain is isolated using Spring's container technology and consists of several child containers under a parent container, each connecting to the database using a different Datasource.

In this case, there are times when we want transactions to cross between the different domains for convenience. Using the traditional SpringTransactionManager, if a child transaction is executed, the parent transaction may encounter a "No transaction in context" error.

This error is caused by the current transaction manager in the TransactionManager interface not being updated properly across configuration boundaries.

Our team tried to solve this problem using the Stack.

We created logic that pushes to Stack when each transaction is executed and pops when the transaction ends, and after a year of using it, we haven't seen too many cases where it's broken, so we thought we'd contribute.

The above code may still have the following issues. 
1. If you run the transaction in a Container that doesn't use SpringTransactionManager, it may not handle the transaction properly.
2. it does not yet properly support Spring's Transaction Propagation policy.

There may be additional issues besides the above, but at the very least, you should be able to use multiple data sources in Spring.