### PR TITLE
feat: EXPOSED-43 Add support for timestamp with time zone

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3191,6 +3191,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/DataTypeProvider {
 	public fun shortType ()Ljava/lang/String;
 	public fun textType ()Ljava/lang/String;
 	public fun timeType ()Ljava/lang/String;
+	public fun timestampWithTimeZoneType ()Ljava/lang/String;
 	public fun ubyteType ()Ljava/lang/String;
 	public fun uintegerType ()Ljava/lang/String;
 	public fun ulongType ()Ljava/lang/String;
@@ -3497,6 +3498,7 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	public fun getSupportsTernaryAffectedRowValues ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public final fun isFractionDateTimeSupported ()Z
+	public final fun isTimeZoneOffsetSupported ()Z
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -91,6 +91,9 @@ abstract class DataTypeProvider {
     /** Data type for storing both date and time without a time zone. */
     open fun dateTimeType(): String = "DATETIME"
 
+    /** Data type for storing both date and time with a time zone. */
+    open fun timestampWithTimeZoneType(): String = "TIMESTAMP WITH TIME ZONE"
+
     /** Time type for storing time without a time zone. */
     open fun timeType(): String = "TIME"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -14,6 +14,8 @@ internal object H2DataTypeProvider : DataTypeProvider() {
     override fun uuidType(): String = "UUID"
     override fun dateTimeType(): String = "DATETIME(9)"
 
+    override fun timestampWithTimeZoneType(): String = "TIMESTAMP(9) WITH TIME ZONE"
+
     override fun jsonBType(): String = "JSON"
 
     override fun hexToDb(hexString: String): String = "X'$hexString'"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -17,6 +17,12 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
     override fun uuidType(): String = "uniqueidentifier"
     override fun uuidToDB(value: UUID): Any = value.toString()
     override fun dateTimeType(): String = "DATETIME2"
+    override fun timestampWithTimeZoneType(): String =
+        if ((currentDialect as? H2Dialect)?.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
+            "TIMESTAMP(9) WITH TIME ZONE"
+        } else {
+            "DATETIMEOFFSET"
+        }
     override fun booleanType(): String = "BIT"
     override fun booleanToStatementString(bool: Boolean): String = if (bool) "1" else "0"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -15,6 +15,7 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun floatType(): String = "SINGLE"
     override fun binaryType(): String = "BLOB"
     override fun dateTimeType(): String = "TEXT"
+    override fun timestampWithTimeZoneType(): String = "TEXT"
     override fun dateType(): String = "TEXT"
     override fun booleanToStatementString(bool: Boolean) = if (bool) "1" else "0"
     override fun jsonType(): String = "TEXT"

--- a/exposed-java-time/api/exposed-java-time.api
+++ b/exposed-java-time/api/exposed-java-time.api
@@ -38,6 +38,7 @@ public final class org/jetbrains/exposed/sql/javatime/JavaDateColumnTypeKt {
 	public static final fun duration (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static final fun time (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static final fun timestamp (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public static final fun timestampWithTimeZone (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/sql/javatime/JavaDateFunctionsKt {
@@ -46,6 +47,7 @@ public final class org/jetbrains/exposed/sql/javatime/JavaDateFunctionsKt {
 	public static final fun CustomDurationFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomTimeFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomTimeStampFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
+	public static final fun CustomTimestampWithTimeZoneFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun date (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/javatime/Date;
 	public static final fun dateLiteral (Ljava/time/LocalDate;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun dateParam (Ljava/time/LocalDate;)Lorg/jetbrains/exposed/sql/Expression;
@@ -62,6 +64,8 @@ public final class org/jetbrains/exposed/sql/javatime/JavaDateFunctionsKt {
 	public static final fun timeParam (Ljava/time/LocalTime;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun timestampLiteral (Ljava/time/Instant;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun timestampParam (Ljava/time/Instant;)Lorg/jetbrains/exposed/sql/Expression;
+	public static final fun timestampWithTimeZoneLiteral (Ljava/time/OffsetDateTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public static final fun timestampWithTimeZoneParam (Ljava/time/OffsetDateTime;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun year (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/javatime/Year;
 }
 
@@ -132,6 +136,21 @@ public final class org/jetbrains/exposed/sql/javatime/JavaLocalTimeColumnType : 
 }
 
 public final class org/jetbrains/exposed/sql/javatime/JavaLocalTimeColumnType$Companion {
+}
+
+public final class org/jetbrains/exposed/sql/javatime/JavaOffsetDateTimeColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IDateColumnType {
+	public static final field Companion Lorg/jetbrains/exposed/sql/javatime/JavaOffsetDateTimeColumnType$Companion;
+	public fun <init> ()V
+	public fun getHasTimePart ()Z
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/time/OffsetDateTime;
+}
+
+public final class org/jetbrains/exposed/sql/javatime/JavaOffsetDateTimeColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/sql/javatime/Minute : org/jetbrains/exposed/sql/Function {

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.sql.ColumnType
 import org.jetbrains.exposed.sql.IDateColumnType
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
@@ -36,6 +37,26 @@ internal val ORACLE_TIME_STRING_FORMATTER by lazy {
 
 internal val DEFAULT_TIME_STRING_FORMATTER by lazy {
     DateTimeFormatter.ISO_LOCAL_TIME.withLocale(Locale.ROOT).withZone(ZoneId.systemDefault())
+}
+
+// Example result: 2023-07-07 14:42:29.343+02:00 or 2023-07-07 12:42:29.343Z
+internal val SQLITE_OFFSET_DATE_TIME_FORMATTER by lazy {
+    DateTimeFormatter.ofPattern(
+        "yyyy-MM-dd HH:mm:ss.SSS[XXX]",
+        Locale.ROOT
+    )
+}
+
+// For UTC time zone, MySQL rejects the 'Z' and will only accept the offset '+00:00'
+internal val MYSQL_OFFSET_DATE_TIME_FORMATTER by lazy {
+    DateTimeFormatter.ofPattern(
+        "yyyy-MM-dd HH:mm:ss.SSSSSS[xxx]",
+        Locale.ROOT
+    )
+}
+
+internal val DEFAULT_OFFSET_DATE_TIME_FORMATTER by lazy {
+    DateTimeFormatter.ISO_OFFSET_DATE_TIME.withLocale(Locale.ROOT)
 }
 
 internal fun formatterForDateString(date: String) = dateTimeWithFractionFormat(date.substringAfterLast('.', "").length)
@@ -241,6 +262,55 @@ class JavaInstantColumnType : ColumnType(), IDateColumnType {
     }
 }
 
+class JavaOffsetDateTimeColumnType : ColumnType(), IDateColumnType {
+    override val hasTimePart: Boolean = true
+
+    override fun sqlType(): String = currentDialect.dataTypeProvider.timestampWithTimeZoneType()
+
+    override fun nonNullValueToString(value: Any): String = when (value) {
+        is OffsetDateTime -> {
+            when (currentDialect) {
+                is SQLiteDialect -> "'${value.format(SQLITE_OFFSET_DATE_TIME_FORMATTER)}'"
+                is MysqlDialect -> "'${value.format(MYSQL_OFFSET_DATE_TIME_FORMATTER)}'"
+                else -> "'${value.format(DEFAULT_OFFSET_DATE_TIME_FORMATTER)}'"
+            }
+        }
+        else -> error("Unexpected value: $value of ${value::class.qualifiedName}")
+    }
+
+    override fun valueFromDB(value: Any): OffsetDateTime = when (value) {
+        is OffsetDateTime -> value
+        is String -> {
+            if (currentDialect is SQLiteDialect) {
+                OffsetDateTime.parse(value, SQLITE_OFFSET_DATE_TIME_FORMATTER)
+            } else {
+                OffsetDateTime.parse(value)
+            }
+        }
+        else -> error("Unexpected value: $value of ${value::class.qualifiedName}")
+    }
+
+    override fun readObject(rs: ResultSet, index: Int): Any? = when (currentDialect) {
+        is SQLiteDialect -> super.readObject(rs, index)
+        else -> rs.getObject(index, OffsetDateTime::class.java)
+    }
+
+    override fun notNullValueToDB(value: Any): Any = when (value) {
+        is OffsetDateTime -> {
+            when (currentDialect) {
+                is SQLiteDialect -> value.format(SQLITE_OFFSET_DATE_TIME_FORMATTER)
+                is MysqlDialect -> value.format(MYSQL_OFFSET_DATE_TIME_FORMATTER)
+                else -> value
+            }
+        }
+        else -> error("Unexpected value: $value of ${value::class.qualifiedName}")
+    }
+
+    companion object {
+        internal val INSTANCE = JavaOffsetDateTimeColumnType()
+    }
+}
+
 class JavaDurationColumnType : ColumnType() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.longType()
 
@@ -288,7 +358,7 @@ class JavaDurationColumnType : ColumnType() {
 fun Table.date(name: String): Column<LocalDate> = registerColumn(name, JavaLocalDateColumnType())
 
 /**
- * A datetime column to store both a date and a time.
+ * A datetime column to store both a date and a time without time zone.
  *
  * @param name The column name
  */
@@ -305,11 +375,22 @@ fun Table.datetime(name: String): Column<LocalDateTime> = registerColumn(name, J
 fun Table.time(name: String): Column<LocalTime> = registerColumn(name, JavaLocalTimeColumnType())
 
 /**
- * A timestamp column to store both a date and a time.
+ * A timestamp column to store both a date and a time without time zone.
  *
  * @param name The column name
  */
 fun Table.timestamp(name: String): Column<Instant> = registerColumn(name, JavaInstantColumnType())
+
+/**
+ * A timestamp column to store both a date and a time with time zone.
+ *
+ * Note: PostgreSQL and MySQL always store the timestamp in UTC, thereby losing the original time zone. To preserve the
+ * original time zone, store the time zone information in a separate column.
+ *
+ * @param name The column name
+ */
+fun Table.timestampWithTimeZone(name: String): Column<OffsetDateTime> =
+    registerColumn(name, JavaOffsetDateTimeColumnType())
 
 /**
  * A date column to store a duration.

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -12,6 +12,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.OffsetDateTime
 import java.time.temporal.Temporal
 
 class Date<T : Temporal?>(val expr: Expression<T>) : Function<LocalDate>(JavaLocalDateColumnType.INSTANCE) {
@@ -138,6 +139,10 @@ fun dateTimeParam(value: LocalDateTime): Expression<LocalDateTime> =
     QueryParameter(value, JavaLocalDateTimeColumnType.INSTANCE)
 
 fun timestampParam(value: Instant): Expression<Instant> = QueryParameter(value, JavaInstantColumnType.INSTANCE)
+
+fun timestampWithTimeZoneParam(value: OffsetDateTime): Expression<OffsetDateTime> =
+    QueryParameter(value, JavaOffsetDateTimeColumnType.INSTANCE)
+
 fun durationParam(value: Duration): Expression<Duration> = QueryParameter(value, JavaDurationColumnType.INSTANCE)
 
 fun dateLiteral(value: LocalDate): LiteralOp<LocalDate> = LiteralOp(JavaLocalDateColumnType.INSTANCE, value)
@@ -145,6 +150,8 @@ fun timeLiteral(value: LocalTime): LiteralOp<LocalTime> = LiteralOp(JavaLocalTim
 fun dateTimeLiteral(value: LocalDateTime): LiteralOp<LocalDateTime> = LiteralOp(JavaLocalDateTimeColumnType.INSTANCE, value)
 
 fun timestampLiteral(value: Instant): LiteralOp<Instant> = LiteralOp(JavaInstantColumnType.INSTANCE, value)
+fun timestampWithTimeZoneLiteral(value: OffsetDateTime): LiteralOp<OffsetDateTime> =
+    LiteralOp(JavaOffsetDateTimeColumnType.INSTANCE, value)
 fun durationLiteral(value: Duration): LiteralOp<Duration> = LiteralOp(JavaDurationColumnType.INSTANCE, value)
 
 @Suppress("FunctionName")
@@ -162,6 +169,12 @@ fun CustomDateTimeFunction(functionName: String, vararg params: Expression<*>): 
 @Suppress("FunctionName")
 fun CustomTimeStampFunction(functionName: String, vararg params: Expression<*>): CustomFunction<Instant?> =
     CustomFunction(functionName, JavaInstantColumnType.INSTANCE, *params)
+
+@Suppress("FunctionName")
+fun CustomTimestampWithTimeZoneFunction(
+    functionName: String,
+    vararg params: Expression<*>
+): CustomFunction<OffsetDateTime?> = CustomFunction(functionName, JavaOffsetDateTimeColumnType.INSTANCE, *params)
 
 @Suppress("FunctionName")
 fun CustomDurationFunction(functionName: String, vararg params: Expression<*>): CustomFunction<Duration?> =

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -378,4 +378,59 @@ class DefaultsTest : DatabaseTestsBase() {
             }
         }
     }
+
+    @Test
+    fun testTimestampWithTimeZoneDefaults() {
+        // UTC time zone
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+        assertEquals("UTC", ZoneId.systemDefault().id)
+
+        val nowWithTimeZone = OffsetDateTime.now()
+        val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
+
+        val testTable = object : IntIdTable("t") {
+            val t1 = timestampWithTimeZone("t1").default(nowWithTimeZone)
+            val t2 = timestampWithTimeZone("t2").defaultExpression(timestampWithTimeZoneLiteral)
+        }
+
+        fun Expression<*>.itOrNull() = when {
+            currentDialectTest.isAllowedAsColumnDefault(this) ->
+                "DEFAULT ${currentDialectTest.dataTypeProvider.processForDefaultValue(this)} NOT NULL"
+            else -> "NULL"
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE, TestDB.MARIADB)) {
+            if (!isOldMySql()) {
+                SchemaUtils.create(testTable)
+
+                val timestampWithTimeZoneType = currentDialectTest.dataTypeProvider.timestampWithTimeZoneType()
+
+                val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
+                    "${"t".inProperCase()} (" +
+                    "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
+                    "${"t1".inProperCase()} $timestampWithTimeZoneType ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                    "${"t2".inProperCase()} $timestampWithTimeZoneType ${timestampWithTimeZoneLiteral.itOrNull()}" +
+                    ")"
+
+                val expected = if (currentDialectTest is OracleDialect ||
+                    currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+                ) {
+                    arrayListOf(
+                        "CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                        baseExpression
+                    )
+                } else {
+                    arrayListOf(baseExpression)
+                }
+
+                assertEqualLists(expected, testTable.ddl)
+
+                val id1 = testTable.insertAndGetId { }
+
+                val row1 = testTable.select { testTable.id eq id1 }.single()
+                assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
+                assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+            }
+        }
+    }
 }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -19,6 +20,7 @@ import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.*
 import org.junit.Assert.fail
 import org.junit.Test
@@ -28,6 +30,8 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.temporal.Temporal
 import kotlin.test.assertEquals
@@ -306,6 +310,104 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             assertEquals(2, modifiedBeforeCreation[tester.modified].userId)
         }
     }
+
+    @Test
+    fun testTimestampWithTimeZone() {
+        val testTable = object : IntIdTable("TestTable") {
+            val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
+        }
+
+        withDb(excludeSettings = listOf(TestDB.MARIADB)) { testDB ->
+            if (!isOldMySql()) {
+                SchemaUtils.create(testTable)
+
+                // Cairo time zone
+                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+                assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
+
+                val cairoNow = OffsetDateTime.now(ZoneId.systemDefault())
+
+                val cairoId = testTable.insertAndGetId {
+                    it[timestampWithTimeZone] = cairoNow
+                }
+
+                val cairoNowInsertedInCairoTimeZone = testTable.select { testTable.id eq cairoId }
+                    .single()[testTable.timestampWithTimeZone]
+
+                // UTC time zone
+                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+                assertEquals("UTC", ZoneId.systemDefault().id)
+
+                val cairoNowRetrievedInUTCTimeZone = testTable.select { testTable.id eq cairoId }
+                    .single()[testTable.timestampWithTimeZone]
+
+                val utcID = testTable.insertAndGetId {
+                    it[timestampWithTimeZone] = cairoNow
+                }
+
+                val cairoNowInsertedInUTCTimeZone = testTable.select { testTable.id eq utcID }
+                    .single()[testTable.timestampWithTimeZone]
+
+                // Tokyo time zone
+                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Tokyo"))
+                assertEquals("Asia/Tokyo", ZoneId.systemDefault().id)
+
+                val cairoNowRetrievedInTokyoTimeZone = testTable.select { testTable.id eq cairoId }
+                    .single()[testTable.timestampWithTimeZone]
+
+                val tokyoID = testTable.insertAndGetId {
+                    it[timestampWithTimeZone] = cairoNow
+                }
+
+                val cairoNowInsertedInTokyoTimeZone = testTable.select { testTable.id eq tokyoID }
+                    .single()[testTable.timestampWithTimeZone]
+
+                // PostgreSQL and MySQL always store the timestamp in UTC, thereby losing the original time zone.
+                // To preserve the original time zone, store the time zone information in a separate column.
+                val isOriginalTimeZonePreserved = testDB !in listOf(
+                    TestDB.POSTGRESQL,
+                    TestDB.POSTGRESQLNG,
+                    TestDB.MYSQL
+                )
+                if (isOriginalTimeZonePreserved) {
+                    // Assert that time zone is preserved when the same value is inserted in different time zones
+                    assertEqualDateTime(cairoNow, cairoNowInsertedInCairoTimeZone)
+                    assertEqualDateTime(cairoNow, cairoNowInsertedInUTCTimeZone)
+                    assertEqualDateTime(cairoNow, cairoNowInsertedInTokyoTimeZone)
+
+                    // Assert that time zone is preserved when the same record is retrieved in different time zones
+                    assertEqualDateTime(cairoNow, cairoNowRetrievedInUTCTimeZone)
+                    assertEqualDateTime(cairoNow, cairoNowRetrievedInTokyoTimeZone)
+                } else {
+                    // Assert equivalence in UTC when the same value is inserted in different time zones
+                    assertEqualDateTime(cairoNowInsertedInCairoTimeZone, cairoNowInsertedInUTCTimeZone)
+                    assertEqualDateTime(cairoNowInsertedInUTCTimeZone, cairoNowInsertedInTokyoTimeZone)
+
+                    // Assert equivalence in UTC when the same record is retrieved in different time zones
+                    assertEqualDateTime(cairoNowRetrievedInUTCTimeZone, cairoNowRetrievedInTokyoTimeZone)
+                }
+
+                // Reset to original time zone as set up in DatabaseTestsBase init block
+                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+                assertEquals("UTC", ZoneId.systemDefault().id)
+            }
+        }
+    }
+
+    @Test
+    fun testTimestampWithTimeZoneThrowsExceptionForUnsupportedDialects() {
+        val testTable = object : IntIdTable("TestTable") {
+            val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
+        }
+
+        withDb(db = listOf(TestDB.MYSQL, TestDB.MARIADB)) { testDB ->
+            if (testDB == TestDB.MARIADB || isOldMySql()) {
+                expectException<UnsupportedByDialectException> {
+                    SchemaUtils.create(testTable)
+                }
+            }
+        }
+    }
 }
 
 fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {
@@ -320,12 +422,20 @@ fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {
             }
         }
         d1 is LocalDateTime && d2 is LocalDateTime -> {
-            assertEquals(d1.toEpochSecond(ZoneOffset.UTC), d2.toEpochSecond(ZoneOffset.UTC), "Failed on epoch seconds ${currentDialectTest.name}")
+            assertEquals(
+                d1.toEpochSecond(ZoneOffset.UTC),
+                d2.toEpochSecond(ZoneOffset.UTC),
+                "Failed on epoch seconds ${currentDialectTest.name}"
+            )
             assertEqualFractionalPart(d1.nano, d2.nano)
         }
         d1 is Instant && d2 is Instant -> {
             assertEquals(d1.epochSecond, d2.epochSecond, "Failed on epoch seconds ${currentDialectTest.name}")
             assertEqualFractionalPart(d1.nano, d2.nano)
+        }
+        d1 is OffsetDateTime && d2 is OffsetDateTime -> {
+            assertEqualDateTime(d1.toLocalDateTime(), d2.toLocalDateTime())
+            assertEquals(d1.offset, d2.offset)
         }
         else -> assertEquals(d1, d2, "Failed on ${currentDialectTest.name}")
     }

--- a/exposed-jodatime/api/exposed-jodatime.api
+++ b/exposed-jodatime/api/exposed-jodatime.api
@@ -35,11 +35,13 @@ public final class org/jetbrains/exposed/sql/jodatime/DateColumnType$Companion {
 public final class org/jetbrains/exposed/sql/jodatime/DateColumnTypeKt {
 	public static final fun date (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static final fun datetime (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public static final fun timestampWithTimeZone (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/DateFunctionsKt {
 	public static final fun CustomDateFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomDateTimeFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
+	public static final fun CustomTimestampWithTimeZoneFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun date (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Date;
 	public static final fun dateLiteral (Lorg/joda/time/DateTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun dateParam (Lorg/joda/time/DateTime;)Lorg/jetbrains/exposed/sql/Expression;
@@ -50,7 +52,24 @@ public final class org/jetbrains/exposed/sql/jodatime/DateFunctionsKt {
 	public static final fun minute (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Minute;
 	public static final fun month (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Month;
 	public static final fun second (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Second;
+	public static final fun timestampWithTimeZoneLiteral (Lorg/joda/time/DateTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public static final fun timestampWithTimeZoneParam (Lorg/joda/time/DateTime;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun year (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Year;
+}
+
+public final class org/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IDateColumnType {
+	public static final field Companion Lorg/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumnType$Companion;
+	public fun <init> ()V
+	public fun getHasTimePart ()Z
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Lorg/joda/time/DateTime;
+}
+
+public final class org/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/Day : org/jetbrains/exposed/sql/Function {

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
@@ -116,9 +116,13 @@ fun <T : DateTime?> Expression<T>.second() = Second(this)
 
 fun dateParam(value: DateTime): Expression<DateTime> = QueryParameter(value, DateColumnType(false))
 fun dateTimeParam(value: DateTime): Expression<DateTime> = QueryParameter(value, DateColumnType(true))
+fun timestampWithTimeZoneParam(value: DateTime): Expression<DateTime> =
+    QueryParameter(value, DateTimeWithTimeZoneColumnType())
 
 fun dateLiteral(value: DateTime): LiteralOp<DateTime> = LiteralOp(DateColumnType(false), value)
 fun dateTimeLiteral(value: DateTime): LiteralOp<DateTime> = LiteralOp(DateColumnType(true), value)
+fun timestampWithTimeZoneLiteral(value: DateTime): LiteralOp<DateTime> =
+    LiteralOp(DateTimeWithTimeZoneColumnType(), value)
 
 @Suppress("FunctionNaming")
 fun CustomDateTimeFunction(functionName: String, vararg params: Expression<*>) =
@@ -127,3 +131,7 @@ fun CustomDateTimeFunction(functionName: String, vararg params: Expression<*>) =
 @Suppress("FunctionNaming")
 fun CustomDateFunction(functionName: String, vararg params: Expression<*>) =
     CustomFunction<DateTime?>(functionName, DateColumnType(false), *params)
+
+@Suppress("FunctionNaming")
+fun CustomTimestampWithTimeZoneFunction(functionName: String, vararg params: Expression<*>) =
+    CustomFunction<DateTime?>(functionName, DateTimeWithTimeZoneColumnType(), *params)

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -359,6 +359,61 @@ class JodaTimeDefaultsTest : JodaTimeBaseTest() {
         assertEquals("test1", list1?.get(testData.name))
         assertEquals(date.millis, list1?.get(testData.dateTime)?.millis)
     }
+
+    @Test
+    fun testTimestampWithTimeZoneDefaults() {
+        // UTC time zone
+        DateTimeZone.setDefault(DateTimeZone.UTC)
+        assertEquals("UTC", DateTimeZone.getDefault().id)
+
+        val nowWithTimeZone = DateTime.now()
+        val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
+
+        val testTable = object : IntIdTable("t") {
+            val t1 = timestampWithTimeZone("t1").default(nowWithTimeZone)
+            val t2 = timestampWithTimeZone("t2").defaultExpression(timestampWithTimeZoneLiteral)
+        }
+
+        fun Expression<*>.itOrNull() = when {
+            currentDialectTest.isAllowedAsColumnDefault(this) ->
+                "DEFAULT ${currentDialectTest.dataTypeProvider.processForDefaultValue(this)} NOT NULL"
+            else -> "NULL"
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE, TestDB.MARIADB)) {
+            if (!isOldMySql()) {
+                SchemaUtils.create(testTable)
+
+                val timestampWithTimeZoneType = currentDialectTest.dataTypeProvider.timestampWithTimeZoneType()
+
+                val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
+                    "${"t".inProperCase()} (" +
+                    "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
+                    "${"t1".inProperCase()} $timestampWithTimeZoneType ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                    "${"t2".inProperCase()} $timestampWithTimeZoneType ${timestampWithTimeZoneLiteral.itOrNull()}" +
+                    ")"
+
+                val expected = if (currentDialectTest is OracleDialect ||
+                    currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+                ) {
+                    arrayListOf(
+                        "CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                        baseExpression
+                    )
+                } else {
+                    arrayListOf(baseExpression)
+                }
+
+                assertEqualLists(expected, testTable.ddl)
+
+                val id1 = testTable.insertAndGetId { }
+
+                val row1 = testTable.select { testTable.id eq id1 }.single()
+                assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
+                assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+            }
+        }
+    }
 }
 
 fun Table.insertAndWait(duration: Long) {

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -20,6 +20,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnTyp
 	public static final fun duration (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static final fun time (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static final fun timestamp (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public static final fun timestampWithTimeZone (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctionsKt {
@@ -28,6 +29,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions
 	public static final fun CustomDurationFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomTimeFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomTimeStampFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
+	public static final fun CustomTimestampWithTimeZoneFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun InstantDateExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun InstantDateFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun InstantDayExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
@@ -83,6 +85,8 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions
 	public static final fun timeParam (Lkotlinx/datetime/LocalTime;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun timestampLiteral (Lkotlinx/datetime/Instant;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun timestampParam (Lkotlinx/datetime/Instant;)Lorg/jetbrains/exposed/sql/Expression;
+	public static final fun timestampWithTimeZoneLiteral (Ljava/time/OffsetDateTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public static final fun timestampWithTimeZoneParam (Ljava/time/OffsetDateTime;)Lorg/jetbrains/exposed/sql/Expression;
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDurationColumnType : org/jetbrains/exposed/sql/ColumnType {
@@ -152,6 +156,21 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalTimeColu
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalTimeColumnType$Companion {
+}
+
+public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinOffsetDateTimeColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IDateColumnType {
+	public static final field Companion Lorg/jetbrains/exposed/sql/kotlin/datetime/KotlinOffsetDateTimeColumnType$Companion;
+	public fun <init> ()V
+	public fun getHasTimePart ()Z
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/time/OffsetDateTime;
+}
+
+public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinOffsetDateTimeColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/YearInternal : org/jetbrains/exposed/sql/Function {

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
@@ -13,6 +13,7 @@ import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.jetbrains.exposed.sql.vendors.h2Mode
+import java.time.OffsetDateTime
 import kotlin.time.Duration
 
 internal class DateInternal(val expr: Expression<*>) : Function<LocalDate>(KotlinLocalDateColumnType.INSTANCE) {
@@ -235,6 +236,10 @@ fun dateParam(value: LocalDate): Expression<LocalDate> = QueryParameter(value, K
 fun timeParam(value: LocalTime): Expression<LocalTime> = QueryParameter(value, KotlinLocalTimeColumnType.INSTANCE)
 fun dateTimeParam(value: LocalDateTime): Expression<LocalDateTime> = QueryParameter(value, KotlinLocalDateTimeColumnType.INSTANCE)
 fun timestampParam(value: Instant): Expression<Instant> = QueryParameter(value, KotlinInstantColumnType.INSTANCE)
+
+fun timestampWithTimeZoneParam(value: OffsetDateTime): Expression<OffsetDateTime> =
+    QueryParameter(value, KotlinOffsetDateTimeColumnType.INSTANCE)
+
 fun durationParam(value: Duration): Expression<Duration> = QueryParameter(value, KotlinDurationColumnType.INSTANCE)
 
 fun dateLiteral(value: LocalDate): LiteralOp<LocalDate> = LiteralOp(KotlinLocalDateColumnType.INSTANCE, value)
@@ -242,6 +247,10 @@ fun timeLiteral(value: LocalTime): LiteralOp<LocalTime> = LiteralOp(KotlinLocalT
 fun dateTimeLiteral(value: LocalDateTime): LiteralOp<LocalDateTime> = LiteralOp(KotlinLocalDateTimeColumnType.INSTANCE, value)
 
 fun timestampLiteral(value: Instant): LiteralOp<Instant> = LiteralOp(KotlinInstantColumnType.INSTANCE, value)
+
+fun timestampWithTimeZoneLiteral(value: OffsetDateTime): LiteralOp<OffsetDateTime> =
+    LiteralOp(KotlinOffsetDateTimeColumnType.INSTANCE, value)
+
 fun durationLiteral(value: Duration): LiteralOp<Duration> = LiteralOp(KotlinDurationColumnType.INSTANCE, value)
 
 fun CustomDateFunction(functionName: String, vararg params: Expression<*>): CustomFunction<LocalDate?> =
@@ -255,6 +264,12 @@ fun CustomDateTimeFunction(functionName: String, vararg params: Expression<*>): 
 
 fun CustomTimeStampFunction(functionName: String, vararg params: Expression<*>): CustomFunction<Instant?> =
     CustomFunction(functionName, KotlinInstantColumnType.INSTANCE, *params)
+
+@Suppress("FunctionName")
+fun CustomTimestampWithTimeZoneFunction(
+    functionName: String,
+    vararg params: Expression<*>
+): CustomFunction<OffsetDateTime?> = CustomFunction(functionName, KotlinOffsetDateTimeColumnType.INSTANCE, *params)
 
 fun CustomDurationFunction(functionName: String, vararg params: Expression<*>): CustomFunction<Duration?> =
     CustomFunction(functionName, KotlinDurationColumnType.INSTANCE, *params)


### PR DESCRIPTION
The data type **timestamp with time zone** is supported by the following databases:

- [H2](http://www.h2database.com/html/datatypes.html#timestamp_with_time_zone_type)
- [Oracle](https://www.oracletutorial.com/oracle-basics/oracle-timestamp-with-time-zone/)
- [SQLite](https://www.sqlite.org/lang_datefunc.html#:~:text=Formats%202%20through%2010%20may%20be%20optionally%20followed%20by%20a%20timezone%20indicator%20of%20the%20form%20%22%5B%2B%2D%5DHH%3AMM%22%20or%20just%20%22Z%22.)
- [SQL Server](https://www.sqlservertutorial.net/sql-server-basics/sql-server-datetimeoffset/)
- [PostgreSQL (converted to UTC when stored, without preserving time zone info)](https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-timestamp/#:~:text=It%E2%80%99s%20important%20to%20note%20that%20timestamptz%20value%20is%20stored%20as%20a%20UTC%20value.%20PostgreSQL%20does%20not%20store%20any%20timezone%20data%20with%20the%20timestamptz%20value.)
- [MySQL 8.0.19+](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#:~:text=Beginning%20with%20MySQL%208.0.19%2C%20you%20can%20specify%20a%20time%20zone%20offset%20when%20inserting%20TIMESTAMP%20and%20DATETIME%20values%20into%20a%20table.) [(converted to UTC when stored, without preserving time zone info)](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html#:~:text=The%20offset%20is%20not%20displayed%20when%20selecting%20a%20datetime%20value%2C%20even%20if%20one%20was%20used%20when%20inserting%20it.)

It's not supported by the following databases:

- [MariaDB](https://mariadb.com/kb/en/timestamp/#:~:text=MariaDB%20does%20not%20currently,11829%20for%20more%20information.)

Note: PostgreSQL and MySQL always store the timestamp in UTC, thereby losing the original time zone. To preserve the original time zone, store the time zone information in a separate column.