### PR TITLE
fix: EXPOSED-108 Incorrect mapping for UInt data type

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -497,8 +497,15 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /** Creates a numeric column, with the specified [name], for storing 4-byte integers. */
     fun integer(name: String): Column<Int> = registerColumn(name, IntegerColumnType())
 
-    /** Creates a numeric column, with the specified [name], for storing 4-byte unsigned integers. */
-    fun uinteger(name: String): Column<UInt> = registerColumn(name, UIntegerColumnType())
+    /** Creates a numeric column, with the specified [name], for storing 4-byte unsigned integers.
+     *
+     * **Note:** If the database being used is not MySQL or MariaDB, this column will use the database's
+     * 8-byte integer type with a check constraint that ensures storage of only values
+     * between 0 and [UInt.MAX_VALUE] inclusive.
+     */
+    fun uinteger(name: String): Column<UInt> = registerColumn<UInt>(name, UIntegerColumnType()).apply {
+        check("$generatedCheckPrefix$name") { it.between(0u, UInt.MAX_VALUE) }
+    }
 
     /** Creates a numeric column, with the specified [name], for storing 8-byte integers. */
     fun long(name: String): Column<Long> = registerColumn(name, LongColumnType())

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -35,8 +35,11 @@ abstract class DataTypeProvider {
     /** Numeric type for storing 4-byte integers. */
     open fun integerType(): String = "INT"
 
-    /** Numeric type for storing 4-byte unsigned integers. */
-    open fun uintegerType(): String = "INT"
+    /** Numeric type for storing 4-byte unsigned integers.
+     *
+     * **Note:** If the database being used is not MySQL or MariaDB, this will represent the 8-byte integer type.
+     */
+    open fun uintegerType(): String = "BIGINT"
 
     /** Numeric type for storing 4-byte integers, marked as auto-increment. */
     open fun integerAutoincType(): String = "INT AUTO_INCREMENT"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -132,6 +132,71 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testUIntWithCheckConstraint() {
+        withTables(UIntTable) {
+            val ddlEnding = if (currentDialectTest is MysqlDialect) {
+                "(uint INT UNSIGNED NOT NULL)"
+            } else {
+                "CHECK (uint BETWEEN 0 and ${UInt.MAX_VALUE}))"
+            }
+            assertTrue(UIntTable.ddl.single().endsWith(ddlEnding, ignoreCase = true))
+
+            val number = 3_221_225_471u
+            assertTrue(number in Int.MAX_VALUE.toUInt()..UInt.MAX_VALUE)
+
+            UIntTable.insert { it[unsignedInt] = number }
+
+            val result = UIntTable.selectAll()
+            assertEquals(number, result.single()[UIntTable.unsignedInt])
+
+            // test that column itself blocks same out-of-range value that compiler blocks
+            assertFailAndRollback("Check constraint violation (or out-of-range error in MySQL/MariaDB)") {
+                val tableName = UIntTable.nameInDatabaseCase()
+                val columnName = UIntTable.unsignedInt.nameInDatabaseCase()
+                val outOfRangeValue = UInt.MAX_VALUE.toLong() + 1L
+                exec("""INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)""")
+            }
+        }
+    }
+
+    @Test
+    fun testPreviousUIntColumnTypeWorksWithNewBigIntType() {
+        // Oracle was already previously constrained to NUMBER(13)
+        withDb(excludeSettings = listOf(TestDB.MYSQL, TestDB.MARIADB, TestDB.ORACLE)) { testDb ->
+            try {
+                val tableName = UIntTable.nameInDatabaseCase()
+                val columnName = UIntTable.unsignedInt.nameInDatabaseCase()
+                // create table using previous column type INT
+                exec("""CREATE TABLE ${addIfNotExistsIfSupported()}$tableName ($columnName INT NOT NULL)""")
+
+                val number1 = Int.MAX_VALUE.toUInt()
+                UIntTable.insert { it[unsignedInt] = number1 }
+
+                val result1 = UIntTable.select { UIntTable.unsignedInt eq number1 }.count()
+                assertEquals(1, result1)
+
+                // INT maps to INTEGER in SQLite, so it will not throw OoR error
+                if (testDb != TestDB.SQLITE) {
+                    val number2 = Int.MAX_VALUE.toUInt() + 1u
+                    assertFailAndRollback("Out-of-range (OoR) error") {
+                        UIntTable.insert { it[unsignedInt] = number2 }
+                        assertEquals(0, UIntTable.select { UIntTable.unsignedInt less 0u }.count())
+                    }
+
+                    // modify column to now have BIGINT type
+                    exec(UIntTable.unsignedInt.modifyStatement().first())
+                    UIntTable.insert { it[unsignedInt] = number2 }
+
+                    val result2 = UIntTable.selectAll().map { it[UIntTable.unsignedInt] }
+                    assertEqualCollections(listOf(number1, number2), result2)
+                }
+            } finally {
+                SchemaUtils.drop(UIntTable)
+            }
+        }
+    }
+
+    @Test
     fun testULongColumnType() {
         withTables(ULongTable) {
             ULongTable.insert {


### PR DESCRIPTION
Related to [PR #1799](https://github.com/JetBrains/Exposed/pull/1799)

**Current State** of `UIntColumnType` (excluding MySQL/MariaDB):

When attempting to insert a UInt value outside of the range `0..Int.MAX_VALUE`, Exposed first truncates the value by calling `value.toInt()` before sending it to the DB:
```kt
object UIntTable : Table("uint_table") {
    val unsignedInt = uinteger("uint")
}

transaction {
    UIntTable.insert { it[unsignedInt] = 3_221_225_471u }  // compiles OK because it is a UInt
    // but generates SQL:
    // INSERT INTO uint_table (uint) VALUES (-1073741825)
}
```
The value is successfully stored as a negative number because most databases don't support unsigned types natively, which means Exposed is actually mapping UInt to 4-byte `INT`, which accepts the range `-2^31..(2^31)-1`. The value returned from the DB is the negative overflow and an `IllegalStateException` is thrown by `valueFromDB()`.

**Note:** The compiler will prevent a negative number from being assigned to `it[unsignedInt]`, but there is nothing stopping the DB from storing a negative number that is inserted directly using raw SQL:
```kt
exec("""INSERT INTO uint_table ("uint") VALUES (-1073741825);""")  // success with no SQLException
// only throws IllegalStateException if attempting to retrieve data
```
**Solution:**
Change the column type in the DB to use the next higher type, `BIGINT` in this case, and add a check constraint when `uinteger()` is registered. This would ensure that only UInt values are accepted, even if raw SQL is used.

**Exception:**
**[Oracle]** The type has not changed because it was already set to `NUMBER(13)` (versus the `INT` alias for `NUMBER(38)`), but a check constraint has been implemented.

**Saving Storage Space:**
While using a larger numeric type with a check constraint is a common solution for supporting unsigned integers, some users may not want to use 8 bytes of storage for every number. If the end-goal of the user is a column that only uses 4-bytes but does not allow negative values and they know for a fact that inserted data won't exceed `Int.MAX_VALUE`, then the recommendation should be to use a `integer()` column with a manually created check constraint:
```kt
integer("number").check { it.between(0, Int.MAX_VALUE) }
// OR
integer("number").check { (it greaterEq 0) and (it lessEq Int.MAX_VALUE) }
```