### PR TITLE
chore: Bump Exposed version to 0.42.0 in spring-boot-starter, samples, and BOM

### DIFF
--- a/exposed-bom/README.md
+++ b/exposed-bom/README.md
@@ -17,7 +17,7 @@ Bill of Materials for all Exposed modules
         <dependency>
             <groupId>org.jetbrains.exposed</groupId>
             <artifactId>exposed-bom</artifactId>
-            <version>0.41.1</version>
+            <version>0.42.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -46,12 +46,12 @@ Bill of Materials for all Exposed modules
 # Gradle
 ```kotlin
 repositories {
-  // Versions after 0.33.1
-  mavenCentral()
+    // Versions after 0.33.1
+    mavenCentral()
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.exposed:exposed-bom:0.41.1"))
+    implementation(platform("org.jetbrains.exposed:exposed-bom:0.42.0"))
     implementation("org.jetbrains.exposed", "exposed-core")
     implementation("org.jetbrains.exposed", "exposed-dao")
     implementation("org.jetbrains.exposed", "exposed-jdbc")

--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -18,7 +18,7 @@ This starter will give you the latest version of [Exposed](https://github.com/Je
   <dependency>
     <groupId>org.jetbrains.exposed</groupId>
     <artifactId>exposed-spring-boot-starter</artifactId>
-    <version>0.41.1</version>
+    <version>0.42.0</version>
   </dependency>
 </dependencies>
 ```
@@ -28,7 +28,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-  implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.41.1'
+    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.42.0'
 }
 ```
 

--- a/samples/exposed-ktor/gradle.properties
+++ b/samples/exposed-ktor/gradle.properties
@@ -1,6 +1,6 @@
-ktor_version=2.3.1
-kotlin_version=1.8.21
-logback_version=1.2.11
+ktorVersion=2.3.1
+kotlinVersion=1.8.21
+logbackVersion=1.2.11
 kotlin.code.style=official
-exposed_version=0.41.1
-h2_version=2.1.214
+exposedVersion=0.42.0
+h2Version=2.1.214


### PR DESCRIPTION
Bumped to Exposed 0.42.0 version in:

- spring-boot-starter README.md
- samples/exposed-ktor
- exposed-bom

Fixed failing sample build