### PR TITLE
fix: EXPOSED-112 SchemaUtils fails to compare default CURRENT_TIMESTAMP

### DIFF
--- a/exposed-java-time/api/exposed-java-time.api
+++ b/exposed-java-time/api/exposed-java-time.api
@@ -9,7 +9,7 @@ public final class org/jetbrains/exposed/sql/javatime/CurrentDateTime : org/jetb
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/javatime/CurrentTimestamp : org/jetbrains/exposed/sql/Expression {
+public final class org/jetbrains/exposed/sql/javatime/CurrentTimestamp : org/jetbrains/exposed/sql/Function {
 	public fun <init> ()V
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -49,7 +49,7 @@ object CurrentDate : Function<LocalDate>(JavaLocalDateColumnType.INSTANCE) {
     }
 }
 
-class CurrentTimestamp<T : Temporal> : Expression<T>() {
+class CurrentTimestamp<T : Temporal> : Function<T>(JavaInstantColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when {
             (currentDialect as? MysqlDialect)?.isFractionDateTimeSupported() == true -> "CURRENT_TIMESTAMP(6)"

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -16,6 +16,7 @@ import org.jetbrains.exposed.sql.tests.inProperCase
 import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
@@ -364,7 +365,10 @@ class DefaultsTest : DatabaseTestsBase() {
     fun testConsistentSchemeWithFunctionAsDefaultExpression() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
-            val defaultDateTime = datetime("defaultDateTime").defaultExpression(CurrentDateTime)
+            val defaultDate = date("default_date").defaultExpression(CurrentDate)
+            val defaultDateTime = datetime("default_date_time").defaultExpression(CurrentDateTime)
+            val defaultTimeStamp1 = timestamp("default_time_stamp_1").defaultExpression(CurrentTimestamp())
+            val defaultTimeStamp2 = datetime("default_time_stamp_2").defaultExpression(CurrentTimestamp())
         }
 
         withDb {
@@ -372,7 +376,17 @@ class DefaultsTest : DatabaseTestsBase() {
                 SchemaUtils.create(foo)
 
                 val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
-                assertTrue(actual.isEmpty())
+
+                if (currentDialectTest is MysqlDialect) {
+                    // MySQL and MariaDB do not support CURRENT_DATE as default
+                    // so the column is created with a NULL marker, which correctly triggers 1 alter statement
+                    val tableName = foo.nameInDatabaseCase()
+                    val dateColumnName = foo.defaultDate.nameInDatabaseCase()
+                    val alter = "ALTER TABLE $tableName MODIFY COLUMN $dateColumnName DATE NULL"
+                    assertEquals(alter, actual.single())
+                } else {
+                    assertTrue(actual.isEmpty())
+                }
             } finally {
                 SchemaUtils.drop(foo)
             }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -366,9 +366,9 @@ class DefaultsTest : DatabaseTestsBase() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
             val defaultDate = date("default_date").defaultExpression(CurrentDate)
-            val defaultDateTime = datetime("default_date_time").defaultExpression(CurrentDateTime)
-            val defaultTimeStamp1 = timestamp("default_time_stamp_1").defaultExpression(CurrentTimestamp())
-            val defaultTimeStamp2 = datetime("default_time_stamp_2").defaultExpression(CurrentTimestamp())
+            val defaultDateTime1 = datetime("default_date_time_1").defaultExpression(CurrentDateTime)
+            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentTimestamp())
+            val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp())
         }
 
         withDb {

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -9,7 +9,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime : o
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp : org/jetbrains/exposed/sql/Expression {
+public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp : org/jetbrains/exposed/sql/Function {
 	public fun <init> ()V
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
@@ -64,7 +64,7 @@ object CurrentDate : Function<LocalDate>(KotlinLocalDateColumnType.INSTANCE) {
     }
 }
 
-class CurrentTimestamp<T> : Expression<T>() {
+class CurrentTimestamp<T> : Function<T>(KotlinInstantColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when {
             (currentDialect as? MysqlDialect)?.isFractionDateTimeSupported() == true -> "CURRENT_TIMESTAMP(6)"

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -375,9 +375,9 @@ class DefaultsTest : DatabaseTestsBase() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
             val defaultDate = date("default_date").defaultExpression(CurrentDate)
-            val defaultDateTime = datetime("default_date_time").defaultExpression(CurrentDateTime)
-            val defaultTimeStamp1 = timestamp("default_time_stamp_1").defaultExpression(CurrentTimestamp())
-            val defaultTimeStamp2 = datetime("default_time_stamp_2").defaultExpression(CurrentTimestamp())
+            val defaultDateTime1 = datetime("default_date_time_1").defaultExpression(CurrentDateTime)
+            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentTimestamp())
+            val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp())
         }
 
         withDb {


### PR DESCRIPTION
If a `timestamp()` or `datetime()` column is created with `CurrentTimestamp()` as the default expression, verifying the table using `addMissingColumnsStatements()` incorrectly generates an alter column statement.

This is because `CurrentTimestamp()` extends `Expression<T>`, so it is [not caught by](https://github.com/JetBrains/Exposed/blob/main/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt#L136) `processForDefaultValue()` and retains parentheses. This results in a comparison mismatch, e.g. in PostgreSQL, between `CURRENT_TIMESTAMP` (from metadata) and `(CURRENT_TIMESTAMP)` (from Exposed).

This issue was partially fixed by [PR #1642 ](https://github.com/JetBrains/Exposed/pull/1642), but `CurrentTimestamp()` was not covered because it does not extend `Function` like the other date/time functions.

**Choosing a columnType:**

The rationale behind why `CurrentTimestamp()` isn't like its counterparts `CurrentDate` and `CurrentDatetime` may be related to the need to provide a specific column type to the `Function` class. Unlike the other 2 functions, `CurrentTimestamp()` can technically be used/compiled with any column, and what's important is that the chosen type can properly hold the result.

All String functions use `TextColumnType` even though they can be used with any `StringColumnType`.
Functions like `Sum`, which have an unknown-sized result, take a `columnType` argument provided by the expression/column on which the extension function is called. 

`CurrentTimestamp()` doesn't have a way to know the type of the column it's being used with, unless the user provides it directly, so the following is an alternative if there are concerns over restricting the function type:
```kt
class CurrentTimestamp<T : Temporal>(
    columnType: IColumnType = JavaInstantColumnType.INSTANCE
) : Function<T>(columnType) { }
```