### PR TITLE
test: Fix failing datetime comparison tests in Oracle

### DIFF
--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -304,9 +304,9 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             }
 
             // these DB take the nanosecond value 871_130_789 and round up to default precision (e.g. in Oracle: 871_131)
-            val requiresExplicitCast = listOf(TestDB.ORACLE, TestDB.H2_ORACLE, TestDB.H2_PSQL, TestDB.H2_SQLSERVER)
+            val requiresExplicitDTCast = listOf(TestDB.ORACLE, TestDB.H2_ORACLE, TestDB.H2_PSQL, TestDB.H2_SQLSERVER)
             val dateTime = when (testDb) {
-                in requiresExplicitCast -> Cast(dateTimeParam(mayTheFourthDT), JavaLocalDateTimeColumnType())
+                in requiresExplicitDTCast -> Cast(dateTimeParam(mayTheFourthDT), JavaLocalDateTimeColumnType())
                 else -> dateTimeParam(mayTheFourthDT)
             }
             val createdMayFourth = testTableDT.select { testTableDT.created eq dateTime }.count()

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -189,6 +189,36 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
     }
 
     @Test
+    fun testLocalDateTimeComparison() {
+        val testTableDT = object : IntIdTable("test_table_dt") {
+            val created = datetime("created")
+            val modified = datetime("modified")
+        }
+
+        withTables(testTableDT) {
+            val mayTheFourthDT = DateTime.parse("2011-05-04T13:00:21.871130789Z")
+            val nowDT = DateTime.now()
+            val id1 = testTableDT.insertAndGetId {
+                it[created] = mayTheFourthDT
+                it[modified] = mayTheFourthDT
+            }
+            val id2 = testTableDT.insertAndGetId {
+                it[created] = mayTheFourthDT
+                it[modified] = nowDT
+            }
+
+            val createdMayFourth = testTableDT.select { testTableDT.created eq dateTimeParam(mayTheFourthDT) }.count()
+            assertEquals(2, createdMayFourth)
+
+            val modifiedAtSameDT = testTableDT.select { testTableDT.modified eq testTableDT.created }.single()
+            assertEquals(id1, modifiedAtSameDT[testTableDT.id])
+
+            val modifiedAtLaterDT = testTableDT.select { testTableDT.modified greater testTableDT.created }.single()
+            assertEquals(id2, modifiedAtLaterDT[testTableDT.id])
+        }
+    }
+
+    @Test
     fun testDateTimeAsJsonB() {
         val tester = object : Table("tester") {
             val created = datetime("created")

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -276,6 +276,43 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
     }
 
     @Test
+    fun testLocalDateTimeComparison() {
+        val testTableDT = object : IntIdTable("test_table_dt") {
+            val created = datetime("created")
+            val modified = datetime("modified")
+        }
+
+        withTables(testTableDT) { testDb ->
+            val mayTheFourth = "2011-05-04T13:00:21.871130789Z"
+            val mayTheFourthDT = Instant.parse(mayTheFourth).toLocalDateTime(TimeZone.currentSystemDefault())
+            val nowDT = now()
+            val id1 = testTableDT.insertAndGetId {
+                it[created] = mayTheFourthDT
+                it[modified] = mayTheFourthDT
+            }
+            val id2 = testTableDT.insertAndGetId {
+                it[created] = mayTheFourthDT
+                it[modified] = nowDT
+            }
+
+            // these DB take the nanosecond value 871_130_789 and round up to default precision (e.g. in Oracle: 871_131)
+            val requiresExplicitCast = listOf(TestDB.ORACLE, TestDB.H2_ORACLE, TestDB.H2_PSQL, TestDB.H2_SQLSERVER)
+            val dateTime = when (testDb) {
+                in requiresExplicitCast -> Cast(dateTimeParam(mayTheFourthDT), KotlinLocalDateTimeColumnType())
+                else -> dateTimeParam(mayTheFourthDT)
+            }
+            val createdMayFourth = testTableDT.select { testTableDT.created eq dateTime }.count()
+            assertEquals(2, createdMayFourth)
+
+            val modifiedAtSameDT = testTableDT.select { testTableDT.modified eq testTableDT.created }.single()
+            assertEquals(id1, modifiedAtSameDT[testTableDT.id])
+
+            val modifiedAtLaterDT = testTableDT.select { testTableDT.modified greater testTableDT.created }.single()
+            assertEquals(id2, modifiedAtLaterDT[testTableDT.id])
+        }
+    }
+
+    @Test
     fun testDateTimeAsJsonB() {
         val tester = object : Table("tester") {
             val created = datetime("created")

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -296,9 +296,9 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
             }
 
             // these DB take the nanosecond value 871_130_789 and round up to default precision (e.g. in Oracle: 871_131)
-            val requiresExplicitCast = listOf(TestDB.ORACLE, TestDB.H2_ORACLE, TestDB.H2_PSQL, TestDB.H2_SQLSERVER)
+            val requiresExplicitDTCast = listOf(TestDB.ORACLE, TestDB.H2_ORACLE, TestDB.H2_PSQL, TestDB.H2_SQLSERVER)
             val dateTime = when (testDb) {
-                in requiresExplicitCast -> Cast(dateTimeParam(mayTheFourthDT), KotlinLocalDateTimeColumnType())
+                in requiresExplicitDTCast -> Cast(dateTimeParam(mayTheFourthDT), KotlinLocalDateTimeColumnType())
                 else -> dateTimeParam(mayTheFourthDT)
             }
             val createdMayFourth = testTableDT.select { testTableDT.created eq dateTime }.count()

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
@@ -252,10 +252,14 @@ class MiscTableTest : DatabaseTestsBase() {
         }
     }
 
+    // these DB take the datetime nanosecond value and round up to default precision
+    // which causes flaky comparison failures if not cast to TIMESTAMP first
+    private val requiresExplicitDTCast = listOf(TestDB.ORACLE, TestDB.H2_ORACLE, TestDB.H2_PSQL, TestDB.H2_SQLSERVER)
+
     @Test
     fun testSelect01() {
         val tbl = Misc
-        withTables(tbl) {
+        withTables(tbl) { testDb ->
             val date = today
             val dateTime = now()
             val time = dateTime.time
@@ -436,8 +440,12 @@ class MiscTableTest : DatabaseTestsBase() {
                 dblcn = null
             )
 
+            val dtValue = when (testDb) {
+                in requiresExplicitDTCast -> Cast(dateTimeParam(dateTime), KotlinLocalDateTimeColumnType())
+                else -> dateTimeParam(dateTime)
+            }
             tbl.checkRowFull(
-                tbl.select { tbl.dt.eq(dateTime) }.single(),
+                tbl.select { tbl.dt.eq(dtValue) }.single(),
                 by = 13,
                 byn = null,
                 sm = -10,
@@ -692,7 +700,7 @@ class MiscTableTest : DatabaseTestsBase() {
     @Test
     fun testSelect02() {
         val tbl = Misc
-        withTables(tbl) {
+        withTables(tbl) { testDb ->
             val date = today
             val dateTime = now()
             val time = dateTime.time
@@ -858,8 +866,12 @@ class MiscTableTest : DatabaseTestsBase() {
                 dblcn = 567.89
             )
 
+            val dtValue = when (testDb) {
+                in requiresExplicitDTCast -> Cast(dateTimeParam(dateTime), KotlinLocalDateTimeColumnType())
+                else -> dateTimeParam(dateTime)
+            }
             tbl.checkRowFull(
-                tbl.select { tbl.dt.eq(dateTime) }.single(),
+                tbl.select { tbl.dt.eq(dtValue) }.single(),
                 by = 13,
                 byn = 13,
                 sm = -10,


### PR DESCRIPTION
The following tests in `exposed-java-time` and `exposed-kotlin-datetime` fail when run using Oracle:

**MiscTableTest/testSelect01()**
**MiscTableTest/testSelect02()**

Fails with an internal equality comparison issue due to precision, which returns an empty collection when `single()` is called.

The `datetime()` column maps to `TIMESTAMP` without specifying a precision, so the DB defaults to a length of 6 digits, and the value is round up internally instead of being truncated.

For example, if the value "2023-07-31 13:00:21.871130789" is inserted, the value stored is `2023-07-31T13:00:21.871131`. This causes an issue in the WHERE clause when the literal comparison value `'2023-07-31 13:00:21.871'` is used.

Explicitly casting the datetime literal in the WHERE clause causes the appropriate comparison to occur.

A new unit test specifically for this comparison issue showed that the same issue was also occurring in certain H2 modes, causing flaky local tests.