### PR TITLE
refactor: EXPOSED-88 Remove kotlinx-serialization dep from exposed-core

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -926,9 +926,6 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public abstract fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public abstract fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
-	public abstract fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public abstract fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public abstract fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public abstract fun lag (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Lag;
 	public abstract fun lastValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/LastValue;
 	public abstract fun lead (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Lead;
@@ -1034,12 +1031,6 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public static fun isNotNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public static fun isNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
-	public static fun jsonContains (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public static fun jsonContains (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public static synthetic fun jsonContains$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public static synthetic fun jsonContains$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public static fun jsonExists (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
-	public static synthetic fun jsonExists$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public static fun lag (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Lag;
 	public static synthetic fun lag$default (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Lag;
 	public static fun lastValue (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/LastValue;
@@ -1205,50 +1196,6 @@ public final class org/jetbrains/exposed/sql/JoinType : java/lang/Enum {
 	public static final field RIGHT Lorg/jetbrains/exposed/sql/JoinType;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JoinType;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/JoinType;
-}
-
-public final class org/jetbrains/exposed/sql/JsonBColumnType : org/jetbrains/exposed/sql/JsonColumnType {
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public fun sqlType ()Ljava/lang/String;
-}
-
-public class org/jetbrains/exposed/sql/JsonColumnType : org/jetbrains/exposed/sql/ColumnType {
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public final fun getDeserialize ()Lkotlin/jvm/functions/Function1;
-	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/String;
-	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
-	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class org/jetbrains/exposed/sql/JsonContains : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;)V
-	public final fun getCandidate ()Lorg/jetbrains/exposed/sql/Expression;
-	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
-	public final fun getPath ()Ljava/lang/String;
-	public final fun getTarget ()Lorg/jetbrains/exposed/sql/Expression;
-	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
-}
-
-public final class org/jetbrains/exposed/sql/JsonExists : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;)V
-	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
-	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
-	public final fun getOptional ()Ljava/lang/String;
-	public final fun getPath ()[Ljava/lang/String;
-	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
-}
-
-public final class org/jetbrains/exposed/sql/JsonExtract : org/jetbrains/exposed/sql/Function {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/IColumnType;)V
-	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
-	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
-	public final fun getPath ()[Ljava/lang/String;
-	public final fun getToScalar ()Z
-	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
 public final class org/jetbrains/exposed/sql/Key {
@@ -2015,9 +1962,6 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
-	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public fun lag (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Lag;
 	public fun lastValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/LastValue;
 	public fun lead (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Lead;
@@ -2122,9 +2066,6 @@ public class org/jetbrains/exposed/sql/SqlExpressionBuilderClass : org/jetbrains
 	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotNullOp;
 	public fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNullOp;
-	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public fun jsonContains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonContains;
-	public fun jsonExists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JsonExists;
 	public fun lag (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Lag;
 	public fun lastValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/LastValue;
 	public fun lead (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Lead;
@@ -2305,8 +2246,6 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public fun innerJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public final fun integer (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public fun join (Lorg/jetbrains/exposed/sql/ColumnSet;Lorg/jetbrains/exposed/sql/JoinType;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Join;
-	public final fun json (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
-	public final fun jsonb (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun largeText (Ljava/lang/String;Ljava/lang/String;Z)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun largeText$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public fun leftJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;

--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
-    kotlin("plugin.serialization") apply true
 }
 
 repositories {
@@ -13,7 +12,5 @@ dependencies {
     api(kotlin("stdlib"))
     api(kotlin("reflect"))
     api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", Versions.kotlinCoroutines)
-    api("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
-    api("org.postgresql", "postgresql", Versions.postgre)
     api("org.slf4j", "slf4j-api", "1.7.25")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -335,27 +335,6 @@ class VarSamp<T>(
     }
 }
 
-// JSON Functions
-
-/**
- * Represents an SQL function that returns extracted data from a JSON object at the specified [path],
- * either as a JSON representation or as a scalar value.
- */
-class JsonExtract<T>(
-    /** Returns the expression from which to extract JSON subcomponents matched by [path]. */
-    val expression: Expression<*>,
-    /** Returns array of Strings representing JSON path/keys that match fields to be extracted. */
-    vararg val path: String,
-    /** Returns whether the extracted result should be a scalar or text value; if `false`, result will be a JSON object. */
-    val toScalar: Boolean,
-    /** Returns the column type of [expression] to check, if casting to JSONB is required. */
-    val jsonType: IColumnType,
-    columnType: IColumnType
-) : Function<T>(columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
-        currentDialect.functionProvider.jsonExtract(expression, path = path, toScalar, jsonType, queryBuilder)
-}
-
 // Sequence Manipulation Functions
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -548,42 +548,6 @@ class RegexpOp<T : String?>(
     }
 }
 
-// JSON Conditions
-
-/**
- * Represents an SQL operator that checks whether a [candidate] expression is contained within a JSON [target].
- */
-class JsonContains(
-    /** Returns the JSON expression being searched. */
-    val target: Expression<*>,
-    /** Returns the expression being searched for in [target]. */
-    val candidate: Expression<*>,
-    /** Returns an optional String representing JSON path/keys that match specific fields to search for [candidate]. */
-    val path: String?,
-    /** Returns the column type of [target] to check, if casting to JSONB is required. */
-    val jsonType: IColumnType
-) : Op<Boolean>(), ComplexExpression, Op.OpBoolean {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
-        currentDialect.functionProvider.jsonContains(target, candidate, path, jsonType, queryBuilder)
-}
-
-/**
- * Represents an SQL operator that checks whether data exists within a JSON [expression] at the specified [path].
- */
-class JsonExists(
-    /** Returns the JSON expression being checked. */
-    val expression: Expression<*>,
-    /** Returns the array of Strings representing JSON path/keys that match fields to check for existing data. */
-    vararg val path: String,
-    /** Returns an optional String representing any vendor-specific clause or argument. */
-    val optional: String?,
-    /** Returns the column type of [expression] to check, if casting to JSONB is required. */
-    val jsonType: IColumnType
-) : Op<Boolean>(), ComplexExpression, Op.OpBoolean {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
-        currentDialect.functionProvider.jsonExists(expression, path = path, optional, jsonType, queryBuilder)
-}
-
 // Subquery Expressions
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -2,8 +2,6 @@
 
 package org.jetbrains.exposed.sql
 
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.serializer
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
@@ -97,34 +95,6 @@ fun <T : Any?> ExpressionWithColumnType<T>.varPop(scale: Int = 2): VarPop<T> = V
  * @param scale The scale of the decimal column expression returned.
  */
 fun <T : Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> = VarSamp(this, scale)
-
-// JSON Functions
-
-/**
- * Returns the extracted data from a JSON object at the specified [path], either as a JSON representation or as a scalar value.
- *
- * @param path String(s) representing JSON path/keys that match fields to be extracted.
- * If none are provided, the root context item `'$'` will be used by default.
- * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
- * @param toScalar If `true`, the extracted result is a scalar or text value; otherwise, it is a JSON object.
- */
-inline fun <reified T : Any> ExpressionWithColumnType<*>.jsonExtract(vararg path: String, toScalar: Boolean = true): JsonExtract<T> {
-    val columnType = when (T::class) {
-        String::class -> TextColumnType()
-        Boolean::class -> BooleanColumnType()
-        Long::class -> LongColumnType()
-        Int::class -> IntegerColumnType()
-        Short::class -> ShortColumnType()
-        Byte::class -> ByteColumnType()
-        Double::class -> DoubleColumnType()
-        Float::class -> FloatColumnType()
-        ByteArray::class -> BasicBinaryColumnType()
-        else -> {
-            JsonColumnType({ Json.Default.encodeToString(serializer<T>(), it) }, { Json.Default.decodeFromString(serializer<T>(), it) })
-        }
-    }
-    return JsonExtract(this, path = path, toScalar, this.columnType, columnType)
-}
 
 // Sequence Manipulation Functions
 
@@ -587,40 +557,6 @@ interface ISqlExpressionBuilder {
      * (counting from 1); null if no such row.
      */
     fun <T> ExpressionWithColumnType<T>.nthValue(n: ExpressionWithColumnType<Int>): NthValue<T> = NthValue(this, n)
-
-    // JSON Conditions
-
-    /**
-     * Checks whether a [candidate] expression is contained within [this] JSON expression.
-     *
-     * @param candidate Expression to search for in [this] JSON expression.
-     * @param path String representing JSON path/keys that match specific fields to search for [candidate].
-     * **Note:** Optional [path] argument is not supported by all vendors; please check the documentation.
-     */
-    fun ExpressionWithColumnType<*>.jsonContains(candidate: Expression<*>, path: String? = null): JsonContains =
-        JsonContains(this, candidate, path, columnType)
-
-    /**
-     * Checks whether a [candidate] value is contained within [this] JSON expression.
-     *
-     * @param candidate Value to search for in [this] JSON expression.
-     * @param path String representing JSON path/keys that match specific fields to search for [candidate].
-     * **Note:** Optional [path] argument is not supported by all vendors; please check the documentation.
-     */
-    fun <T> ExpressionWithColumnType<*>.jsonContains(candidate: T, path: String? = null): JsonContains =
-        JsonContains(this, asLiteral(candidate), path, columnType)
-
-    /**
-     * Checks whether data exists within [this] JSON expression at the specified [path].
-     *
-     * @param path String(s) representing JSON path/keys that match fields to check for existing data.
-     * If none are provided, the root context item `'$'` will be used by default.
-     * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
-     * @param optional String representing any optional vendor-specific clause or argument.
-     * **Note:** [optional] function arguments are not supported by all vendors; please check the documentation.
-     */
-    fun ExpressionWithColumnType<*>.jsonExists(vararg path: String, optional: String? = null): JsonExists =
-        JsonExists(this, path = path, optional, columnType)
 
     // Conditional Expressions
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1,8 +1,5 @@
 package org.jetbrains.exposed.sql
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.serializer
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
@@ -640,68 +637,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         fromDb: (Any) -> T,
         toDb: (T) -> Any
     ): Column<T> = registerColumn(name, CustomEnumerationColumnType(name, sql, fromDb, toDb))
-
-    // JSON columns
-
-    /**
-     * Creates a column, with the specified [name], for storing JSON data.
-     *
-     * **Note**: This column stores JSON either in non-binary text format or, if the vendor only supports 1 format, the default JSON type format.
-     * If JSON must be stored in binary format, and the vendor supports this, please use `jsonb()` instead.
-     *
-     * @param name Name of the column
-     * @param serialize Function that encodes an object of type [T] to a JSON String
-     * @param deserialize Function that decodes a JSON string to an object of type [T]
-     */
-    fun <T : Any> json(name: String, serialize: (T) -> String, deserialize: (String) -> T): Column<T> =
-        registerColumn(name, JsonColumnType(serialize, deserialize))
-
-    /**
-     * Creates a column, with the specified [name], for storing JSON data.
-     *
-     * **Note**: This column stores JSON either in non-binary text format or, if the vendor only supports 1 format, the default JSON type format.
-     * If JSON must be stored in binary format, and the vendor supports this, please use `jsonb()` instead.
-     *
-     * @param name Name of the column
-     * @param jsonConfig Configured instance of the `Json` class
-     * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
-     * Defaults to a generic serializer for type [T]
-     */
-    inline fun <reified T : Any> json(
-        name: String,
-        jsonConfig: Json,
-        kSerializer: KSerializer<T> = serializer<T>()
-    ): Column<T> =
-        json(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })
-
-    /**
-     * Creates a column, with the specified [name], for storing JSON data in decomposed binary format.
-     *
-     * **Note**: JSON storage in binary format is not supported by all vendors; please check the documentation.
-     *
-     * @param name Name of the column
-     * @param serialize Function that encodes an object of type [T] to a JSON String
-     * @param deserialize Function that decodes a JSON string to an object of type [T]
-     */
-    fun <T : Any> jsonb(name: String, serialize: (T) -> String, deserialize: (String) -> T): Column<T> =
-        registerColumn(name, JsonBColumnType(serialize, deserialize))
-
-    /**
-     * Creates a column, with the specified [name], for storing JSON data in decomposed binary format.
-     *
-     * **Note**: JSON storage in binary format is not supported by all vendors; please check the documentation.
-     *
-     * @param name Name of the column
-     * @param jsonConfig Configured instance of the `Json` class
-     * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
-     * Defaults to a generic serializer for type [T]
-     */
-    inline fun <reified T : Any> jsonb(
-        name: String,
-        jsonConfig: Json,
-        kSerializer: KSerializer<T> = serializer<T>()
-    ): Column<T> =
-        jsonb(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })
 
     // Auto-generated values
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -135,7 +135,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         path?.let {
             TransactionManager.current().throwUnsupportedException("PostgreSQL does not support a JSON path argument")
         }
-        val isNotJsonB = jsonType !is JsonBColumnType<*>
+        val isNotJsonB = jsonType.sqlType() != "JSONB"
         queryBuilder {
             append(target)
             if (isNotJsonB) append("::jsonb")
@@ -154,7 +154,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         if (path.size > 1) {
             TransactionManager.current().throwUnsupportedException("PostgreSQL does not support multiple JSON path arguments")
         }
-        val isNotJsonB = jsonType !is JsonBColumnType<*>
+        val isNotJsonB = jsonType.sqlType() != "JSONB"
         queryBuilder {
             append("JSONB_PATH_EXISTS(")
             if (isNotJsonB) {

--- a/exposed-java-time/build.gradle.kts
+++ b/exposed-java-time/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     api(project(":exposed-core"))
     testImplementation(project(":exposed-dao"))
     testImplementation(project(":exposed-tests"))
+    testImplementation(project(":exposed-json"))
     testImplementation("junit", "junit", "4.12")
     testImplementation(kotlin("test-junit"))
 }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -12,6 +12,8 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.javatime.*
+import org.jetbrains.exposed.sql.json.extract
+import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -290,15 +292,15 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             val prefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
 
             // value extracted in same manner it is stored, a json string
-            val modifiedAsString = tester.modified.jsonExtract<String>("${prefix}timestamp")
+            val modifiedAsString = tester.modified.extract<String>("${prefix}timestamp")
             val allModifiedAsString = tester.slice(modifiedAsString).selectAll()
             assertTrue(allModifiedAsString.all { it[modifiedAsString] == dateTimeNow.toString() })
 
             // PostgreSQL requires explicit type cast to timestamp for in-DB comparison
             val dateModified = if (currentDialectTest is PostgreSQLDialect) {
-                tester.modified.jsonExtract<LocalDateTime>("${prefix}timestamp").castTo(JavaLocalDateTimeColumnType())
+                tester.modified.extract<LocalDateTime>("${prefix}timestamp").castTo(JavaLocalDateTimeColumnType())
             } else {
-                tester.modified.jsonExtract<LocalDateTime>("${prefix}timestamp")
+                tester.modified.extract<LocalDateTime>("${prefix}timestamp")
             }
             val modifiedBeforeCreation = tester.select { dateModified less tester.created }.single()
             assertEquals(2, modifiedBeforeCreation[tester.modified].userId)

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -11,6 +11,8 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.jodatime.*
+import org.jetbrains.exposed.sql.json.extract
+import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -205,15 +207,15 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
             val prefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
 
             // value extracted in same manner it is stored, a json string
-            val modifiedAsString = tester.modified.jsonExtract<String>("${prefix}timestamp")
+            val modifiedAsString = tester.modified.extract<String>("${prefix}timestamp")
             val allModifiedAsString = tester.slice(modifiedAsString).selectAll()
             assertTrue(allModifiedAsString.all { it[modifiedAsString] == dateTimeNow.toString() })
 
             // PostgreSQL requires explicit type cast to timestamp for in-DB comparison
             val dateModified = if (currentDialectTest is PostgreSQLDialect) {
-                tester.modified.jsonExtract<DateTime>("${prefix}timestamp").castTo(DateColumnType(true))
+                tester.modified.extract<DateTime>("${prefix}timestamp").castTo(DateColumnType(true))
             } else {
-                tester.modified.jsonExtract<DateTime>("${prefix}timestamp")
+                tester.modified.extract<DateTime>("${prefix}timestamp")
             }
             val modifiedBeforeCreation = tester.select { dateModified less tester.created }.single()
             assertEquals(2, modifiedBeforeCreation[tester.modified].userId)

--- a/exposed-json/api/exposed-json.api
+++ b/exposed-json/api/exposed-json.api
@@ -1,0 +1,61 @@
+public final class org/jetbrains/exposed/sql/json/Contains : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getCandidate ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getTarget ()Lorg/jetbrains/exposed/sql/Expression;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/json/Exists : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public final fun getOptional ()Ljava/lang/String;
+	public final fun getPath ()[Ljava/lang/String;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/json/Extract : org/jetbrains/exposed/sql/Function {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;[Ljava/lang/String;ZLorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getJsonType ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public final fun getPath ()[Ljava/lang/String;
+	public final fun getToScalar ()Z
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/json/JsonBColumnType : org/jetbrains/exposed/sql/json/JsonColumnType {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun sqlType ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/exposed/sql/json/JsonBColumnTypeKt {
+	public static final fun jsonb (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
+}
+
+public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/exposed/sql/ColumnType {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final fun getDeserialize ()Lkotlin/jvm/functions/Function1;
+	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/String;
+	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
+	public fun sqlType ()Ljava/lang/String;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/sql/json/JsonColumnTypeKt {
+	public static final fun json (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
+}
+
+public final class org/jetbrains/exposed/sql/json/JsonConditionsKt {
+	public static final fun contains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/json/Contains;
+	public static final fun contains (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/json/Contains;
+	public static synthetic fun contains$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/json/Contains;
+	public static synthetic fun contains$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/json/Contains;
+	public static final fun exists (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/json/Exists;
+	public static synthetic fun exists$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;[Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/json/Exists;
+}
+

--- a/exposed-json/build.gradle.kts
+++ b/exposed-json/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.exposed.gradle.Versions
+
 plugins {
     kotlin("jvm") apply true
     kotlin("plugin.serialization") apply true
@@ -10,10 +12,10 @@ repositories {
 
 dependencies {
     api(project(":exposed-core"))
-    api("joda-time", "joda-time", "2.10.13")
+    api("org.jetbrains.kotlinx", "kotlinx-serialization-json", Versions.kotlinxSerialization)
+    compileOnly("org.postgresql", "postgresql", Versions.postgre)
     testImplementation(project(":exposed-dao"))
     testImplementation(project(":exposed-tests"))
-    testImplementation(project(":exposed-json"))
     testImplementation("junit", "junit", "4.12")
     testImplementation(kotlin("test-junit"))
 }

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnType.kt
@@ -1,0 +1,58 @@
+package org.jetbrains.exposed.sql.json
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.currentDialect
+
+/**
+ * Column for storing JSON data in binary format.
+ *
+ * @param serialize Function that encodes an object of type [T] to a JSON String
+ * @param deserialize Function that decodes a JSON String to an object of type [T]
+ */
+class JsonBColumnType<T : Any>(
+    serialize: (T) -> String,
+    deserialize: (String) -> T
+) : JsonColumnType<T>(serialize, deserialize) {
+    override fun sqlType(): String = when (currentDialect) {
+        is H2Dialect -> (currentDialect as H2Dialect).originalDataTypeProvider.jsonBType()
+        else -> currentDialect.dataTypeProvider.jsonBType()
+    }
+}
+
+/**
+ * Creates a column, with the specified [name], for storing JSON data in decomposed binary format.
+ *
+ * **Note**: JSON storage in binary format is not supported by all vendors; please check the documentation.
+ *
+ * @param name Name of the column
+ * @param serialize Function that encodes an object of type [T] to a JSON String
+ * @param deserialize Function that decodes a JSON string to an object of type [T]
+ */
+fun <T : Any> Table.jsonb(
+    name: String,
+    serialize: (T) -> String,
+    deserialize: (String) -> T
+): Column<T> =
+    registerColumn(name, JsonBColumnType(serialize, deserialize))
+
+/**
+ * Creates a column, with the specified [name], for storing JSON data in decomposed binary format.
+ *
+ * **Note**: JSON storage in binary format is not supported by all vendors; please check the documentation.
+ *
+ * @param name Name of the column
+ * @param jsonConfig Configured instance of the `Json` class
+ * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
+ * Defaults to a generic serializer for type [T]
+ */
+inline fun <reified T : Any> Table.jsonb(
+    name: String,
+    jsonConfig: Json,
+    kSerializer: KSerializer<T> = serializer<T>()
+): Column<T> =
+    jsonb(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
@@ -1,0 +1,93 @@
+package org.jetbrains.exposed.sql.json
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ColumnType
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.postgresql.util.PGobject
+
+/**
+ * Column for storing JSON data, either in non-binary text format or the vendor's default JSON type format.
+ */
+open class JsonColumnType<T : Any>(
+    /** Returns the function that encodes an object of type [T] to a JSON String. */
+    val serialize: (T) -> String,
+    /** Returns the function that decodes a JSON String to an object of type [T]. */
+    val deserialize: (String) -> T
+) : ColumnType() {
+    override fun sqlType(): String = currentDialect.dataTypeProvider.jsonType()
+
+    override fun valueFromDB(value: Any): Any {
+        return when {
+            currentDialect is PostgreSQLDialect && value is PGobject -> deserialize(value.value!!)
+            value is String -> deserialize(value)
+            value is ByteArray -> deserialize(value.decodeToString())
+            else -> value
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun notNullValueToDB(value: Any) = serialize(value as T)
+
+    override fun nonNullValueToString(value: Any): String {
+        return when (currentDialect) {
+            is H2Dialect -> "JSON '${notNullValueToDB(value)}'"
+            else -> super.nonNullValueToString(value)
+        }
+    }
+
+    override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
+        val parameterValue = when (currentDialect) {
+            is PostgreSQLDialect -> PGobject().apply {
+                type = sqlType()
+                this.value = value as String?
+            }
+            is H2Dialect -> (value as String).encodeToByteArray()
+            else -> value
+        }
+        super.setParameter(stmt, index, parameterValue)
+    }
+}
+
+/**
+ * Creates a column, with the specified [name], for storing JSON data.
+ *
+ * **Note**: This column stores JSON either in non-binary text format or,
+ * if the vendor only supports 1 format, the default JSON type format.
+ * If JSON must be stored in binary format, and the vendor supports this, please use `jsonb()` instead.
+ *
+ * @param name Name of the column
+ * @param serialize Function that encodes an object of type [T] to a JSON String
+ * @param deserialize Function that decodes a JSON string to an object of type [T]
+ */
+fun <T : Any> Table.json(
+    name: String,
+    serialize: (T) -> String,
+    deserialize: (String) -> T
+): Column<T> =
+    registerColumn(name, JsonColumnType(serialize, deserialize))
+
+/**
+ * Creates a column, with the specified [name], for storing JSON data.
+ *
+ * **Note**: This column stores JSON either in non-binary text format or,
+ * if the vendor only supports 1 format, the default JSON type format.
+ * If JSON must be stored in binary format, and the vendor supports this, please use `jsonb()` instead.
+ *
+ * @param name Name of the column
+ * @param jsonConfig Configured instance of the `Json` class
+ * @param kSerializer Serializer responsible for the representation of a serial form of type [T].
+ * Defaults to a generic serializer for type [T]
+ */
+inline fun <reified T : Any> Table.json(
+    name: String,
+    jsonConfig: Json,
+    kSerializer: KSerializer<T> = serializer<T>()
+): Column<T> =
+    json(name, { jsonConfig.encodeToString(kSerializer, it) }, { jsonConfig.decodeFromString(kSerializer, it) })

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonConditions.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonConditions.kt
@@ -1,0 +1,80 @@
+package org.jetbrains.exposed.sql.json
+
+import org.jetbrains.exposed.sql.ComplexExpression
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.ExpressionWithColumnType
+import org.jetbrains.exposed.sql.IColumnType
+import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.asLiteral
+import org.jetbrains.exposed.sql.vendors.currentDialect
+
+// Operator Classes
+
+/**
+ * Represents an SQL operator that checks whether a [candidate] expression is contained within a JSON [target].
+ */
+class Contains(
+    /** Returns the JSON expression being searched. */
+    val target: Expression<*>,
+    /** Returns the expression being searched for in [target]. */
+    val candidate: Expression<*>,
+    /** Returns an optional String representing JSON path/keys that match specific fields to search for [candidate]. */
+    val path: String?,
+    /** Returns the column type of [target] to check, if casting to JSONB is required. */
+    val jsonType: IColumnType
+) : Op<Boolean>(), ComplexExpression {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
+        currentDialect.functionProvider.jsonContains(target, candidate, path, jsonType, queryBuilder)
+}
+
+/**
+ * Represents an SQL operator that checks whether data exists within a JSON [expression] at the specified [path].
+ */
+class Exists(
+    /** Returns the JSON expression being checked. */
+    val expression: Expression<*>,
+    /** Returns the array of Strings representing JSON path/keys that match fields to check for existing data. */
+    vararg val path: String,
+    /** Returns an optional String representing any vendor-specific clause or argument. */
+    val optional: String?,
+    /** Returns the column type of [expression] to check, if casting to JSONB is required. */
+    val jsonType: IColumnType
+) : Op<Boolean>(), ComplexExpression {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
+        currentDialect.functionProvider.jsonExists(expression, path = path, optional, jsonType, queryBuilder)
+}
+
+// Extension Functions
+
+/**
+ * Checks whether a [candidate] expression is contained within [this] JSON expression.
+ *
+ * @param candidate Expression to search for in [this] JSON expression.
+ * @param path String representing JSON path/keys that match specific fields to search for [candidate].
+ * **Note:** Optional [path] argument is not supported by all vendors; please check the documentation.
+ */
+fun ExpressionWithColumnType<*>.contains(candidate: Expression<*>, path: String? = null): Contains =
+    Contains(this, candidate, path, columnType)
+
+/**
+ * Checks whether a [candidate] value is contained within [this] JSON expression.
+ *
+ * @param candidate Value to search for in [this] JSON expression.
+ * @param path String representing JSON path/keys that match specific fields to search for [candidate].
+ * **Note:** Optional [path] argument is not supported by all vendors; please check the documentation.
+ */
+fun <T> ExpressionWithColumnType<*>.contains(candidate: T, path: String? = null): Contains =
+    Contains(this, asLiteral(candidate), path, columnType)
+
+/**
+ * Checks whether data exists within [this] JSON expression at the specified [path].
+ *
+ * @param path String(s) representing JSON path/keys that match fields to check for existing data.
+ * If none are provided, the root context item `'$'` will be used by default.
+ * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
+ * @param optional String representing any optional vendor-specific clause or argument.
+ * **Note:** [optional] function arguments are not supported by all vendors; please check the documentation.
+ */
+fun ExpressionWithColumnType<*>.exists(vararg path: String, optional: String? = null): Exists =
+    Exists(this, path = path, optional, columnType)

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
@@ -1,0 +1,62 @@
+package org.jetbrains.exposed.sql.json
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.Function
+import org.jetbrains.exposed.sql.vendors.currentDialect
+
+// Function Classes
+
+/**
+ * Represents an SQL function that returns extracted data from a JSON object at the specified [path],
+ * either as a JSON representation or as a scalar value.
+ */
+class Extract<T>(
+    /** Returns the expression from which to extract JSON subcomponents matched by [path]. */
+    val expression: Expression<*>,
+    /** Returns array of Strings representing JSON path/keys that match fields to be extracted. */
+    vararg val path: String,
+    /** Returns whether the extracted result should be a scalar or text value; if `false`, result will be a JSON object. */
+    val toScalar: Boolean,
+    /** Returns the column type of [expression] to check, if casting to JSONB is required. */
+    val jsonType: IColumnType,
+    columnType: IColumnType
+) : Function<T>(columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) =
+        currentDialect.functionProvider.jsonExtract(expression, path = path, toScalar, jsonType, queryBuilder)
+}
+
+// Extension Functions
+
+/**
+ * Returns the extracted data from a JSON object at the specified [path], either as a JSON representation or as a scalar value.
+ *
+ * @param path String(s) representing JSON path/keys that match fields to be extracted.
+ * If none are provided, the root context item `'$'` will be used by default.
+ * **Note:** Multiple [path] arguments are not supported by all vendors; please check the documentation.
+ * @param toScalar If `true`, the extracted result is a scalar or text value; otherwise, it is a JSON object.
+ */
+inline fun <reified T : Any> ExpressionWithColumnType<*>.extract(
+    vararg path: String,
+    toScalar: Boolean = true
+): Extract<T> {
+    val columnType = when (T::class) {
+        String::class -> TextColumnType()
+        Boolean::class -> BooleanColumnType()
+        Long::class -> LongColumnType()
+        Int::class -> IntegerColumnType()
+        Short::class -> ShortColumnType()
+        Byte::class -> ByteColumnType()
+        Double::class -> DoubleColumnType()
+        Float::class -> FloatColumnType()
+        ByteArray::class -> BasicBinaryColumnType()
+        else -> {
+            JsonColumnType(
+                { Json.Default.encodeToString(serializer<T>(), it) },
+                { Json.Default.decodeFromString(serializer<T>(), it) }
+            )
+        }
+    }
+    return Extract(this, path = path, toScalar, this.columnType, columnType)
+}

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
@@ -1,27 +1,24 @@
-package org.jetbrains.exposed.sql.tests.shared.types
+package org.jetbrains.exposed.sql.json
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonContains
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonExists
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
-import org.jetbrains.exposed.sql.tests.currentTestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.junit.Test
 
-class JsonBColumnTypeTests : DatabaseTestsBase() {
+class JsonBColumnTests : DatabaseTestsBase() {
     private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER) + TestDB.ORACLE
 
     @Test
     fun testInsertAndSelect() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, _, _ ->
             val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = newData
@@ -34,7 +31,7 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdate() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, data1 ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, data1, _ ->
             assertEquals(data1, tester.selectAll().single()[tester.jsonBColumn])
 
             val updatedData = data1.copy(active = false)
@@ -48,18 +45,18 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWithSliceExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, user1, data1 ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, user1, data1, _ ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
-            val isActive = tester.jsonBColumn.jsonExtract<Boolean>("${pathPrefix}active", toScalar = false)
+            val isActive = tester.jsonBColumn.extract<Boolean>("${pathPrefix}active", toScalar = false)
             val result1 = tester.slice(isActive).selectAll().singleOrNull()
             assertEquals(data1.active, result1?.get(isActive))
 
-            val storedUser = tester.jsonBColumn.jsonExtract<User>("${pathPrefix}user", toScalar = false)
+            val storedUser = tester.jsonBColumn.extract<User>("${pathPrefix}user", toScalar = false)
             val result2 = tester.slice(storedUser).selectAll().singleOrNull()
             assertEquals(user1, result2?.get(storedUser))
 
             val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "name") else arrayOf(".user.name")
-            val username = tester.jsonBColumn.jsonExtract<String>(*path)
+            val username = tester.jsonBColumn.extract<String>(*path)
             val result3 = tester.slice(username).selectAll().singleOrNull()
             assertEquals(user1.name, result3?.get(username))
         }
@@ -67,16 +64,16 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWhereWithExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, data1 ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, data1, _ ->
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(logins = 1000)
             }
 
             // Postgres requires type casting to compare jsonb field as integer value in DB ???
             val logins = if (currentDialectTest is PostgreSQLDialect) {
-                tester.jsonBColumn.jsonExtract<Int>("logins").castTo(IntegerColumnType())
+                tester.jsonBColumn.extract<Int>("logins").castTo(IntegerColumnType())
             } else {
-                tester.jsonBColumn.jsonExtract<Int>(".logins")
+                tester.jsonBColumn.extract<Int>(".logins")
             }
             val tooManyLogins = logins greaterEq 1000
 
@@ -111,9 +108,9 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
                 if (testDb !in TestDB.allH2TestDB) {
                     dataEntity.new { jsonBColumn = dataA }
                     val loginCount = if (currentDialectTest is PostgreSQLDialect) {
-                        dataTable.jsonBColumn.jsonExtract<Int>("logins").castTo(IntegerColumnType())
+                        dataTable.jsonBColumn.extract<Int>("logins").castTo(IntegerColumnType())
                     } else {
-                        dataTable.jsonBColumn.jsonExtract<Int>(".logins")
+                        dataTable.jsonBColumn.extract<Int>(".logins")
                     }
                     val frequentUser = dataEntity.find { loginCount greaterEq 50 }.single()
                     assertEquals(updatedUser, frequentUser.jsonBColumn)
@@ -126,22 +123,22 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonContains() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, user1, data1 ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, user1, data1, testDb ->
             val alphaTeamUser = user1.copy(team = "Alpha")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(user = alphaTeamUser)
             }
 
-            val userIsInactive = tester.jsonBColumn.jsonContains("{\"active\":false}")
+            val userIsInactive = tester.jsonBColumn.contains("{\"active\":false}")
             assertEquals(0, tester.select { userIsInactive }.count())
 
             val alphaTeamUserAsJson = "{\"user\":${Json.Default.encodeToString(alphaTeamUser)}}"
-            var userIsInAlphaTeam = tester.jsonBColumn.jsonContains(stringLiteral(alphaTeamUserAsJson))
+            var userIsInAlphaTeam = tester.jsonBColumn.contains(stringLiteral(alphaTeamUserAsJson))
             assertEquals(1, tester.select { userIsInAlphaTeam }.count())
 
             // test target contains candidate at specified path
-            if (currentTestDB in TestDB.mySqlRelatedDB) {
-                userIsInAlphaTeam = tester.jsonBColumn.jsonContains("\"Alpha\"", ".user.team")
+            if (testDb in TestDB.mySqlRelatedDB) {
+                userIsInAlphaTeam = tester.jsonBColumn.contains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.slice(tester.id).select { userIsInAlphaTeam }
                 assertEquals(newId, alphaTeamUsers.single()[tester.id])
             }
@@ -150,34 +147,34 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExists() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, data1 ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, data1, testDb ->
             val maximumLogins = 1000
             val teamA = "A"
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(user = data1.user.copy(team = teamA), logins = maximumLogins)
             }
 
-            val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
+            val optional = if (testDb in TestDB.mySqlRelatedDB) "one" else null
 
             // test data at path root '$' exists by providing no path arguments
-            val hasAnyData = tester.jsonBColumn.jsonExists(optional = optional)
+            val hasAnyData = tester.jsonBColumn.exists(optional = optional)
             assertEquals(2, tester.select { hasAnyData }.count())
 
-            val hasFakeKey = tester.jsonBColumn.jsonExists(".fakeKey", optional = optional)
+            val hasFakeKey = tester.jsonBColumn.exists(".fakeKey", optional = optional)
             assertEquals(0, tester.select { hasFakeKey }.count())
 
-            val hasLogins = tester.jsonBColumn.jsonExists(".logins", optional = optional)
+            val hasLogins = tester.jsonBColumn.exists(".logins", optional = optional)
             assertEquals(2, tester.select { hasLogins }.count())
 
             // test data at path exists with filter condition & optional arguments
             if (currentDialectTest is PostgreSQLDialect) {
                 val filterPath = ".logins ? (@ == $maximumLogins)"
-                val hasMaxLogins = tester.jsonBColumn.jsonExists(filterPath)
+                val hasMaxLogins = tester.jsonBColumn.exists(filterPath)
                 val usersWithMaxLogin = tester.slice(tester.id).select { hasMaxLogins }
                 assertEquals(newId, usersWithMaxLogin.single()[tester.id])
 
                 val (jsonPath, optionalArg) = ".user.team ? (@ == \$team)" to "{\"team\":\"$teamA\"}"
-                val isOnTeamA = tester.jsonBColumn.jsonExists(jsonPath, optional = optionalArg)
+                val isOnTeamA = tester.jsonBColumn.exists(jsonPath, optional = optionalArg)
                 val usersOnTeamA = tester.slice(tester.id).select { isOnTeamA }
                 assertEquals(newId, usersOnTeamA.single()[tester.id])
             }
@@ -186,26 +183,30 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExtractWithArrays() {
-        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, singleId, _ ->
-            val path1 = if (currentDialectTest is PostgreSQLDialect) arrayOf("users", "0", "team") else arrayOf(".users[0].team")
-            val firstIsOnTeamA = tester.groups.jsonExtract<String>(*path1) eq "Team A"
+        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, singleId, _, _ ->
+            val path1 = if (currentDialectTest is PostgreSQLDialect) {
+                arrayOf("users", "0", "team")
+            } else {
+                arrayOf(".users[0].team")
+            }
+            val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             assertEquals(singleId, tester.select { firstIsOnTeamA }.single()[tester.id])
 
             // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
             val path2 = if (currentDialectTest is PostgreSQLDialect) "0" else "[0]"
-            val firstNumber = tester.numbers.jsonExtract<Int>(path2, toScalar = !isOldMySql())
+            val firstNumber = tester.numbers.extract<Int>(path2, toScalar = !isOldMySql())
             assertEqualCollections(listOf(100, 3), tester.slice(firstNumber).selectAll().map { it[firstNumber] })
         }
     }
 
     @Test
     fun testJsonContainsWithArrays() {
-        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, tripleId ->
-            val hasSmallNumbers = tester.numbers.jsonContains("[3, 5]")
+        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, tripleId, testDb ->
+            val hasSmallNumbers = tester.numbers.contains("[3, 5]")
             assertEquals(tripleId, tester.select { hasSmallNumbers }.single()[tester.id])
 
-            if (currentTestDB in TestDB.mySqlRelatedDB) {
-                val hasUserNameB = tester.groups.jsonContains("\"B\"", ".users[0].name")
+            if (testDb in TestDB.mySqlRelatedDB) {
+                val hasUserNameB = tester.groups.contains("\"B\"", ".users[0].name")
                 assertEquals(tripleId, tester.select { hasUserNameB }.single()[tester.id])
             }
         }
@@ -213,13 +214,13 @@ class JsonBColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExistsWithArrays() {
-        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, tripleId ->
-            val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
+        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.allH2TestDB) { tester, _, tripleId, testDb ->
+            val optional = if (testDb in TestDB.mySqlRelatedDB) "one" else null
 
-            val hasMultipleUsers = tester.groups.jsonExists(".users[1]", optional = optional)
+            val hasMultipleUsers = tester.groups.exists(".users[1]", optional = optional)
             assertEquals(tripleId, tester.select { hasMultipleUsers }.single()[tester.id])
 
-            val hasAtLeast3Numbers = tester.numbers.jsonExists("[2]", optional = optional)
+            val hasAtLeast3Numbers = tester.numbers.exists("[2]", optional = optional)
             assertEquals(tripleId, tester.select { hasAtLeast3Numbers }.single()[tester.id])
         }
     }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -1,4 +1,4 @@
-package org.jetbrains.exposed.sql.tests.shared.types
+package org.jetbrains.exposed.sql.json
 
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
@@ -6,12 +6,9 @@ import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonContains
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.jsonExists
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
-import org.jetbrains.exposed.sql.tests.currentTestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
@@ -20,10 +17,10 @@ import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.junit.Test
 
-class JsonColumnTypeTests : DatabaseTestsBase() {
+class JsonColumnTests : DatabaseTestsBase() {
     @Test
     fun testInsertAndSelect() {
-        withJsonTable { tester, _, _ ->
+        withJsonTable { tester, _, _, _ ->
             val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
             val newId = tester.insertAndGetId {
                 it[jsonColumn] = newData
@@ -36,7 +33,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdate() {
-        withJsonTable { tester, _, data1 ->
+        withJsonTable { tester, _, data1, _ ->
             assertEquals(data1, tester.selectAll().single()[tester.jsonColumn])
 
             val updatedData = data1.copy(active = false)
@@ -50,20 +47,20 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWithSliceExtract() {
-        withJsonTable(exclude = TestDB.allH2TestDB) { tester, user1, data1 ->
+        withJsonTable(exclude = TestDB.allH2TestDB) { tester, user1, data1, _ ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
             // SQLServer & Oracle return null if extracted JSON is not scalar
             val requiresScalar = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
-            val isActive = tester.jsonColumn.jsonExtract<Boolean>("${pathPrefix}active", toScalar = requiresScalar)
+            val isActive = tester.jsonColumn.extract<Boolean>("${pathPrefix}active", toScalar = requiresScalar)
             val result1 = tester.slice(isActive).selectAll().singleOrNull()
             assertEquals(data1.active, result1?.get(isActive))
 
-            val storedUser = tester.jsonColumn.jsonExtract<User>("${pathPrefix}user", toScalar = false)
+            val storedUser = tester.jsonColumn.extract<User>("${pathPrefix}user", toScalar = false)
             val result2 = tester.slice(storedUser).selectAll().singleOrNull()
             assertEquals(user1, result2?.get(storedUser))
 
             val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "name") else arrayOf(".user.name")
-            val username = tester.jsonColumn.jsonExtract<String>(*path)
+            val username = tester.jsonColumn.extract<String>(*path)
             val result3 = tester.slice(username).selectAll().singleOrNull()
             assertEquals(user1.name, result3?.get(username))
         }
@@ -71,16 +68,16 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWhereWithExtract() {
-        withJsonTable(exclude = TestDB.allH2TestDB) { tester, _, data1 ->
+        withJsonTable(exclude = TestDB.allH2TestDB) { tester, _, data1, _ ->
             val newId = tester.insertAndGetId {
                 it[jsonColumn] = data1.copy(logins = 1000)
             }
 
             // Postgres requires type casting to compare json field as integer value in DB
             val logins = if (currentDialectTest is PostgreSQLDialect) {
-                tester.jsonColumn.jsonExtract<Int>("logins").castTo(IntegerColumnType())
+                tester.jsonColumn.extract<Int>("logins").castTo(IntegerColumnType())
             } else {
-                tester.jsonColumn.jsonExtract<Int>(".logins")
+                tester.jsonColumn.extract<Int>(".logins")
             }
             val tooManyLogins = logins greaterEq 1000
 
@@ -131,8 +128,12 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
                 if (testDb !in TestDB.allH2TestDB) {
                     dataEntity.new { jsonColumn = dataA }
-                    val path = if (currentDialectTest is PostgreSQLDialect) arrayOf("user", "team") else arrayOf(".user.team")
-                    val userTeam = dataTable.jsonColumn.jsonExtract<String>(*path)
+                    val path = if (currentDialectTest is PostgreSQLDialect) {
+                        arrayOf("user", "team")
+                    } else {
+                        arrayOf(".user.team")
+                    }
+                    val userTeam = dataTable.jsonColumn.extract<String>(*path)
                     val userInTeamB = dataEntity.find { userTeam like "B%" }.single()
 
                     assertEquals(updatedUser, userInTeamB.jsonColumn)
@@ -143,29 +144,28 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
         }
     }
 
-    private val jsonContainsNotSupported = TestDB.values().toList() - listOf(
-        TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.MYSQL, TestDB.MARIADB
-    )
+    private val jsonContainsNotSupported = TestDB.values().toList() -
+        listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.MYSQL, TestDB.MARIADB)
 
     @Test
     fun testJsonContains() {
-        withJsonTable(exclude = jsonContainsNotSupported) { tester, user1, data1 ->
+        withJsonTable(exclude = jsonContainsNotSupported) { tester, user1, data1, testDb ->
             val alphaTeamUser = user1.copy(team = "Alpha")
             val newId = tester.insertAndGetId {
                 it[jsonColumn] = data1.copy(user = alphaTeamUser)
             }
 
-            val userIsInactive = tester.jsonColumn.jsonContains("{\"active\":false}")
+            val userIsInactive = tester.jsonColumn.contains("{\"active\":false}")
             val result = tester.select { userIsInactive }.toList()
             assertEquals(0, result.size)
 
             val alphaTeamUserAsJson = "{\"user\":${Json.Default.encodeToString(alphaTeamUser)}}"
-            var userIsInAlphaTeam = tester.jsonColumn.jsonContains(stringLiteral(alphaTeamUserAsJson))
+            var userIsInAlphaTeam = tester.jsonColumn.contains(stringLiteral(alphaTeamUserAsJson))
             assertEquals(1, tester.select { userIsInAlphaTeam }.count())
 
             // test target contains candidate at specified path
-            if (currentTestDB in TestDB.mySqlRelatedDB) {
-                userIsInAlphaTeam = tester.jsonColumn.jsonContains("\"Alpha\"", ".user.team")
+            if (testDb in TestDB.mySqlRelatedDB) {
+                userIsInAlphaTeam = tester.jsonColumn.contains("\"Alpha\"", ".user.team")
                 val alphaTeamUsers = tester.slice(tester.id).select { userIsInAlphaTeam }
                 assertEquals(newId, alphaTeamUsers.single()[tester.id])
             }
@@ -174,23 +174,23 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExists() {
-        withJsonTable(exclude = TestDB.allH2TestDB + TestDB.SQLSERVER) { tester, _, data1 ->
+        withJsonTable(exclude = TestDB.allH2TestDB + TestDB.SQLSERVER) { tester, _, data1, testDb ->
             val maximumLogins = 1000
             val teamA = "A"
             val newId = tester.insertAndGetId {
                 it[jsonColumn] = data1.copy(user = data1.user.copy(team = teamA), logins = maximumLogins)
             }
 
-            val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
+            val optional = if (testDb in TestDB.mySqlRelatedDB) "one" else null
 
             // test data at path root '$' exists by providing no path arguments
-            val hasAnyData = tester.jsonColumn.jsonExists(optional = optional)
+            val hasAnyData = tester.jsonColumn.exists(optional = optional)
             assertEquals(2, tester.select { hasAnyData }.count())
 
-            val hasFakeKey = tester.jsonColumn.jsonExists(".fakeKey", optional = optional)
+            val hasFakeKey = tester.jsonColumn.exists(".fakeKey", optional = optional)
             assertEquals(0, tester.select { hasFakeKey }.count())
 
-            val hasLogins = tester.jsonColumn.jsonExists(".logins", optional = optional)
+            val hasLogins = tester.jsonColumn.exists(".logins", optional = optional)
             assertEquals(2, tester.select { hasLogins }.count())
 
             // test data at path exists with filter condition & optional arguments
@@ -201,7 +201,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
                 } else {
                     ".logins ? (@ == $maximumLogins)"
                 }
-                val hasMaxLogins = tester.jsonColumn.jsonExists(filterPath)
+                val hasMaxLogins = tester.jsonColumn.exists(filterPath)
                 val usersWithMaxLogin = tester.slice(tester.id).select { hasMaxLogins }
                 assertEquals(newId, usersWithMaxLogin.single()[tester.id])
 
@@ -210,7 +210,7 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
                 } else {
                     ".user.team ? (@ == \$team)" to "{\"team\":\"$teamA\"}"
                 }
-                val isOnTeamA = tester.jsonColumn.jsonExists(jsonPath, optional = optionalArg)
+                val isOnTeamA = tester.jsonColumn.exists(jsonPath, optional = optionalArg)
                 val usersOnTeamA = tester.slice(tester.id).select { isOnTeamA }
                 assertEquals(newId, usersOnTeamA.single()[tester.id])
             }
@@ -219,26 +219,30 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExtractWithArrays() {
-        withJsonArrays(exclude = TestDB.allH2TestDB) { tester, singleId, _ ->
-            val path1 = if (currentDialectTest is PostgreSQLDialect) arrayOf("users", "0", "team") else arrayOf(".users[0].team")
-            val firstIsOnTeamA = tester.groups.jsonExtract<String>(*path1) eq "Team A"
+        withJsonArrays(exclude = TestDB.allH2TestDB) { tester, singleId, _, _ ->
+            val path1 = if (currentDialectTest is PostgreSQLDialect) {
+                arrayOf("users", "0", "team")
+            } else {
+                arrayOf(".users[0].team")
+            }
+            val firstIsOnTeamA = tester.groups.extract<String>(*path1) eq "Team A"
             assertEquals(singleId, tester.select { firstIsOnTeamA }.single()[tester.id])
 
             // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
             val path2 = if (currentDialectTest is PostgreSQLDialect) "0" else "[0]"
-            val firstNumber = tester.numbers.jsonExtract<Int>(path2, toScalar = !isOldMySql())
+            val firstNumber = tester.numbers.extract<Int>(path2, toScalar = !isOldMySql())
             assertEqualCollections(listOf(100, 3), tester.slice(firstNumber).selectAll().map { it[firstNumber] })
         }
     }
 
     @Test
     fun testJsonContainsWithArrays() {
-        withJsonArrays(exclude = jsonContainsNotSupported) { tester, _, tripleId ->
-            val hasSmallNumbers = tester.numbers.jsonContains("[3, 5]")
+        withJsonArrays(exclude = jsonContainsNotSupported) { tester, _, tripleId, testDb ->
+            val hasSmallNumbers = tester.numbers.contains("[3, 5]")
             assertEquals(tripleId, tester.select { hasSmallNumbers }.single()[tester.id])
 
-            if (currentTestDB in TestDB.mySqlRelatedDB) {
-                val hasUserNameB = tester.groups.jsonContains("\"B\"", ".users[0].name")
+            if (testDb in TestDB.mySqlRelatedDB) {
+                val hasUserNameB = tester.groups.contains("\"B\"", ".users[0].name")
                 assertEquals(tripleId, tester.select { hasUserNameB }.single()[tester.id])
             }
         }
@@ -246,13 +250,13 @@ class JsonColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExistsWithArrays() {
-        withJsonArrays(exclude = TestDB.allH2TestDB + TestDB.SQLSERVER) { tester, _, tripleId ->
-            val optional = if (currentTestDB in TestDB.mySqlRelatedDB) "one" else null
+        withJsonArrays(exclude = TestDB.allH2TestDB + TestDB.SQLSERVER) { tester, _, tripleId, testDb ->
+            val optional = if (testDb in TestDB.mySqlRelatedDB) "one" else null
 
-            val hasMultipleUsers = tester.groups.jsonExists(".users[1]", optional = optional)
+            val hasMultipleUsers = tester.groups.exists(".users[1]", optional = optional)
             assertEquals(tripleId, tester.select { hasMultipleUsers }.single()[tester.id])
 
-            val hasAtLeast3Numbers = tester.numbers.jsonExists("[2]", optional = optional)
+            val hasAtLeast3Numbers = tester.numbers.exists("[2]", optional = optional)
             assertEquals(tripleId, tester.select { hasAtLeast3Numbers }.single()[tester.id])
         }
     }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonTestsData.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonTestsData.kt
@@ -1,4 +1,4 @@
-package org.jetbrains.exposed.sql.tests.shared.types
+package org.jetbrains.exposed.sql.json
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -47,7 +47,7 @@ object JsonTestsData {
 
 fun DatabaseTestsBase.withJsonTable(
     exclude: List<TestDB> = emptyList(),
-    statement: Transaction.(tester: JsonTestsData.JsonTable, user1: User, data1: DataHolder) -> Unit
+    statement: Transaction.(tester: JsonTestsData.JsonTable, user1: User, data1: DataHolder, testDb: TestDB) -> Unit
 ) {
     val tester = JsonTestsData.JsonTable
 
@@ -60,7 +60,7 @@ fun DatabaseTestsBase.withJsonTable(
 
             tester.insert { it[jsonColumn] = data1 }
 
-            statement(tester, user1, data1)
+            statement(tester, user1, data1, testDb)
 
             SchemaUtils.drop(tester)
         }
@@ -69,7 +69,7 @@ fun DatabaseTestsBase.withJsonTable(
 
 fun DatabaseTestsBase.withJsonBTable(
     exclude: List<TestDB> = emptyList(),
-    statement: Transaction.(tester: JsonTestsData.JsonBTable, user1: User, data1: DataHolder) -> Unit
+    statement: Transaction.(tester: JsonTestsData.JsonBTable, user1: User, data1: DataHolder, testDb: TestDB) -> Unit
 ) {
     val tester = JsonTestsData.JsonBTable
 
@@ -82,7 +82,7 @@ fun DatabaseTestsBase.withJsonBTable(
 
             tester.insert { it[jsonBColumn] = data1 }
 
-            statement(tester, user1, data1)
+            statement(tester, user1, data1, testDb)
 
             SchemaUtils.drop(tester)
         }
@@ -91,7 +91,12 @@ fun DatabaseTestsBase.withJsonBTable(
 
 fun DatabaseTestsBase.withJsonArrays(
     exclude: List<TestDB> = emptyList(),
-    statement: Transaction.(tester: JsonTestsData.JsonArrays, singleId: EntityID<Int>, tripleId: EntityID<Int>) -> Unit
+    statement: Transaction.(
+        tester: JsonTestsData.JsonArrays,
+        singleId: EntityID<Int>,
+        tripleId: EntityID<Int>,
+        testDb: TestDB
+    ) -> Unit
 ) {
     val tester = JsonTestsData.JsonArrays
 
@@ -108,7 +113,7 @@ fun DatabaseTestsBase.withJsonArrays(
                 it[tester.numbers] = intArrayOf(3, 4, 5)
             }
 
-            statement(tester, singleId, tripleId)
+            statement(tester, singleId, tripleId, testDb)
 
             SchemaUtils.drop(tester)
         }
@@ -117,7 +122,12 @@ fun DatabaseTestsBase.withJsonArrays(
 
 fun DatabaseTestsBase.withJsonBArrays(
     exclude: List<TestDB> = emptyList(),
-    statement: Transaction.(tester: JsonTestsData.JsonBArrays, singleId: EntityID<Int>, tripleId: EntityID<Int>) -> Unit
+    statement: Transaction.(
+        tester: JsonTestsData.JsonBArrays,
+        singleId: EntityID<Int>,
+        tripleId: EntityID<Int>,
+        testDb: TestDB
+    ) -> Unit
 ) {
     val tester = JsonTestsData.JsonBArrays
 
@@ -134,7 +144,7 @@ fun DatabaseTestsBase.withJsonBArrays(
                 it[tester.numbers] = intArrayOf(3, 4, 5)
             }
 
-            statement(tester, singleId, tripleId)
+            statement(tester, singleId, tripleId, testDb)
 
             SchemaUtils.drop(tester)
         }

--- a/exposed-kotlin-datetime/build.gradle.kts
+++ b/exposed-kotlin-datetime/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     api("org.jetbrains.kotlinx", "kotlinx-datetime-jvm", "0.4.0")
     testImplementation(project(":exposed-dao"))
     testImplementation(project(":exposed-tests"))
+    testImplementation(project(":exposed-json"))
     testImplementation("junit", "junit", "4.12")
     testImplementation(kotlin("test-junit"))
 }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -8,6 +8,8 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
+import org.jetbrains.exposed.sql.json.extract
+import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -281,19 +283,19 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
             val prefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
 
             // value extracted in same manner it is stored, a json string
-            val modifiedAsString = tester.modified.jsonExtract<String>("${prefix}timestamp")
+            val modifiedAsString = tester.modified.extract<String>("${prefix}timestamp")
             val allModifiedAsString = tester.slice(modifiedAsString).selectAll()
             assertTrue(allModifiedAsString.all { it[modifiedAsString] == dateTimeNow.toString() })
             // value extracted as json, with implicit LocalDateTime serializer() performing conversions
-            val modifiedAsJson = tester.modified.jsonExtract<LocalDateTime>("${prefix}timestamp", toScalar = false)
+            val modifiedAsJson = tester.modified.extract<LocalDateTime>("${prefix}timestamp", toScalar = false)
             val allModifiedAsJson = tester.slice(modifiedAsJson).selectAll()
             assertTrue(allModifiedAsJson.all { it[modifiedAsJson] == dateTimeNow })
 
             // PostgreSQL requires explicit type cast to timestamp for in-DB comparison
             val dateModified = if (currentDialectTest is PostgreSQLDialect) {
-                tester.modified.jsonExtract<LocalDateTime>("${prefix}timestamp").castTo(KotlinLocalDateTimeColumnType())
+                tester.modified.extract<LocalDateTime>("${prefix}timestamp").castTo(KotlinLocalDateTimeColumnType())
             } else {
-                tester.modified.jsonExtract<LocalDateTime>("${prefix}timestamp")
+                tester.modified.extract<LocalDateTime>("${prefix}timestamp")
             }
             val modifiedBeforeCreation = tester.select { dateModified less tester.created }.single()
             assertEquals(2, modifiedBeforeCreation[tester.modified].userId)

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
-    kotlin("plugin.serialization") apply true
     id("testWithDBs")
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ include("exposed-money")
 include("exposed-bom")
 include("exposed-kotlin-datetime")
 include("exposed-crypt")
+include("exposed-json")
 
 pluginManagement {
     plugins {


### PR DESCRIPTION
Create new module `exposed-json`.

Migrate over all JSON/JSONB column type classes, function classes, extension functions, & test suites from `exposed-core`.

Make `postgresql` driver `compileOnly` (and update `valueFromDB()` in column type classes to check for PostgresqlDialect) in new module.

Remove all `kotlinx-serialization` and `postgresql` driver dependencies from `exposed-core` and `exposed-tests` modules.

Add `testDependency` on new module to all 3 datetime modules.

**Code & Visibility Modifier Changes:**
- Replace internal `H2DataProvider` used in `JsonBColumnType` with public `originalDataProvider`.
- Replace column type check in `PostgreSQLFunctionProvider` that used `!is JsonBColumnType<*>` with a string check: `sqlType() != "JSONB"`.
- Replace internal `currentTestDb` with `testDb` value passed to unit tests by refactoring `withJsonTable` and other wrapping test functions.
- Remove internal interface `Op.OpBoolean` implementation from JSON conditions classes, as not accessible. This is potentially used in `ResultRow.get()`, which [calls](https://github.com/JetBrains/Exposed/blob/main/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt#L58) `rawTocolumnvalue()`.
- Rename public API extension functions by removing 'json' prefix (e.g. `.jsonContains()` is now `.contains()`). Note that the function names in exposed-core module's vendor `FunctionProvider` have not been renamed to properly emphasize that they are related to the new module.