### PR TITLE
fix: EXPOSED-82 Inaccurate UShort column type mapping

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -285,7 +285,7 @@ class ShortColumnType : ColumnType() {
  * Numeric column for storing unsigned 2-byte integers.
  *
  * **Note:** If the database being used is not MySQL or MariaDB, this column will represent the database's 4-byte
- * integer type with a check constraint that ensures storage of only values between 0 and 65535 inclusive.
+ * integer type with a check constraint that ensures storage of only values between 0 and [UShort.MAX_VALUE] inclusive.
  */
 class UShortColumnType : ColumnType() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.ushortType()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -360,6 +360,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     private val checkConstraints = mutableListOf<Pair<String, Op<Boolean>>>()
 
+    private val generatedCheckPrefix = "chk_unsigned_"
+
     /**
      * Returns the table name in proper case.
      * Should be called within transaction or default [tableName] will be returned.
@@ -483,8 +485,14 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /** Creates a numeric column, with the specified [name], for storing 2-byte integers. */
     fun short(name: String): Column<Short> = registerColumn(name, ShortColumnType())
 
-    /** Creates a numeric column, with the specified [name], for storing 2-byte unsigned integers. */
-    fun ushort(name: String): Column<UShort> = registerColumn(name, UShortColumnType())
+    /** Creates a numeric column, with the specified [name], for storing 2-byte unsigned integers.
+     *
+     * **Note:** If the database being used is not MySQL or MariaDB, this column will use the database's 4-byte
+     * integer type with a check constraint that ensures storage of only values between 0 and 65535 inclusive.
+     */
+    fun ushort(name: String): Column<UShort> = registerColumn<UShort>(name, UShortColumnType()).apply {
+        check("$generatedCheckPrefix$name") { it.between(0u, UShort.MAX_VALUE) }
+    }
 
     /** Creates a numeric column, with the specified [name], for storing 4-byte integers. */
     fun integer(name: String): Column<Int> = registerColumn(name, IntegerColumnType())
@@ -1043,29 +1051,33 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /**
      * Creates a check constraint in this column.
-     * @param name The name to identify the constraint, optional. Must be **unique** (case-insensitive) to this table, otherwise, the constraint will
-     * not be created. All names are [trimmed][String.trim], blank names are ignored and the database engine decides the default name.
+     * @param name The name to identify the constraint, optional. Must be **unique** (case-insensitive) to this table,
+     * otherwise, the constraint will not be created. All names are [trimmed][String.trim], blank names are ignored and
+     * the database engine decides the default name.
      * @param op The expression against which the newly inserted values will be compared.
      */
     fun <T> Column<T>.check(name: String = "", op: SqlExpressionBuilder.(Column<T>) -> Op<Boolean>): Column<T> = apply {
         if (name.isEmpty() || table.checkConstraints.none { it.first.equals(name, true) }) {
             table.checkConstraints.add(name to SqlExpressionBuilder.op(this))
         } else {
-            exposedLogger.warn("A CHECK constraint with name '$name' was ignored because there is already one with that name")
+            exposedLogger
+                .warn("A CHECK constraint with name '$name' was ignored because there is already one with that name")
         }
     }
 
     /**
      * Creates a check constraint in this table.
-     * @param name The name to identify the constraint, optional. Must be **unique** (case-insensitive) to this table, otherwise, the constraint will
-     * not be created. All names are [trimmed][String.trim], blank names are ignored and the database engine decides the default name.
+     * @param name The name to identify the constraint, optional. Must be **unique** (case-insensitive) to this table,
+     * otherwise, the constraint will not be created. All names are [trimmed][String.trim], blank names are ignored and
+     * the database engine decides the default name.
      * @param op The expression against which the newly inserted values will be compared.
      */
     fun check(name: String = "", op: SqlExpressionBuilder.() -> Op<Boolean>) {
         if (name.isEmpty() || checkConstraints.none { it.first.equals(name, true) }) {
             checkConstraints.add(name to SqlExpressionBuilder.op())
         } else {
-            exposedLogger.warn("A CHECK constraint with name '$name' was ignored because there is already one with that name")
+            exposedLogger
+                .warn("A CHECK constraint with name '$name' was ignored because there is already one with that name")
         }
     }
 
@@ -1104,7 +1116,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         return primaryKey?.let { primaryKey ->
             val tr = TransactionManager.current()
             val constraint = tr.db.identifierManager.cutIfNecessaryAndQuote(primaryKey.name)
-            return primaryKey.columns.joinToString(prefix = "CONSTRAINT $constraint PRIMARY KEY (", postfix = ")", transform = tr::identity)
+            return primaryKey.columns
+                .joinToString(prefix = "CONSTRAINT $constraint PRIMARY KEY (", postfix = ")", transform = tr::identity)
         }
     }
 
