### PR TITLE
feat: EXPOSED-89 Support functions in Create Index

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1106,23 +1106,25 @@ public final class org/jetbrains/exposed/sql/InSubQueryOp : org/jetbrains/expose
 }
 
 public final class org/jetbrains/exposed/sql/Index : org/jetbrains/exposed/sql/DdlAware {
-	public fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;)V
-	public synthetic fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Ljava/util/List;Lorg/jetbrains/exposed/sql/Table;)V
+	public synthetic fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Ljava/util/List;Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lorg/jetbrains/exposed/sql/Op;
-	public final fun component6 ()Lkotlin/Pair;
-	public final fun copy (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/Index;
-	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/Index;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Index;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lorg/jetbrains/exposed/sql/Table;
+	public final fun copy (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Ljava/util/List;Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Index;
+	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/Index;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Ljava/util/List;Lorg/jetbrains/exposed/sql/Table;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Index;
 	public fun createStatement ()Ljava/util/List;
 	public fun dropStatement ()Ljava/util/List;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColumns ()Ljava/util/List;
 	public final fun getCustomName ()Ljava/lang/String;
 	public final fun getFilterCondition ()Lorg/jetbrains/exposed/sql/Op;
-	public final fun getFunctions ()Lkotlin/Pair;
+	public final fun getFunctions ()Ljava/util/List;
+	public final fun getFunctionsTable ()Lorg/jetbrains/exposed/sql/Table;
 	public final fun getIndexName ()Ljava/lang/String;
 	public final fun getIndexType ()Ljava/lang/String;
 	public final fun getTable ()Lorg/jetbrains/exposed/sql/Table;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1106,21 +1106,23 @@ public final class org/jetbrains/exposed/sql/InSubQueryOp : org/jetbrains/expose
 }
 
 public final class org/jetbrains/exposed/sql/Index : org/jetbrains/exposed/sql/DdlAware {
-	public fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;)V
-	public synthetic fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;)V
+	public synthetic fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lorg/jetbrains/exposed/sql/Op;
-	public final fun copy (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Index;
-	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/Index;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Index;
+	public final fun component6 ()Lkotlin/Pair;
+	public final fun copy (Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/Index;
+	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/Index;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Op;Lkotlin/Pair;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Index;
 	public fun createStatement ()Ljava/util/List;
 	public fun dropStatement ()Ljava/util/List;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColumns ()Ljava/util/List;
 	public final fun getCustomName ()Ljava/lang/String;
 	public final fun getFilterCondition ()Lorg/jetbrains/exposed/sql/Op;
+	public final fun getFunctions ()Lkotlin/Pair;
 	public final fun getIndexName ()Ljava/lang/String;
 	public final fun getIndexType ()Ljava/lang/String;
 	public final fun getTable ()Lorg/jetbrains/exposed/sql/Table;
@@ -2291,10 +2293,10 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public fun getPrimaryKey ()Lorg/jetbrains/exposed/sql/Table$PrimaryKey;
 	public fun getTableName ()Ljava/lang/String;
 	public fun hashCode ()I
-	public final fun index (Ljava/lang/String;Z[Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun index (Ljava/lang/String;Z[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public final fun index (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;Z)Lorg/jetbrains/exposed/sql/Column;
 	public final fun index (Z[Lorg/jetbrains/exposed/sql/Column;)V
-	public static synthetic fun index$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Z[Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun index$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Z[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun index$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun index$default (Lorg/jetbrains/exposed/sql/Table;Z[Lorg/jetbrains/exposed/sql/Column;ILjava/lang/Object;)V
 	public fun innerJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
@@ -2339,10 +2341,10 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public final fun ubyte (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun uinteger (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun ulong (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
-	public final fun uniqueIndex (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;)V
+	public final fun uniqueIndex (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
 	public final fun uniqueIndex (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun uniqueIndex ([Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun uniqueIndex$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun uniqueIndex$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun uniqueIndex$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun uniqueIndex$default (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun ushort (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
@@ -3524,6 +3526,7 @@ public final class org/jetbrains/exposed/sql/vendors/KeywordsKt {
 public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbrains/exposed/sql/vendors/MysqlDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion;
 	public fun <init> ()V
+	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	public fun getFunctionProvider ()Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;
 	public fun getName ()Ljava/lang/String;
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
@@ -3535,6 +3538,7 @@ public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion : 
 public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/exposed/sql/vendors/VendorDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/MysqlDialect$Companion;
 	public fun <init> ()V
+	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	public fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
@@ -3557,6 +3561,7 @@ public class org/jetbrains/exposed/sql/vendors/OracleDialect : org/jetbrains/exp
 	public fun createDatabase (Ljava/lang/String;)Ljava/lang/String;
 	public fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;
+	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public fun getDefaultReferenceOption ()Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public fun getNeedsQuotesWhenSymbolsInNames ()Z
@@ -3605,6 +3610,7 @@ public class org/jetbrains/exposed/sql/vendors/SQLServerDialect : org/jetbrains/
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/SQLServerDialect$Companion;
 	public fun <init> ()V
 	public fun createDatabase (Ljava/lang/String;)Ljava/lang/String;
+	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	protected fun createIndexWithType (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -986,8 +986,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /**
      * Creates an index.
      *
-     * @param columns Columns that compose the index.
      * @param isUnique Whether the index is unique or not.
+     * @param columns Columns that compose the index.
      */
     fun index(isUnique: Boolean = false, vararg columns: Column<*>): Unit = index(null, isUnique, *columns)
 
@@ -995,8 +995,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * Creates an index.
      *
      * @param customIndexName Name of the index.
-     * @param columns Columns that compose the index.
      * @param isUnique Whether the index is unique or not.
+     * @param columns Columns that compose the index.
+     * @param functions Functions that compose the index.
      * @param indexType A custom index type (e.g., "BTREE" or "HASH").
      * @param filterCondition Index filtering conditions (also known as "partial index") declaration.
      */
@@ -1004,10 +1005,13 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         customIndexName: String? = null,
         isUnique: Boolean = false,
         vararg columns: Column<*>,
+        functions: List<ExpressionWithColumnType<*>>? = null,
         indexType: String? = null,
         filterCondition: FilterCondition = null
     ) {
-        _indices.add(Index(columns.toList(), isUnique, customIndexName, indexType = indexType, filterCondition?.invoke(SqlExpressionBuilder)))
+        _indices.add(
+            Index(columns.toList(), isUnique, customIndexName, indexType, filterCondition?.invoke(SqlExpressionBuilder), functions?.let { this to it })
+        )
     }
 
     /**
@@ -1041,10 +1045,16 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      *
      * @param customIndexName Name of the index.
      * @param columns Columns that compose the index.
+     * @param functions Functions that compose the index.
      * @param filterCondition Index filtering conditions (also known as "partial index") declaration.
      */
-    fun uniqueIndex(customIndexName: String? = null, vararg columns: Column<*>, filterCondition: FilterCondition = null): Unit =
-        index(customIndexName, true, *columns, filterCondition = filterCondition)
+    fun uniqueIndex(
+        customIndexName: String? = null,
+        vararg columns: Column<*>,
+        functions: List<ExpressionWithColumnType<*>>? = null,
+        filterCondition: FilterCondition = null
+    ): Unit =
+        index(customIndexName, true, *columns, functions = functions, filterCondition = filterCondition)
 
     /**
      * Creates a composite foreign key.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -989,7 +989,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param isUnique Whether the index is unique or not.
      * @param columns Columns that compose the index.
      */
-    fun index(isUnique: Boolean = false, vararg columns: Column<*>): Unit = index(null, isUnique, *columns)
+    fun index(isUnique: Boolean = false, vararg columns: Column<*>) { index(null, isUnique, *columns) }
 
     /**
      * Creates an index.
@@ -1010,7 +1010,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         filterCondition: FilterCondition = null
     ) {
         _indices.add(
-            Index(columns.toList(), isUnique, customIndexName, indexType, filterCondition?.invoke(SqlExpressionBuilder), functions?.let { this to it })
+            Index(
+                columns.toList(), isUnique, customIndexName, indexType,
+                filterCondition?.invoke(SqlExpressionBuilder),
+                functions, functions?.let { this }
+            )
         )
     }
 
@@ -1037,8 +1041,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param columns Columns that compose the index.
      * @param filterCondition Index filtering conditions (also known as "partial index") declaration.
      */
-    fun uniqueIndex(vararg columns: Column<*>, filterCondition: FilterCondition = null): Unit =
+    fun uniqueIndex(vararg columns: Column<*>, filterCondition: FilterCondition = null) {
         index(null, true, *columns, filterCondition = filterCondition)
+    }
 
     /**
      * Creates a unique index.
@@ -1053,8 +1058,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         vararg columns: Column<*>,
         functions: List<ExpressionWithColumnType<*>>? = null,
         filterCondition: FilterCondition = null
-    ): Unit =
+    ) {
         index(customIndexName, true, *columns, functions = functions, filterCondition = filterCondition)
+    }
 
     /**
      * Creates a composite foreign key.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -1182,7 +1182,7 @@ abstract class VendorDialect(
         val t = TransactionManager.current()
         val quotedTableName = t.identity(index.table)
         val quotedIndexName = t.db.identifierManager.cutIfNecessaryAndQuote(index.indexName)
-        val keyFields = index.columns.plus(index.functions?.second ?: emptyList())
+        val keyFields = index.columns.plus(index.functions ?: emptyList())
         val fieldsList = keyFields.joinToString(prefix = "(", postfix = ")") {
             when (it) {
                 is Column<*> -> t.identity(it)
@@ -1193,7 +1193,7 @@ abstract class VendorDialect(
                 }
             }
         }
-        val includesOnlyColumns = index.functions?.second?.isEmpty() != false
+        val includesOnlyColumns = index.functions?.isEmpty() != false
         val maybeFilterCondition = filterCondition(index) ?: return ""
 
         return when {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -1161,6 +1161,16 @@ abstract class VendorDialect(
         } ?: ""
     }
 
+    private fun indexFunctionToString(function: Function<*>): String {
+        val baseString = function.toString()
+        return when (currentDialect) {
+            // SQLite & Oracle do not support "." operator (with table prefix) in index expressions
+            is SQLiteDialect, is OracleDialect -> baseString.replace(Regex("""^*[^( ]*\."""), "")
+            is MysqlDialect -> if (baseString.first() != '(') "($baseString)" else baseString
+            else -> baseString
+        }
+    }
+
     /**
      * Uniqueness might be required for foreign key constraints.
      *
@@ -1172,29 +1182,38 @@ abstract class VendorDialect(
         val t = TransactionManager.current()
         val quotedTableName = t.identity(index.table)
         val quotedIndexName = t.db.identifierManager.cutIfNecessaryAndQuote(index.indexName)
-        val columnsList = index.columns.joinToString(prefix = "(", postfix = ")") { t.identity(it) }
-
+        val keyFields = index.columns.plus(index.functions?.second ?: emptyList())
+        val fieldsList = keyFields.joinToString(prefix = "(", postfix = ")") {
+            when (it) {
+                is Column<*> -> t.identity(it)
+                is Function<*> -> indexFunctionToString(it)
+                else -> {
+                    exposedLogger.warn("Unexpected defining key field will be passed as String: $it")
+                    it.toString()
+                }
+            }
+        }
+        val includesOnlyColumns = index.functions?.second?.isEmpty() != false
         val maybeFilterCondition = filterCondition(index) ?: return ""
 
         return when {
             // unique and no filter -> constraint, the type is not supported
-            index.unique && maybeFilterCondition.isEmpty() -> {
-                "ALTER TABLE $quotedTableName ADD CONSTRAINT $quotedIndexName UNIQUE $columnsList"
+            index.unique && maybeFilterCondition.isEmpty() && includesOnlyColumns -> {
+                "ALTER TABLE $quotedTableName ADD CONSTRAINT $quotedIndexName UNIQUE $fieldsList"
             }
             // unique and filter -> index only, the type is not supported
             index.unique -> {
-                "CREATE UNIQUE INDEX $quotedIndexName ON $quotedTableName $columnsList$maybeFilterCondition"
+                "CREATE UNIQUE INDEX $quotedIndexName ON $quotedTableName $fieldsList$maybeFilterCondition"
             }
             // type -> can't be unique or constraint
             index.indexType != null -> {
                 createIndexWithType(
                     name = quotedIndexName, table = quotedTableName,
-                    columns = columnsList, type = index.indexType, filterCondition = maybeFilterCondition
+                    columns = fieldsList, type = index.indexType, filterCondition = maybeFilterCondition
                 )
             }
-            // any other indexes. May be can be merged with `createIndexWithType`
             else -> {
-                "CREATE INDEX $quotedIndexName ON $quotedTableName $columnsList$maybeFilterCondition"
+                "CREATE INDEX $quotedIndexName ON $quotedTableName $fieldsList$maybeFilterCondition"
             }
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -246,7 +246,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         }
         if (index.functions != null) {
             exposedLogger.warn(
-                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in H2"
+                "Functional index on ${index.table.tableName} using ${index.functions.joinToString { it.toString() }} can't be created in H2"
             )
             return ""
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -244,6 +244,12 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
             )
             return ""
         }
+        if (index.functions != null) {
+            exposedLogger.warn(
+                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in H2"
+            )
+            return ""
+        }
         return super.createIndex(index)
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -1,9 +1,11 @@
 package org.jetbrains.exposed.sql.vendors
 
 import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.Index
 import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.append
+import org.jetbrains.exposed.sql.exposedLogger
 
 internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
     override fun nextVal(seq: Sequence, builder: QueryBuilder) = builder {
@@ -35,6 +37,16 @@ class MariaDBDialect : MysqlDialect() {
     override val name: String = dialectName
     override val functionProvider: FunctionProvider = MariaDBFunctionProvider
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
+
+    override fun createIndex(index: Index): String {
+        if (index.functions != null) {
+            exposedLogger.warn(
+                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in MariaDB"
+            )
+            return ""
+        }
+        return super.createIndex(index)
+    }
 
     companion object : DialectNameProvider("mariadb")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -41,7 +41,7 @@ class MariaDBDialect : MysqlDialect() {
     override fun createIndex(index: Index): String {
         if (index.functions != null) {
             exposedLogger.warn(
-                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in MariaDB"
+                "Functional index on ${index.table.tableName} using ${index.functions.joinToString { it.toString() }} can't be created in MariaDB"
             )
             return ""
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -330,7 +330,7 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
     override fun createIndex(index: Index): String {
         if (index.functions != null && !isMysql8) {
             exposedLogger.warn(
-                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in MySQL prior to 8.0"
+                "Functional index on ${index.table.tableName} using ${index.functions.joinToString { it.toString() }} can't be created in MySQL prior to 8.0"
             )
             return ""
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -327,6 +327,16 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         }
     }
 
+    override fun createIndex(index: Index): String {
+        if (index.functions != null && !isMysql8) {
+            exposedLogger.warn(
+                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in MySQL prior to 8.0"
+            )
+            return ""
+        }
+        return super.createIndex(index)
+    }
+
     override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String =
         "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -296,6 +296,10 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String {
+        return "DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
+    }
+
     override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> {
         val result = super.modifyColumn(column, columnDiff).map {
             it.replace("MODIFY COLUMN", "MODIFY")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -262,6 +262,16 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
         }
     }
 
+    override fun createIndex(index: Index): String {
+        if (index.functions != null) {
+            exposedLogger.warn(
+                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in SQLServer"
+            )
+            return ""
+        }
+        return super.createIndex(index)
+    }
+
     override fun createIndexWithType(name: String, table: String, columns: String, type: String, filterCondition: String): String {
         return "CREATE $type INDEX $name ON $table $columns$filterCondition"
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -265,7 +265,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     override fun createIndex(index: Index): String {
         if (index.functions != null) {
             exposedLogger.warn(
-                "Functional index on ${index.table.tableName} using ${index.functions.second.joinToString { it.toString() }} can't be created in SQLServer"
+                "Functional index on ${index.table.tableName} using ${index.functions.joinToString { it.toString() }} can't be created in SQLServer"
             )
             return ""
         }


### PR DESCRIPTION
Add support for functional indices.

**Problem 1 - Getting Table Info:**
Data class `Index` currently gets `Table` information from user-provided `columns`. If an index is defined using only functions, the `table` property cannot be derived, since `Function` class does not store such info. In this case, table info needs to be directly provided, so this is done automatically if a user defines `functions`.

**Problem 2 - Naming the Index:**
Current behavior is to append column names to table name. `Function` class does not store a name, so it will be derived from the function string (works for Exposed functions of the form NAME(expr)). If a custom function doesn't have this format, the entire string is used instead.
- _Alternative_: Force users to provide a `customIndexName` if functions are included.

**Problem 3 - Multiple Vararg Prohibited:**
All current index creation functions have a parameter named `columns` that only accepts `List<Column<*>>`. Multiple function arguments need to be supported, but a second `vararg` cannot be used, so the new parameter accepts `List<ExpressionWithColumnType<*>>` instead.
- _Alternative_: Change `columns` type to this mutual super class so the user could easily provide column and function arguments together without named arguments. But then the name `columns` would be misleading and would need to be replaced with something like `columnsAndFunctions` or `keyFields`, which would break uses that include named arguments. This would also break Exposed code that uses `Index.columns`, which would require handling/filtering to provide expected  `List<Column<*>>`.

**Note:**
- Add `dropIndex()` override for Oracle as default was not correct.