### PR TITLE
fix: EXPOSED-91 NPE in existingIndices() with function index

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -281,7 +281,9 @@ data class Index(
 
     override fun createStatement(): List<String> = listOf(currentDialect.createIndex(this))
     override fun modifyStatement(): List<String> = dropStatement() + createStatement()
-    override fun dropStatement(): List<String> = listOf(currentDialect.dropIndex(table.nameInDatabaseCase(), indexName, unique, filterCondition != null))
+    override fun dropStatement(): List<String> = listOf(
+        currentDialect.dropIndex(table.nameInDatabaseCase(), indexName, unique, filterCondition != null || functions != null)
+    )
 
     /** Returns `true` if the [other] index has the same columns and uniqueness as this index, but a different name, `false` otherwise */
     fun onlyNameDiffer(other: Index): Boolean = indexName != other.indexName && columns == other.columns && unique == other.unique

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -337,7 +337,7 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         return super.createIndex(index)
     }
 
-    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String =
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String =
         "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
 
     override fun setSchema(schema: Schema): String = "USE ${schema.identifier}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -296,7 +296,7 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
-    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String {
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String {
         return "DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -324,8 +324,8 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
         return "CREATE INDEX $name ON $table USING $type $columns$filterCondition"
     }
 
-    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String {
-        return if (isUnique && !isPartial) {
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String {
+        return if (isUnique && !isPartialOrFunctional) {
             "ALTER TABLE IF EXISTS ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
         } else {
             "DROP INDEX IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -276,8 +276,8 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
         return "CREATE $type INDEX $name ON $table $columns$filterCondition"
     }
 
-    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String {
-        return if (isUnique && !isPartial) {
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String {
+        return if (isUnique && !isPartialOrFunctional) {
             "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
         } else {
             "DROP INDEX IF EXISTS ${identifierManager.quoteIfNecessary(indexName)} ON ${identifierManager.quoteIfNecessary(tableName)}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -266,7 +266,7 @@ open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQ
         }
     }
 
-    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartial: Boolean): String {
+    override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String {
         return "DROP INDEX IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
     }
 


### PR DESCRIPTION
**Affected DB : SQLite, MySQL**

`existingIndices()` in `JdbcDatabaseMetadataImpl` requires a COLUMN_NAME value from every table index retrieved through `DatabaseMetadata`. There is no metadata option for functions in the event that a function-based index is created instead.

The 4 databases that support function-based indices return different COLUMN_NAME values:
- [PostgreSQL] returns the function definition, e.g. `"lower((item)::text)"`
- [Oracle] returns the internal name of the virtual column, e.g. `"SYS_NC00006$"`
- [SQLite, MySQL] return null

The `!!` operator throwing the NPE has been replaced to ensure that indices defined by functions alone are still included instead of being ignored/throwing. This is important for `SchemaUtils` functions that validate index count, index name, or table statements in general.

**Additional:**
- PostgreSQL functional indices follow same rules as partial indices, in that they must be dropped using DROP INDEX, not ALTER TABLE. Vendor dialect `dropIndex()` has had its parameter `isPartial` renamed to `isPartialOrFunctional` to combine both conditions.
- Extracted common private function from unit tests.