### PR TITLE
refactor: Adjust kotlinx-serialization & postgresql dependencies in core

### DIFF
--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
-    kotlin("plugin.serialization") apply true
 }
 
 repositories {
@@ -13,7 +12,6 @@ dependencies {
     api(kotlin("stdlib"))
     api(kotlin("reflect"))
     api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", Versions.kotlinCoroutines)
-    api("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
-    api("org.postgresql", "postgresql", Versions.postgre)
+    compileOnly("org.postgresql", "postgresql", Versions.postgre)
     api("org.slf4j", "slf4j-api", "1.7.25")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -915,10 +915,10 @@ open class JsonColumnType<T : Any>(
     override fun sqlType(): String = currentDialect.dataTypeProvider.jsonType()
 
     override fun valueFromDB(value: Any): Any {
-        return when (value) {
-            is String -> deserialize(value)
-            is PGobject -> deserialize(value.value!!)
-            is ByteArray -> deserialize(value.decodeToString())
+        return when {
+            value is String -> deserialize(value)
+            value is ByteArray -> deserialize(value.decodeToString())
+            currentDialect is PostgreSQLDialect && value is PGobject -> deserialize(value.value!!)
             else -> value
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1,8 +1,5 @@
 package org.jetbrains.exposed.sql
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.serializer
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
@@ -668,24 +665,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         registerColumn(name, JsonColumnType(serialize, deserialize))
 
     /**
-     * Creates a column, with the specified [name], for storing JSON data.
-     *
-     * **Note**: This column stores JSON either in non-binary text format or, if the vendor only supports 1 format, the default JSON type format.
-     * If JSON must be stored in binary format, and the vendor supports this, please use `jsonb()` instead.
-     *
-     * @param name Name of the column
-     * @param jsonConfig Configured instance of the `Json` class
-     * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
-     * Defaults to a generic serializer for type [T]
-     */
-    inline fun <reified T : Any> json(
-        name: String,
-        jsonConfig: Json,
-        kSerializer: KSerializer<T> = serializer<T>()
-    ): Column<T> =
-        json(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })
-
-    /**
      * Creates a column, with the specified [name], for storing JSON data in decomposed binary format.
      *
      * **Note**: JSON storage in binary format is not supported by all vendors; please check the documentation.
@@ -696,23 +675,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      */
     fun <T : Any> jsonb(name: String, serialize: (T) -> String, deserialize: (String) -> T): Column<T> =
         registerColumn(name, JsonBColumnType(serialize, deserialize))
-
-    /**
-     * Creates a column, with the specified [name], for storing JSON data in decomposed binary format.
-     *
-     * **Note**: JSON storage in binary format is not supported by all vendors; please check the documentation.
-     *
-     * @param name Name of the column
-     * @param jsonConfig Configured instance of the `Json` class
-     * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
-     * Defaults to a generic serializer for type [T]
-     */
-    inline fun <reified T : Any> jsonb(
-        name: String,
-        jsonConfig: Json,
-        kSerializer: KSerializer<T> = serializer<T>()
-    ): Column<T> =
-        jsonb(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })
 
     // Auto-generated values
 

--- a/exposed-java-time/build.gradle.kts
+++ b/exposed-java-time/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
@@ -15,6 +16,7 @@ dependencies {
     api(project(":exposed-core"))
     testImplementation(project(":exposed-dao"))
     testImplementation(project(":exposed-tests"))
+    testImplementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
     testImplementation("junit", "junit", "4.12")
     testImplementation(kotlin("test-junit"))
 }

--- a/exposed-jodatime/build.gradle.kts
+++ b/exposed-jodatime/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api("joda-time", "joda-time", "2.10.13")
     testImplementation(project(":exposed-dao"))
     testImplementation(project(":exposed-tests"))
+    testImplementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
     testImplementation("junit", "junit", "4.12")
     testImplementation(kotlin("test-junit"))
 }

--- a/exposed-kotlin-datetime/build.gradle.kts
+++ b/exposed-kotlin-datetime/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
@@ -16,6 +17,7 @@ dependencies {
     api("org.jetbrains.kotlinx", "kotlinx-datetime-jvm", "0.4.0")
     testImplementation(project(":exposed-dao"))
     testImplementation(project(":exposed-tests"))
+    testImplementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
     testImplementation("junit", "junit", "4.12")
     testImplementation(kotlin("test-junit"))
 }

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-core", Versions.kotlinCoroutines)
+    implementation("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
     implementation(project(":exposed-core"))
     implementation(project(":exposed-jdbc"))
     implementation(project(":exposed-dao"))

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonBColumnTypeTests.kt
@@ -54,7 +54,7 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
             val result1 = tester.slice(isActive).selectAll().singleOrNull()
             assertEquals(data1.active, result1?.get(isActive))
 
-            val storedUser = tester.jsonBColumn.jsonExtract<User>("${pathPrefix}user", toScalar = false)
+            val storedUser = tester.jsonBColumn.jsonExtractImpl<User>("${pathPrefix}user", toScalar = false)
             val result2 = tester.slice(storedUser).selectAll().singleOrNull()
             assertEquals(user1, result2?.get(storedUser))
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/JsonColumnTypeTests.kt
@@ -58,7 +58,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
             val result1 = tester.slice(isActive).selectAll().singleOrNull()
             assertEquals(data1.active, result1?.get(isActive))
 
-            val storedUser = tester.jsonColumn.jsonExtract<User>("${pathPrefix}user", toScalar = false)
+            val storedUser = tester.jsonColumn.jsonExtractImpl<User>("${pathPrefix}user", toScalar = false)
             val result2 = tester.slice(storedUser).selectAll().singleOrNull()
             assertEquals(user1, result2?.get(storedUser))
 


### PR DESCRIPTION
Remove kotlinx-serialization-json dependency from exposed-core:
- Remove json()/jsonb table functions that use implicit `serializer<T>()` (and place them in exposed-tests as samples).
- Refactor `jsonExtract()` to either use columnType mapping for primitive types or user-defined serializer/deserializer, if provided, with `JsonColumnType`.

Make org.postgresql dependency in exposed-core `compileOnly`:
- Refactor `JsonColumnType.valueFromDB()` to only check for PGobject if PostgreSQL is being used.

Add kotlinx-serialization-json dependency to exposed-tests:
- Add json/jsonb table function overrides as sample for user-defined use.
- Add `jsonExtract()` override as example of how it can be simplified for non-primitive types.
- Refactor the 3 datetime modules' build files and test source similarly.