### PR TITLE
EXPOSED-121, allowing option for "real" blobs in postgres

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -236,6 +236,9 @@ public class org/jetbrains/exposed/sql/BinaryColumnType : org/jetbrains/exposed/
 
 public final class org/jetbrains/exposed/sql/BlobColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getUseObjectIdentifier ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public synthetic fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
@@ -1534,7 +1537,8 @@ public final class org/jetbrains/exposed/sql/OpKt {
 	public static final fun andNot (Lorg/jetbrains/exposed/sql/Expression;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun arrayLiteral (Ljava/util/List;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun arrayParam (Ljava/util/List;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/Expression;
-	public static final fun blobParam (Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;)Lorg/jetbrains/exposed/sql/Expression;
+	public static final fun blobParam (Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;Z)Lorg/jetbrains/exposed/sql/Expression;
+	public static synthetic fun blobParam$default (Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun booleanLiteral (Z)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun booleanParam (Z)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun byteLiteral (B)Lorg/jetbrains/exposed/sql/LiteralOp;
@@ -2213,7 +2217,8 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public static synthetic fun autoinc$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun binary (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun binary (Ljava/lang/String;I)Lorg/jetbrains/exposed/sql/Column;
-	public final fun blob (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun blob (Ljava/lang/String;Z)Lorg/jetbrains/exposed/sql/Column;
+	public static synthetic fun blob$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun bool (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun byte (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun char (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
@@ -3147,7 +3152,7 @@ public abstract interface class org/jetbrains/exposed/sql/statements/api/Prepare
 	public abstract fun set (ILjava/lang/Object;)V
 	public abstract fun setArray (ILjava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun setFetchSize (Ljava/lang/Integer;)V
-	public abstract fun setInputStream (ILjava/io/InputStream;)V
+	public abstract fun setInputStream (ILjava/io/InputStream;Z)V
 	public abstract fun setNull (ILorg/jetbrains/exposed/sql/IColumnType;)V
 	public abstract fun setTimeout (Ljava/lang/Integer;)V
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -745,8 +745,14 @@ fun stringParam(value: String): Expression<String> = QueryParameter(value, TextC
 /** Returns the specified [value] as a decimal query parameter. */
 fun decimalParam(value: BigDecimal): Expression<BigDecimal> = QueryParameter(value, DecimalColumnType(value.precision(), value.scale()))
 
-/** Returns the specified [value] as a blob query parameter. */
-fun blobParam(value: ExposedBlob): Expression<ExposedBlob> = QueryParameter(value, BlobColumnType())
+/**
+ * Returns the specified [value] as a blob query parameter.
+ *
+ * Set [useObjectIdentifier] to `true` if the parameter should be processed using an OID column instead of a
+ * BYTEA column. This is only supported by PostgreSQL databases.
+ */
+fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Expression<ExposedBlob> =
+    QueryParameter(value, BlobColumnType(useObjectIdentifier))
 
 /** Returns the specified [value] as an array query parameter, with elements parsed by the [delegateType]. */
 fun <T> arrayParam(value: List<T>, delegateType: ColumnType): Expression<List<T>> =

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -759,7 +759,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.testBlob
      */
-    fun blob(name: String): Column<ExposedBlob> = registerColumn(name, BlobColumnType())
+    fun blob(name: String, useObjectIdentifier: Boolean = false): Column<ExposedBlob> =
+        registerColumn(name, BlobColumnType(useObjectIdentifier))
 
     /** Creates a binary column, with the specified [name], for storing UUIDs. */
     fun uuid(name: String): Column<UUID> = registerColumn(name, UUIDColumnType())

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -756,6 +756,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /**
      * Creates a binary column, with the specified [name], for storing BLOBs.
+     * If [useObjectIdentifier] is `true`, then the column will use the `OID` type on PostgreSQL
+     * for storing large binary objects. The parameter must not be `true` for other databases.
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.testBlob
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
@@ -61,8 +61,11 @@ interface PreparedStatementApi {
     /** Sets the statement parameter at the [index] position to SQL NULL, if allowed wih the specified [columnType]. */
     fun setNull(index: Int, columnType: IColumnType)
 
-    /** Sets the statement parameter at the [index] position to the provided [inputStream]. */
-    fun setInputStream(index: Int, inputStream: InputStream)
+    /**
+     * Sets the statement parameter at the [index] position to the provided [inputStream],
+     * either directly as a BLOB if `setAsBlobObject` is `true` or as determined by the driver.
+     */
+    fun setInputStream(index: Int, inputStream: InputStream, setAsBlobObject: Boolean)
 
     /** Sets the statement parameter at the [index] position to the provided [array] of SQL [type]. */
     fun setArray(index: Int, type: String, array: Array<*>)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -28,6 +28,9 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
             val cast = if (e.columnType.usesBinaryFormat) "::jsonb" else "::json"
             "${super.processForDefaultValue(e)}$cast"
         }
+        e is LiteralOp<*> && e.columnType is BlobColumnType && e.columnType.useObjectIdentifier && (currentDialect as? H2Dialect) == null -> {
+            "lo_from_bytea(0, ${super.processForDefaultValue(e)} :: bytea)"
+        }
         e is LiteralOp<*> && e.columnType is ArrayColumnType -> {
             val processed = super.processForDefaultValue(e)
             processed

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -77,7 +77,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStateme
 	public fun set (ILjava/lang/Object;)V
 	public fun setArray (ILjava/lang/String;[Ljava/lang/Object;)V
 	public fun setFetchSize (Ljava/lang/Integer;)V
-	public fun setInputStream (ILjava/io/InputStream;)V
+	public fun setInputStream (ILjava/io/InputStream;Z)V
 	public fun setNull (ILorg/jetbrains/exposed/sql/IColumnType;)V
 	public fun setTimeout (Ljava/lang/Integer;)V
 }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
@@ -72,15 +72,19 @@ class JdbcPreparedStatementImpl(
     }
 
     override fun setNull(index: Int, columnType: IColumnType) {
-        if (columnType is BinaryColumnType || columnType is BlobColumnType) {
+        if (columnType is BinaryColumnType || (columnType is BlobColumnType && !columnType.useObjectIdentifier)) {
             statement.setNull(index, Types.LONGVARBINARY)
         } else {
             statement.setObject(index, null)
         }
     }
 
-    override fun setInputStream(index: Int, inputStream: InputStream) {
-        statement.setBinaryStream(index, inputStream, inputStream.available())
+    override fun setInputStream(index: Int, inputStream: InputStream, setAsBlobObject: Boolean) {
+        if (setAsBlobObject) {
+            statement.setBlob(index, inputStream)
+        } else {
+            statement.setBinaryStream(index, inputStream)
+        }
     }
 
     override fun setArray(index: Int, type: String, array: Array<*>) {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
@@ -83,7 +83,7 @@ class JdbcPreparedStatementImpl(
         if (setAsBlobObject) {
             statement.setBlob(index, inputStream)
         } else {
-            statement.setBinaryStream(index, inputStream)
+            statement.setBinaryStream(index, inputStream, inputStream.available())
         }
     }
 


### PR DESCRIPTION
The current implementation has a limit of 2GB and causes large memory allocations. This PR changes this to streaming for reading/writing the blob.
SQLite does not know the `setBlob()` function and has no `setBinaryStream()` function, therefor `setBytes()` is used.

This PR is not compatible to existing Postgres implementations (the column-type is changed from `bytes` to `old`).