### PR TITLE
test: Fix failing testSqrtFunction test for SQLite

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/MathFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/MathFunctionTests.kt
@@ -105,7 +105,7 @@ class MathFunctionTests : FunctionsTestBase() {
             assertExpressionEqual(BigDecimal("11.2"), SqrtFunction(decimalLiteral(BigDecimal("125.44"))))
 
             when (testDb) {
-                TestDB.MYSQL, TestDB.MARIADB -> {
+                TestDB.MYSQL, TestDB.MARIADB, TestDB.SQLITE -> {
                     assertExpressionEqual(null, SqrtFunction(intLiteral(-100)))
                 }
                 TestDB.SQLSERVER -> {
@@ -114,8 +114,8 @@ class MathFunctionTests : FunctionsTestBase() {
                         assertExpressionEqual(null, SqrtFunction(intLiteral(-100)))
                     }
                 }
-                TestDB.SQLITE, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.ORACLE -> {
-                    // SQLite, PSQL, Oracle fail to execute sqrt with negative value
+                TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.ORACLE -> {
+                    // PostgreSQL and Oracle fail to execute sqrt with negative value
                     expectException<ExposedSQLException> {
                         assertExpressionEqual(null, SqrtFunction(intLiteral(-100)))
                     }


### PR DESCRIPTION
This test fails locally for me, but not on TeamCity for some reason. According to [SQLite documentation](https://www.sqlite.org/lang_mathfunc.html#sqrt:~:text=sine%20of%20X.-,sqrt(X),square%20root%20of%20X.%20NULL%20is%20returned%20if%20X%20is%20negative.,-tan(X)), using the `SQRT` math function on a negative value returns NULL, but there is no mention of an error being thrown, so we need not expect an exception. I tried it on DataGrip and using exec function to execute raw SQL in the test, and both did not throw an error and simply returned null.