### PR TITLE
fix: EXPOSED-133 Suspend transactions blocking Hikari connection pool

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
@@ -162,6 +162,7 @@ private fun Transaction.resetIfClosed(): Transaction {
     }
 }
 
+@Suppress("CyclomaticComplexMethod")
 private fun <T> TransactionScope.suspendedTransactionAsyncInternal(
     shouldCommit: Boolean,
     statement: suspend Transaction.() -> T
@@ -172,7 +173,7 @@ private fun <T> TransactionScope.suspendedTransactionAsyncInternal(
 
     var answer: T
     while (true) {
-        val transaction = tx.value.resetIfClosed()
+        val transaction = if (repetitions == 0) tx.value else tx.value.resetIfClosed()
 
         @Suppress("TooGenericExceptionCaught")
         try {

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -24,13 +24,14 @@ dependencies {
     implementation("org.apache.logging.log4j", "log4j-core", Versions.log4j2)
     implementation("junit", "junit", "4.12")
     implementation("org.hamcrest", "hamcrest-library", "1.3")
+    implementation("com.zaxxer", "HikariCP", "5.0.1")
     implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-debug", Versions.kotlinCoroutines)
 
     implementation("org.testcontainers", "mysql", Versions.testContainers)
     implementation("org.testcontainers", "postgresql", Versions.testContainers)
     testCompileOnly("org.postgresql", "postgresql", Versions.postgre)
     testCompileOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
-    compileOnly("com.h2database", "h2", Versions.h2)
+    implementation("com.h2database", "h2", Versions.h2)
     testCompileOnly("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
 }
 

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     implementation("org.testcontainers", "postgresql", Versions.testContainers)
     testCompileOnly("org.postgresql", "postgresql", Versions.postgre)
     testCompileOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
-    implementation("com.h2database", "h2", Versions.h2)
+    compileOnly("com.h2database", "h2", Versions.h2)
     testCompileOnly("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
@@ -1,0 +1,70 @@
+package org.jetbrains.exposed.sql.tests.h2
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Assume
+import org.junit.Test
+
+class ConnectionPoolTests {
+    private val hikariDataSource1 by lazy {
+        HikariDataSource(
+            HikariConfig().apply {
+                jdbcUrl = "jdbc:h2:mem:hikariDB1"
+                maximumPoolSize = 10
+            }
+        )
+    }
+
+    private val hikariDB1 by lazy {
+        Database.connect(hikariDataSource1)
+    }
+
+    @Test
+    fun testSuspendTransactionsExceedingPoolSize() {
+        Assume.assumeTrue(TestDB.H2 in TestDB.enabledInTests())
+        transaction(db = hikariDB1) {
+            SchemaUtils.create(TestTable)
+        }
+
+        val exceedsPoolSize = (hikariDataSource1.maximumPoolSize * 2 + 1).coerceAtMost(50)
+        runBlocking {
+            repeat(exceedsPoolSize) {
+                launch {
+                    newSuspendedTransaction {
+                        delay(100)
+                        TestEntity.new { testValue = "test$it" }
+                    }
+                }
+            }
+        }
+
+        transaction(db = hikariDB1) {
+            assertEquals(exceedsPoolSize, TestEntity.all().toList().count())
+
+            SchemaUtils.drop(TestTable)
+        }
+    }
+
+    object TestTable : IntIdTable("HIKARI_TESTER") {
+        val testValue = varchar("test_value", 32)
+    }
+
+    class TestEntity(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<TestEntity>(TestTable)
+
+        var testValue by TestTable.testValue
+    }
+}


### PR DESCRIPTION
If the `maximumPoolSize` of a `HikariDataSource` is exceeded, any active connections made through `newSuspendedTransaction()` are not released back into the pool after job completion. This leads to a connection timeout exception when attempting to get more connections.

`resetIfClosed()`, invoked in `suspendedTransactionAsyncInternal()`, calls `getConnection()` to check if a transaction is closed (may happen after a repetition attempt fails), so that it can be properly reset for another attempt. This blocks the connections being released.

The function was introduced in [PR #1774 ](https://github.com/JetBrains/Exposed/pull/1774) and should not be necessary for the first loop, as the transaction is created with an open connection.

Now `resetIfClosed()` is only called on subsequent repetition attempt loops.

**Unit test**:
- No unit test has been included as it would require including a permanent dependency on Hikari CP in the `exposed-tests` module.
- To test on the branch, include the following in `exposed-tests/build.gradle.kts`, before running the test provided in the original YT issue:
```kt
implementation("com.zaxxer:HikariCP:5.0.1")
implementation("com.h2database", "h2", Versions.h2)
// compileOnly("com.h2database", "h2", Versions.h2)
```