### PR TITLE
chore: EXPOSED-104 Update gradle test tasks

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/DBTestingPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/DBTestingPlugin.kt
@@ -56,6 +56,10 @@ class DBTestingPlugin : Plugin<Project> {
                 testRuntimeOnly("org.postgresql", "postgresql", Versions.postgre)
                 testRuntimeOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
             }
+            val postgresAll = register<Test>("postgresAllTest") {
+                group = "verification"
+                delegatedTo(postgres, postgresNG)
+            }
 
             val oracle = register<DBTestWithDockerCompose>("oracleTest", Parameters("ORACLE", 1521)) {
                 testRuntimeOnly("com.oracle.database.jdbc", "ojdbc8", Versions.oracle12)
@@ -68,23 +72,35 @@ class DBTestingPlugin : Plugin<Project> {
             val mariadb_v2 = register<DBTestWithDockerCompose>("mariadb_v2Test", Parameters("MARIADB", 3306)) {
                 testRuntimeOnly("org.mariadb.jdbc", "mariadb-java-client", Versions.mariaDB_v2)
             }
-
             val mariadb_v3 = register<DBTestWithDockerCompose>("mariadb_v3Test", Parameters("MARIADB", 3306)) {
                 testRuntimeOnly("org.mariadb.jdbc", "mariadb-java-client", Versions.mariaDB_v3)
             }
-
             val mariadb = register<Test>("mariadbTest") {
                 group = "verification"
                 delegatedTo(mariadb_v2, mariadb_v3)
+            }
+
+            val testPartial = register<Test>("testPartial") {
+                group = "verification"
+                delegatedTo(
+                    h2_v2,
+                    sqlite,
+                    mysql80,
+                    postgres,
+                    mariadb_v3,
+                    sqlServer
+                )
             }
 
             named<Test>("test") {
                 delegatedTo(
                     h2,
                     sqlite,
-                    mysql51,
-                    postgres,
-                    postgresNG
+                    mysql,
+                    postgresAll,
+                    oracle,
+                    sqlServer,
+                    mariadb
                 )
             }
         }

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/DBTestingPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/DBTestingPlugin.kt
@@ -80,18 +80,6 @@ class DBTestingPlugin : Plugin<Project> {
                 delegatedTo(mariadb_v2, mariadb_v3)
             }
 
-            val testPartial = register<Test>("testPartial") {
-                group = "verification"
-                delegatedTo(
-                    h2_v2,
-                    sqlite,
-                    mysql80,
-                    postgres,
-                    mariadb_v3,
-                    sqlServer
-                )
-            }
-
             named<Test>("test") {
                 delegatedTo(
                     h2,


### PR DESCRIPTION
Update registered Gradle tasks in `DBTestingPlugin`:
- Add a new task that delegates to both PostgreSQL tasks: `postgresAll`
- Add a new task that covers most databases, at least the latest versions: `testPartial`
- Change Gradle verification task `test` so that it includes all supported databases.

Open to any naming or list element suggestions.

**Before:**
![tasks_before](https://github.com/JetBrains/Exposed/assets/82039410/98e45bf3-a448-4462-a073-0a0464cf1581)

**After:**
![tasks_after](https://github.com/JetBrains/Exposed/assets/82039410/1025772f-dff6-4cac-b7a7-457b6a5a1b5f)
