### PR TITLE
test: Fix failing exposed-tests in SQL Server

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
@@ -25,8 +26,8 @@ class ConditionsTests : DatabaseTestsBase() {
             val number1 = integer("number_1").nullable()
             val number2 = integer("number_2").nullable()
         }
-
-        withTables(table) {
+        // remove SQL Server exclusion once test container supports SQL Server 2022
+        withTables(excludeSettings = listOf(TestDB.SQLSERVER), table) {
             val sameNumberId = table.insert {
                 it[number1] = 0
                 it[number2] = 0


### PR DESCRIPTION
The following tests in `exposed-tests` module fail when run using SQL Server:

**InsertTests/'batch insert number of inserted rows is accurate'()**
- SQL Server does not support insert or ignore (neither does Oracle, on which it also fails), so it has been excluded from the test.
- The test suite is adjusted to use a common list of databases that don't support insert or ignore.
- The failing test is also refactored to better cover MySQL-related databases, which actually support insert or ignore.

**ConditionsTests/testNullSafeEqualityOps()**
- Fails with the error: `com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near the keyword 'DISTINCT'` because IS DISTINCT FROM operator is only supported as of [SQL Server 2022](https://learn.microsoft.com/en-us/sql/t-sql/queries/is-distinct-from-transact-sql?view=sql-server-ver16). The current testing docker image [does not support](https://learn.microsoft.com/en-us/azure/azure-sql-edge/release-notes) this version, so it has been temporarily excluded.