### PR TITLE
fix: EXPOSED-123 ExposedBlob.getBytes() fails on Oracle with IOException

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -442,7 +442,8 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testBlob() {
+    @Test
+    fun testBlob() {
         val t = object : Table("t1") {
             val id = integer("id").autoIncrement()
             val b = blob("blob")
@@ -455,11 +456,6 @@ class DDLTests : DatabaseTestsBase() {
             val longBytes = Random.nextBytes(1024)
             val shortBlob = ExposedBlob(shortBytes)
             val longBlob = ExposedBlob(longBytes)
-//            if (currentDialectTest.dataTypeProvider.blobAsStream) {
-//                    SerialBlob(bytes)
-//                } else connection.createBlob().apply {
-//                    setBytes(1, bytes)
-//                }
 
             val id1 = t.insert {
                 it[t.b] = shortBlob
@@ -497,7 +493,7 @@ class DDLTests : DatabaseTestsBase() {
         val defaultBlobStr = "test"
         val defaultBlob = ExposedBlob(defaultBlobStr.encodeToByteArray())
 
-        val TestTable = object : Table("TestTable") {
+        val testTable = object : Table("TestTable") {
             val number = integer("number")
             val blobWithDefault = blob("blobWithDefault").default(defaultBlob)
         }
@@ -506,18 +502,18 @@ class DDLTests : DatabaseTestsBase() {
             when (testDb) {
                 TestDB.MYSQL -> {
                     expectException<ExposedSQLException> {
-                        SchemaUtils.create(TestTable)
+                        SchemaUtils.create(testTable)
                     }
                 }
                 else -> {
-                    SchemaUtils.create(TestTable)
+                    SchemaUtils.create(testTable)
 
-                    TestTable.insert {
+                    testTable.insert {
                         it[number] = 1
                     }
-                    assertEquals(defaultBlobStr, String(TestTable.selectAll().first()[TestTable.blobWithDefault].bytes))
+                    assertEquals(defaultBlobStr, String(testTable.selectAll().first()[testTable.blobWithDefault].bytes))
 
-                    SchemaUtils.drop(TestTable)
+                    SchemaUtils.drop(testTable)
                 }
             }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -111,7 +111,8 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testBlobField() {
+    @Test
+    fun testBlobField() {
         withTables(EntityTestsData.YTable) {
             val y1 = EntityTestsData.YEntity.new {
                 x = false


### PR DESCRIPTION
The following tests fail when run using Oracle:

**DDLTests/testBlob()**
**DDLTests/testBlobDefault()**
**EntityTests/testBlobField()**

They all fail with the same error:
```
Caused by: java.io.IOException: Mark invalid or stream not marked.
	at oracle.jdbc.driver.OracleBlobInputStream.reset(OracleBlobInputStream.java:308)
	at org.jetbrains.exposed.sql.statements.api.ExposedBlob.getBytes(ExposedBlob.kt:13)
```
This exception is thrown by `inputStream.reset()`:
```kt
val bytes: ByteArray
  get() = inputStream.readBytes().also {
    if (inputStream.markSupported()) {
      inputStream.reset()
    } else {
      inputStream = it.inputStream()
    }
  }
```
Because the `InputStream` retrieved by the DB is of type `oracle.jdbc.driver.OracleBlobInputStream`, which throws, as per the [documentation](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#reset--):
> If the method mark has not been called since the stream was created, or the number of bytes read from the stream since mark was last called is larger than the argument to mark at that last call, then an IOException might be thrown. 

**Possible Solutions:**
1. Retrieve the column value from the DB as a `ByteArray` instead of an `InputStream`:
```kt
override fun readObject(rs: ResultSet, index: Int) = when (currentDialect) {
    is SQLServerDialect, is OracleDialect -> rs.getBytes(index)?.let(::ExposedBlob)
    else -> rs.getBinaryStream(index)?.let(::ExposedBlob)
}
```
This fixes the issue because an `ExposedBlob` is created using the secondary constructor:
```kt
constructor(bytes: ByteArray) : this (bytes.inputStream())
```
which instantiates a `java.io.ByteArrayInputStream`, with a `reset()` override that [doesn't throw](https://docs.oracle.com/javase/8/docs/api/java/io/ByteArrayInputStream.html#reset--).

This works fine, but seems less than ideal especially since most [recommendations](https://docs.oracle.com/cd/A84870_01/doc/java.816/a81354/oralob2.htm) about reading BLOBs from Oracle suggest using `getBlob()` or `getBinaryStream()` because of the potential size of a BLOB. The current code uses [`getBinaryStream()`](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html#getBinaryStream-int-):
> Retrieves the value of the designated column in the current row of this ResultSet object as a stream of uninterpreted bytes. The value can then be read in chunks from the stream. This method is particularly suitable for retrieving large LONGVARBINARY values.
 
2. Continue to retrieve the DB object as an `InputStream`, but ensure `mark()` is invoked:
```kt
override fun readObject(rs: ResultSet, index: Int) = when (currentDialect) {
    is SQLServerDialect -> rs.getBytes(index)?.let(::ExposedBlob)
    is OracleDialect -> rs.getBinaryStream(index)?.let(::ExposedBlob)?.also {
            it.inputStream.mark(it.inputStream.available())
    }
    else -> rs.getBinaryStream(index)?.let(::ExposedBlob)
}
```
Using `it.inputStream.available()` as the `readlimit` value tells the input stream to allow that many bytes to be read before the mark position gets invalidated. This works, but seems like a step too far especially since [documentation](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#available--) shows this warning:
>  It is never correct to use the return value of this method to allocate a buffer intended to hold all data in this stream.
3. **[Implemented]** Make no changes to `readObject()` and instead handle the `IOException` inside `ExposedBlob.getBytes()`. This ensures that the BLOB value is still being retrieved as a stream and does not affect the returned `ByteArray` value.