### PR TITLE
fix: Inaccurate drop database statement in Oracle

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -318,7 +318,7 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
 
     override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
 
-    override fun dropDatabase(name: String): String = "DROP DATABASE ${name.inProperCase()}"
+    override fun dropDatabase(name: String): String = "DROP DATABASE"
 
     override fun setSchema(schema: Schema): String = "ALTER SESSION SET CURRENT_SCHEMA = ${schema.identifier}"
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
@@ -9,13 +9,13 @@ import java.sql.SQLException
 class CreateDatabaseTest : DatabaseTestsBase() {
 
     @Test
-    fun `create database test`() {
+    fun testCreateAndDropDatabase() {
         withDb(excludeSettings = listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.ORACLE)) {
             val dbName = "jetbrains"
             try {
                 SchemaUtils.dropDatabase(dbName)
-            } catch (e: SQLException) {
-                //ignore
+            } catch (cause: SQLException) {
+                // ignore
             }
             SchemaUtils.createDatabase(dbName)
             SchemaUtils.dropDatabase(dbName)
@@ -23,7 +23,7 @@ class CreateDatabaseTest : DatabaseTestsBase() {
     }
 
     @Test
-    fun `create database test in postgreSQL`() {
+    fun testCreateAndDropDatabaseInPostgresql() {
         // PostgreSQL needs auto commit to be "ON" to allow create database statement
         withDb(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
             connection.autoCommit = true

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateDatabaseTest.kt
@@ -10,8 +10,7 @@ class CreateDatabaseTest : DatabaseTestsBase() {
 
     @Test
     fun `create database test`() {
-        // PostgreSQL will be tested in the next test function
-        withDb(excludeSettings = listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
+        withDb(excludeSettings = listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.ORACLE)) {
             val dbName = "jetbrains"
             try {
                 SchemaUtils.dropDatabase(dbName)


### PR DESCRIPTION
The following test fails when run locally with Oracle:

**CreateDatabaseTest/'create database test'()**

The first failure `ORA-01501: CREATE DATABASE failed, ORA-01100: database already mounted` occurs because the create statement is executed while a database already exists. This occurs because the `dropDatabase()` statement executed in the try block fails as the [syntax is not correct](https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/DROP-DATABASE.html#GUID-4FFC1AF5-538D-4882-8979-7A9957492A23).

Once the syntax is fixed, the test still fails with error `ORA-65040: operation not allowed from within a pluggable database` because certain operations, including dropping the DB, need to be performed only at the root container level.

Attempting to fix this with `exec("ALTER SESSION SET CONTAINER=CDB\$ROOT")` then fails with error `ORA-01031: insufficient privileges`. This is in spite of the [test container connection](https://github.com/JetBrains/Exposed/blob/main/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt#L78) being setup using `sys as sysdba` and granting all privileges to user.

The documentation confirms that dropping a database requires certain conditions:

> You must have the SYSDBA system privilege to issue this statement. The database must be mounted in exclusive and restricted mode, and it must be closed. 

Attempting to execute variants of the following statements doesn't work either (most likely because they are SQL*PLUS CLI commands):
```kt
exec("""SHUTDOWN IMMEDIATE""")
exec("""STARTUP RESTRICT MOUNT""")
```

Oracle has been excluded from this test.