### PR TITLE
Add Dokka and deploy scripts to GH pages

### DIFF
--- a/.github/workflows/dokka-publish.yml
+++ b/.github/workflows/dokka-publish.yml
@@ -29,5 +29,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/dokka/htmlMultiModule
-          desination_dir: api
+          destination_dir: api
           full_commit_message: Publish API reference documentation

--- a/.github/workflows/dokka-publish.yml
+++ b/.github/workflows/dokka-publish.yml
@@ -1,0 +1,33 @@
+name: Deploy Dokka to GitHub Pages
+
+# Published API reference docs to GitHub Pages automatically
+# for every release. Can also be triggered manually
+on:
+  workflow_dispatch:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Build API reference
+        run: ./gradlew dokkaHtmlMultiModule
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/dokka/htmlMultiModule
+          desination_dir: api
+          full_commit_message: Publish API reference documentation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin") apply true
     id("io.gitlab.arturbosch.detekt")
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 allprojects {
@@ -43,6 +44,11 @@ subprojects {
             languageVersion = "1.6"
         }
     }
+}
+
+tasks.dokkaHtmlMultiModule {
+    // sets the project name in the header, otherwise it's lowercase `exposed`
+    moduleName.set("Exposed")
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation("com.avast.gradle", "gradle-docker-compose-plugin", "0.14.9")
     implementation("io.github.gradle-nexus", "publish-plugin", "1.0.0")
     implementation("io.gitlab.arturbosch.detekt", "detekt-gradle-plugin", "1.21.0")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
 }
 
 plugins {

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/conventions/dokka.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/conventions/dokka.gradle.kts
@@ -1,0 +1,5 @@
+package org.jetbrains.exposed.gradle.conventions
+
+plugins {
+    id("org.jetbrains.dokka")
+}

--- a/exposed-core/build.gradle.kts
+++ b/exposed-core/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.exposed.gradle.Versions
 
 plugins {
     kotlin("jvm") apply true
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-crypt/build.gradle.kts
+++ b/exposed-crypt/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") apply true
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-dao/build.gradle.kts
+++ b/exposed-dao/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") apply true
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-java-time/build.gradle.kts
+++ b/exposed-java-time/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     kotlin("jvm") apply true
     kotlin("plugin.serialization") apply true
     id("testWithDBs")
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-jdbc/build.gradle.kts
+++ b/exposed-jdbc/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") apply true
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-jodatime/build.gradle.kts
+++ b/exposed-jodatime/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm") apply true
     kotlin("plugin.serialization") apply true
     id("testWithDBs")
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-json/build.gradle.kts
+++ b/exposed-json/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     kotlin("jvm") apply true
     kotlin("plugin.serialization") apply true
     id("testWithDBs")
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-kotlin-datetime/build.gradle.kts
+++ b/exposed-kotlin-datetime/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     kotlin("jvm") apply true
     kotlin("plugin.serialization") apply true
     id("testWithDBs")
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {

--- a/exposed-money/build.gradle.kts
+++ b/exposed-money/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm") apply true
     id("testWithDBs")
+    id("org.jetbrains.exposed.gradle.conventions.dokka")
 }
 
 repositories {


### PR DESCRIPTION
Fixes #1482

This PR adds API reference documentation generation and publishing of it to GitHub Pages. 

The API reference will be published to the `gh-pages` branch, under the `api` directory (in case you'll want to add other pages later on), which will be deployed by GitHub automatically.

Only the latest version of the API reference docs will be available, so there's no versioning - it needs to be added separately.

I've enabled GH Pages in my fork and [ran the workflow](https://github.com/IgnatBeresnev/Exposed/actions/runs/5727704602), here is a live demo of the result: [ignatberesnev.github.io/Exposed/api/index.html](https://ignatberesnev.github.io/Exposed/api/index.html)

## How to enable GitHub Pages

Create and push a branch named `gh-pages`, which is the default name that is used by GitHub.

After that, go to Settings -> Pages, and verify that it's enabled and that the correct branch is selected.

<details>

<summary>screenshot</summary>

![2023-08-01_15-52-51](https://github.com/JetBrains/Exposed/assets/22685910/a87293ba-1e14-472a-8a58-a3967aba1e0b)

</details>

## First deploy after merge

Because the GitHub Action workflow is triggered by release events (little point in publishing snapshot docs), you'll have to trigger the first deploy manually by going to Actions -> Deploy Dokka to GitHub Pages, and selecting the latest release branch/tag under Run workflow.

<details>

<summary>screenshot</summary>

![2023-08-01_15-58-19](https://github.com/JetBrains/Exposed/assets/22685910/d5858d94-8e52-4ebe-b922-bc10450fa794)

</details>