### PR TITLE
fix: EXPOSED-99 SchemaUtils incorrectly compares datetime defaults

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -187,6 +187,19 @@ object SchemaUtils {
                     else -> processForDefaultValue(exp)
                 }
             }
+            is Function<*> -> {
+                var processed = processForDefaultValue(exp)
+                if (
+                    exp.columnType is IDateColumnType &&
+                    (processed.startsWith("CURRENT_TIMESTAMP") || processed == "GETDATE()")
+                ) {
+                    when (currentDialect) {
+                        is SQLServerDialect -> processed = "getdate"
+                        is MariaDBDialect -> processed = processed.lowercase()
+                    }
+                }
+                processed
+            }
             else -> processForDefaultValue(exp)
         }
     }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -291,7 +291,6 @@ class DefaultsTest : DatabaseTestsBase() {
 
     @Test
     fun testDefaultExpressions01() {
-
         fun abs(value: Int) = object : ExpressionWithColumnType<Int>() {
             override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("ABS($value)") }
 


### PR DESCRIPTION
The following test fails in `exposed-javatime` and `exposed-kotlin-datetime` modules (**Note** it was missing from `exposed-jodatime` module and has now been included):

**DefaultTests/testConsistentSchemeWithFunctionAsDefaultExpression()**

The test fails because an existing and unchanged datetime column with a database default is marked as modified, triggering an unnecessary ALTER statement. This is because the metadata value returned in `addMissingColumnsStatements()` does not match the returned value of `dbDefaultToString()`:

- [SQL Server maps](https://learn.microsoft.com/en-us/sql/t-sql/functions/current-timestamp-transact-sql?view=sql-server-ver16) both CURRENT_TIMESTAMP and GETDATE() to the ANSI standard equivalent, getdate.
- MariaDB returns CURRENT_TIMESTAMP(6) correctly, but in lower case.

Changes to the parsing of the default value cannot be done in `DataTypeProvider.processForDefaultValue()` because this function is also used in create statements, for example. So the processing needed to ensure a good match for these edge cases is confined to the existing private extension function in `SchemaUtils` -> `DataTypeProvider.dbDefaultToString()`.

Additional:
- Fix Detekt warnings.