### PR TITLE
docs: Update pages with new version documentation

### DIFF
--- a/documentation-website/Writerside/hi.tree
+++ b/documentation-website/Writerside/hi.tree
@@ -21,6 +21,11 @@
     </toc-element>
     <toc-element topic="Deep-Dive-into-DSL.md"/>
     <toc-element topic="Deep-Dive-into-DAO.md"/>
+    <toc-element topic="Schemas.md">
+        <toc-element topic="Table-Definition.md"/>
+        <toc-element topic="Data-Types.md"/>
+        <toc-element topic="Functions.md"/>
+    </toc-element>
     <toc-element topic="Modules-Documentation.md"/>
     <toc-element topic="Frequently-Asked-Questions.md"/>
     <toc-element topic="Migration-Guide.md"/>

--- a/documentation-website/Writerside/topics/Data-Types.md
+++ b/documentation-website/Writerside/topics/Data-Types.md
@@ -26,7 +26,9 @@ The `exposed-java-time` extension (`org.jetbrains.exposed:exposed-java-time:$exp
 * `timestamp` - `TIMESTAMP`
 * `duration` - `DURATION`
 
-**Note**: some types are different for specific DB dialect.
+<note>
+Some types are different for specific DB dialect.
+</note>
 
 The `exposed-json` extension (`org.jetbrains.exposed:exposed-json:$exposed_version`) provides additional types 
 (see [how to use](#how-to-use-json-and-jsonb-types)):
@@ -34,16 +36,19 @@ The `exposed-json` extension (`org.jetbrains.exposed:exposed-json:$exposed_versi
 * `json` - `JSON`
 * `jsonb` - `JSONB`
 
-**Note**: Databases store JSON values either in text or binary format, so Exposed provides two types to account for any potential 
+<note>
+Databases store JSON values either in text or binary format, so Exposed provides two types to account for any potential 
 differences, if they exist, for example:
+
 - **PostgreSQL**: `json()` maps to `JSON`, while `jsonb()` maps to `JSONB`.
-- **SQLite**: No native JSON type so `json()` maps to TEXT, while `jsonb()` throws.
+- **SQLite**: No native JSON type, so `json()` maps to TEXT, while `jsonb()` throws.
 - **MySQL**: JSON type only supports binary format, so `json()` and `jsonb()` both map to JSON.
 - **Oracle**: Exposed does not currently support the JSON binary format of Oracle 21c; only text format `json()` can be used.
+</note>
 
-## How to use database Enum types
-Some of the databases (e.g. MySQL, PostgreSQL, H2) supports explicit ENUM types. Because keeping such columns in sync with 
-kotlin enumerations using only jdbc metadata could be a huge challenge, Exposed doesn't provide a possibility to manage 
+## How to use database ENUM types
+Some of the databases (e.g. MySQL, PostgreSQL, H2) support explicit ENUM types. Because keeping such columns in sync with 
+Kotlin enumerations using only JDBC metadata could be a huge challenge, Exposed doesn't provide a possibility to manage 
 such columns in an automatic way, but that doesn't mean that you can't use such column types.
 You have two options to work with ENUM database types:
 1. Use existing ENUM column from your tables
@@ -53,7 +58,7 @@ You have two options to work with ENUM database types:
 As a jdbc-driver can provide/expect specific classes for Enum type, you must provide from/to transformation functions for 
 them when defining a `customEnumeration`.
 
-For such enum `private enum class Foo { Bar, Baz }` you can use provided code for your database:
+For such enum `private enum class Foo { Bar, Baz }`, you can use the provided code for your database:
 
 **H2**
 ```Kotlin
@@ -70,7 +75,7 @@ val newEnumColumn = customEnumeration("enumColumn", "ENUM('Bar', 'Baz')", { valu
 **PostgreSQL**
 
 PostgreSQL requires that ENUM is defined as a separate type, so you have to create it before creating your table. 
-Also postgresql jdbc driver returns PGobject instances for such values. The full working sample is provided below:
+Also, PostgreSQL JDBC driver returns PGobject instances for such values. The full working sample is provided below:
 ```Kotlin
 class PGEnum<T : Enum<T>>(enumTypeName: String, enumValue: T?) : PGobject() {
     init {
@@ -143,9 +148,12 @@ val projectName = Team.project.extract<String>("name")
 val languageIsKotlin = Team.project.extract<String>("language").lowerCase() eq "kotlin"
 Team.slice(projectName).select { languageIsKotlin }.map { it[projectName] }
 ```
-**Note:** Databases that support a path context root `$` will have this value appended to the generated SQL path expression 
+
+<note>
+Databases that support a path context root `$` will have this value appended to the generated SQL path expression 
 by default, so it is not necessary to include it in the provided argument String. In the above example, if MySQL is being 
 used, the provided path arguments should be `.name` and `.language` respectively.
+</note>
 
 The JSON functions `exists()` and `contains()` are currently supported as well:
 ```kotlin

--- a/documentation-website/Writerside/topics/Data-Types.md
+++ b/documentation-website/Writerside/topics/Data-Types.md
@@ -1,0 +1,168 @@
+# Data Types
+
+Exposed supports the following data types in the table definition:
+* `integer` - translates to DB `INT`
+* `short` - translates to DB `SMALLINT`
+* `long` - `BIGINT`
+* `float` - `FLOAT`
+* `decimal` - `DECIMAL` with scale and precision
+* `bool` - `BOOLEAN`
+* `char` - `CHAR`
+* `varchar` - `VARCHAR` with length
+* `text` - `TEXT`
+* `enumeration` - `INT` ordinal value
+* `enumerationByName` - `VARCHAR`
+* `customEnumeration` - see [additional section](#how-to-use-database-enum-types)
+* `blob` - `BLOB`
+* `binary` - `VARBINARY` with length
+* `uuid` - `BINARY(16)`
+* `reference` - a foreign key
+
+The `exposed-java-time` extension (`org.jetbrains.exposed:exposed-java-time:$exposed_version`) provides additional types:
+
+* `date` - `DATETIME`
+* `time` - `TIME`
+* `datetime` - `DATETIME`
+* `timestamp` - `TIMESTAMP`
+* `duration` - `DURATION`
+
+**Note**: some types are different for specific DB dialect.
+
+The `exposed-json` extension (`org.jetbrains.exposed:exposed-json:$exposed_version`) provides additional types 
+(see [how to use](#how-to-use-json-and-jsonb-types)):
+
+* `json` - `JSON`
+* `jsonb` - `JSONB`
+
+**Note**: Databases store JSON values either in text or binary format, so Exposed provides two types to account for any potential 
+differences, if they exist, for example:
+- **PostgreSQL**: `json()` maps to `JSON`, while `jsonb()` maps to `JSONB`.
+- **SQLite**: No native JSON type so `json()` maps to TEXT, while `jsonb()` throws.
+- **MySQL**: JSON type only supports binary format, so `json()` and `jsonb()` both map to JSON.
+- **Oracle**: Exposed does not currently support the JSON binary format of Oracle 21c; only text format `json()` can be used.
+
+## How to use database Enum types
+Some of the databases (e.g. MySQL, PostgreSQL, H2) supports explicit ENUM types. Because keeping such columns in sync with 
+kotlin enumerations using only jdbc metadata could be a huge challenge, Exposed doesn't provide a possibility to manage 
+such columns in an automatic way, but that doesn't mean that you can't use such column types.
+You have two options to work with ENUM database types:
+1. Use existing ENUM column from your tables
+2. Create column from Exposed by providing raw definition SQL
+   In both cases, you should use `customEnumeration` function (available since version 0.10.3)
+
+As a jdbc-driver can provide/expect specific classes for Enum type, you must provide from/to transformation functions for 
+them when defining a `customEnumeration`.
+
+For such enum `private enum class Foo { Bar, Baz }` you can use provided code for your database:
+
+**H2**
+```Kotlin
+val existingEnumColumn = customEnumeration("enumColumn", { Foo.values()[it as Int] }, { it.name })
+val newEnumColumn = customEnumeration("enumColumn", "ENUM('Bar', 'Baz')", { Foo.values()[it as Int] }, { it.name })
+```
+
+**MySQL**
+```Kotlin
+val existingEnumColumn = customEnumeration("enumColumn", { value -> Foo.valueOf(value as String) }, { it.name })
+val newEnumColumn = customEnumeration("enumColumn", "ENUM('Bar', 'Baz')", { value -> Foo.valueOf(value as String) }, { it.name })
+```
+
+**PostgreSQL**
+
+PostgreSQL requires that ENUM is defined as a separate type, so you have to create it before creating your table. 
+Also postgresql jdbc driver returns PGobject instances for such values. The full working sample is provided below:
+```Kotlin
+class PGEnum<T : Enum<T>>(enumTypeName: String, enumValue: T?) : PGobject() {
+    init {
+        value = enumValue?.name
+        type = enumTypeName
+    }
+}
+
+object EnumTable : Table() {
+    val enumColumn = customEnumeration("enumColumn", "FooEnum", {value -> Foo.valueOf(value as String)}, { PGEnum("FooEnum", it) }
+}
+...
+transaction {
+   exec("CREATE TYPE FooEnum AS ENUM ('Bar', 'Baz');")
+   SchemaUtils.create(EnumTable)
+   ...
+}
+```
+
+## How to use Json and JsonB types
+
+Add the following dependencies to your `build.gradle.kts`:
+```kotlin
+val exposedVersion: String by project
+
+dependencies {
+    implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-json:$exposedVersion")
+}
+```
+
+Exposed works together with [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) to support 
+`@Serializable` classes and JSON serialization/deserialization:
+```kotlin
+@Serializable
+data class Project(val name: String, val language: String, val active: Boolean)
+
+val format = Json { prettyPrint = true }
+
+object Team : Table("team") {
+    val groupId = varchar("group_id", 32)
+    val project = json<Project>("project", format) // equivalent to json("project", format, Project.serializer())
+}
+
+transaction {
+    val mainProject = Project("Main", "Java", true)
+    Team.insert {
+        it[groupId] = "A"
+        it[project] = mainProject
+    }
+    Team.update({ Team.groupId eq "A" }) {
+        it[project] = mainProject.copy(language = "Kotlin")
+    }
+
+    Team.selectAll().map { "Team ${it[Team.groupId]} -> ${it[Team.project]}" }.forEach { println(it) }
+    // Team A -> Project(name=Main, language=Kotlin, active=true)
+}
+```
+
+Both column types also support custom serializer and deserializer arguments, using the form:
+```kotlin
+fun <T : Any> json(name: String, serialize: (T) -> String, deserialize: (String) -> T): Column<T>
+```
+
+### Json Functions
+
+JSON path strings can be used to extract values (either as JSON or as a scalar value) at a specific field/key:
+```kotlin
+val projectName = Team.project.extract<String>("name")
+val languageIsKotlin = Team.project.extract<String>("language").lowerCase() eq "kotlin"
+Team.slice(projectName).select { languageIsKotlin }.map { it[projectName] }
+```
+**Note:** Databases that support a path context root `$` will have this value appended to the generated SQL path expression 
+by default, so it is not necessary to include it in the provided argument String. In the above example, if MySQL is being 
+used, the provided path arguments should be `.name` and `.language` respectively.
+
+The JSON functions `exists()` and `contains()` are currently supported as well:
+```kotlin
+val hasActiveStatus = Team.project.exists(".active")
+val activeProjects = Team.select { hasActiveStatus }.count()
+
+// Depending on the database, filter paths can be provided instead, as well as optional arguments
+// PostgreSQL example
+val mainId = "Main"
+val hasMainProject = Team.project.exists(".name ? (@ == \$main)", optional = "{\"main\":\"$mainId\"}")
+val mainProjects = Team.select { hasMainProject }.map { it[Team.groupId] }
+
+val usesKotlin = Team.project.contains("{\"language\":\"Kotlin\"}")
+val kotlinTeams = Team.select { usesKotlin }.count()
+
+// Depending on the database, an optional path can be provided too
+// MySQL example
+val usesKotlin = Team.project.contains("\"Kotlin\"", ".language")
+val kotlinTeams = Team.select { usesKotlin }.count()
+```

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -276,8 +276,7 @@ val cities = Cities
 ```
 
 ### Add computed fields to entity class
-Imagine that you want to use a window function to rank films with each entity fetch.
-The companion object of the entity class can override any open function in `EntityClass`, but to achieve this functionality only `searchQuery()` needs to 
+Imagine that you want to use a window function to rank films with each entity fetch. The companion object of the entity class can override any open function in `EntityClass`, but to achieve this functionality only `searchQuery()` needs to 
 be overriden. The results of the function can then be accessed using a property of the entity class:
 ```kotlin
 object StarWarsFilms : IntIdTable() {

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -184,7 +184,7 @@ compoundOr()
 ## Conditional where
 
 It is a rather common case to have a query with a `where` clause that depends on some other code's conditions. Moreover, independent or nested conditions could 
-make it more complicated to prepare such where clauses.
+make it more complicated to prepare such `where` clauses.
 Let's imagine that we have a form on a website where a user can optionally filter "Star Wars" films by a director and/or a sequel.
 In Exposed version before 0.8.1 you had to code it like:
 
@@ -577,5 +577,7 @@ If a specific database supports user-defined key columns and none are provided, 
 is no defined primary key, the first unique index is used. If there are no unique indices, each database handles this case 
 differently, so it is strongly advised that keys are defined to avoid unexpected results.
 
-**Note:** Databases that do not support a specific upsert command implement the standard `MERGE USING` statement with aliases 
+<note>
+Databases that do not support a specific upsert command implement the standard `MERGE USING` statement with aliases 
 and a derived table. These include Oracle, SQL Server, and H2 compatibility modes (except for MySQL mode).
+</note>

--- a/documentation-website/Writerside/topics/Frequently-Asked-Questions.md
+++ b/documentation-website/Writerside/topics/Frequently-Asked-Questions.md
@@ -15,12 +15,11 @@ The complete list of supported data types can be found here: [[Data Types|DataTy
 
 ### Q: Is `upsert` supported?
 
-A: Upsert is an instruction to the Database to insert a new row or update existing row based on a table key. It is not supported as part of the library but it is possible to implement on top of it. See this issue: https://github.com/JetBrains/Exposed/issues/167 and example here: https://medium.com/@OhadShai/first-steps-with-kotlin-exposed-cb361a9bf5ac
+A: Yes. See [[Insert Or Update|DSL#insert-or-update]]
 
 ### Q: Is `json` type supported?
 
-A: Not at the moment. Here is the issue: https://github.com/JetBrains/Exposed/issues/127  
-The complete list of supported data types can be found here: [[Data Types|DataTypes]].
+A: Yes. See [[How to use Json and JsonB types|DataTypes#how-to-use-json-and-jsonb-types]]
 
 ### Q: How to get a plain SQL query which will be executed?
 

--- a/documentation-website/Writerside/topics/Functions.md
+++ b/documentation-website/Writerside/topics/Functions.md
@@ -69,7 +69,7 @@ val (min, max, avg) = FooTable.slice(minId, maxId, averageId).selecAll().map {
 ```
 
 ## Custom functions
-If you can't find your most loved function used in your database (as Exposed provides only basic support for classic SQL functions) you can define your own functions.
+If you can't find your most loved function used in your database (as Exposed provides only basic support for classic SQL functions), you can define your own functions.
 
 Since Exposed 0.15.1 there multiple options to define custom functions:
 1. Function without parameters:
@@ -83,7 +83,7 @@ In SQL representation it will be `SQRT(FooTable.id)`
 val replacedName = CustomFunction<String?>("REPLACE", VarCharColumnType(), FooTable.name, stringParam("foo"), stringParam("bar"))
 
 ``` 
-`CustomFunction` class accepts function name as a first parameter and resulting column type as second, after that you can provide any amount of parameters separated by a comma.
+`CustomFunction` class accepts a function name as a first parameter and the resulting column type as second. After that, you can provide any amount of parameters separated by a comma.
 
 There are also shortcuts for string, long, and datetime functions:
 * `CustomStringFunction`
@@ -186,4 +186,7 @@ FooTable.amount.sum().over()
     .orderBy(FooTable.amount)
     .range(WindowFrameBound.offsetPreceding(2), WindowFrameBound.currentRow())
 ```
-**Note**: If multiple frame clause functions are chained together, only the last one will be used.
+
+<note>
+If multiple frame clause functions are chained together, only the last one will be used.
+</note>

--- a/documentation-website/Writerside/topics/Functions.md
+++ b/documentation-website/Writerside/topics/Functions.md
@@ -1,0 +1,189 @@
+# Functions
+
+Exposed provides basic support for classic SQL functions. This topic consists of definitions for those functions, and their 
+usage examples. It also explains how to define [custom functions](#custom-functions).
+
+## How to use functions
+If you want to retrieve a function result from a query, you have to declare the function as a variable:
+```kotlin
+val lowerCasedName = FooTable.name.lowerCase()
+val lowerCasedNames = FooTable.slice(lowerCasedName).selectAll().map { it[lowerCasedName] }
+
+``` 
+Also, functions could be chained and combined:
+```kotlin
+val trimmedAndLoweredFullName = Concat(FooTable.firstName, stringLiteral(" "), FooTable.lastName).trim().lowerCase()
+val fullNames = FooTable.slice(trimmedAndLoweredFullName).selectAll().map { it[trimmedAndLoweredFullName] }
+
+```
+
+## String functions
+### LowerCase/UpperCase
+Returns a lower-cased/upper-cased string value.
+```kotlin
+val lowerCasedName = FooTable.name.lowerCase()
+val lowerCasedNames = FooTable.slice(lowerCasedName).selectAll().map { it[lowerCasedName] }
+
+```
+### Substring
+Returns a substring value from the specified start and with the specified length.
+```kotlin
+val shortenedName = FooTable.name.substring(start = 1, length = 3)
+val shortenedNames = FooTable.slice(shortenedName).selectAll().map { it[shortenedName] }
+
+```
+### Concat
+Returns a string value that concatenates the text representations of all non-null input values, separated by an optional separator.
+```kotlin
+val userName = concat(stringLiteral("User - "), FooTable.name)
+val userNames = FooTable.slice(userName).selectAll().map { it[userName] }
+
+```
+### Locate
+Returns the index of the first occurrence of a specified substring or 0.
+```kotlin
+val firstAIndex = FooTable.name.locate("a")
+val firstAIndices = FooTable.slice(firstAIndex).selectAll().map { it[firstAIndex] }
+
+```
+### CharLength
+Returns the length, measured in characters, or `null` if the String value is null.
+```kotlin
+val nameLength = FooTable.name.charLength()
+val nameLengths = FooTable.slice(nameLength).selectAll().map { it[nameLength] }
+
+```
+
+## Aggregating functions
+These functions should be used in queries with [[groupBy|DSL#group-by]].
+### Min/Max/Average
+Returns minimum/maximum/average value and can be applied to any comparable expression:
+```kotlin
+val minId = FooTable.id.min()
+val maxId = FooTable.id.max()
+val averageId = FooTable.id.avg()
+val (min, max, avg) = FooTable.slice(minId, maxId, averageId).selecAll().map { 
+    Triple(it[minId], it[maxId], it[averageId]) 
+}
+
+```
+
+## Custom functions
+If you can't find your most loved function used in your database (as Exposed provides only basic support for classic SQL functions) you can define your own functions.
+
+Since Exposed 0.15.1 there multiple options to define custom functions:
+1. Function without parameters:
+```kotlin
+val sqrt = FooTable.id.function("SQRT")
+```
+In SQL representation it will be `SQRT(FooTable.id)`
+
+2. Function with additional parameters:
+```kotlin
+val replacedName = CustomFunction<String?>("REPLACE", VarCharColumnType(), FooTable.name, stringParam("foo"), stringParam("bar"))
+
+``` 
+`CustomFunction` class accepts function name as a first parameter and resulting column type as second, after that you can provide any amount of parameters separated by a comma.
+
+There are also shortcuts for string, long, and datetime functions:
+* `CustomStringFunction`
+* `CustomLongFunction`
+* `CustomDateTimeFunction`
+
+The code above could be simplified to:
+```kotlin
+val replacedName = CustomStringFunction("REPLACE", FooTable.name, stringParam("foo"), stringParam("bar"))
+
+``` 
+For example, the following could be used in SQLite to mimic its `date()` function:
+```kotlin
+val lastDayOfMonth = CustomDateFunction(
+    "date",
+    FooTable.dateColumn,
+    stringLiteral("start of month"),
+    stringLiteral("+1 month"),
+    stringLiteral("-1 day")
+)
+```
+3. Function that requires more complex query building:
+
+All functions in Exposed extend the abstract class `Function`, which takes a column type and allows overriding `toQueryBuilder()`. This is what `CustomFunction` actually does, which can be leveraged to create more complex queries.
+
+For example, Exposed provides a `trim()` function that removes leading and trailing whitespace from a String. In MySQL, this is just the default behavior as specifiers can be provided to limit the trim to either leading or trailing, as well as providing a specific substring other than spaces to remove. The custom function below supports this extended behavior:
+```kotlin
+enum class TrimSpecifier { BOTH, LEADING, TRAILING }
+
+class CustomTrim<T : String?>(
+    val expression: Expression<T>,
+    val toRemove: Expression<T>?,
+    val trimSpecifier: TrimSpecifier
+) : Function<T>(TextColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder {
+            append("TRIM(")
+            append(trimSpecifier.name)
+            toRemove?.let { +" $it" }
+            append(" FROM ")
+            append(expression)
+            append(")")
+        }
+    }
+}
+
+fun <T : String?> Expression<T>.customTrim(
+    toRemove: Expression<T>? = null,
+    specifier: TrimSpecifier = TrimSpecifier.BOTH
+): CustomTrim<T> = CustomTrim(this, toRemove, specifier)
+
+transaction {
+    FooTable.insert { it[name] = "xxxbarxxx" }
+
+    val leadingXTrim = FooTable.name.customTrim(stringLiteral("x"), TrimSpecifier.LEADING)
+    val trailingXTrim = FooTable.name.customTrim(stringLiteral("x"), TrimSpecifier.TRAILING)
+
+    FooTable.slice(leadingXTrim).selectAll() // barxxx
+    FooTable.slice(trailingXTrim).selectAll()  // xxxbar
+}
+
+```
+
+## Window Functions
+
+Window functions allow calculations across a set of table rows that are related to the current row.
+
+Existing aggregate functions (like `sum()`, `avg()`) can be used, as well as new rank and value functions:
+* `cumeDist()`
+* `denseRank()`
+* `firstValue()`
+* `lag()`
+* `lastValue()`
+* `lead()`
+* `nthValue()`
+* `nTile()`
+* `percentRank()`
+* `rank()`
+* `rowNumber()`
+
+To use a window function, include the `OVER` clause by chaining `.over()` after the function call. A `PARTITION BY` and 
+`ORDER BY` clause can be optionally chained using `.partitionBy()` and `.orderBy()`, which both take multiple arguments:
+```kotlin
+FooTable.amount.sum().over().partitionBy(FooTable.year, FooTable.product).orderBy(FooTable.amount)
+
+rowNumber().over().partitionBy(FooTable.year, FooTable.product).orderBy(FooTable.amount)
+
+FooTable.amount.sum().over().orderBy(FooTable.year to SortOrder.DESC, FooTable.product to SortOrder.ASC_NULLS_FIRST)
+```
+Frame clause functions (like `rows()`, `range()`, and `groups()`) are also supported and take a `WindowFrameBound` option 
+depending on the expected result:
+* `WindowFrameBound.currentRow()`
+* `WindowFrameBound.unboundedPreceding()`
+* `WindowFrameBound.unboundedFollowing()`
+* `WindowFrameBound.offsetPreceding()`
+* `WindowFrameBound.offsetFollowing()`
+```kotlin
+FooTable.amount.sum().over()
+    .partitionBy(FooTable.year, FooTable.product)
+    .orderBy(FooTable.amount)
+    .range(WindowFrameBound.offsetPreceding(2), WindowFrameBound.currentRow())
+```
+**Note**: If multiple frame clause functions are chained together, only the last one will be used.

--- a/documentation-website/Writerside/topics/Modules-Documentation.md
+++ b/documentation-website/Writerside/topics/Modules-Documentation.md
@@ -69,8 +69,9 @@ At the moment `Exposed` coexists of provided modules
 * exposed-kotlin-datetime - date-time extensions based on kotlinx-datetime
 * exposed-money - extensions to support MonetaryAmount from "javax.money:money-api"
 * exposed-crypt - provides additional column types to store encrypted data in DB and encode/decode it on client-side
+* exposed-json - JSON and JSONB data type extensions
 
-Dependencies mapping listed bellow is similar (by functionality) to the previous versions:
+Dependencies mapping listed below is similar (by functionality) to the previous versions:
 #### Maven
 ```xml
 

--- a/documentation-website/Writerside/topics/Schemas.md
+++ b/documentation-website/Writerside/topics/Schemas.md
@@ -1,0 +1,7 @@
+# Schemas
+
+[Table Definition](Table-Definition.md)
+
+[Data Types](Data-Types.md)
+
+[Functions](Functions.md)

--- a/documentation-website/Writerside/topics/Table-Definition.md
+++ b/documentation-website/Writerside/topics/Table-Definition.md
@@ -23,7 +23,7 @@ object Cities : Table(name = "citiesTable") {
 ```
 Also, Exposed provides `IdTable` class which is inherited by `IntIdTable()`, `LongIdTable()`, and `UUIDTable(`) classes from 
 **org.jetbrains.exposed.dao.id** package of **exposed-core** module. These tables could be declared without the `id` attribute. 
-IDs of appropriate type will be generated automatically with any operations create new table rows. To configure a custom name 
+IDs of appropriate type will be generated automatically when creating new table rows. To configure a custom name 
 for the `id` attribute, pass it to the `columnName` parameter of the appropriate table constructor.
 
 Depending on what DBMS you use, types of columns could be different in actual SQL queries. We use H2 database in our examples.
@@ -32,7 +32,7 @@ Depending on what DBMS you use, types of columns could be different in actual SQ
 
 ### Nullable
 
-The `NOT NULL` SQL constraint restricts the column to accept the `null` value. By default, Exposed apply this constraint to 
+The `NOT NULL` SQL constraint restricts the column to accept the `null` value. By default, Exposed applies this constraint to 
 all the columns. To allow the column to be nullable, apply the `nullable()` method to a definition of an appropriate column.
 
 For example, to make the population column `nullable`, use the following code:
@@ -115,10 +115,13 @@ are represented by the data class `Index`, so its properties can be checked in t
 ```kotlin
 Table.indices.map { it.indexName to it.createStatement().first() }
 ```
-**Note:** An instance of the `Index` data class can be created directly using its public constructor, for the purpose of 
+
+<note>
+An instance of the `Index` data class can be created directly using its public constructor, for the purpose of 
 evaluating or using  create/modify/drop statements, for example. Doing so will not add the instance to an existing table's 
 list of indices in the way that using `index()` would. Also, if an instance is created with arguments provided to the 
 `functions` parameter, a `functionsTable` argument must also be provided.
+</note>
 
 ### Unique
 
@@ -161,10 +164,11 @@ method. The second one let the foreign key accept the `null` value.
 
 Enum class `ReferenceOption` has four values:
 
-* `RESTRICT` is an option restricts changes on referenced column, and the default option for MySQL dialect.
+* `RESTRICT` is an option that restricts changes on a referenced column, and the default option for MySQL dialect.
 * `NO_ACTION` is the same as RESTRICT, and the default option for Oracle and SQL Server dialects.
-* `CASCADE` is an option allows updating or deleting the referring rows.
-* `SET_NULL` is an option sets null to the referring column values.
+* `CASCADE` is an option that allows updating or deleting the referring rows.
+* `SET_NULL` is an option that sets the referring column values to null.
+* `SET_DEFAULT` is an option that sets the referring column values to the default value.
 
 Consider the following `Citizens` table. This table has the `name` and `city` columns. Since the `Cities` table has 
 configured `name` primary key, the `Citizens` table can refer to it by its `city` column, which is a foreign key. To 
@@ -180,13 +184,13 @@ If any `Cities` row will be deleted, the appropriate `Citizens` row will be dele
 
 ### Check
 
-The `CHECK` SQL constraint checks that all values in a column match the condition. Exposed supports the `check()` method. 
+The `CHECK` SQL constraint checks that all values in a column match some condition. Exposed supports the `check()` method. 
 You apply this method to a column and pass the appropriate condition to it.
 
-For example, to check that the `name` column contains strings that begins with capital letter, use the following code:
+For example, to check that the `name` column contains strings that begin with a capital letter, use the following code:
 ```kotlin
 // SQL: CONSTRAINT check_Cities_0 CHECK (REGEXP_LIKE("NAME", '^[A-Z].*', 'c')))
 val name = varchar("name", 50).check { it regexp "^[A-Z].*" }
 ```
 
-Some DBMS could not support any condition. For more information, see its documentations.
+Some databases, like older MySQL versions, may not support `CHECK` constraints. For more information, consult the relevant documentation.

--- a/documentation-website/Writerside/topics/Table-Definition.md
+++ b/documentation-website/Writerside/topics/Table-Definition.md
@@ -1,0 +1,192 @@
+# Table Definition
+
+This topic shows what table types Exposed supports and how to define and create tables. Also, it contains tips on configuring 
+constraints, such as `PRIMARY KEY`, `DEFAULT`, `INDEX` and so on.
+
+## Table Types
+
+The most primitive table type is `Table()`. It's located in **org.jetbrains.exposed.sql** package and has `NOT NULL` SQL constraint 
+configured by default on all columns. To configure a custom name for the table, which will be used in actual SQL queries, pass 
+it to the `name` parameter of the `Table()` constructor. Otherwise, Exposed will generate it from a class name.
+
+For example, to create a simple table called `"citiesTable"` with integer `id` column and string `name` column, use the 
+following code.
+```kotlin
+// SQL: CREATE TABLE IF NOT EXISTS CITIESTABLE (
+//          ID INT NOT NULL,
+//          "NAME" VARCHAR(50) NOT NULL
+//      )
+object Cities : Table(name = "citiesTable") {
+    val id = integer("id")
+    val name = varchar("name", 50)
+}
+```
+Also, Exposed provides `IdTable` class which is inherited by `IntIdTable()`, `LongIdTable()`, and `UUIDTable(`) classes from 
+**org.jetbrains.exposed.dao.id** package of **exposed-core** module. These tables could be declared without the `id` attribute. 
+IDs of appropriate type will be generated automatically with any operations create new table rows. To configure a custom name 
+for the `id` attribute, pass it to the `columnName` parameter of the appropriate table constructor.
+
+Depending on what DBMS you use, types of columns could be different in actual SQL queries. We use H2 database in our examples.
+
+## Constraints
+
+### Nullable
+
+The `NOT NULL` SQL constraint restricts the column to accept the `null` value. By default, Exposed apply this constraint to 
+all the columns. To allow the column to be nullable, apply the `nullable()` method to a definition of an appropriate column.
+
+For example, to make the population column `nullable`, use the following code:
+```kotlin
+// SQL: POPULATION INT NULL
+val population: Column<Int?> = integer("population").nullable()
+```
+
+### Default
+
+The `DEFAULT` SQL constraint provides the default value for the column. Exposed supports three methods for configuring 
+default values:
+
+* `default(defaultValue: T)` accepts a value with a type of the column.
+* `defaultExpression(defaultValue: Expression<T>)` accepts an expression.
+* `clientDefault(defaultValue: () -> T)` accepts a function.
+
+For example, to configure the default value for the `name` column, use the following code:
+```kotlin
+// SQL: "NAME" VARCHAR(50) DEFAULT 'Unknown'
+val name: Column<String> = varchar("name", 50).default("Unknown")
+```
+
+### Index
+
+The `INDEX` SQL constraint makes traversing through tables quicker. Exposed supports the `index()` method. 
+It has six parameters, most of which are optional:
+
+* `val customIndexName: String? = null` is a custom name for the index, which will be used in actual SQL queries.
+* `val unique: Boolean` defines whether the index is unique or not.
+* `val columns: List<Column<*>>` defines a column set.
+* `val functions: List<ExpressionWithColumnType<*>>? = null` defines functional key parts.
+* `val indexType: String? = null` is a custom type. Can be `"BTREE"` or `"HASH"`.
+* `val filterCondition: (SqlExpressionBuilder.() -> Op<Boolean>)? = null` defines a condition used to create a partial index.
+
+The simplest way to create an index is to use an extension function directly on a column. For example, to apply a non-unique 
+`INDEX` constraint to the `name` column, use the following code:
+```kotlin
+val name = varchar("name", 50).index()
+```
+If the parameter `customIndexName` is not set, the name of the index is determined by the table and column names.
+
+Also, Exposed supports complex indexes. If you have a frequent query for two columns, Exposed can perform it more efficiently.
+It creates a tree from the first column with the references to the second one. For example, to create a non-unique complex
+index on the `name` and `population` columns, paste the following code:
+```kotlin
+val indexName = index("indexName", false, *arrayOf(name, population))
+// or inside an init block within the table object
+init {
+    index("indexName", isUnique = false, name, population)
+}
+```
+
+Exposed also supports creating an index with a custom type. For example, to retrieve data from the `name` column faster 
+with a hash function for traversing, use the following code:
+```kotlin
+val indexName = index("indexName", false, *arrayOf(name), indexType = "HASH")
+```
+
+Some databases support functional key parts that index expressions instead of columns directly:
+```kotlin
+init {
+    index(functions = listOf(name.lowerCase(), address.substring(1, 5)))
+    uniqueIndex(columns = arrayOf(name), functions = listOf(Coalesce(address, stringLiteral("*"))))
+}
+```
+Operator expressions, like `plus()`, are also accepted by the `functions` parameter.
+
+Some databases support creating a partial index by defining a filter expression to improve querying performance. The 
+created index will only contain entries for the table rows that match this predicate:
+```kotlin
+init {
+    index(columns = arrayOf(name, flag)) { flag eq true }
+    index(columns = arrayOf(name, population)) { (name like "A%") and (population greaterEq 10) }
+}
+```
+
+Once a table has been created, the list of its indices can be accessed using the property `Table.indices`. Table indices 
+are represented by the data class `Index`, so its properties can be checked in the following manner, for example:
+```kotlin
+Table.indices.map { it.indexName to it.createStatement().first() }
+```
+**Note:** An instance of the `Index` data class can be created directly using its public constructor, for the purpose of 
+evaluating or using  create/modify/drop statements, for example. Doing so will not add the instance to an existing table's 
+list of indices in the way that using `index()` would. Also, if an instance is created with arguments provided to the 
+`functions` parameter, a `functionsTable` argument must also be provided.
+
+### Unique
+
+The `UNIQUE` SQL constraint restricts duplicates within this column. Exposed supports the `uniqueIndex()` method which 
+creates a unique index for the column. This method is the composition of `UNIQUE` and `INDEX` constraint, the quicker 
+modification of `UNIQUE` constraint.
+
+For example, to apply `UNIQUE` and `INDEX` constraint to the `name` column, use the following code:
+```kotlin
+val name = varchar("name", 50).uniqueIndex()
+```
+
+### Primary Key
+
+The `PRIMARY KEY` SQL constraint applied to columns means each value in a column identifies the row. It's the composition 
+of `NOT NULL` and `UNIQUE` constraints. Each kind of table in Exposed, inherited from `IdTable()`, has the `primaryKey` 
+field. For example, the `IntIdTable` has default integer `id` primary key. If you want to change column set, add columns, 
+or change primary key name to a custom one, you need to override this field of the appropriate table class.
+
+For example, if you want to define the `name` column as a primary key, use the following code. The "Cities_name" string 
+will be used in actual SQL query.
+```kotlin
+// SQL: CONSTRAINT Cities_name PRIMARY KEY ("NAME")
+override val primaryKey = PrimaryKey(name, name = "Cities_name")
+```
+
+### Foreign Key
+
+The `FOREIGN KEY` SQL constraint links two tables. Foreign key is a column from one table that refers to the primary key 
+or columns with a unique index from another table. To configure the foreign key, use `reference()` or `optReference()` 
+method. The second one let the foreign key accept the `null` value.
+
+`reference()` and `optReference()` methods have several parameters:
+
+* `name: String` is a name for foreign key column, which will be used in actual SQL queries.
+* `ref: Column<T>` is a target column from another parent table.
+* `onDelete: ReferenceOption? = null` is an action to the case when linked row from a parent table can be deleted.
+* `onUpdate: ReferenceOption? = null` is an action to the case when value in a referenced column can be changed.
+* `fkName: String? = null` is a foreign key constraint name.
+
+Enum class `ReferenceOption` has four values:
+
+* `RESTRICT` is an option restricts changes on referenced column, and the default option for MySQL dialect.
+* `NO_ACTION` is the same as RESTRICT, and the default option for Oracle and SQL Server dialects.
+* `CASCADE` is an option allows updating or deleting the referring rows.
+* `SET_NULL` is an option sets null to the referring column values.
+
+Consider the following `Citizens` table. This table has the `name` and `city` columns. Since the `Cities` table has 
+configured `name` primary key, the `Citizens` table can refer to it by its `city` column, which is a foreign key. To 
+configure such reference and make it nullable, use the `optReference()` method:
+```kotlin
+object Citizens : IntIdTable() {
+    val name = varchar("name", 50)
+    val city = optReference("city", Cities.name, onDelete=ReferenceOption.CASCADE)
+}
+```
+
+If any `Cities` row will be deleted, the appropriate `Citizens` row will be deleted too.
+
+### Check
+
+The `CHECK` SQL constraint checks that all values in a column match the condition. Exposed supports the `check()` method. 
+You apply this method to a column and pass the appropriate condition to it.
+
+For example, to check that the `name` column contains strings that begins with capital letter, use the following code:
+```kotlin
+// SQL: CONSTRAINT check_Cities_0 CHECK (REGEXP_LIKE("NAME", '^[A-Z].*', 'c')))
+val name = varchar("name", 50).check { it regexp "^[A-Z].*" }
+```
+
+Some DBMS could not support any condition. For more information, see its documentations.


### PR DESCRIPTION
Edit docs to be in sync with the updated Wiki pages after the release of version 0.42.0:
- Add new subsections in: Deep Dive into DAO, Deep Dive into DSL
- Edit FAQ and Modules pages
- Add Schemas section to tree with the subsections: Table Definition, Data Types, and Functions
  - matches the new documentation structure and allows addition of new feature sections