### PR TITLE
fix: EXPOSED-54 CaseWhen.Else returns narrow Expression<R>

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -259,7 +259,7 @@ public final class org/jetbrains/exposed/sql/Case {
 
 public final class org/jetbrains/exposed/sql/CaseWhen {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;)V
-	public final fun Else (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Expression;
+	public final fun Else (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;
 	public final fun When (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CaseWhen;
 	public final fun getCases ()Ljava/util/List;
 	public final fun getValue ()Lorg/jetbrains/exposed/sql/Expression;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -73,8 +73,9 @@ class Random(
 class CharLength<T : String?>(
     val expr: Expression<T>
 ) : Function<Int?>(IntegerColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.charLength(expr, queryBuilder)
+    }
 }
 
 /**
@@ -106,8 +107,9 @@ class Concat(
     /** Returns the expressions being concatenated. */
     vararg val expr: Expression<*>
 ) : Function<String>(TextColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.concat(separator, queryBuilder, expr = expr)
+    }
 }
 
 /**
@@ -123,8 +125,9 @@ class GroupConcat<T : String?>(
     /** Returns the order in which the elements of each group are sorted. */
     vararg val orderBy: Pair<Expression<*>, SortOrder>
 ) : Function<T>(TextColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.groupConcat(this, queryBuilder)
+    }
 }
 
 /**
@@ -136,8 +139,9 @@ class Substring<T : String?>(
     /** Returns the length of the substring. */
     val length: Expression<Int>
 ) : Function<T>(TextColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.substring(expr, start, length, queryBuilder)
+    }
 }
 
 /**
@@ -350,8 +354,9 @@ sealed class NextVal<T>(
     columnType: IColumnType
 ) : Function<T>(columnType) {
 
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.nextVal(seq, queryBuilder)
+    }
 
     class IntNextVal(seq: Sequence) : NextVal<Int>(seq, IntegerColumnType())
     class LongNextVal(seq: Sequence) : NextVal<Long>(seq, LongColumnType())
@@ -386,18 +391,20 @@ class CaseWhenElse<T, R : T>(
             ?: caseWhen.cases.map { it.second }.filterIsInstance<ExpressionWithColumnType<*>>().firstOrNull()?.columnType
             ?: BooleanColumnType.INSTANCE
 
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        append("CASE ")
-        if (caseWhen.value != null) {
-            +caseWhen.value
-            +" "
-        }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder {
+            append("CASE ")
+            if (caseWhen.value != null) {
+                +caseWhen.value
+                +" "
+            }
 
-        for ((first, second) in caseWhen.cases) {
-            append("WHEN ", first, " THEN ", second)
-        }
+            for ((first, second) in caseWhen.cases) {
+                append("WHEN ", first, " THEN ", second)
+            }
 
-        append(" ELSE ", elseResult, " END")
+            append(" ELSE ", elseResult, " END")
+        }
     }
 }
 
@@ -428,6 +435,7 @@ class Cast<T>(
     val expr: Expression<*>,
     columnType: IColumnType
 ) : Function<T>(columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.cast(expr, columnType, queryBuilder)
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -73,7 +73,8 @@ class Random(
 class CharLength<T : String?>(
     val expr: Expression<T>
 ) : Function<Int?>(IntegerColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.charLength(expr, queryBuilder)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+        currentDialect.functionProvider.charLength(expr, queryBuilder)
 }
 
 /**
@@ -105,7 +106,8 @@ class Concat(
     /** Returns the expressions being concatenated. */
     vararg val expr: Expression<*>
 ) : Function<String>(TextColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.concat(separator, queryBuilder, expr = expr)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+        currentDialect.functionProvider.concat(separator, queryBuilder, expr = expr)
 }
 
 /**
@@ -121,7 +123,8 @@ class GroupConcat<T : String?>(
     /** Returns the order in which the elements of each group are sorted. */
     vararg val orderBy: Pair<Expression<*>, SortOrder>
 ) : Function<T>(TextColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.groupConcat(this, queryBuilder)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+        currentDialect.functionProvider.groupConcat(this, queryBuilder)
 }
 
 /**
@@ -133,7 +136,8 @@ class Substring<T : String?>(
     /** Returns the length of the substring. */
     val length: Expression<Int>
 ) : Function<T>(TextColumnType()) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.substring(expr, start, length, queryBuilder)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+        currentDialect.functionProvider.substring(expr, start, length, queryBuilder)
 }
 
 /**
@@ -346,7 +350,8 @@ sealed class NextVal<T>(
     columnType: IColumnType
 ) : Function<T>(columnType) {
 
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.nextVal(seq, queryBuilder)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+        currentDialect.functionProvider.nextVal(seq, queryBuilder)
 
     class IntNextVal(seq: Sequence) : NextVal<Int>(seq, IntegerColumnType())
     class LongNextVal(seq: Sequence) : NextVal<Long>(seq, LongColumnType())
@@ -368,10 +373,13 @@ class CaseWhen<T>(val value: Expression<*>?) {
         return this as CaseWhen<R>
     }
 
-    fun <R : T> Else(e: Expression<R>): Expression<R> = CaseWhenElse(this, e)
+    fun <R : T> Else(e: Expression<R>): ExpressionWithColumnType<R> = CaseWhenElse(this, e)
 }
 
-class CaseWhenElse<T, R : T>(val caseWhen: CaseWhen<T>, val elseResult: Expression<R>) : ExpressionWithColumnType<R>(), ComplexExpression {
+class CaseWhenElse<T, R : T>(
+    val caseWhen: CaseWhen<T>,
+    val elseResult: Expression<R>
+) : ExpressionWithColumnType<R>(), ComplexExpression {
 
     override val columnType: IColumnType =
         (elseResult as? ExpressionWithColumnType<R>)?.columnType
@@ -382,10 +390,11 @@ class CaseWhenElse<T, R : T>(val caseWhen: CaseWhen<T>, val elseResult: Expressi
         append("CASE ")
         if (caseWhen.value != null) {
             +caseWhen.value
+            +" "
         }
 
         for ((first, second) in caseWhen.cases) {
-            append(" WHEN ", first, " THEN ", second)
+            append("WHEN ", first, " THEN ", second)
         }
 
         append(" ELSE ", elseResult, " END")
@@ -419,5 +428,6 @@ class Cast<T>(
     val expr: Expression<*>,
     columnType: IColumnType
 ) : Function<T>(columnType) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = currentDialect.functionProvider.cast(expr, columnType, queryBuilder)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit =
+        currentDialect.functionProvider.cast(expr, columnType, queryBuilder)
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
@@ -178,7 +178,6 @@ class ConditionsTests : DatabaseTestsBase() {
     @Test
     fun testCaseWhenElseAsArgument() {
         withCitiesAndUsers { cities, _, _ ->
-            addLogger(StdOutSqlLogger)
             val original = "ORIGINAL"
             val copy = "COPY"
             val condition = Op.build { cities.id eq 1 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
@@ -13,9 +13,9 @@ class ConditionsTests : DatabaseTestsBase() {
     @Test
     fun testTRUEandFALSEOps() {
         withCitiesAndUsers { cities, _, _ ->
-            val allSities = cities.selectAll().toCityNameList()
+            val allCities = cities.selectAll().toCityNameList()
             assertEquals(0L, cities.select { Op.FALSE }.count())
-            assertEquals(allSities.size.toLong(), cities.select { Op.TRUE }.count())
+            assertEquals(allCities.size.toLong(), cities.select { Op.TRUE }.count())
         }
     }
 
@@ -158,9 +158,9 @@ class ConditionsTests : DatabaseTestsBase() {
     @Test
     fun nullOpInCaseTest() {
         withCitiesAndUsers { cities, _, _ ->
-            val caseCondition = Case().
-                When(Op.build { cities.id eq 1 }, Op.nullOp<String>()).
-                Else(cities.name)
+            val caseCondition = Case()
+                .When(Op.build { cities.id eq 1 }, Op.nullOp<String>())
+                .Else(cities.name)
             var nullBranchWasExecuted = false
             cities.slice(cities.id, cities.name, caseCondition).selectAll().forEach {
                 val result = it[caseCondition]
@@ -172,6 +172,42 @@ class ConditionsTests : DatabaseTestsBase() {
                 }
             }
             assertEquals(true, nullBranchWasExecuted)
+        }
+    }
+
+    @Test
+    fun testCaseWhenElseAsArgument() {
+        withCitiesAndUsers { cities, _, _ ->
+            addLogger(StdOutSqlLogger)
+            val original = "ORIGINAL"
+            val copy = "COPY"
+            val condition = Op.build { cities.id eq 1 }
+
+            val caseCondition1 = Case()
+                .When(condition, stringLiteral(original))
+                .Else(Op.nullOp())
+            // Case().When().Else() invokes CaseWhenElse() so the 2 formats should be interchangeable as arguments
+            val caseCondition2 = CaseWhenElse(
+                Case().When(condition, stringLiteral(original)),
+                Op.nullOp()
+            )
+            val function1 = Coalesce(caseCondition1, stringLiteral(copy))
+            val function2 = Coalesce(caseCondition2, stringLiteral(copy))
+
+            // confirm both formats produce identical SQL
+            val query1 = cities.slice(cities.id, function1).selectAll().prepareSQL(this, prepared = false)
+            val query2 = cities.slice(cities.id, function2).selectAll().prepareSQL(this, prepared = false)
+            assertEquals(query1, query2)
+
+            val results1 = cities.slice(cities.id, function1).selectAll().toList()
+            cities.slice(cities.id, function2).selectAll().forEachIndexed { i, row ->
+                val currentId = row[cities.id]
+                val functionResult = row[function2]
+
+                assertEquals(if (currentId == 1) original else copy, functionResult)
+                assertEquals(currentId, results1[i][cities.id])
+                assertEquals(functionResult, results1[i][function1])
+            }
         }
     }
 }


### PR DESCRIPTION
The class `CaseWhen` has a function `Else()` with a return type `Expression<R>`, which creates and returns an instance of the `CaseWhenElse` class. According to [commit 008db328](https://github.com/JetBrains/Exposed/commit/008db328c88ad65943e6e7b281af600234317da2), the `CaseWhenElse` class used to also extend `Expression<R>:

![commit_008db328](https://github.com/JetBrains/Exposed/assets/82039410/e8831636-a359-4de7-a1a6-24502046bb8a)

A few years ago, in [commit ff3ed717](https://github.com/JetBrains/Exposed/commit/ff3ed717ad4c13e47f4ea12ecdd1a747c1003887), `CaseWhenElse` was changed to extend `ExpressionWithColumnType<R>` instead. In spite of this, the return type of `Else()` did not change:

![commit_ff3ed717](https://github.com/JetBrains/Exposed/assets/82039410/966d3d9e-75dc-498e-afb6-5484b685bdba)

This means that a case instantiated using the constructor of `CaseWhenElse` is not interchangeable with an identical case instantiated using the `Else` method of the `CaseWhen` class:
```kt
// for example, Coalesce() requires an argument of type ExpressionWithColumnType

// compiles successfully
Coalesce(
    expr = CaseWhenElse(
        Case().When(Op.build { cities.id eq 1 }, stringParam("1")),
        Op.nullOp()
    ),
    alternate = stringParam("2")
)
// does not compile
Coalesce(
    expr = Case()
        .When(Op.build { cities.id eq 1 }, stringParam("1"))
        .Else(Op.nullOp()),
    alternate = stringParam("2")
)
```

Update `Else()` return type to be as broad as the `CaseWhenElse` instance it returns.

**Additional:**
- Remove extra whitespace in Case query builder.
- Fix Detekt issues.