### PR TITLE
fix: EXPOSED-97 Unsigned column types truncate MySQL values

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -725,66 +725,6 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
-        @Test fun testUByteColumnType() {
-        val UbyteTable = object : Table("ubyteTable") {
-            val ubyte = ubyte("ubyte")
-        }
-
-        withTables(UbyteTable) {
-            UbyteTable.insert {
-                it[ubyte] = 123u
-            }
-            val result = UbyteTable.selectAll().toList()
-            assertEquals(1, result.size)
-            assertEquals(123u, result.single()[UbyteTable.ubyte])
-        }
-    }
-
-        @Test fun testUshortColumnType() {
-        val UshortTable = object : Table("ushortTable") {
-            val ushort = ushort("ushort")
-        }
-
-        withTables(UshortTable) {
-            UshortTable.insert {
-                it[ushort] = 123u
-            }
-            val result = UshortTable.selectAll().toList()
-            assertEquals(1, result.size)
-            assertEquals(123u, result.single()[UshortTable.ushort])
-        }
-    }
-
-        @Test fun testUintColumnType() {
-        val UintTable = object : Table("uintTable") {
-            val uint = uinteger("uint")
-        }
-
-        withTables(UintTable) {
-            UintTable.insert {
-                it[uint] = 123u
-            }
-            val result = UintTable.selectAll().toList()
-            assertEquals(1, result.size)
-            assertEquals(123u, result.single()[UintTable.uint])
-        }
-    }
-
-        @Test fun testUlongColumnType() {
-        val UlongTable = object : Table("ulongTable") {
-            val ulong = ulong("ulong")
-        }
-
-        withTables(UlongTable) {
-            UlongTable.insert {
-                it[ulong] = 123uL
-            }
-            val result = UlongTable.selectAll().toList()
-            assertEquals(1, result.size)
-            assertEquals(123uL, result.single()[UlongTable.ulong])
-        }
-    }
-
     @Test fun tableWithDifferentTextTypes() {
         val TestTable = object : Table("different_text_column_types") {
             val id = integer("id").autoIncrement()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -1,0 +1,101 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class UnsignedColumnTypeTests : DatabaseTestsBase() {
+    object UByteTable : Table("uByteTable") {
+        val unsignedByte = ubyte("uByte")
+    }
+
+    object UShortTable : Table("uShortTable") {
+        val unsignedShort = ushort("uShort")
+    }
+
+    object UIntTable : Table("uIntTable") {
+        val unsignedInt = uinteger("uInt")
+    }
+
+    object ULongTable : Table("uLongTable") {
+        val unsignedLong = ulong("uLong")
+    }
+
+    @Test
+    fun testUByteColumnType() {
+        withTables(UByteTable) {
+            UByteTable.insert {
+                it[unsignedByte] = 123u
+            }
+
+            val result = UByteTable.selectAll().toList()
+            assertEquals(1, result.size)
+            assertEquals(123u, result.single()[UByteTable.unsignedByte])
+        }
+    }
+
+    @Test
+    fun testUShortColumnType() {
+        withTables(UShortTable) {
+            UShortTable.insert {
+                it[unsignedShort] = 123u
+            }
+
+            val result = UShortTable.selectAll().toList()
+            assertEquals(1, result.size)
+            assertEquals(123u, result.single()[UShortTable.unsignedShort])
+        }
+    }
+
+    @Test
+    fun testUIntColumnType() {
+        withTables(UIntTable) {
+            UIntTable.insert {
+                it[unsignedInt] = 123u
+            }
+
+            val result = UIntTable.selectAll().toList()
+            assertEquals(1, result.size)
+            assertEquals(123u, result.single()[UIntTable.unsignedInt])
+        }
+    }
+
+    @Test
+    fun testULongColumnType() {
+        withTables(ULongTable) {
+            ULongTable.insert {
+                it[unsignedLong] = 123uL
+            }
+
+            val result = ULongTable.selectAll().toList()
+            assertEquals(1, result.size)
+            assertEquals(123uL, result.single()[ULongTable.unsignedLong])
+        }
+    }
+
+    @Test
+    fun testMaxUnsignedTypesInMySql() {
+        withDb(listOf(TestDB.MYSQL, TestDB.MARIADB)) {
+            SchemaUtils.create(UByteTable, UShortTable, UIntTable, ULongTable)
+
+            UByteTable.insert { it[unsignedByte] = UByte.MAX_VALUE }
+            assertEquals(UByte.MAX_VALUE, UByteTable.selectAll().single()[UByteTable.unsignedByte])
+
+            UShortTable.insert { it[unsignedShort] = UShort.MAX_VALUE }
+            assertEquals(UShort.MAX_VALUE, UShortTable.selectAll().single()[UShortTable.unsignedShort])
+
+            UIntTable.insert { it[unsignedInt] = UInt.MAX_VALUE }
+            assertEquals(UInt.MAX_VALUE, UIntTable.selectAll().single()[UIntTable.unsignedInt])
+
+            ULongTable.insert { it[unsignedLong] = ULong.MAX_VALUE }
+            assertEquals(ULong.MAX_VALUE, ULongTable.selectAll().single()[ULongTable.unsignedLong])
+
+            SchemaUtils.drop(UByteTable, UShortTable, UIntTable, ULongTable)
+        }
+    }
+}


### PR DESCRIPTION
MySQL and MariaDB are the only Exposed databases that actually support unsigned types natively, using the UNSIGNED type prefix. In spite of this, any value sent/received to/from the database is truncated to fit within the smaller Kotlin type SIGNED range (so it usually overflows).

For example:
```kt
// SMALLINT UNSIGNED ranges from 0 to 65535
object Tester : Table("tester") {
    val unsignedShort = ushort("u_short")
}

transaction {
    Tester.insert {
        it[unsignedShort] = 65000u
    }
    // generates SQL:
    // INSERT INTO tester (u_short) VALUES (-536)
    // and fails with:
    // com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Out of range value for column 'u_short' at row 1
}
```

Fix the logic in the 4 unsigned column type classes to ensure that both dialects' values are not truncated when inserted.

Move existing tests for unsigned column types out of the `DDLTests.kt` test suite and into their own file `UnsignedColumnTypeTests.kt` inside the the more appropriate `types` package. This reduces the size a bit of the already very long `DDLTests.kt` file and allows table objects to be shared with less scrolling.

Add a test specific to MySQL & MariaDB testing the upper limits of the native unsigned types.

Fix Detekt issues in altered file.