### PR TITLE
fix: EXPOSED-135 Oracle does not use setSchema value as currentScheme

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -64,7 +64,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                 field = try {
                     when (databaseDialectName) {
                         MysqlDialect.dialectName, MariaDBDialect.dialectName -> metadata.connection.catalog.orEmpty()
-                        OracleDialect.dialectName -> databaseName
+                        OracleDialect.dialectName -> metadata.connection.schema ?: databaseName
                         else -> metadata.connection.schema.orEmpty()
                     }
                 } catch (_: Throwable) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateIndexTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateIndexTests.kt
@@ -69,8 +69,8 @@ class CreateIndexTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test possibility to create indexes when table exists in different schemas`() {
-        val TestTable = object : Table("test_table") {
+    fun testCreateIndexWithTableInDifferentSchemas() {
+        val testTable = object : Table("test_table") {
             val id = integer("id").uniqueIndex()
             val name = varchar("name", length = 42).index("test_index")
             init {
@@ -81,15 +81,14 @@ class CreateIndexTests : DatabaseTestsBase() {
         val schema2 = Schema("Schema2")
         withSchemas(listOf(TestDB.SQLITE, TestDB.SQLSERVER), schema1, schema2) {
             SchemaUtils.setSchema(schema1)
-            SchemaUtils.createMissingTablesAndColumns(TestTable)
-            assertEquals(true, TestTable.exists())
+            SchemaUtils.createMissingTablesAndColumns(testTable)
+            assertEquals(true, testTable.exists())
             SchemaUtils.setSchema(schema2)
-            assertEquals(false, TestTable.exists())
-            SchemaUtils.createMissingTablesAndColumns(TestTable)
-            assertEquals(true, TestTable.exists())
+            assertEquals(false, testTable.exists())
+            SchemaUtils.createMissingTablesAndColumns(testTable)
+            assertEquals(true, testTable.exists())
         }
     }
-
 
     @Test
     fun testCreateAndDropPartialIndexWithPostgres() {


### PR DESCRIPTION
The following test fails when run on Oracle:

**CreateIndexTests/'test possibility to create indexes when table exists in different schemas'()**

Fails with:
```
ORA-01430: column being added already exists in table
Statement: ALTER TABLE TEST_TABLE ADD ID NUMBER(12) NOT NULL
```

This happens because metadata incorrectly returns an empty map of existing table columns when `columns()` is invoked in `JdbcDatabaseMetadataImpl`:
```kt
override fun columns(vararg tables: Table): Map<Table, List<ColumnMetadata>> {
        val rs = metadata.getColumns(databaseName, currentScheme, "%", "%")
        val result = rs.extractColumns(tables) { // .. }
}
```
`metadata.getColumns()` relies on the property `currentScheme`, which is invariably set to `databaseName` in Oracle; that means, it is set to the default user created at connection, EXPOSEDTEST.

So, even though this correct SQL is executed (which correctly changes the schema internally in the DB):
```
ALTER SESSION SET CURRENT_SCHEMA = Schema1
```
Exposed continues to use the default schema, EXPOSEDTEST, as the argument when querying metadata.

[Commit 920428b](https://github.com/JetBrains/Exposed/commit/920428b0b7dc3f0730700b59d0257692ded9e7ed) shows a similar change, but only done local to a single function.