### PR TITLE
fix: EXPOSED-145 Quoted table name breaks CREATE SEQUENCE in Oracle

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1115,7 +1115,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     private fun <T> Column<T>.cloneWithAutoInc(idSeqName: String?): Column<T> = when (columnType) {
         is AutoIncColumnType -> this
         is ColumnType -> {
-            this.withColumnType(AutoIncColumnType(columnType, idSeqName, "${tableName}_${name}_seq"))
+            this.withColumnType(
+                AutoIncColumnType(columnType, idSeqName, "${tableName?.replace("\"", "")}_${name}_seq")
+            )
         }
 
         else -> error("Unsupported column type for auto-increment $columnType")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -335,16 +335,14 @@ class CreateTableTests : DatabaseTestsBase() {
                 onDelete = ReferenceOption.NO_ACTION,
             )
         }
-        withTables(excludeSettings = listOf(TestDB.H2_ORACLE, TestDB.ORACLE), parent, child) {
-            val expected = listOf(
-                "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(child)} (" +
-                    "${child.columns.joinToString { it.descriptionDdl(false) }}," +
-                    " CONSTRAINT ${"fk_Child_parent_id__id".inProperCase()}" +
-                    " FOREIGN KEY (${this.identity(child.parentId)})" +
-                    " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
-                    ")"
-            )
-            assertEqualCollections(child.ddl, expected)
+        withTables(parent, child) {
+            val expected = "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(child)} (" +
+                "${child.columns.joinToString { it.descriptionDdl(false) }}," +
+                " CONSTRAINT ${"fk_Child_parent_id__id".inProperCase()}" +
+                " FOREIGN KEY (${this.identity(child.parentId)})" +
+                " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
+                ")"
+            assertEquals(child.ddl.last(), expected)
         }
     }
 


### PR DESCRIPTION
When a table with an auto-increment column is created in Oracle, a sequence must be created first.
If the provided table name has escaped double quotes, this CREATE SEQUENCE statement throws a syntax error:
```kt
object Parent : LongIdTable("\"Parent\"") {}

// java.sql.SQLSyntaxErrorException: ORA-01741: illegal zero-length identifier
// Statement(s): CREATE SEQUENCE ""Parent"_id_seq" START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807
```
In the case of all the `IdTable` subclasses, this happens because `autoincrement()` on the id column is not being provided a custom name, so the `fallbackSeqName` string is being used. This string now removes double quotes from a table name.

**Note:**
Oracle (and H2 Oracle) are the only DB that rely on `fallbackSeqName` as they are the only supported DB that have `needsSequenceToAutoInc == true`:
```kt
/** Returns the name of the sequence used to generate new values for this auto-increment column. */
val autoincSeq: String?
    get() = _autoincSeq.takeIf { currentDialect.supportsCreateSequence }
        ?: fallbackSeqName.takeIf { currentDialect.needsSequenceToAutoInc }
```