### PR TITLE
fix: EXPOSED-98: Add instructions to log-in to see and log issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more information visit the links below:
 
 ## Filing issues
 
-Please note that we are moving away from GitHub Issues for reporting of bugs and features. Please log any new requests on [YouTrack](https://youtrack.jetbrains.com/issues/EXPOSED). 
+Please note that we are moving away from GitHub Issues for reporting of bugs and features. Please log any new requests on [YouTrack](https://youtrack.jetbrains.com/issues/EXPOSED). You must be logged in to view and log issues, otherwise you will be met with a 404.
 
 ## Community
 


### PR DESCRIPTION
The README.md has a link to YouTrack, and if you aren't logged in, it just shows:

![image](https://github.com/JetBrains/Exposed/assets/1522149/aa54bce7-f68a-4f49-b4c1-522f33b61b74)

I've used YouTrack before and was still pretty confused by this.
"You might have more luck if you log in" is pretty subtle and easy to miss.

The README.md should likely have a note added.

