### PR TITLE
fix: EXPOSED-122 Fix timestampWithTimeZone tests in Oracle

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -55,6 +55,14 @@ internal val MYSQL_OFFSET_DATE_TIME_FORMATTER by lazy {
     )
 }
 
+// Example result: 2023-07-07 14:42:29.343789 +02:00
+internal val ORACLE_OFFSET_DATE_TIME_FORMATTER by lazy {
+    DateTimeFormatter.ofPattern(
+        "yyyy-MM-dd HH:mm:ss.SSSSSS [xxx]",
+        Locale.ROOT
+    )
+}
+
 internal val DEFAULT_OFFSET_DATE_TIME_FORMATTER by lazy {
     DateTimeFormatter.ISO_OFFSET_DATE_TIME.withLocale(Locale.ROOT)
 }
@@ -272,6 +280,7 @@ class JavaOffsetDateTimeColumnType : ColumnType(), IDateColumnType {
             when (currentDialect) {
                 is SQLiteDialect -> "'${value.format(SQLITE_OFFSET_DATE_TIME_FORMATTER)}'"
                 is MysqlDialect -> "'${value.format(MYSQL_OFFSET_DATE_TIME_FORMATTER)}'"
+                is OracleDialect -> "'${value.format(ORACLE_OFFSET_DATE_TIME_FORMATTER)}'"
                 else -> "'${value.format(DEFAULT_OFFSET_DATE_TIME_FORMATTER)}'"
             }
         }

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -66,6 +66,14 @@ internal val MYSQL_OFFSET_DATE_TIME_FORMATTER by lazy {
     )
 }
 
+// Example result: 2023-07-07 14:42:29.343789 +02:00
+internal val ORACLE_OFFSET_DATE_TIME_FORMATTER by lazy {
+    DateTimeFormatter.ofPattern(
+        "yyyy-MM-dd HH:mm:ss.SSSSSS [xxx]",
+        Locale.ROOT
+    )
+}
+
 internal val DEFAULT_OFFSET_DATE_TIME_FORMATTER by lazy {
     DateTimeFormatter.ISO_OFFSET_DATE_TIME.withLocale(Locale.ROOT)
 }
@@ -281,6 +289,7 @@ class KotlinOffsetDateTimeColumnType : ColumnType(), IDateColumnType {
             when (currentDialect) {
                 is SQLiteDialect -> "'${value.format(SQLITE_OFFSET_DATE_TIME_FORMATTER)}'"
                 is MysqlDialect -> "'${value.format(MYSQL_OFFSET_DATE_TIME_FORMATTER)}'"
+                is OracleDialect -> "'${value.format(ORACLE_OFFSET_DATE_TIME_FORMATTER)}'"
                 else -> "'${value.format(DEFAULT_OFFSET_DATE_TIME_FORMATTER)}'"
             }
         }


### PR DESCRIPTION
The following test fails when run on Oracle in the 3 modules: `exposed-kotlin-datetime`, `exposed-java-time`, `exposed-jodatime`

**DefaultsTest/testTimestampWithTimeZoneDefaults()**

The following tests also fail when run on Oracle, but in `exposed-jodatime` only:

**JodaTimeBaseTest/testTimestampWithTimeZone()**
**JodaTimeMiscTableTest/testTimestampWithTimeZone()**

**Issue 1:**

Fails with: `ORA-01861: literal does not match format string`
Because Oracle is set to use the default formatter, instead of [the accepted pattern](https://docs.oracle.com/en/database/oracle/oracle-database/21/nlspg/datetime-data-types-and-time-zone-support.html#GUID-5BC5D2C1-6506-49BE-8177-F743A46FDC09):
```
Current -> TIMESTAMP '2023-08-09T11:26:32.7367231Z'
Accepted -> TIMESTAMP '2023-08-09 11:26:32.7367231 +00:00'
```

Oracle now has its own datetime formatter in each module.

**Issue 2:**

In `exposed-jodatime` module only, reading a timestamp with time zone object in Oracle then fails with a NPE at this line: `rs.getObject(index, offsetDateTimeClass)`.
This occurs because of a read conversion error since `DateTime` is sent to the DB as `java.sql.Timestamp` and ends up being stored as `oracle.sql.TIMESTAMPTZ`.

The object is instead read and retrieved as a `java.sql.Timestamp`.