### PR TITLE
fix: EXPOSED-130 Logger throws ClassCastException with JSON and ListSerializer

### DIFF
--- a/exposed-json/api/exposed-json.api
+++ b/exposed-json/api/exposed-json.api
@@ -46,6 +46,7 @@ public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/expos
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueToString (Ljava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/json/JsonColumnTypeKt {

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
@@ -38,6 +38,11 @@ open class JsonColumnType<T : Any>(
     @Suppress("UNCHECKED_CAST")
     override fun notNullValueToDB(value: Any) = serialize(value as T)
 
+    override fun valueToString(value: Any?): String = when (value) {
+        is Iterable<*> -> nonNullValueToString(value)
+        else -> super.valueToString(value)
+    }
+
     override fun nonNullValueToString(value: Any): String {
         return when (currentDialect) {
             is H2Dialect -> "JSON '${notNullValueToDB(value)}'"

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.exposed.sql.json
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ArraySerializer
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
@@ -18,6 +21,7 @@ import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.junit.Test
+import kotlin.test.assertContentEquals
 
 class JsonColumnTests : DatabaseTestsBase() {
     @Test
@@ -296,6 +300,44 @@ class JsonColumnTests : DatabaseTestsBase() {
 
                     SchemaUtils.drop(defaultTester)
                 }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Test
+    fun testLoggerWithJsonCollections() {
+        val iterables = object : Table("iterables_tester") {
+            val userList = json("user_list", Json.Default, ListSerializer(User.serializer()))
+            val intList = json<List<Int>>("int_list", Json.Default)
+            val userArray = json("user_array", Json.Default, ArraySerializer(User.serializer()))
+            val intArray = json<IntArray>("int_array", Json.Default)
+        }
+
+        withDb { testDb ->
+            excludingH2Version1(testDb) {
+                // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
+                addLogger(StdOutSqlLogger)
+                SchemaUtils.create(iterables)
+
+                val user1 = User("A", "Team A")
+                val user2 = User("B", "Team B")
+                val integerList = listOf(1, 2, 3)
+                val integerArray = intArrayOf(1, 2, 3)
+                iterables.insert {
+                    it[userList] = listOf(user1, user2)
+                    it[intList] = integerList
+                    it[userArray] = arrayOf(user1, user2)
+                    it[intArray] = integerArray
+                }
+
+                val result = iterables.selectAll().single()
+                assertEqualCollections(listOf(user1, user2), result[iterables.userList])
+                assertEqualCollections(integerList, result[iterables.intList])
+                assertContentEquals(arrayOf(user1, user2), result[iterables.userArray])
+                assertContentEquals(integerArray, result[iterables.intArray])
+
+                SchemaUtils.drop(iterables)
             }
         }
     }


### PR DESCRIPTION
When a JSON/JSONB column that takes a `List` or `ListSerializer` is created, it correctly deserializes/serializes the JSON array to and from the database. However, attempting to log any SQL statements with the collection as a String throws a `ClassCastException`.

If the column is created to take an `Array` or `ArraySerializer` instead, then no exception is thrown when the logger is used.

This happens because lists are processed by `ColumnType.valueToString()` as `ArrayList`, which extends the `Iterable` superclass and is handled separately:
```kt
fun valueToString(value: Any?): String = when (value) {
    null -> {
        check(nullable) { "NULL in non-nullable column" }
        "NULL"
    }
    DefaultValueMarker -> "DEFAULT"
    is Iterable<*> -> value.joinToString(",", transform = ::valueToString)
    else -> nonNullValueToString(value)
}
```
Whereas arrays are processed as `Array` (or another type-specific class), which does not extend `Iterable`, so the `else` branch is reached.

This function now has an override in `JsonColumnType`.