@@ -1140,10 +1153,17 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
                 }
 
                 if (checkConstraints.isNotEmpty()) {
-                    checkConstraints.mapIndexed { index, (name, op) ->
+                    val filteredChecks = if (currentDialect is MysqlDialect) {
+                        checkConstraints
+                            .filterNot { (name, _) -> name.startsWith(generatedCheckPrefix) }
+                            .ifEmpty { null }
+                    } else {
+                        checkConstraints
+                    }
+                    filteredChecks?.mapIndexed { index, (name, op) ->
                         val resolvedName = name.ifBlank { "check_${tableName}_$index" }
                         CheckConstraint.from(this@Table, resolvedName, op).checkPart
-                    }.joinTo(this, prefix = ", ")
+                    }?.joinTo(this, prefix = ", ")
                 }
 
                 append(")")
@@ -1159,7 +1179,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         return createSequence + createTable + createConstraint
     }
 
-    override fun modifyStatement(): List<String> = throw UnsupportedOperationException("Use modify on columns and indices")
+    override fun modifyStatement(): List<String> =
+        throw UnsupportedOperationException("Use modify on columns and indices")
 
     override fun dropStatement(): List<String> {
         val dropTable = buildString {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -488,7 +488,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /** Creates a numeric column, with the specified [name], for storing 2-byte unsigned integers.
      *
      * **Note:** If the database being used is not MySQL or MariaDB, this column will use the database's 4-byte
-     * integer type with a check constraint that ensures storage of only values between 0 and 65535 inclusive.
+     * integer type with a check constraint that ensures storage of only values between 0 and [UShort.MAX_VALUE] inclusive.
      */
     fun ushort(name: String): Column<UShort> = registerColumn<UShort>(name, UShortColumnType()).apply {
         check("$generatedCheckPrefix$name") { it.between(0u, UShort.MAX_VALUE) }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -26,8 +26,11 @@ abstract class DataTypeProvider {
     /** Numeric type for storing 2-byte integers. */
     open fun shortType(): String = "SMALLINT"
 
-    /** Numeric type for storing 2-byte unsigned integers. */
-    open fun ushortType(): String = "SMALLINT"
+    /** Numeric type for storing 2-byte unsigned integers.
+     *
+     * **Note:** If the database being used is not MySQL or MariaDB, this will represent the 4-byte integer type.
+     */
+    open fun ushortType(): String = "INT"
 
     /** Numeric type for storing 4-byte integers. */
     open fun integerType(): String = "INT"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun byteType(): String = "SMALLINT"
     override fun ubyteType(): String = "SMALLINT"
+    override fun ushortType(): String = "NUMBER(6)"
     override fun integerType(): String = "NUMBER(12)"
     override fun integerAutoincType(): String = "NUMBER(12)"
     override fun uintegerType(): String = "NUMBER(13)"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -83,11 +83,12 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testUShortTypeRegression() {
+    fun testPreviousUShortColumnTypeWorksWithNewIntType() {
         withDb(excludeSettings = listOf(TestDB.MYSQL, TestDB.MARIADB)) { testDb ->
             try {
                 val tableName = UShortTable.nameInDatabaseCase()
                 val columnName = UShortTable.unsignedShort.nameInDatabaseCase()
+                // create table using previous column type SMALLINT
                 exec("""CREATE TABLE ${addIfNotExistsIfSupported()}$tableName ($columnName SMALLINT NOT NULL)""")
 
                 val number1 = Short.MAX_VALUE.toUShort()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -101,7 +101,7 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
                     val number2 = (Short.MAX_VALUE + 1).toUShort()
                     assertFailAndRollback("Out-of-range (OoR) error") {
                         UShortTable.insert { it[unsignedShort] = number2 }
-                        assertEquals(0, UShortTable.select { UShortTable.unsignedShort less 0u })
+                        assertEquals(0, UShortTable.select { UShortTable.unsignedShort less 0u }.count())
                     }
 
                     // modify column to now have INT type

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -6,24 +6,28 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.junit.Test
 
 class UnsignedColumnTypeTests : DatabaseTestsBase() {
-    object UByteTable : Table("uByteTable") {
-        val unsignedByte = ubyte("uByte")
+    object UByteTable : Table("ubyte_table") {
+        val unsignedByte = ubyte("ubyte")
     }
 
-    object UShortTable : Table("uShortTable") {
-        val unsignedShort = ushort("uShort")
+    object UShortTable : Table("ushort_table") {
+        val unsignedShort = ushort("ushort")
     }
 
-    object UIntTable : Table("uIntTable") {
-        val unsignedInt = uinteger("uInt")
+    object UIntTable : Table("uint_table") {
+        val unsignedInt = uinteger("uint")
     }
 
-    object ULongTable : Table("uLongTable") {
-        val unsignedLong = ulong("uLong")
+    object ULongTable : Table("ulong_table") {
+        val unsignedLong = ulong("ulong")
     }
 
     @Test
@@ -49,6 +53,34 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             val result = UShortTable.selectAll().toList()
             assertEquals(1, result.size)
             assertEquals(123u, result.single()[UShortTable.unsignedShort])
+        }
+    }
+
+    @Test
+    fun testUShortWithCheckConstraint() {
+        withTables(UShortTable) {
+            val ddlEnding = if (currentDialectTest is MysqlDialect) {
+                "(ushort SMALLINT UNSIGNED NOT NULL)"
+            } else {
+                "CHECK (ushort BETWEEN 0 and ${UShort.MAX_VALUE}))"
+            }
+            assertTrue(UShortTable.ddl.single().endsWith(ddlEnding, ignoreCase = true))
+
+            val number = 49151.toUShort()
+            assertTrue(number in Short.MAX_VALUE.toUShort()..UShort.MAX_VALUE)
+
+            UShortTable.insert { it[unsignedShort] = number }
+
+            val result = UShortTable.selectAll()
+            assertEquals(number, result.single()[UShortTable.unsignedShort])
+
+            // test that column itself blocks same out-of-range value that compiler blocks
+            assertFailAndRollback("Check constraint violation or out-of-range error (MySQL/MariaDB)") {
+                val tableName = UShortTable.nameInDatabaseCase()
+                val columnName = UShortTable.unsignedShort.nameInDatabaseCase()
+                val outOfRangeValue = UShort.MAX_VALUE + 1u
+                exec("""INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)""")
+            }
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -1,12 +1,10 @@
 package org.jetbrains.exposed.sql.tests.shared.types
 
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
@@ -75,11 +73,46 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             assertEquals(number, result.single()[UShortTable.unsignedShort])
 
             // test that column itself blocks same out-of-range value that compiler blocks
-            assertFailAndRollback("Check constraint violation or out-of-range error (MySQL/MariaDB)") {
+            assertFailAndRollback("Check constraint violation (or out-of-range error in MySQL/MariaDB)") {
                 val tableName = UShortTable.nameInDatabaseCase()
                 val columnName = UShortTable.unsignedShort.nameInDatabaseCase()
                 val outOfRangeValue = UShort.MAX_VALUE + 1u
                 exec("""INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)""")
+            }
+        }
+    }
+
+    @Test
+    fun testUShortTypeRegression() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL, TestDB.MARIADB)) { testDb ->
+            try {
+                val tableName = UShortTable.nameInDatabaseCase()
+                val columnName = UShortTable.unsignedShort.nameInDatabaseCase()
+                exec("""CREATE TABLE ${addIfNotExistsIfSupported()}$tableName ($columnName SMALLINT NOT NULL)""")
+
+                val number1 = Short.MAX_VALUE.toUShort()
+                UShortTable.insert { it[unsignedShort] = number1 }
+
+                val result1 = UShortTable.select { UShortTable.unsignedShort eq number1 }.count()
+                assertEquals(1, result1)
+
+                // SMALLINT maps to INTEGER in SQLite and NUMBER(38) in Oracle, so they will not throw OoR error
+                if (testDb != TestDB.SQLITE && testDb != TestDB.ORACLE) {
+                    val number2 = (Short.MAX_VALUE + 1).toUShort()
+                    assertFailAndRollback("Out-of-range (OoR) error") {
+                        UShortTable.insert { it[unsignedShort] = number2 }
+                        assertEquals(0, UShortTable.select { UShortTable.unsignedShort less 0u })
+                    }
+
+                    // modify column to now have INT type
+                    exec(UShortTable.unsignedShort.modifyStatement().first())
+                    UShortTable.insert { it[unsignedShort] = number2 }
+
+                    val result2 = UShortTable.selectAll().map { it[UShortTable.unsignedShort] }
+                    assertEqualCollections(listOf(number1, number2), result2)
+                }
+            } finally {
+                SchemaUtils.drop(UShortTable)
             }
         }
     }


### PR DESCRIPTION
**Current State** of `UShortColumnType` (excluding MySQL/MariaDB):

When attempting to insert a `UShort` value outside of the range `0..32767`, Exposed first truncates the value by calling `value.toShort()` before sending it to the DB:
```kt
object UShortTable : Table("ushort_table") {
    val unsignedShort = ushort("ushort")
}

transaction {
    UShortTable.insert { it[unsignedShort] = 49151u }  // compiles OK because it is a valid UShort
    // but generates SQL:
    // INSERT INTO ushort_table (uShort) VALUES (-16385)
}
```
The value is successfully stored as a negative number because most databases don't support unsigned types natively, which means Exposed is actually mapping UShort to 2-byte `SMALLINT`, which accepts the range `-32768..32767`. The value returned from the DB is the negative overflow and an `IllegalStateException` is thrown by `valueFromDB()`.

**Note:** The compiler will prevent a negative number from being assigned to `it[unsignedShort]`, but there is nothing stopping the DB from storing a negative number that is inserted directly using raw SQL:
```kt
exec("""INSERT INTO ushort_table ("uShort") VALUES (-16385);""")  // success with no SQLException
// only throws IllegalStateException if attempting to retrieve data
```

So the current state is misleading on 2 fronts:
1. It does not allow DB storage of the full range of `UShort` values despite no compilation errors or logged warnings.
2. The column in the DB is not actually constraining its stored values to non-negatives.

**Possible Solutions:**
1. Change nothing on the DB level but make Exposed fail early with an `IllegalArgumentException` if a user tries to insert a value outside the range `0..32767`. This would mean making it very clear in KDocs that the columns are constrained by Exposed to the range `0..32767` but that the DB itself still allows negative values.
2. Only change the column type in the DB to use the next higher type, `INT` in this case. The full UShort range could then be stored but this would still allow intended behavior to be overriden using `exec()`. That means both negative values could be stored, as well as much larger values in `UShort.MAX_VALUE..Int.MAX_VALUE`.
3. Change the column type in the DB to use the next higher type, `INT` in this case, and add a check constraint when `ushort()` is registered. This would ensure that only UShort values are accepted, even if raw SQL is used. **[Implemented]**

**Saving Storage Space:**
While using a larger numeric type with a check constraint is a common solution for supporting unsigned integers, some users may not want to use 4 bytes of storage for every number. If the end-goal of the user is a column that only uses 2-bytes but does not allow negative values and they know for a fact that inserted data won't exceed 32767, then the recommendation should be to use a `short()` column with a manually created check constraint:
```kt
short("number").check { it.between(0, Short.MAX_VALUE) }
// OR
short("number").check { (it greaterEq 0) and (it lessEq Short.MAX_VALUE) }
```
