### PR TITLE
fix: SQLServerException: The port number -1 is not valid.

### DIFF
--- a/buildScripts/docker/docker-compose-sqlserver.yml
+++ b/buildScripts/docker/docker-compose-sqlserver.yml
@@ -1,12 +1,11 @@
 version: '3.1'
 
 services:
-  sqlserver:
-    container_name: SQLServer
-    image: mcr.microsoft.com/mssql/server:2017-latest
-    ports:
-      - "1433"
-    environment:
-      ACCEPT_EULA: "Y"
-      SA_PASSWORD: "yourStrong(!)Password"
-      MSSQL_PID: "Express"
+    sqlserver:
+        container_name: SQLServer
+        image: mcr.microsoft.com/azure-sql-edge:1.0.7
+        ports:
+            - "1433:1433"
+        environment:
+            ACCEPT_EULA: "1"
+            SA_PASSWORD: "yourStrong(!)Password"


### PR DESCRIPTION
Switched to Azure SQL Edge because it's not possible to run earlier MS SQL Server version on hardware with ARM CPU. M1 and M2 chips from Apple use ARM architecture.

I tried to use 2.0.0, which is the [latest](https://mcr.microsoft.com/v2/azure-sql-edge/tags/list) at the time of writing this, but it didn't work for me and threw this error:
<img width="559" alt="Screenshot 2023-07-13 at 1 24 53 PM" src="https://github.com/JetBrains/Exposed/assets/38375996/f5304107-5d71-4649-833d-f48011d09efe">
So I ended up using 1.0.7

How to test:
- Checkout branch locally
- Run any test for SQL Server
- It should pass with no issues