### PR TITLE
fix: EXPOSED-127 Default values for JSON columns are not quoted

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -881,6 +881,10 @@ public abstract interface class org/jetbrains/exposed/sql/IDateColumnType {
 	public abstract fun getHasTimePart ()Z
 }
 
+public abstract interface class org/jetbrains/exposed/sql/IJsonColumnType {
+	public abstract fun getUsesBinaryFormat ()Z
+}
+
 public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder {
 	public abstract fun asLiteral (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public abstract fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -881,10 +881,6 @@ public abstract interface class org/jetbrains/exposed/sql/IDateColumnType {
 	public abstract fun getHasTimePart ()Z
 }
 
-public abstract interface class org/jetbrains/exposed/sql/IJsonColumnType {
-	public abstract fun getUsesBinaryFormat ()Z
-}
-
 public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder {
 	public abstract fun asLiteral (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public abstract fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
@@ -1200,6 +1196,10 @@ public final class org/jetbrains/exposed/sql/JoinType : java/lang/Enum {
 	public static final field RIGHT Lorg/jetbrains/exposed/sql/JoinType;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JoinType;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/JoinType;
+}
+
+public abstract interface class org/jetbrains/exposed/sql/JsonColumnMarker {
+	public abstract fun getUsesBinaryFormat ()Z
 }
 
 public final class org/jetbrains/exposed/sql/Key {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -998,6 +998,6 @@ interface IDateColumnType {
 /**
  * Marker interface for json/jsonb related column types.
  */
-interface IJsonColumnType {
+interface JsonColumnMarker {
     val usesBinaryFormat: Boolean
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -992,3 +992,12 @@ class CustomEnumerationColumnType<T : Enum<T>>(
 interface IDateColumnType {
     val hasTimePart: Boolean
 }
+
+// JSON/JSONB columns
+
+/**
+ * Marker interface for json/jsonb related column types.
+ */
+interface IJsonColumnType {
+    val usesBinaryFormat: Boolean
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -185,7 +185,7 @@ object SchemaUtils {
                         else -> processForDefaultValue(exp)
                     }
                     else -> {
-                        if (column.columnType is IJsonColumnType) {
+                        if (column.columnType is JsonColumnMarker) {
                             val processed = processForDefaultValue(exp)
                             when (dialect) {
                                 is PostgreSQLDialect -> {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -184,7 +184,25 @@ object SchemaUtils {
                         is MysqlDialect -> value.setScale((exp.columnType as DecimalColumnType).scale).toString()
                         else -> processForDefaultValue(exp)
                     }
-                    else -> processForDefaultValue(exp)
+                    else -> {
+                        if (column.columnType is IJsonColumnType) {
+                            val processed = processForDefaultValue(exp)
+                            when (dialect) {
+                                is PostgreSQLDialect -> {
+                                    if (column.columnType.usesBinaryFormat) {
+                                        processed.replace(Regex("(\"|})(:|,)(\\[|\\{|\")"), "$1$2 $3")
+                                    } else {
+                                        processed
+                                    }
+                                }
+                                is MariaDBDialect -> processed.trim('\'')
+                                is MysqlDialect -> "_utf8mb4\\'${processed.trim('(', ')', '\'')}\\"
+                                else -> processed.trim('\'')
+                            }
+                        } else {
+                            processForDefaultValue(exp)
+                        }
+                    }
                 }
             }
             is Function<*> -> {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -134,6 +134,11 @@ abstract class DataTypeProvider {
 
     /** Returns the SQL representation of the specified expression, for it to be used as a column default value. */
     open fun processForDefaultValue(e: Expression<*>): String = when {
+        e is LiteralOp<*> && e.columnType is IJsonColumnType -> if (currentDialect is H2Dialect) {
+            "$e".substringAfter("JSON ")
+        } else {
+            "'$e'"
+        }
         e is LiteralOp<*> -> "$e"
         e is Function<*> -> "$e"
         currentDialect is MysqlDialect -> "$e"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -134,7 +134,7 @@ abstract class DataTypeProvider {
 
     /** Returns the SQL representation of the specified expression, for it to be used as a column default value. */
     open fun processForDefaultValue(e: Expression<*>): String = when {
-        e is LiteralOp<*> && e.columnType is IJsonColumnType -> if (currentDialect is H2Dialect) {
+        e is LiteralOp<*> && e.columnType is JsonColumnMarker -> if (currentDialect is H2Dialect) {
             "$e".substringAfter("JSON ")
         } else {
             "'$e'"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -51,7 +51,7 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
     override fun jsonBType(): String = "JSON"
 
     override fun processForDefaultValue(e: Expression<*>): String = when {
-        e is LiteralOp<*> && e.columnType is IJsonColumnType -> when {
+        e is LiteralOp<*> && e.columnType is JsonColumnMarker -> when {
             currentDialect is MariaDBDialect -> super.processForDefaultValue(e)
             (currentDialect as? MysqlDialect)?.isMysql8 == true -> "(${super.processForDefaultValue(e)})"
             else -> throw UnsupportedByDialectException(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Mysql.kt
@@ -50,8 +50,19 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
 
     override fun jsonBType(): String = "JSON"
 
-    override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {
+    override fun processForDefaultValue(e: Expression<*>): String = when {
+        e is LiteralOp<*> && e.columnType is IJsonColumnType -> when {
+            currentDialect is MariaDBDialect -> super.processForDefaultValue(e)
+            (currentDialect as? MysqlDialect)?.isMysql8 == true -> "(${super.processForDefaultValue(e)})"
+            else -> throw UnsupportedByDialectException(
+                "MySQL versions prior to 8.0.13 do not accept default values on JSON columns",
+                currentDialect
+            )
+        }
+        else -> super.processForDefaultValue(e)
+    }
 
+    override fun precessOrderByClause(queryBuilder: QueryBuilder, expression: Expression<*>, sortOrder: SortOrder) {
         when (sortOrder) {
             SortOrder.ASC, SortOrder.DESC -> super.precessOrderByClause(queryBuilder, expression, sortOrder)
             SortOrder.ASC_NULLS_FIRST -> super.precessOrderByClause(queryBuilder, expression, SortOrder.ASC)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -22,7 +22,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun jsonBType(): String = "JSONB"
 
     override fun processForDefaultValue(e: Expression<*>): String = when {
-        e is LiteralOp<*> && e.columnType is IJsonColumnType && (currentDialect as? H2Dialect) == null -> {
+        e is LiteralOp<*> && e.columnType is JsonColumnMarker && (currentDialect as? H2Dialect) == null -> {
             val cast = if (e.columnType.usesBinaryFormat) "::jsonb" else "::json"
             "${super.processForDefaultValue(e)}$cast"
         }
@@ -143,7 +143,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         path?.let {
             TransactionManager.current().throwUnsupportedException("PostgreSQL does not support a JSON path argument")
         }
-        val isNotJsonB = !(jsonType as IJsonColumnType).usesBinaryFormat
+        val isNotJsonB = !(jsonType as JsonColumnMarker).usesBinaryFormat
         queryBuilder {
             append(target)
             if (isNotJsonB) append("::jsonb")
@@ -162,7 +162,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         if (path.size > 1) {
             TransactionManager.current().throwUnsupportedException("PostgreSQL does not support multiple JSON path arguments")
         }
-        val isNotJsonB = !(jsonType as IJsonColumnType).usesBinaryFormat
+        val isNotJsonB = !(jsonType as JsonColumnMarker).usesBinaryFormat
         queryBuilder {
             append("JSONB_PATH_EXISTS(")
             if (isNotJsonB) {

--- a/exposed-json/api/exposed-json.api
+++ b/exposed-json/api/exposed-json.api
@@ -27,6 +27,7 @@ public final class org/jetbrains/exposed/sql/json/Extract : org/jetbrains/expose
 
 public final class org/jetbrains/exposed/sql/json/JsonBColumnType : org/jetbrains/exposed/sql/json/JsonColumnType {
 	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public fun getUsesBinaryFormat ()Z
 	public fun sqlType ()Ljava/lang/String;
 }
 
@@ -34,10 +35,11 @@ public final class org/jetbrains/exposed/sql/json/JsonBColumnTypeKt {
 	public static final fun jsonb (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
 }
 
-public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/exposed/sql/ColumnType {
+public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IJsonColumnType {
 	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public final fun getDeserialize ()Lkotlin/jvm/functions/Function1;
 	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;
+	public fun getUsesBinaryFormat ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/String;

--- a/exposed-json/api/exposed-json.api
+++ b/exposed-json/api/exposed-json.api
@@ -35,7 +35,7 @@ public final class org/jetbrains/exposed/sql/json/JsonBColumnTypeKt {
 	public static final fun jsonb (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
 }
 
-public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IJsonColumnType {
+public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/JsonColumnMarker {
 	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public final fun getDeserialize ()Lkotlin/jvm/functions/Function1;
 	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnType.kt
@@ -18,6 +18,8 @@ class JsonBColumnType<T : Any>(
     serialize: (T) -> String,
     deserialize: (String) -> T
 ) : JsonColumnType<T>(serialize, deserialize) {
+    override val usesBinaryFormat: Boolean = true
+
     override fun sqlType(): String = when (currentDialect) {
         is H2Dialect -> (currentDialect as H2Dialect).originalDataTypeProvider.jsonBType()
         else -> currentDialect.dataTypeProvider.jsonBType()

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ColumnType
-import org.jetbrains.exposed.sql.IJsonColumnType
+import org.jetbrains.exposed.sql.JsonColumnMarker
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.H2Dialect
@@ -21,7 +21,7 @@ open class JsonColumnType<T : Any>(
     val serialize: (T) -> String,
     /** Returns the function that decodes a JSON String to an object of type [T]. */
     val deserialize: (String) -> T
-) : ColumnType(), IJsonColumnType {
+) : ColumnType(), JsonColumnMarker {
     override val usesBinaryFormat: Boolean = false
 
     override fun sqlType(): String = currentDialect.dataTypeProvider.jsonType()

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ColumnType
+import org.jetbrains.exposed.sql.IJsonColumnType
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.H2Dialect
@@ -20,7 +21,9 @@ open class JsonColumnType<T : Any>(
     val serialize: (T) -> String,
     /** Returns the function that decodes a JSON String to an object of type [T]. */
     val deserialize: (String) -> T
-) : ColumnType() {
+) : ColumnType(), IJsonColumnType {
+    override val usesBinaryFormat: Boolean = false
+
     override fun sqlType(): String = currentDialect.dataTypeProvider.jsonType()
 
     override fun valueFromDB(value: Any): Any {

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.sql.json
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
@@ -10,6 +11,8 @@ import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.junit.Test
 
@@ -222,6 +225,43 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
             val hasAtLeast3Numbers = tester.numbers.exists("[2]", optional = optional)
             assertEquals(tripleId, tester.select { hasAtLeast3Numbers }.single()[tester.id])
+        }
+    }
+
+    @Test
+    fun testJsonBWithDefaults() {
+        val defaultUser = User("UNKNOWN", "UNASSIGNED")
+        val defaultTester = object : Table("default_tester") {
+            val user1 = jsonb<User>("user_1", Json.Default).default(defaultUser)
+            val user2 = jsonb<User>("user_2", Json.Default).clientDefault { defaultUser }
+        }
+
+        withDb(excludeSettings = binaryJsonNotSupportedDB) { testDb ->
+            excludingH2Version1(testDb) {
+                if (isOldMySql()) {
+                    expectException<UnsupportedByDialectException> {
+                        SchemaUtils.createMissingTablesAndColumns(defaultTester)
+                    }
+                } else {
+                    SchemaUtils.createMissingTablesAndColumns(defaultTester)
+                    assertTrue(defaultTester.exists())
+                    // ensure defaults match returned metadata defaults
+                    val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                    assertTrue(alters.isEmpty())
+
+                    defaultTester.insert {}
+
+                    defaultTester.selectAll().single().also {
+                        assertEquals(defaultUser.name, it[defaultTester.user1].name)
+                        assertEquals(defaultUser.team, it[defaultTester.user1].team)
+
+                        assertEquals(defaultUser.name, it[defaultTester.user2].name)
+                        assertEquals(defaultUser.team, it[defaultTester.user2].team)
+                    }
+
+                    SchemaUtils.drop(defaultTester)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Assigning a default value to a JSON/JSONB column using `default()` results in syntax exceptions in all databases except H2 because the current `nonNullValueToString()` result is an unquoted JSON string literal.

**Step 1:**
Extend both JSON column types with a new marker interface, `IJsonColumnType`, to act as a bridge to the `exposed-core` module (like what is done for date/time columns with `IDateColumnType`).

**Step 2:**
Override `processForDefaultValue()` to appropriately wrap the defaults according to database specifics:
- MySQL only allows default values on JSON columns if they are wrapped like an expression and the version is 8.0+:

> The BLOB, TEXT, GEOMETRY, and JSON data types can be assigned a default value only if the value is written as an expression, even if the expression value is a literal.

- PostgreSQL requires a cast depending on whether json or jsonb is used.

**Step 3:**
Add block to `SchemaUtils.dbDefaultToString()` to process these defaults, which ensures that they match the returned metadata default values and don't trigger unnecessary alter statements.
- The implemented PostgreSQL parser covers the case when a JSONB column value is returned as metadata, which adds whitespace to a previously minified JSON string. It does not guarantee an accurate comparison, however, because, as [documentation](https://www.postgresql.org/docs/15/datatype-json.html) states:

> JSONB does not preserve white space, does not preserve the order of object keys, and does not keep duplicate object keys. If duplicate keys are specified in the input, only the last value is kept.

So a potentially complex literal used as a default may trigger a false comparison match and produce an ALTER statement.  

**Additional:**
Replace hard-coded data type string in PostgreSQL json function overrides with new `IJsonColumnType.usesBinaryFormat` property.