### PR TITLE
fix: EXPOSED-107 Inaccurate UByte column type mapping

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -20,8 +20,12 @@ abstract class DataTypeProvider {
     /** Numeric type for storing 1-byte integers. */
     open fun byteType(): String = "TINYINT"
 
-    /** Numeric type for storing 1-byte unsigned integers. */
-    open fun ubyteType(): String = "TINYINT"
+    /** Numeric type for storing 1-byte unsigned integers.
+     *
+     * **Note:** If the database being used is not MySQL, MariaDB, or SQL Server, this will represent the 2-byte
+     * integer type.
+     */
+    open fun ubyteType(): String = "SMALLINT"
 
     /** Numeric type for storing 2-byte integers. */
     open fun shortType(): String = "SMALLINT"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 
 internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun byteType(): String = "SMALLINT"
-    override fun ubyteType(): String = "SMALLINT"
+    override fun ubyteType(): String = "NUMBER(4)"
     override fun ushortType(): String = "NUMBER(6)"
     override fun integerType(): String = "NUMBER(12)"
     override fun integerAutoincType(): String = "NUMBER(12)"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -19,7 +19,6 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun blobType(): String = "bytea"
     override fun uuidToDB(value: UUID): Any = value
     override fun dateTimeType(): String = "TIMESTAMP"
-    override fun ubyteType(): String = "SMALLINT"
     override fun jsonBType(): String = "JSONB"
     override fun hexToDb(hexString: String): String = """E'\\x$hexString'"""
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -6,6 +6,13 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.util.*
 
 internal object SQLServerDataTypeProvider : DataTypeProvider() {
+    override fun ubyteType(): String {
+        return if ((currentDialect as? H2Dialect)?.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
+            "SMALLINT"
+        } else {
+            "TINYINT"
+        }
+    }
     override fun integerAutoincType(): String = "INT IDENTITY(1,1)"
     override fun longAutoincType(): String = "BIGINT IDENTITY(1,1)"
     override fun binaryType(): String {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -77,6 +77,7 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             try {
                 val tableName = UByteTable.nameInDatabaseCase()
                 val columnName = UByteTable.unsignedByte.nameInDatabaseCase()
+                // create table using previous column type TINYINT
                 exec("""CREATE TABLE ${addIfNotExistsIfSupported()}$tableName ($columnName TINYINT NOT NULL)""")
 
                 val number1 = Byte.MAX_VALUE.toUByte()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
+import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.junit.Test
 
 class UnsignedColumnTypeTests : DatabaseTestsBase() {
@@ -38,6 +39,70 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             val result = UByteTable.selectAll().toList()
             assertEquals(1, result.size)
             assertEquals(123u, result.single()[UByteTable.unsignedByte])
+        }
+    }
+
+    @Test
+    fun testUByteWithCheckConstraint() {
+        withTables(UByteTable) {
+            val ddlEnding = when (currentDialectTest) {
+                is MysqlDialect -> "(ubyte TINYINT UNSIGNED NOT NULL)"
+                is SQLServerDialect -> "(ubyte TINYINT NOT NULL)"
+                else -> "CHECK (ubyte BETWEEN 0 and ${UByte.MAX_VALUE}))"
+            }
+            assertTrue(UByteTable.ddl.single().endsWith(ddlEnding, ignoreCase = true))
+
+            val number = 191.toUByte()
+            assertTrue(number in Byte.MAX_VALUE.toUByte()..UByte.MAX_VALUE)
+
+            UByteTable.insert { it[unsignedByte] = number }
+
+            val result = UByteTable.selectAll()
+            assertEquals(number, result.single()[UByteTable.unsignedByte])
+
+            // test that column itself blocks same out-of-range value that compiler blocks
+            assertFailAndRollback("Check constraint violation (or out-of-range error in MySQL/MariaDB/SQL Server)") {
+                val tableName = UByteTable.nameInDatabaseCase()
+                val columnName = UByteTable.unsignedByte.nameInDatabaseCase()
+                val outOfRangeValue = UByte.MAX_VALUE + 1u
+                exec("""INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)""")
+            }
+        }
+    }
+
+    @Test
+    fun testPreviousUByteColumnTypeWorksWithNewSmallIntType() {
+        // MySQL and MariaDB type hasn't changed, and PostgreSQL and Oracle never supported TINYINT
+        withDb(TestDB.allH2TestDB - TestDB.H2_PSQL + TestDB.SQLITE) { testDb ->
+            try {
+                val tableName = UByteTable.nameInDatabaseCase()
+                val columnName = UByteTable.unsignedByte.nameInDatabaseCase()
+                exec("""CREATE TABLE ${addIfNotExistsIfSupported()}$tableName ($columnName TINYINT NOT NULL)""")
+
+                val number1 = Byte.MAX_VALUE.toUByte()
+                UByteTable.insert { it[unsignedByte] = number1 }
+
+                val result1 = UByteTable.select { UByteTable.unsignedByte eq number1 }.count()
+                assertEquals(1, result1)
+
+                // TINYINT maps to INTEGER in SQLite, so it will not throw OoR error
+                if (testDb != TestDB.SQLITE) {
+                    val number2 = (Byte.MAX_VALUE + 1).toUByte()
+                    assertFailAndRollback("Out-of-range (OoR) error") {
+                        UByteTable.insert { it[unsignedByte] = number2 }
+                        assertEquals(0, UByteTable.select { UByteTable.unsignedByte less 0u }.count())
+                    }
+
+                    // modify column to now have SMALLINT type
+                    exec(UByteTable.unsignedByte.modifyStatement().first())
+                    UByteTable.insert { it[unsignedByte] = number2 }
+
+                    val result2 = UByteTable.selectAll().map { it[UByteTable.unsignedByte] }
+                    assertEqualCollections(listOf(number1, number2), result2)
+                }
+            } finally {
+                SchemaUtils.drop(UByteTable)
+            }
         }
     }
 


### PR DESCRIPTION
Related to [PR #1799](https://github.com/JetBrains/Exposed/pull/1799)

**Current State** of `UByteColumnType` (excluding MySQL/MariaDB):

When attempting to insert a UByte value outside of the range `0..127`, Exposed first truncates the value by calling `value.toByte()` before sending it to the DB:
```kt
object UByteTable : Table("ubyte_table") {
    val unsignedByte = ubyte("ubyte")
}

transaction {
    UByteTable.insert { it[unsignedByte] = 191u }  // compiles OK because it is a UByte
    // but generates SQL:
    // INSERT INTO ubyte_table (ubyte) VALUES (-65)
}
```
The value is successfully stored as a negative number because most databases don't support unsigned types natively, which means Exposed is actually mapping UByte to 1-byte `TINYINT`, which accepts the range `-128..127`. The value returned from the DB is the negative overflow and an `IllegalStateException` is thrown by `valueFromDB()`.

**Note:** The compiler will prevent a negative number from being assigned to `it[unsignedByte]`, but there is nothing stopping the DB from storing a negative number that is inserted directly using raw SQL:
```kt
exec("""INSERT INTO ubyte_table ("ubyte") VALUES (-65);""")  // success with no SQLException
// only throws IllegalStateException if attempting to retrieve data
```
**Solution:**
Change the column type in the DB to use the next higher type, `SMALLINT` in this case, and add a check constraint when `ubyte()` is registered. This would ensure that only UByte values are accepted, even if raw SQL is used.

**Exceptions:**
**[SQL Server]** In this DB, `TINYINT` actually represents an unsigned 1-byte integer of the range `0..255`. So this is the only DB that retains the original type and, like MySQL/MariaDB, does not require a check constraint.
**[PostgreSQL]** The type has not changed because the DB never supported `TINYINT`, but a check constraint has been implemented.

**Saving Storage Space:**
While using a larger numeric type with a check constraint is a common solution for supporting unsigned integers, some users may not want to use 2 bytes of storage for every number. If the end-goal of the user is a column that only uses 1-byte but does not allow negative values and they know for a fact that inserted data won't exceed 127, then the recommendation should be to use a `byte()` column with a manually created check constraint:
```kt
byte("number").check { it.between(0, Byte.MAX_VALUE) }
// OR
byte("number").check { (it greaterEq 0) and (it lessEq Byte.MAX_VALUE) }
```