### PR TITLE
fix: EXPOSED-83 createMissingTablesAndColumns not detecting missing PK

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3203,7 +3203,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/DataTypeProvider {
 
 public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect$Companion;
-	public abstract fun addPrimaryKey (Ljava/lang/String;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;
+	public abstract fun addPrimaryKey (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;
 	public abstract fun allTablesNames ()Ljava/util/List;
 	public abstract fun catalog (Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public abstract fun checkTableMapping (Lorg/jetbrains/exposed/sql/Table;)Z
@@ -3213,7 +3213,6 @@ public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialec
 	public abstract fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public abstract fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
-	public abstract fun dropPrimaryKey (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public abstract fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
@@ -3494,7 +3493,6 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	public fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
-	public fun dropPrimaryKey (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	protected fun fillConstraintCacheForTables (Ljava/util/List;)V
 	public fun getSupportsCreateSequence ()Z
@@ -3560,6 +3558,19 @@ public class org/jetbrains/exposed/sql/vendors/PostgreSQLNGDialect : org/jetbrai
 public final class org/jetbrains/exposed/sql/vendors/PostgreSQLNGDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
 }
 
+public final class org/jetbrains/exposed/sql/vendors/PrimaryKeyMetadata {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lorg/jetbrains/exposed/sql/vendors/PrimaryKeyMetadata;
+	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/vendors/PrimaryKeyMetadata;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/vendors/PrimaryKeyMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColumnNames ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public class org/jetbrains/exposed/sql/vendors/SQLServerDialect : org/jetbrains/exposed/sql/vendors/VendorDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/SQLServerDialect$Companion;
 	public fun <init> ()V
@@ -3604,7 +3615,7 @@ public final class org/jetbrains/exposed/sql/vendors/SQLiteDialect$Companion : o
 
 public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetbrains/exposed/sql/vendors/DatabaseDialect {
 	public fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/DataTypeProvider;Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;)V
-	public fun addPrimaryKey (Ljava/lang/String;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;
+	public fun addPrimaryKey (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;
 	public fun allTablesNames ()Ljava/util/List;
 	public fun catalog (Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun checkTableMapping (Lorg/jetbrains/exposed/sql/Table;)Z
@@ -3615,7 +3626,6 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
-	public fun dropPrimaryKey (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2968,6 +2968,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun cleanCache ()V
 	public abstract fun columns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public abstract fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun getCurrentScheme ()Ljava/lang/String;
 	public final fun getDatabase ()Ljava/lang/String;
 	public abstract fun getDatabaseDialectName ()Ljava/lang/String;
@@ -3202,6 +3203,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/DataTypeProvider {
 
 public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect$Companion;
+	public abstract fun addPrimaryKey (Ljava/lang/String;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;
 	public abstract fun allTablesNames ()Ljava/util/List;
 	public abstract fun catalog (Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public abstract fun checkTableMapping (Lorg/jetbrains/exposed/sql/Table;)Z
@@ -3211,8 +3213,10 @@ public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialec
 	public abstract fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public abstract fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
+	public abstract fun dropPrimaryKey (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public abstract fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public abstract fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun getDataTypeProvider ()Lorg/jetbrains/exposed/sql/vendors/DataTypeProvider;
 	public abstract fun getDatabase ()Ljava/lang/String;
 	public abstract fun getDefaultReferenceOption ()Lorg/jetbrains/exposed/sql/ReferenceOption;
@@ -3256,6 +3260,7 @@ public final class org/jetbrains/exposed/sql/vendors/DatabaseDialect$DefaultImpl
 	public static fun dropDatabase (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Ljava/lang/String;)Ljava/lang/String;
 	public static fun dropSchema (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public static fun existingIndices (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;[Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public static fun existingPrimaryKeys (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;[Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public static fun getDefaultReferenceOption (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public static fun getLikePatternSpecialChars (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Ljava/util/Map;
 	public static fun getNeedsQuotesWhenSymbolsInNames (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
@@ -3489,6 +3494,7 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	public fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
+	public fun dropPrimaryKey (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	protected fun fillConstraintCacheForTables (Ljava/util/List;)V
 	public fun getSupportsCreateSequence ()Z
@@ -3598,6 +3604,7 @@ public final class org/jetbrains/exposed/sql/vendors/SQLiteDialect$Companion : o
 
 public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetbrains/exposed/sql/vendors/DatabaseDialect {
 	public fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/DataTypeProvider;Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;)V
+	public fun addPrimaryKey (Ljava/lang/String;Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;
 	public fun allTablesNames ()Ljava/util/List;
 	public fun catalog (Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun checkTableMapping (Lorg/jetbrains/exposed/sql/Table;)Z
@@ -3608,8 +3615,10 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun createSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
+	public fun dropPrimaryKey (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	protected fun fillConstraintCacheForTables (Ljava/util/List;)V
 	public final fun filterCondition (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	public final fun getAllTablesNames ()Ljava/util/List;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -196,6 +196,10 @@ object SchemaUtils {
             currentDialect.tableColumns(*tables)
         }
 
+        val existingPrimaryKeys = logTimeSpent("Extracting primary keys", withLogs) {
+            currentDialect.existingPrimaryKeys(*tables)
+        }
+
         val dbSupportsAlterTableWithAddColumn = TransactionManager.current().db.supportsAlterTableWithAddColumn
 
         for (table in tables) {
@@ -206,6 +210,32 @@ object SchemaUtils {
                 if (existingColumn != null) column to existingColumn else null
             }.toMap()
             val missingTableColumns = table.columns.filter { it !in existingTableColumns }
+
+            if (dbSupportsAlterTableWithAddColumn) {
+                // modify primary key before missing columns added in case old PK must be dropped first
+                val thisTableExistingPK = existingPrimaryKeys[table].orEmpty()
+                val thisTableExistingPKName = thisTableExistingPK.keys.firstOrNull()
+
+                table.primaryKey?.let { newPK ->
+                    val missingPK = newPK.takeIf { pk -> pk.columns.none { it in missingTableColumns } }
+                    val missingPKName = missingPK?.name?.takeIf { table.isCustomPKNameDefined() }
+                    thisTableExistingPKName?.let { existingPKName ->
+                        val thisTableExistingPKColumns = thisTableExistingPK.values.firstOrNull()?.map(String::lowercase)
+                        val pkDiffers = missingPKName?.let { it != thisTableExistingPKName } == true ||
+                            newPK.columns.map { it.name.lowercase() } != thisTableExistingPKColumns
+                        if (pkDiffers) {
+                            statements.add(currentDialect.dropPrimaryKey(table.tableName, existingPKName))
+                            missingPK?.let {
+                                statements.add(currentDialect.addPrimaryKey(table.tableName, missingPKName, *missingPK.columns))
+                            }
+                        }
+                    } ?: missingPK?.let {
+                        statements.add(currentDialect.addPrimaryKey(table.tableName, missingPKName, *missingPK.columns))
+                    }
+                } ?: thisTableExistingPKName?.let {
+                    statements.add(currentDialect.dropPrimaryKey(table.tableName, it))
+                }
+            }
 
             missingTableColumns.flatMapTo(statements) { it.ddl }
 
@@ -235,24 +265,32 @@ object SchemaUtils {
         }
 
         if (dbSupportsAlterTableWithAddColumn) {
-            val existingColumnConstraint = logTimeSpent("Extracting column constraints", withLogs) {
-                currentDialect.columnConstraints(*tables)
-            }
+            statements.addAll(addMissingColumnConstraints(*tables, withLogs = withLogs))
+        }
 
-            val foreignKeyConstraints = tables.flatMap { table ->
-                table.foreignKeys.map { it to existingColumnConstraint[table to it.from]?.firstOrNull() }
-            }
+        return statements
+    }
 
-            for ((foreignKey, existingConstraint) in foreignKeyConstraints) {
-                if (existingConstraint == null) {
-                    statements.addAll(createFKey(foreignKey))
-                } else if (existingConstraint.targetTable != foreignKey.targetTable ||
-                    foreignKey.deleteRule != existingConstraint.deleteRule ||
-                    foreignKey.updateRule != existingConstraint.updateRule
-                ) {
-                    statements.addAll(existingConstraint.dropStatement())
-                    statements.addAll(createFKey(foreignKey))
-                }
+    private fun addMissingColumnConstraints(vararg tables: Table, withLogs: Boolean): List<String> {
+        val existingColumnConstraint = logTimeSpent("Extracting column constraints", withLogs) {
+            currentDialect.columnConstraints(*tables)
+        }
+
+        val foreignKeyConstraints = tables.flatMap { table ->
+            table.foreignKeys.map { it to existingColumnConstraint[table to it.from]?.firstOrNull() }
+        }
+
+        val statements = ArrayList<String>()
+
+        for ((foreignKey, existingConstraint) in foreignKeyConstraints) {
+            if (existingConstraint == null) {
+                statements.addAll(createFKey(foreignKey))
+            } else if (existingConstraint.targetTable != foreignKey.targetTable ||
+                foreignKey.deleteRule != existingConstraint.deleteRule ||
+                foreignKey.updateRule != existingConstraint.updateRule
+            ) {
+                statements.addAll(existingConstraint.dropStatement())
+                statements.addAll(createFKey(foreignKey))
             }
         }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
 import java.math.BigDecimal
 
+@Suppress("TooManyFunctions")
 object SchemaUtils {
     private inline fun <R> logTimeSpent(message: String, withLogs: Boolean, block: () -> R): R {
         return if (withLogs) {
@@ -19,8 +20,9 @@ object SchemaUtils {
 
     private class TableDepthGraph(val tables: Iterable<Table>) {
         val graph = fetchAllTables().let { tables ->
-            if (tables.isEmpty()) emptyMap()
-            else {
+            if (tables.isEmpty()) {
+                emptyMap()
+            } else {
                 tables.associateWith { t ->
                     t.columns.mapNotNull { c ->
                         c.referee?.let { it.table to c.columnType.nullable }
@@ -125,7 +127,9 @@ object SchemaUtils {
     )
     fun createFKey(reference: Column<*>): List<String> {
         val foreignKey = reference.foreignKey
-        require(foreignKey != null && (foreignKey.deleteRule != null || foreignKey.updateRule != null)) { "$reference does not reference anything" }
+        require(foreignKey != null && (foreignKey.deleteRule != null || foreignKey.updateRule != null)) {
+            "$reference does not reference anything"
+        }
         return createFKey(foreignKey)
     }
 
@@ -226,9 +230,11 @@ object SchemaUtils {
                         val columnType = col.columnType
                         val incorrectNullability = existingCol.nullable != columnType.nullable
                         // Exposed doesn't support changing sequences on columns
-                        val incorrectAutoInc = existingCol.autoIncrement != columnType.isAutoInc && col.autoIncColumnType?.autoincSeq == null
-                        val incorrectDefaults =
-                            existingCol.defaultDbValue != col.dbDefaultValue?.let { dataTypeProvider.dbDefaultToString(col, it) }
+                        val incorrectAutoInc = existingCol.autoIncrement != columnType.isAutoInc &&
+                            col.autoIncColumnType?.autoincSeq == null
+                        val incorrectDefaults = existingCol.defaultDbValue != col.dbDefaultValue?.let {
+                            dataTypeProvider.dbDefaultToString(col, it)
+                        }
                         val incorrectCaseSensitiveName = existingCol.name.inProperCase() != col.nameInDatabaseCase()
                         ColumnDiff(incorrectNullability, incorrectAutoInc, incorrectDefaults, incorrectCaseSensitiveName)
                     }
@@ -237,45 +243,24 @@ object SchemaUtils {
                 redoColumns.flatMapTo(statements) { (col, changedState) -> col.modifyStatements(changedState) }
 
                 // add missing primary key
-                if (table.primaryKey != null && existingPrimaryKeys[table] == null) {
-                    val missingPK = table.primaryKey?.takeIf { pk -> pk.columns.none { it in missingTableColumns } }
-                    missingPK?.let {
-                        val missingPKName = missingPK.name.takeIf { table.isCustomPKNameDefined() }
-                        statements.add(
-                            currentDialect.addPrimaryKey(table, missingPKName, pkColumns = missingPK.columns)
-                        )
-                    }
+                val missingPK = table.primaryKey?.takeIf { pk -> pk.columns.none { it in missingTableColumns } }
+                if (missingPK != null && existingPrimaryKeys[table] == null) {
+                    val missingPKName = missingPK.name.takeIf { table.isCustomPKNameDefined() }
+                    statements.add(
+                        currentDialect.addPrimaryKey(table, missingPKName, pkColumns = missingPK.columns)
+                    )
                 }
             }
         }
 
         if (dbSupportsAlterTableWithAddColumn) {
-            //statements.addAll(addMissingColumnConstraints(*tables, withLogs = withLogs))
-            val existingColumnConstraint = logTimeSpent("Extracting column constraints", withLogs) {
-                currentDialect.columnConstraints(*tables)
-            }
-
-            val foreignKeyConstraints = tables.flatMap { table ->
-                table.foreignKeys.map { it to existingColumnConstraint[table to it.from]?.firstOrNull() }
-            }
-
-            for ((foreignKey, existingConstraint) in foreignKeyConstraints) {
-                if (existingConstraint == null) {
-                    statements.addAll(createFKey(foreignKey))
-                } else if (existingConstraint.targetTable != foreignKey.targetTable ||
-                    foreignKey.deleteRule != existingConstraint.deleteRule ||
-                    foreignKey.updateRule != existingConstraint.updateRule
-                ) {
-                    statements.addAll(existingConstraint.dropStatement())
-                    statements.addAll(createFKey(foreignKey))
-                }
-            }
+            statements.addAll(addMissingColumnConstraints(*tables, withLogs = withLogs))
         }
 
         return statements
     }
 
-    /*private fun addMissingColumnConstraints(vararg tables: Table, withLogs: Boolean): List<String> {
+    private fun addMissingColumnConstraints(vararg tables: Table, withLogs: Boolean): List<String> {
         val existingColumnConstraint = logTimeSpent("Extracting column constraints", withLogs) {
             currentDialect.columnConstraints(*tables)
         }
@@ -299,7 +284,7 @@ object SchemaUtils {
         }
 
         return statements
-    }*/
+    }
 
     private fun Transaction.execStatements(inBatch: Boolean, statements: List<String>) {
         if (inBatch) {
@@ -342,7 +327,9 @@ object SchemaUtils {
                     "${currentDialect.name} requires autoCommit to be enabled for CREATE DATABASE",
                     exception
                 )
-            } else throw exception
+            } else {
+                throw exception
+            }
         }
     }
 
@@ -369,7 +356,9 @@ object SchemaUtils {
                     "${currentDialect.name} requires autoCommit to be enabled for DROP DATABASE",
                     exception
                 )
-            } else throw exception
+            } else {
+                throw exception
+            }
         }
     }
 
@@ -409,7 +398,8 @@ object SchemaUtils {
             }
             val executedStatements = createStatements + alterStatements
             logTimeSpent("Checking mapping consistence", withLogs) {
-                val modifyTablesStatements = checkMappingConsistence(tables = tables, withLogs).filter { it !in executedStatements }
+                val modifyTablesStatements = checkMappingConsistence(tables = tables, withLogs)
+                    .filter { it !in executedStatements }
                 execStatements(inBatch, modifyTablesStatements)
                 commit()
             }
@@ -431,7 +421,8 @@ object SchemaUtils {
         }
         val executedStatements = createStatements + alterStatements
         val modifyTablesStatements = logTimeSpent("Checking mapping consistence", withLogs) {
-            checkMappingConsistence(tables = tablesToAlter.toTypedArray(), withLogs).filter { it !in executedStatements }
+            checkMappingConsistence(tables = tablesToAlter.toTypedArray(), withLogs)
+                .filter { it !in executedStatements }
         }
         return executedStatements + modifyTablesStatements
     }
@@ -468,7 +459,9 @@ object SchemaUtils {
         }
 
         val excessiveIndices =
-            currentDialect.existingIndices(*tables).flatMap { it.value }.groupBy { Triple(it.table, it.unique, it.columns.joinToString { it.name }) }
+            currentDialect.existingIndices(*tables)
+                .flatMap { it.value }
+                .groupBy { Triple(it.table, it.unique, it.columns.joinToString { it.name }) }
                 .filter { it.value.size > 1 }
         if (excessiveIndices.isNotEmpty()) {
             exposedLogger.warn("List of excessive indices:")
@@ -528,7 +521,8 @@ object SchemaUtils {
                 nameDiffers.add(mappedIndex)
             }
 
-            notMappedIndices.getOrPut(table.nameInDatabaseCase()) { hashSetOf() }.addAll(existingTableIndices.subtract(mappedIndices))
+            notMappedIndices.getOrPut(table.nameInDatabaseCase()) { hashSetOf() }
+                .addAll(existingTableIndices.subtract(mappedIndices))
 
             missingIndices.addAll(mappedIndices.subtract(existingTableIndices))
         }
@@ -643,7 +637,11 @@ object SchemaUtils {
     fun dropSchema(vararg schemas: Schema, cascade: Boolean = false, inBatch: Boolean = false) {
         if (schemas.isEmpty()) return
         with(TransactionManager.current()) {
-            val schemasForDeletion = if (currentDialect.supportsIfNotExists) schemas.distinct() else schemas.distinct().filter { it.exists() }
+            val schemasForDeletion = if (currentDialect.supportsIfNotExists) {
+                schemas.distinct()
+            } else {
+                schemas.distinct().filter { it.exists() }
+            }
             val dropStatements = schemasForDeletion.flatMap { it.dropStatement(cascade) }
 
             execStatements(inBatch, dropStatements)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.sql.ForeignKeyConstraint
 import org.jetbrains.exposed.sql.Index
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.vendors.ColumnMetadata
+import org.jetbrains.exposed.sql.vendors.PrimaryKeyMetadata
 import java.math.BigDecimal
 
 abstract class ExposedDatabaseMetadata(val database: String) {
@@ -33,7 +34,7 @@ abstract class ExposedDatabaseMetadata(val database: String) {
 
     abstract fun existingIndices(vararg tables: Table): Map<Table, List<Index>>
 
-    abstract fun existingPrimaryKeys(vararg tables: Table): Map<Table, Map<String, List<String>>>
+    abstract fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?>
 
     abstract fun tableConstraints(tables: List<Table>): Map<String, List<ForeignKeyConstraint>>
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -33,6 +33,8 @@ abstract class ExposedDatabaseMetadata(val database: String) {
 
     abstract fun existingIndices(vararg tables: Table): Map<Table, List<Index>>
 
+    abstract fun existingPrimaryKeys(vararg tables: Table): Map<Table, Map<String, List<String>>>
+
     abstract fun tableConstraints(tables: List<Table>): Map<String, List<ForeignKeyConstraint>>
 
     abstract fun cleanCache()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -928,7 +928,7 @@ interface DatabaseDialect {
     /** Returns a map with all the defined indices in each of the specified [tables]. */
     fun existingIndices(vararg tables: Table): Map<Table, List<Index>> = emptyMap()
 
-    /** Returns a map with the primary key name and defining columns in each of the specified [tables]. */
+    /** Returns a map with the primary key metadata in each of the specified [tables]. */
     fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> = emptyMap()
 
     /** Returns `true` if the dialect supports `SELECT FOR UPDATE` statements, `false` otherwise. */
@@ -957,7 +957,7 @@ interface DatabaseDialect {
     /** Returns the SQL command that modifies the specified [column]. */
     fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String>
 
-    /** Returns the SQL command that adds a primary key to an existing table specified [tableName]. */
+    /** Returns the SQL command that adds a primary key specified [pkName] to an existing [table]. */
     fun addPrimaryKey(table: Table, pkName: String?, vararg pkColumns: Column<*>): String
 
     fun createDatabase(name: String) = "CREATE DATABASE IF NOT EXISTS ${name.inProperCase()}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -921,7 +921,9 @@ interface DatabaseDialect {
     fun tableColumns(vararg tables: Table): Map<Table, List<ColumnMetadata>> = emptyMap()
 
     /** Returns a map with the foreign key constraints of all the defined columns sets in each of the specified [tables]. */
-    fun columnConstraints(vararg tables: Table): Map<Pair<Table, LinkedHashSet<Column<*>>>, List<ForeignKeyConstraint>> = emptyMap()
+    fun columnConstraints(
+        vararg tables: Table
+    ): Map<Pair<Table, LinkedHashSet<Column<*>>>, List<ForeignKeyConstraint>> = emptyMap()
 
     /** Returns a map with all the defined indices in each of the specified [tables]. */
     fun existingIndices(vararg tables: Table): Map<Table, List<Index>> = emptyMap()
@@ -1010,7 +1012,11 @@ sealed class ForUpdateOption(open val querySuffix: String) {
             NO_WAIT("NOWAIT"), SKIP_LOCKED("SKIP LOCKED")
         }
 
-        abstract class ForUpdateBase(querySuffix: String, private val mode: MODE? = null, private vararg val ofTables: Table) : ForUpdateOption("") {
+        abstract class ForUpdateBase(
+            querySuffix: String,
+            private val mode: MODE? = null,
+            private vararg val ofTables: Table
+        ) : ForUpdateOption("") {
             private val preparedQuerySuffix = buildString {
                 append(querySuffix)
                 ofTables.takeIf { it.isNotEmpty() }?.let { tables ->
@@ -1024,17 +1030,29 @@ sealed class ForUpdateOption(open val querySuffix: String) {
             final override val querySuffix: String = preparedQuerySuffix
         }
 
-        class ForUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR UPDATE", mode, ofTables = ofTables)
+        class ForUpdate(
+            mode: MODE? = null,
+            vararg ofTables: Table
+        ) : ForUpdateBase("FOR UPDATE", mode, ofTables = ofTables)
 
-        open class ForNoKeyUpdate(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR NO KEY UPDATE", mode, ofTables = ofTables) {
+        open class ForNoKeyUpdate(
+            mode: MODE? = null,
+            vararg ofTables: Table
+        ) : ForUpdateBase("FOR NO KEY UPDATE", mode, ofTables = ofTables) {
             companion object : ForNoKeyUpdate()
         }
 
-        open class ForShare(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR SHARE", mode, ofTables = ofTables) {
+        open class ForShare(
+            mode: MODE? = null,
+            vararg ofTables: Table
+        ) : ForUpdateBase("FOR SHARE", mode, ofTables = ofTables) {
             companion object : ForShare()
         }
 
-        open class ForKeyShare(mode: MODE? = null, vararg ofTables: Table) : ForUpdateBase("FOR KEY SHARE", mode, ofTables = ofTables) {
+        open class ForKeyShare(
+            mode: MODE? = null,
+            vararg ofTables: Table
+        ) : ForUpdateBase("FOR KEY SHARE", mode, ofTables = ofTables) {
             companion object : ForKeyShare()
         }
     }
@@ -1123,7 +1141,9 @@ abstract class VendorDialect(
     override fun tableColumns(vararg tables: Table): Map<Table, List<ColumnMetadata>> =
         TransactionManager.current().connection.metadata { columns(*tables) }
 
-    override fun columnConstraints(vararg tables: Table): Map<Pair<Table, LinkedHashSet<Column<*>>>, List<ForeignKeyConstraint>> {
+    override fun columnConstraints(
+        vararg tables: Table
+    ): Map<Pair<Table, LinkedHashSet<Column<*>>>, List<ForeignKeyConstraint>> {
         val constraints = HashMap<Pair<Table, LinkedHashSet<Column<*>>>, MutableList<ForeignKeyConstraint>>()
 
         val tablesToLoad = tables.filter { !columnConstraintsCache.containsKey(it.nameInDatabaseCase()) }
@@ -1143,7 +1163,9 @@ abstract class VendorDialect(
     override fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> =
         TransactionManager.current().db.metadata { existingPrimaryKeys(*tables) }
 
-    private val supportsSelectForUpdate: Boolean by lazy { TransactionManager.current().db.metadata { supportsSelectForUpdate } }
+    private val supportsSelectForUpdate: Boolean by lazy {
+        TransactionManager.current().db.metadata { supportsSelectForUpdate }
+    }
 
     override fun supportsSelectForUpdate(): Boolean = supportsSelectForUpdate
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -340,6 +340,10 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
     override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String =
         "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
 
+    override fun dropPrimaryKey(tableName: String, pkName: String): String {
+        return "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP PRIMARY KEY"
+    }
+
     override fun setSchema(schema: Schema): String = "USE ${schema.identifier}"
 
     override fun createSchema(schema: Schema): String = buildString {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -340,10 +340,6 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
     override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String =
         "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
 
-    override fun dropPrimaryKey(tableName: String, pkName: String): String {
-        return "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP PRIMARY KEY"
-    }
-
     override fun setSchema(schema: Schema): String = "USE ${schema.identifier}"
 
     override fun createSchema(schema: Schema): String = buildString {

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -37,6 +37,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun cleanCache ()V
 	public fun columns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun getCurrentScheme ()Ljava/lang/String;
 	public fun getDatabaseDialectName ()Ljava/lang/String;
 	public fun getDatabaseProductVersion ()Ljava/lang/String;

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -239,19 +239,17 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         return HashMap(existingIndicesCache)
     }
 
-    override fun existingPrimaryKeys(vararg tables: Table): Map<Table, Map<String, List<String>>> {
+    override fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> {
         return tables.associateWith { table ->
             metadata.getPrimaryKeys(databaseName, currentScheme, table.nameInDatabaseCase()).let { rs ->
-                val columnNames = arrayListOf<String>()
+                val columnNames = mutableListOf<String>()
                 var pkName = ""
                 while (rs.next()) {
-                    rs.getString("PK_NAME")?.let {
-                        pkName = it
-                        columnNames += rs.getString("COLUMN_NAME")
-                    }
+                    rs.getString("PK_NAME")?.let { pkName = it }
+                    columnNames += rs.getString("COLUMN_NAME")
                 }
                 rs.close()
-                if (pkName.isEmpty()) emptyMap() else mapOf(pkName to columnNames)
+                if (pkName.isEmpty()) null else PrimaryKeyMetadata(pkName, columnNames)
             }
         }
     }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -80,7 +80,10 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         _currentScheme = null
     }
 
-    private inner class CachableMapWithDefault<K, V>(private val map: MutableMap<K, V> = mutableMapOf(), val default: (K) -> V) : Map<K, V> by map {
+    private inner class CachableMapWithDefault<K, V>(
+        private val map: MutableMap<K, V> = mutableMapOf(),
+        val default: (K) -> V
+    ) : Map<K, V> by map {
         override fun get(key: K): V? = map.getOrPut(key) { default(key) }
         override fun containsKey(key: K): Boolean = true
         override fun isEmpty(): Boolean = false

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
@@ -5,10 +5,13 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.RepeatableTestRule
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertFalse
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.vendors.ForUpdateOption
 import org.jetbrains.exposed.sql.vendors.ForUpdateOption.PostgreSQL
 import org.junit.Rule
 import org.junit.Test
+import java.sql.ResultSet
 import kotlin.test.assertEquals
 
 class PostgresqlTests : DatabaseTestsBase() {
@@ -58,6 +61,59 @@ class PostgresqlTests : DatabaseTestsBase() {
                 assertEquals(name, forNoKeyUpdateRes)
                 assertEquals(name, notForUpdateRes)
             }
+        }
+    }
+
+    @Test
+    fun testPrimaryKeyCreatedInPostgresql() {
+        val tableName = "tester"
+        val tester1 = object : Table(tableName) {
+            val age = integer("age")
+        }
+
+        val tester2 = object : Table(tableName) {
+            val age = integer("age")
+
+            override val primaryKey = PrimaryKey(age)
+        }
+
+        val tester3 = object : IntIdTable(tableName) {
+            val age = integer("age")
+        }
+
+        fun <T : Any> Transaction.assertPrimaryKey(transform: (ResultSet) -> T): T? {
+            return exec(
+                """
+                SELECT ct.relname as TABLE_NAME, ci.relname AS PK_NAME
+                FROM pg_catalog.pg_class ct
+                JOIN pg_index i ON (ct.oid = i.indrelid AND indisprimary)
+                JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid)
+                WHERE ct.relname IN ('$tableName')
+                """.trimIndent()
+            ) { rs ->
+                transform(rs)
+            }
+        }
+        withDb(listOf(TestDB.POSTGRESQLNG, TestDB.POSTGRESQL)) {
+            val defaultPKName = "tester_pkey"
+            SchemaUtils.createMissingTablesAndColumns(tester1)
+            assertPrimaryKey {
+                assertFalse(it.next())
+            }
+
+            SchemaUtils.createMissingTablesAndColumns(tester2)
+            assertPrimaryKey {
+                assertTrue(it.next())
+                assertEquals(defaultPKName, it.getString("PK_NAME"))
+            }
+
+            SchemaUtils.createMissingTablesAndColumns(tester3)
+            assertPrimaryKey {
+                assertTrue(it.next())
+                assertEquals(defaultPKName, it.getString("PK_NAME"))
+            }
+
+            SchemaUtils.drop(tester1)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.RepeatableTestRule
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
 import org.jetbrains.exposed.sql.tests.shared.assertFalse
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.vendors.ForUpdateOption
@@ -107,10 +108,8 @@ class PostgresqlTests : DatabaseTestsBase() {
                 assertEquals(defaultPKName, it.getString("PK_NAME"))
             }
 
-            SchemaUtils.createMissingTablesAndColumns(tester3)
-            assertPrimaryKey {
-                assertTrue(it.next())
-                assertEquals(defaultPKName, it.getString("PK_NAME"))
+            assertFailAndRollback("Multiple primary keys are not allowed") {
+                SchemaUtils.createMissingTablesAndColumns(tester3)
             }
 
             SchemaUtils.drop(tester1)


### PR DESCRIPTION
`SchemaUtils.createMissingTablesAndColumns()` invokes `addMissingColumnsStatements()` to generate the necessary ALTER statements when actualizing a new schema. The latter relies on detecting missing columns to create indices or primary keys (PK) on the new columns.

Attempting to move from a table without a PK, to a new table with a PK will not successfully create the PK if it is defined using only columns that already exist (i.e. no new columns detected to trigger adding a constraint):
```kt
// SUCCESS
object NoPKTable : Table("Foo") {
    val bar = integer("bar")
}
object CompPKTable : Table("Foo") {
    val bar = integer("bar")
    val baz = varchar("baz", 32)
    override val primaryKey = PrimaryKey(bar, baz)
}
transaction {
    SchemaUtils.createMissingTablesAndColumns(NoPKTable)
    SchemaUtils.createMissingTablesAndColumns(CompPKTable)
}

// QUIET FAIL - no PK created
object NoPKTable : Table("Foo") {
    val bar = integer("bar")
}
object SinglePKTable : Table("Foo") {
    val bar = integer("bar")
    override val primaryKey = PrimaryKey(bar)
}
transaction {
    SchemaUtils.createMissingTablesAndColumns(NoPKTable)
    SchemaUtils.createMissingTablesAndColumns(SinglePKTable)
}
```

A new function `existingPrimaryKeys()` has been created that checks existing table metadata for PK info (stored in `PrimaryKeyMetadata` data class). This is then used by `addMissingColumnsStatements()` to detect cases when metadata does not match the new table mapping, in the event that no new columns were added.

**Note**: The block that checks for foreign key constraints mismatch has been extracted to its own function to fix detekt errors (nested too deep & cyclomatic complexity) for `addMissingColumnsStatements()`. Some formatting changes were also made to resolve detekt errors.