### PR TITLE
test: Fix failing Oracle tests in exposed-tests

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -520,7 +520,8 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             val traceNumber = reference("traceNumber", ordersTable.traceNumber)
         }
 
-        withDb {
+        // Oracle metadata only returns foreign keys that reference primary keys
+        withDb(excludeSettings = listOf(TestDB.ORACLE)) {
             SchemaUtils.createMissingTablesAndColumns(ordersTable, receiptsTable)
             assertTrue(ordersTable.exists())
             assertTrue(receiptsTable.exists())

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -8,9 +8,11 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
+import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.junit.Test
 import java.sql.Connection
 import java.util.*
@@ -754,10 +756,9 @@ class EntityTests : DatabaseTestsBase() {
         var holidays by Holiday via SchoolHolidays
     }
 
-    @Test fun preloadReferencesOnASizedIterable() {
-
+    @Test
+    fun preloadReferencesOnASizedIterable() {
         withTables(Regions, Schools) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -796,10 +797,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadReferencesOnAnEntity() {
-
+    @Test
+    fun preloadReferencesOnAnEntity() {
         withTables(Regions, Schools) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -829,9 +829,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadOptionalReferencesOnASizedIterable() {
+    @Test
+    fun preloadOptionalReferencesOnASizedIterable() {
         withTables(Regions, Schools) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -844,6 +844,9 @@ class EntityTests : DatabaseTestsBase() {
                 name = "Eton"
                 region = region1
                 secondaryRegion = region2
+            }.apply {
+                // otherwise Oracle provides school1.id = 0 to testCache(), which returns null
+                if (currentDialectTest is OracleDialect) flush()
             }
 
             val school2 = School.new {
@@ -866,10 +869,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadOptionalReferencesOnAnEntity() {
-
+    @Test
+    fun preloadOptionalReferencesOnAnEntity() {
         withTables(Regions, Schools) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -897,10 +899,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadReferrersOnASizedIterable() {
-
+    @Test
+    fun preloadReferrersOnASizedIterable() {
         withTables(Regions, Schools, Students) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -959,9 +960,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadReferrersOnAnEntity() {
+    @Test
+    fun preloadReferrersOnAnEntity() {
         withTables(Regions, Schools, Students) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -999,10 +1000,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadOptionalReferrersOnASizedIterable() {
-
+    @Test
+    fun preloadOptionalReferrersOnASizedIterable() {
         withTables(Regions, Schools, Students, Detentions) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -1048,10 +1048,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadInnerTableLinkOnASizedIterable() {
-
+    @Test
+    fun preloadInnerTableLinkOnASizedIterable() {
         withTables(Regions, Schools, Holidays, SchoolHolidays) {
-
             val now = System.currentTimeMillis()
             val now10 = now + 10
 
@@ -1110,9 +1109,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadInnerTableLinkOnAnEntity() {
+    @Test
+    fun preloadInnerTableLinkOnAnEntity() {
         withTables(Regions, Schools, Holidays, SchoolHolidays) {
-
             val now = System.currentTimeMillis()
             val now10 = now + 10
 
@@ -1169,10 +1168,9 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadRelationAtDepth() {
-
+    @Test
+    fun preloadRelationAtDepth() {
         withTables(Regions, Schools, Holidays, SchoolHolidays, Students, Notes) {
-
             val region1 = Region.new {
                 name = "United Kingdom"
             }
@@ -1213,8 +1211,8 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadBackReferrenceOnASizedIterable() {
-
+    @Test
+    fun preloadBackReferrenceOnASizedIterable() {
         withTables(Regions, Schools, Students, StudentBios) {
             val region1 = Region.new {
                 name = "United States"
@@ -1258,8 +1256,8 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun preloadBackReferrenceOnAnEntity() {
-
+    @Test
+    fun preloadBackReferrenceOnAnEntity() {
         withTables(Regions, Schools, Students, StudentBios) {
             val region1 = Region.new {
                 name = "United States"


### PR DESCRIPTION
The following tests fail when run on Oracle:

**CreateMissingTablesAndColumnsTests/testCamelCaseForeignKeyCreation()**

Fails with:
```
ORA-02275: such a referential constraint already exists in the table.
Statement(s): ALTER TABLE RECEIPTS ADD CONSTRAINT FK_RECEIPTS_TRACENUMBER__TRACENUMBER FOREIGN KEY (TRACENUMBER) REFERENCES TMPORDERS(TRACENUMBER)
```

This happens because Oracle metadata (via `getImportedKeys()`) only returns foreign keys that reference primary keys of the referenced table ([documentation](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getImportedKeys-java.lang.String-java.lang.String-java.lang.String-)), so an empty map is being retrieved, which triggers an unnecessary alter statement.

This test passes in other DB as their metadata seems to be more lenient, but the metadata being the issue can be confirmed by changing the table mapping. For example, if the referenced table column `traceNumber` is made to be the primary key instead of a unique index, `getImportedKeys()` returns a map with the FK and the test passes.

This is a known issue with Oracle JDBC, so the test now excludes it:
- [Oracle forum](https://forums.oracle.com/ords/apexds/post/problem-with-getimportedkeys-method-0563)
- [Stackoverflow](https://stackoverflow.com/questions/23699899/get-all-foreign-keys-to-unique-indexes-from-oracle-using-jdbc)

***

**EntityTests/preloadOptionalReferencesOnASizedIterable()**

Fails on the first `assertNotNull()` because `testCache()` is passed the argument `school1.id = 0`, which does not exist. The new entity `school1` is actually cached with `id.value = 1`, but the argument passed does not reflect this unless the entity is first flushed.

This seems to be Oracle specific because all reference syntax and all breakpoints match between Oracle and other DB used as comparison, until the point where `testCache(school1.id)` is invoked (other DB correctly return `id.value = 1`).

 It may be related, but another way to have the test pass is to:
- Have the second `School` entity, `school2`, provide an argument for `secondaryRegion` instead of using the default `null`. So this may actually be an Oracle issue specific to nullable foreign key constraints, but no documentation states that the latter is not possible.

Also, this test has a consistent and significant lag between the creation of the second and third entities (where it attempts to store a value to the nullable FK constraint).

The entity is flushed to allow the test to continue, but Oracle could be excluded if the underlying issue requires more investigation.