### PR TITLE
fix: EXPOSED-116 UUID conversion error with upsert in H2

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -4,6 +4,7 @@ import org.intellij.lang.annotations.Language
 import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
+import java.util.*
 
 internal object H2DataTypeProvider : DataTypeProvider() {
     override fun binaryType(): String {
@@ -12,6 +13,7 @@ internal object H2DataTypeProvider : DataTypeProvider() {
     }
 
     override fun uuidType(): String = "UUID"
+    override fun uuidToDB(value: UUID): Any = value.toString()
     override fun dateTimeType(): String = "DATETIME(9)"
 
     override fun timestampWithTimeZoneType(): String = "TIMESTAMP(9) WITH TIME ZONE"


### PR DESCRIPTION
Using a UUID column as a key `id` constraint in H2's `MERGE INTO .. USING` statement fails with:
```
org.h2.jdbc.JdbcSQLDataException:
Data conversion error converting "U&'\\fffdK\\fffdS\\001bJr\\fffdG%\\fffdE\\00100\\fffd' (TESTER: ""ID"" UUID NOT NULL)";
```

This error occurs because the statement uses a derived column list to merge `ON (T.ID=S.ID)`, so the UUID as a `ByteArray` stored in T.ID needs to be converted internally to compare with the `String` in S.ID (from generated SQL). This error goes away if a regular integer `id` column is used or if the key constraint is swapped with another non-UUID type.

The error also goes away if an identical MERGE statement is placed in `exec()` directly, indicating that the issue lies with how Exposed sends UUID values to the H2 database.

Switching the sent value from a ByteArray to a String allows comparison without conversion. A String is still one of [3 acceptable ways](https://www.h2database.com/html/datatypes.html#uuid_type) to store a UUID in H2 and sending a String still results in a UUID being retrieved back from the database (via `valueFromDB()` and `readObject()`).

Additional:
- Because H2_Oracle is delegating to Oracle, it uses Oracle's `RAW(16)` type instead of H2's `UUID` type and leads to a second error:
 ```
org.h2.jdbc.JdbcSQLSyntaxErrorException:
Values of types "BINARY VARYING(16)" and "CHARACTER VARYING" are not comparable;
```
To resolve this, H2_Oracle could also be made to use the Oracle-specific UPSERT statement, but this syntax fails when sent to H2. Instead, the compatibility mode now uses the `H2DatatypeProvider` overrides.