### PR TITLE
test: Fix failing exposed-tests in Oracle

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -922,7 +922,7 @@ class DDLTests : DatabaseTestsBase() {
         withSchemas(two, one) {
             SchemaUtils.create(TableFromSchemeOne)
             if (currentDialectTest is OracleDialect) {
-                exec("GRANT SELECT ON ${TableFromSchemeOne.tableName} to TWO;")
+                exec("GRANT REFERENCES ON ${TableFromSchemeOne.tableName} to TWO")
             }
             SchemaUtils.create(TableFromSchemeTwo)
             val idFromOne = TableFromSchemeOne.insertAndGetId { }
@@ -1114,8 +1114,6 @@ class DDLTests : DatabaseTestsBase() {
             if (currentDialectTest is SQLServerDialect) {
                 SchemaUtils.drop(tableA, tableB)
             }
-
         }
     }
-
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -335,8 +335,7 @@ class CreateTableTests : DatabaseTestsBase() {
                 onDelete = ReferenceOption.NO_ACTION,
             )
         }
-        withTables(excludeSettings = listOf(TestDB.H2_ORACLE), parent, child) {
-            // Different dialects use different mix of lowercase/uppercase in their names
+        withTables(excludeSettings = listOf(TestDB.H2_ORACLE, TestDB.ORACLE), parent, child) {
             val expected = listOf(
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(child)} (" +
                     "${child.columns.joinToString { it.descriptionDdl(false) }}," +
@@ -360,17 +359,14 @@ class CreateTableTests : DatabaseTestsBase() {
                 onDelete = ReferenceOption.NO_ACTION,
             )
         }
-        withTables(excludeSettings = listOf(TestDB.H2_ORACLE), parent, child) {
-            // Different dialects use different mix of lowercase/uppercase in their names
-            val expected = listOf(
-                "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(child)} (" +
-                    "${child.columns.joinToString { it.descriptionDdl(false) }}," +
-                    " CONSTRAINT ${"fk_Child2_parent_id__id".inProperCase()}" +
-                    " FOREIGN KEY (${this.identity(child.parentId)})" +
-                    " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
-                    ")"
-            )
-            assertEqualCollections(child.ddl, expected)
+        withTables(parent, child) {
+            val expected = "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(child)} (" +
+                "${child.columns.joinToString { it.descriptionDdl(false) }}," +
+                " CONSTRAINT ${"fk_Child2_parent_id__id".inProperCase()}" +
+                " FOREIGN KEY (${this.identity(child.parentId)})" +
+                " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
+                ")"
+            assertEquals(child.ddl.last(), expected)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -12,12 +12,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.tests.shared.dml.withCitiesAndUsers
-import org.jetbrains.exposed.sql.vendors.H2Dialect
-import org.jetbrains.exposed.sql.vendors.OracleDialect
-import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
-import org.jetbrains.exposed.sql.vendors.SQLServerDialect
-import org.jetbrains.exposed.sql.vendors.SQLiteDialect
-import org.jetbrains.exposed.sql.vendors.h2Mode
+import org.jetbrains.exposed.sql.vendors.*
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -356,16 +351,14 @@ class FunctionsTests : DatabaseTestsBase() {
     @Test
     fun testLocate03() {
         withCitiesAndUsers { cities, _, _ ->
-            val isCaseSensitiveDialect = currentDialectTest is SQLiteDialect ||
-                currentDialectTest is PostgreSQLDialect ||
-                currentDialectTest is H2Dialect
+            val isNotCaseSensitiveDialect = currentDialectTest is MysqlDialect || currentDialectTest is SQLServerDialect
 
             val locate = cities.name.locate("p")
             val results = cities.slice(locate).selectAll().toList()
 
-            assertEquals(if (isCaseSensitiveDialect) 0 else 5, results[0][locate]) // St. Petersburg
+            assertEquals(if (isNotCaseSensitiveDialect) 5 else 0, results[0][locate]) // St. Petersburg
             assertEquals(0, results[1][locate]) // Munich
-            assertEquals(if (isCaseSensitiveDialect) 0 else 1, results[2][locate]) // Prague
+            assertEquals(if (isNotCaseSensitiveDialect) 1 else 0, results[2][locate]) // Prague
         }
     }
 


### PR DESCRIPTION
The following tests in `exposed-tests` module fail when run using Oracle:

**FunctionsTests/testLocate03()**
- Oracle substring search is also case sensitive. The list of case sensitive DB became longer so it was more concise to create a condition for non-case sensitive DB and swap the test cases.

**DDLTests/createTableWithForeignKeyToAnotherSchema()**
- SQL statement used in `exec()` is terminated with a semi-colon and also does not provide the required privileges to reference tables across different schema, so the GRANT statement was altered.

**CreateTableTests/createTableWithQuotes()**
- Throws error `ORA-01741: illegal zero-length identifier` because Oracle does not tolerate a quoted table identifier in a sequence name: `CREATE SEQUENCE ""Parent"_id_seq" START WITH...` Oracle has been excluded until the test is revisited when `IdentifierManager`  and quotation rules are properly addressed.

**CreateTableTests/createTableWithSingleQuotes()**
- Oracle (and H2 Oracle mode) produces 2 DDL statements, as a sequence must be created first for the auto-increment primary key before table creation. The test has been adjusted to only check the last DDL statement.