### PR TITLE
fix: EXPOSED-137 SET DEFAULT reference option should not be supported in Oracle

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -129,6 +129,10 @@ data class ForeignKeyConstraint(
                             "MySQL doesn't support FOREIGN KEY with SET DEFAULT reference option with ON DELETE clause. " +
                                 "Please check your $fromTableName table."
                         )
+                        is OracleDialect -> exposedLogger.warn(
+                            "Oracle doesn't support FOREIGN KEY with SET DEFAULT reference option with ON DELETE clause. " +
+                                "Please check your $fromTableName table."
+                        )
                         else -> append(" ON DELETE $deleteRule")
                     }
                 } else {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -573,7 +573,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @Test
     fun createTableWithOnDeleteSetDefault() {
-        withDb(excludeSettings = listOf(TestDB.MARIADB, TestDB.MYSQL)) {
+        withDb(excludeSettings = listOf(TestDB.MARIADB, TestDB.MYSQL, TestDB.ORACLE)) {
             val expected = listOf(
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(Item)} (" +
                     "${Item.columns.joinToString { it.descriptionDdl(false) }}," +

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
@@ -21,7 +21,7 @@ class ForeignKeyConstraintTests : DatabaseTestsBase() {
 
     @Test
     fun `test ON DELETE SET DEFAULT for databases that support it without SQLite`() {
-        withDb(excludeSettings = listOf(TestDB.MARIADB, TestDB.MYSQL, TestDB.SQLITE)) {
+        withDb(excludeSettings = listOf(TestDB.MARIADB, TestDB.MYSQL, TestDB.SQLITE, TestDB.ORACLE)) {
             testOnDeleteSetDefault()
         }
     }


### PR DESCRIPTION
The following test fails when run on Oracle:

**sqlite/ForeignKeyConstraintTests/'test ON DELETE SET DEFAULT for databases that support it without SQLite'()**

Fails with:
```
java.sql.SQLException: ORA-03001: unimplemented feature.
Statement(s):
CREATE TABLE ITEM (ID NUMBER(12) PRIMARY KEY, "NAME" VARCHAR2(20 CHAR) NOT NULL, CATEGORYID NUMBER(12) DEFAULT 0 NOT NULL,
CONSTRAINT FK_ITEM_CATEGORYID__ID FOREIGN KEY (CATEGORYID) REFERENCES CATEGORY(ID) ON DELETE SET DEFAULT)
```

Oracle's ON DELETE clause only supports CASCADE or SET NULL reference options ([documentation](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/constraint.html#GUID-1055EA97-BA6F-4764-A15F-1024FD5B6DFE__CJAIHHGC)).

A warning is now logged instead of appending to the query string and Oracle is excluded from relevant tests.