### PR TITLE
fix: Exclude deleted and renamed files from detekt GitHub Action

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "changed-files"
         run: |
           git fetch origin main:refs/remotes/origin/main
-          CHANGED_FILES=$(git --no-pager diff --name-only origin/main HEAD -- . ':!exposed-tests' | grep '\(.*.kt\|.*.kts\)$' | tr '\n' , | rev | cut -c 2- | rev)
+          CHANGED_FILES=$(git --no-pager diff --name-only --diff-filter=dr origin/main HEAD -- . ':!exposed-tests' | grep '\(.*.kt\|.*.kts\)$' | tr '\n' , | rev | cut -c 2- | rev)
           echo "Changed files: $CHANGED_FILES"
           echo "CHANGED_FILES=$CHANGED_FILES" >> "$GITHUB_ENV"
       # Resolves and installs a specific version of detekt on to a GitHub Actions Runner if not already present in the tool cache

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/DBTestingPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/DBTestingPlugin.kt
@@ -1,3 +1,5 @@
+@file:Suppress("VariableNaming", "MagicNumber", "UnusedPrivateMember")
+
 package org.jetbrains.exposed.gradle
 
 import org.gradle.api.Plugin
@@ -104,7 +106,7 @@ fun Test.delegatedTo(vararg tasks: TaskProvider<out AbstractTestTask>): Test {
         isFailOnNoMatchingTests = false
     }
     finalizedBy(tasks)
-    //Pass --tests CLI option value into delegates
+    // Pass --tests CLI option value into delegates
     doFirst {
         val testsFilter = (filter as DefaultTestFilter).commandLineIncludePatterns.toList()
         tasks.forEach {

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/tasks/DBTest.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/tasks/DBTest.kt
@@ -45,4 +45,3 @@ open class DBTest @Inject constructor(@get:Input val dialect: String) : Test() {
             }
         }
 }
-


### PR DESCRIPTION
The `detekt` GitHub Action will fail if there is a deleted file among the changed files because it attempts to check its content and fails at doing so. Also, there is no need to check the content of a file that was simply renamed. So I excluded deleted and renamed files from the `detekt` check.

The second commit is to test that the fix works because it includes a deleted file. I tested it on renamed files locally.