### PR TITLE
fix: EXPOSED-50 customEnumeration reference column error

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -482,6 +482,19 @@ public final class org/jetbrains/exposed/sql/Count : org/jetbrains/exposed/sql/F
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
+public final class org/jetbrains/exposed/sql/CustomEnumerationColumnType : org/jetbrains/exposed/sql/StringColumnType {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final fun getFromDb ()Lkotlin/jvm/functions/Function1;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSql ()Ljava/lang/String;
+	public final fun getToDb ()Lkotlin/jvm/functions/Function1;
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Enum;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public class org/jetbrains/exposed/sql/CustomFunction : org/jetbrains/exposed/sql/Function {
 	public fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;[Lorg/jetbrains/exposed/sql/Expression;)V
 	public final fun getExpr ()[Lorg/jetbrains/exposed/sql/Expression;

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
@@ -63,8 +63,10 @@ class EnumerationTests : DatabaseTestsBase() {
                 }
                 EnumTable.initEnumColumn(sqlType)
                 SchemaUtils.create(EnumTable)
-                // drop shared table object's unique index created in other test
-                exec(EnumTable.indices.first().dropStatement().single())
+                // drop shared table object's unique index if created in other test
+                if (EnumTable.indices.isNotEmpty()) {
+                    exec(EnumTable.indices.first().dropStatement().single())
+                }
                 EnumTable.insert {
                     it[enumColumn] = DDLTests.Foo.Bar
                 }
@@ -110,8 +112,10 @@ class EnumerationTests : DatabaseTestsBase() {
                     enumColumn.default(DDLTests.Foo.Bar)
                 }
                 SchemaUtils.create(EnumTable)
-                // drop shared table object's unique index created in other test
-                exec(EnumTable.indices.first().dropStatement().single())
+                // drop shared table object's unique index if created in other test
+                if (EnumTable.indices.isNotEmpty()) {
+                    exec(EnumTable.indices.first().dropStatement().single())
+                }
 
                 EnumTable.insert { }
                 val default = EnumTable.selectAll().single()[EnumTable.enumColumn]
@@ -148,7 +152,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 }
                 EnumTable.initEnumColumn(sqlType)
                 with(EnumTable) {
-                    enumColumn.uniqueIndex()
+                    if (indices.isEmpty()) enumColumn.uniqueIndex()
                 }
                 SchemaUtils.create(EnumTable)
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
@@ -63,6 +63,8 @@ class EnumerationTests : DatabaseTestsBase() {
                 }
                 EnumTable.initEnumColumn(sqlType)
                 SchemaUtils.create(EnumTable)
+                // drop shared table object's unique index created in other test
+                exec(EnumTable.indices.first().dropStatement().single())
                 EnumTable.insert {
                     it[enumColumn] = DDLTests.Foo.Bar
                 }
@@ -108,6 +110,8 @@ class EnumerationTests : DatabaseTestsBase() {
                     enumColumn.default(DDLTests.Foo.Bar)
                 }
                 SchemaUtils.create(EnumTable)
+                // drop shared table object's unique index created in other test
+                exec(EnumTable.indices.first().dropStatement().single())
 
                 EnumTable.insert { }
                 val default = EnumTable.selectAll().single()[EnumTable.enumColumn]
@@ -162,7 +166,9 @@ class EnumerationTests : DatabaseTestsBase() {
                 assertEquals(fooBar, EnumTable.selectAll().single()[EnumTable.enumColumn])
                 assertEquals(fooBar, referenceTable.selectAll().single()[referenceTable.referenceColumn])
             } finally {
-                SchemaUtils.drop(EnumTable, referenceTable)
+                SchemaUtils.drop(referenceTable)
+                exec(EnumTable.indices.first().dropStatement().single())
+                SchemaUtils.drop(EnumTable)
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
@@ -16,6 +16,8 @@ import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.junit.Test
 
 class EnumerationTests : DatabaseTestsBase() {
+    private val supportsCustomEnumerationDB = TestDB.mySqlRelatedDB + listOf(TestDB.H2, TestDB.H2_PSQL, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)
+
     object EnumTable : IntIdTable("EnumTable") {
         internal var enumColumn: Column<DDLTests.Foo> = enumeration("enumColumn")
 
@@ -41,7 +43,7 @@ class EnumerationTests : DatabaseTestsBase() {
 
     @Test
     fun testCustomEnumeration01() {
-        withDb(listOf(TestDB.H2, TestDB.H2_PSQL, TestDB.MYSQL, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
+        withDb(supportsCustomEnumerationDB) {
             val sqlType = when (currentDialectTest) {
                 is H2Dialect, is MysqlDialect -> "ENUM('Bar', 'Baz')"
                 is PostgreSQLDialect -> "FooEnum"
@@ -90,7 +92,7 @@ class EnumerationTests : DatabaseTestsBase() {
 
     @Test
     fun testCustomEnumerationWithDefaultValue() {
-        withDb(listOf(TestDB.H2, TestDB.H2_MYSQL, TestDB.H2_PSQL, TestDB.MYSQL, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
+        withDb(supportsCustomEnumerationDB) {
             val sqlType = when (currentDialectTest) {
                 is H2Dialect, is MysqlDialect -> "ENUM('Bar', 'Baz')"
                 is PostgreSQLDialect -> "FooEnum2"
@@ -103,7 +105,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 }
                 EnumTable.initEnumColumn(sqlType)
                 with(EnumTable) {
-                    EnumTable.enumColumn.default(DDLTests.Foo.Bar)
+                    enumColumn.default(DDLTests.Foo.Bar)
                 }
                 SchemaUtils.create(EnumTable)
 
@@ -115,6 +117,84 @@ class EnumerationTests : DatabaseTestsBase() {
                     SchemaUtils.drop(EnumTable)
                 } catch (ignore: Exception) {}
             }
+        }
+    }
+
+    @Test
+    fun testCustomEnumerationWithReference() {
+        val referenceTable = object : Table("ref_table") {
+            var referenceColumn: Column<DDLTests.Foo> = enumeration("ref_column")
+
+            fun initRefColumn() {
+                (columns as MutableList<Column<*>>).remove(referenceColumn)
+                referenceColumn = reference("ref_column", EnumTable.enumColumn)
+            }
+        }
+
+        withDb(supportsCustomEnumerationDB) {
+            val sqlType = when (currentDialectTest) {
+                is H2Dialect, is MysqlDialect -> "ENUM('Bar', 'Baz')"
+                is PostgreSQLDialect -> "RefEnum"
+                else -> error("Unsupported case")
+            }
+            try {
+                if (currentDialectTest is PostgreSQLDialect) {
+                    exec("DROP TYPE IF EXISTS $sqlType;")
+                    exec("CREATE TYPE $sqlType AS ENUM ('Bar', 'Baz');")
+                }
+                EnumTable.initEnumColumn(sqlType)
+                with(EnumTable) {
+                    enumColumn.uniqueIndex()
+                }
+                SchemaUtils.create(EnumTable)
+
+                referenceTable.initRefColumn()
+                SchemaUtils.create(referenceTable)
+
+                val fooBar = DDLTests.Foo.Bar
+                val id1 = EnumTable.insert {
+                    it[enumColumn] = fooBar
+                } get EnumTable.enumColumn
+                referenceTable.insert {
+                    it[referenceColumn] = id1
+                }
+
+                assertEquals(fooBar, EnumTable.selectAll().single()[EnumTable.enumColumn])
+                assertEquals(fooBar, referenceTable.selectAll().single()[referenceTable.referenceColumn])
+            } finally {
+                SchemaUtils.drop(EnumTable, referenceTable)
+            }
+        }
+    }
+
+    @Test
+    fun testEnumerationColumnsWithReference() {
+        val tester = object : Table("tester") {
+            val enumColumn = enumeration<DDLTests.Foo>("enum_column").uniqueIndex()
+            val enumNameColumn = enumerationByName<DDLTests.Foo>("enum_name_column", 32).uniqueIndex()
+        }
+        val referenceTable = object : Table("ref_table") {
+            val referenceColumn = reference("ref_column", tester.enumColumn)
+            val referenceNameColumn = reference("ref_name_column", tester.enumNameColumn)
+        }
+
+        withTables(tester, referenceTable) {
+            val fooBar = DDLTests.Foo.Bar
+            val fooBaz = DDLTests.Foo.Baz
+            val entry = tester.insert {
+                it[enumColumn] = fooBar
+                it[enumNameColumn] = fooBaz
+            }
+            referenceTable.insert {
+                it[referenceColumn] = entry[tester.enumColumn]
+                it[referenceNameColumn] = entry[tester.enumNameColumn]
+            }
+
+            assertEquals(fooBar, tester.selectAll().single()[tester.enumColumn])
+            assertEquals(fooBar, referenceTable.selectAll().single()[referenceTable.referenceColumn])
+
+            assertEquals(fooBaz, tester.selectAll().single()[tester.enumNameColumn])
+            assertEquals(fooBaz, referenceTable.selectAll().single()[referenceTable.referenceNameColumn])
         }
     }
 }


### PR DESCRIPTION
Currently, a column can be created with a reference to either `EnumerationColumnType` or `EnumerationNameColumnType`, but trying to do so using a column created via `customEnumeration()` throws a `NullPointerException`.

The NPE is thrown by `clone()` when attempting [to first access the column type's primary constructor](https://github.com/JetBrains/Exposed/blob/main/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt#L1135). Because `customEnumeration()` specifies a database-specific type, its `IColumnType` is being registered as the custom SQL type argument through an anonymous object. The anonymous object does not provide a `KClass` with a valid `primaryConstructor`.

Extracting this object to a new class `CustomEnumerationColumnType` provides a valid `KClass` instance to `clone()` a new instance for reference. This is also more inline with how all other Table column functions are registered. 

Add unit tests for all 3 types of enumeration columns with references.