### PR TITLE
fix: EXPOSED-111 Allow check constraint statements in MySQL8

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -461,8 +461,9 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun `rollback on constraint exception normal transactions`() {
-        val TestTable = object : IntIdTable("TestRollback") {
+    @Test
+    fun testRollbackOnConstraintExceptionWithNormalTransactions() {
+        val testTable = object : IntIdTable("TestRollback") {
             val foo = integer("foo").check { it greater 0 }
         }
         val dbToTest = TestDB.enabledInTests() - setOfNotNull(
@@ -474,16 +475,16 @@ class InsertTests : DatabaseTestsBase() {
             try {
                 try {
                     withDb(db) {
-                        SchemaUtils.create(TestTable)
-                        TestTable.insert { it[foo] = 1 }
-                        TestTable.insert { it[foo] = 0 }
+                        SchemaUtils.create(testTable)
+                        testTable.insert { it[foo] = 1 }
+                        testTable.insert { it[foo] = 0 }
                     }
                     fail("Should fail on constraint > 0 with $db")
                 } catch (_: SQLException) {
                     // expected
                 }
                 withDb(db) {
-                    assertTrue(TestTable.selectAll().empty())
+                    assertTrue(testTable.selectAll().empty())
                 }
             } finally {
                 withDb(db) {
@@ -493,8 +494,9 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun `rollback on constraint exception normal suspended transactions`() {
-        val TestTable = object : IntIdTable("TestRollback") {
+    @Test
+    fun testRollbackOnConstraintExceptionWithSuspendTransactions() {
+        val testTable = object : IntIdTable("TestRollback") {
             val foo = integer("foo").check { it greater 0 }
         }
         val dbToTest = TestDB.enabledInTests() - setOfNotNull(
@@ -506,12 +508,12 @@ class InsertTests : DatabaseTestsBase() {
             try {
                 try {
                     withDb(db) {
-                        SchemaUtils.create(TestTable)
+                        SchemaUtils.create(testTable)
                     }
                     runBlocking {
                         newSuspendedTransaction(db = db.db) {
-                            TestTable.insert { it[foo] = 1 }
-                            TestTable.insert { it[foo] = 0 }
+                            testTable.insert { it[foo] = 1 }
+                            testTable.insert { it[foo] = 0 }
                         }
                     }
                     fail("Should fail on constraint > 0")
@@ -520,7 +522,7 @@ class InsertTests : DatabaseTestsBase() {
                 }
 
                 withDb(db) {
-                    assertTrue(TestTable.selectAll().empty())
+                    assertTrue(testTable.selectAll().empty())
                 }
             } finally {
                 withDb(db) {


### PR DESCRIPTION
Currently, all databases can have column check constraints included when a table is created, but MySQL is prevented from producing create/drop statements for its check constraints. This makes sense  for older MySQL versions that simply parsed and ignored any CHECK constraint in the CREATE TABLE statement.

As of [version 8.0.16](https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html), MySQL fully supports check constraints, so this limitation is now removed.

The new unit test confirmed that SQLite also [does not allow](https://www.sqlite.org/lang_altertable.html) its constraints to be created/dropped outside of a CREATE TABLE statement, so it has been included to log a warning and prevent alters.

Additional:
- 2 tests with check constraints that don't actually test the constraint itself have been renamed with a clearer description. They are a result of a fix for [this issue](https://github.com/JetBrains/Exposed/issues/1415).
- Refactor some constraints tests to match style convention.