### PR TITLE
fix!: EXPOSED-150 Auto-quoted column names change case across databases

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -752,6 +752,9 @@ public final class org/jetbrains/exposed/sql/Exists : org/jetbrains/exposed/sql/
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
+public abstract interface annotation class org/jetbrains/exposed/sql/ExperimentalKeywordApi : java/lang/annotation/Annotation {
+}
+
 public abstract class org/jetbrains/exposed/sql/Expression {
 	public static final field Companion Lorg/jetbrains/exposed/sql/Expression$Companion;
 	public fun <init> ()V

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -569,7 +569,7 @@ public final class org/jetbrains/exposed/sql/Database$Companion {
 
 public final class org/jetbrains/exposed/sql/DatabaseConfig {
 	public static final field Companion Lorg/jetbrains/exposed/sql/DatabaseConfig$Companion;
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDefaultIsolationLevel ()I
 	public final fun getDefaultMaxRepetitionDelay ()J
@@ -581,6 +581,7 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig {
 	public final fun getKeepLoadedReferencesOutOfTransaction ()Z
 	public final fun getLogTooMuchResultSetsThreshold ()I
 	public final fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public final fun getPreserveKeywordCasing ()Z
 	public final fun getSqlLogger ()Lorg/jetbrains/exposed/sql/SqlLogger;
 	public final fun getUseNestedTransactions ()Z
 	public final fun getWarnLongQueriesDuration ()Ljava/lang/Long;
@@ -588,8 +589,8 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig {
 
 public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public fun <init> ()V
-	public fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;I)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZ)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDefaultIsolationLevel ()I
 	public final fun getDefaultMaxRepetitionDelay ()J
@@ -601,6 +602,7 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public final fun getKeepLoadedReferencesOutOfTransaction ()Z
 	public final fun getLogTooMuchResultSetsThreshold ()I
 	public final fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public final fun getPreserveKeywordCasing ()Z
 	public final fun getSqlLogger ()Lorg/jetbrains/exposed/sql/SqlLogger;
 	public final fun getUseNestedTransactions ()Z
 	public final fun getWarnLongQueriesDuration ()Ljava/lang/Long;
@@ -615,6 +617,7 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public final fun setKeepLoadedReferencesOutOfTransaction (Z)V
 	public final fun setLogTooMuchResultSetsThreshold (I)V
 	public final fun setMaxEntitiesToStoreInCachePerEntity (I)V
+	public final fun setPreserveKeywordCasing (Z)V
 	public final fun setSqlLogger (Lorg/jetbrains/exposed/sql/SqlLogger;)V
 	public final fun setUseNestedTransactions (Z)V
 	public final fun setWarnLongQueriesDuration (Ljava/lang/Long;)V

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -17,7 +17,8 @@ class DatabaseConfig private constructor(
     val keepLoadedReferencesOutOfTransaction: Boolean,
     val explicitDialect: DatabaseDialect?,
     val defaultSchema: Schema?,
-    val logTooMuchResultSetsThreshold: Int
+    val logTooMuchResultSetsThreshold: Int,
+    val preserveKeywordCasing: Boolean,
 ) {
 
     class Builder(
@@ -85,19 +86,16 @@ class DatabaseConfig private constructor(
          * Useful when [eager loading](https://github.com/JetBrains/Exposed/wiki/DAO#eager-loading) is used.
          */
         var keepLoadedReferencesOutOfTransaction: Boolean = false,
-
         /**
          * Set the explicit dialect for a database.
          * This can be useful when working with unsupported dialects which have the same behavior as the one that
          * Exposed supports.
          */
         var explicitDialect: DatabaseDialect? = null,
-
         /**
          * Set the default schema for a database.
          */
         var defaultSchema: Schema? = null,
-
         /**
          * Log too much result sets opened in parallel.
          * The error log will contain the stacktrace of the place in the code where a new result set occurs, and it
@@ -105,6 +103,11 @@ class DatabaseConfig private constructor(
          * 0 value means no log needed.
          */
         var logTooMuchResultSetsThreshold: Int = 0,
+        /**
+         * Toggle whether table and column identifiers that are also keywords should retain their case sensitivity.
+         * Keeping user-defined case sensitivity (value set to `true`) will become the default in future releases.
+         */
+        var preserveKeywordCasing: Boolean = true,
     )
 
     companion object {
@@ -124,7 +127,8 @@ class DatabaseConfig private constructor(
                 keepLoadedReferencesOutOfTransaction = builder.keepLoadedReferencesOutOfTransaction,
                 explicitDialect = builder.explicitDialect,
                 defaultSchema = builder.defaultSchema,
-                logTooMuchResultSetsThreshold = builder.logTooMuchResultSetsThreshold
+                logTooMuchResultSetsThreshold = builder.logTooMuchResultSetsThreshold,
+                preserveKeywordCasing = builder.preserveKeywordCasing,
             )
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -105,14 +105,16 @@ class DatabaseConfig private constructor(
         var logTooMuchResultSetsThreshold: Int = 0,
         /**
          * Toggle whether table and column identifiers that are also keywords should retain their case sensitivity.
-         * Keeping user-defined case sensitivity (value set to `true`) will become the default in future releases.
+         * Keeping user-defined case sensitivity (value set to `true`) may become the default in future releases.
          */
-        var preserveKeywordCasing: Boolean = true,
+        @ExperimentalKeywordApi
+        var preserveKeywordCasing: Boolean = false,
     )
 
     companion object {
         operator fun invoke(body: Builder.() -> Unit = {}): DatabaseConfig {
             val builder = Builder().apply(body)
+            @OptIn(ExperimentalKeywordApi::class)
             return DatabaseConfig(
                 sqlLogger = builder.sqlLogger ?: Slf4jSqlDebugLogger,
                 useNestedTransactions = builder.useNestedTransactions,
@@ -133,3 +135,11 @@ class DatabaseConfig private constructor(
         }
     }
 }
+
+@RequiresOptIn(
+    message = "This API is experimental and the behavior defined by setting this value to 'true' may become the default " +
+        "in future releases. Its usage must be marked with '@OptIn(org.jetbrains.exposed.sql.ExperimentalKeywordApi::class)' " +
+        "or '@org.jetbrains.exposed.sql.ExperimentalKeywordApi'."
+)
+@Target(AnnotationTarget.PROPERTY)
+annotation class ExperimentalKeywordApi

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1221,13 +1221,10 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     private fun String.warnIfUnflaggedKeyword() {
         val warn = TransactionManager.currentOrNull()?.db?.identifierManager?.isUnflaggedKeyword(this) == true
         if (warn) {
-            val actual = inProperCase()
-            if (this != actual) {
-                exposedLogger.warn(
-                    "Keyword identifier used: '$this'. Case sensitivity is not kept when quoted by default: '$actual'. " +
-                        "To keep case sensitivity, opt-in and set 'preserveKeywordCasing' to true in DatabaseConfig block."
-                )
-            }
+            exposedLogger.warn(
+                "Keyword identifier used: '$this'. Case sensitivity may not be kept when quoted by default: '${inProperCase()}'. " +
+                    "To keep case sensitivity, opt-in and set 'preserveKeywordCasing' to true in DatabaseConfig block."
+            )
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
@@ -66,7 +66,7 @@ abstract class IdentifierManagerApi {
             alreadyQuoted && supportsMixedQuotedIdentifiers -> identity
             alreadyQuoted && isUpperCaseQuotedIdentifiers -> identity.uppercase()
             alreadyQuoted && isLowerCaseQuotedIdentifiers -> identity.lowercase()
-            supportsMixedIdentifiers -> identity
+            supportsMixedIdentifiers || keywords.any { identity.equals(it, true) } -> identity
             oracleVersion != OracleVersion.NonOracle -> identity.uppercase()
             isUpperCaseIdentifiers -> identity.uppercase()
             isLowerCaseIdentifiers -> identity.lowercase()

--- a/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyTests.kt
+++ b/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyTests.kt
@@ -80,7 +80,7 @@ open class MoneyBaseTest : DatabaseTestsBase() {
 
     @Test
     fun testNullableCompositeColumnInsertAndSelect() {
-        val table = object : IntIdTable("Table") {
+        val table = object : IntIdTable("CompositeTable") {
             val composite_money = compositeMoney(8, AMOUNT_SCALE, "composite_money").nullable()
         }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -25,16 +25,17 @@ class ConnectionTests : DatabaseTestsBase() {
             val columnMetadata = connection.metadata {
                 requireNotNull(columns(People)[People])
             }.toSet()
+            // 'name' is a reserved keyword and is quoted with case unchanged
             val expected = when ((db.dialect as H2Dialect).isSecondVersion) {
                 false -> setOf(
                     ColumnMetadata("ID", Types.BIGINT, false, 19, true, null),
-                    ColumnMetadata("NAME", Types.VARCHAR, true, 80, false, null),
+                    ColumnMetadata("name", Types.VARCHAR, true, 80, false, null),
                     ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
                     ColumnMetadata("AGE", Types.INTEGER, false, 10, false, "18"),
                 )
                 true -> setOf(
                     ColumnMetadata("ID", Types.BIGINT, false, 64, true, null),
-                    ColumnMetadata("NAME", Types.VARCHAR, true, 80, false, null),
+                    ColumnMetadata("name", Types.VARCHAR, true, 80, false, null),
                     ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
                     ColumnMetadata("AGE", Types.INTEGER, false, 32, false, "18"),
                 )

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -25,17 +25,16 @@ class ConnectionTests : DatabaseTestsBase() {
             val columnMetadata = connection.metadata {
                 requireNotNull(columns(People)[People])
             }.toSet()
-            // 'name' is a reserved keyword and is quoted with case unchanged
             val expected = when ((db.dialect as H2Dialect).isSecondVersion) {
                 false -> setOf(
                     ColumnMetadata("ID", Types.BIGINT, false, 19, true, null),
-                    ColumnMetadata("name", Types.VARCHAR, true, 80, false, null),
+                    ColumnMetadata("NAME", Types.VARCHAR, true, 80, false, null),
                     ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
                     ColumnMetadata("AGE", Types.INTEGER, false, 10, false, "18"),
                 )
                 true -> setOf(
                     ColumnMetadata("ID", Types.BIGINT, false, 64, true, null),
-                    ColumnMetadata("name", Types.VARCHAR, true, 80, false, null),
+                    ColumnMetadata("NAME", Types.VARCHAR, true, 80, false, null),
                     ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
                     ColumnMetadata("AGE", Types.INTEGER, false, 32, false, "18"),
                 )

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -88,7 +88,7 @@ class DDLTests : DatabaseTestsBase() {
             val expectedSelect = "SELECT $tableName.$publicName, $tableName.$dataName, $tableName.$constraintName FROM $tableName"
             keywordTable.selectAll().also {
                 assertEquals(expectedSelect, it.prepareSQL(this, prepared = false))
-            }.single()
+            }
 
             // check that identifiers match with returned jdbc metadata
             val statements = SchemaUtils.statementsRequiredToActualizeScheme(keywordTable)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -25,7 +25,6 @@ import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Assume
 import org.junit.Test
 import org.postgresql.util.PGobject
-import java.sql.Connection
 import java.util.*
 import kotlin.random.Random
 import kotlin.test.assertNotNull
@@ -127,10 +126,13 @@ class DDLTests : DatabaseTestsBase() {
     @Test
     fun testKeywordIdentifiersWithOptOutFlag() {
         Assume.assumeTrue(TestDB.H2 in TestDB.enabledDialects())
-        val db = Database.connect("jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;", "org.h2.Driver", "root", "", databaseConfig = DatabaseConfig {
-            defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED
-            preserveKeywordCasing = false
-        })
+        val db = Database.connect(
+            url = "jdbc:h2:mem:flagtest;DB_CLOSE_DELAY=-1;",
+            driver = "org.h2.Driver",
+            user = "root",
+            password = "",
+            databaseConfig = DatabaseConfig { preserveKeywordCasing = false }
+        )
 
         val keywords = listOf("Integer", "name")
         val tester = object : Table(keywords[0]) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -65,6 +65,6 @@ class ThreadLocalManagerTest : DatabaseTestsBase() {
     }
 }
 
-object RollbackTable : IntIdTable() {
+object RollbackTable : IntIdTable("rollbackTable") {
     val value = varchar("value", 20)
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/LikeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/LikeTests.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 
 class LikeTests : DatabaseTestsBase() {
 
-    object t : Table("table") {
+    object t : Table("testTable") {
         val id = integer("charnum")
         val char = varchar("thechar", 255)
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -246,8 +246,8 @@ class SelectTests : DatabaseTestsBase() {
 
     @Test
     fun `test select on nullable reference column`() {
-        val firstTable = object : IntIdTable("first") {}
-        val secondTable = object : IntIdTable("second") {
+        val firstTable = object : IntIdTable("firstTable") {}
+        val secondTable = object : IntIdTable("secondTable") {
             val firstOpt = optReference("first", firstTable)
         }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/BooleanColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/BooleanColumnTypeTests.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.junit.Test
 
 class BooleanColumnTypeTests : DatabaseTestsBase() {
-    object BooleanTable : IntIdTable() {
+    object BooleanTable : IntIdTable("booleanTable") {
         val boolColumn = bool("boolColumn")
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/CharColumnType.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/CharColumnType.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.junit.Test
 
 class CharColumnType : DatabaseTestsBase() {
-    object CharTable : IntIdTable() {
+    object CharTable : IntIdTable("charTable") {
         val charColumn = char("charColumn")
     }
 


### PR DESCRIPTION
Currently, if [a reserved keyword](https://github.com/JetBrains/Exposed/blob/main/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Keywords.kt#L8) is used as a table or column name, Exposed first changes the case based on the proper database case, then quotes the name.

This means that a table object will create different-cased quoted identifiers in different databases, which is problematic when using migration scripts to enable use of a table object across databases:
```kt
object Tester : Table("Public") {
    val col = integer("integer")
}

// PostgreSQL -> CREATE TABLE IF NOT EXISTS "public" ("integer" INT NOT NULL)
// H2         -> CREATE TABLE IF NOT EXISTS "PUBLIC" ("INTEGER" INT NOT NULL)
// MySQL      -> CREATE TABLE IF NOT EXISTS `Public` (`integer` INT NOT NULL)
```

This fix ensures that a reserved keyword used as an identifier is only ever quoted, so the exact case provided by the user will be retained.

**Index Names:**
Because of this fix, any auto-generated index names would retain column case, causing strings like `TABLE_name_IDX`.
To ensure that these index names do not have breaking changes, now `inProperCase()` is only applied to the final `buildString`, rather than each separate string component.
This is what is already done for auto-generated foreign-key constraint names.

**BREAKING CHANGES:**
- **H2 & Oracle**: This fix primarily affects these databases as they both support folding identifiers to upper case.
    - e.g. If a column was called "name", it would have previously been sent to the DB as "NAME", but will now remain as "name".
- **PostgreSQL**: Supports folding identifiers to lower case, so this fix only affects keyword identifiers that are provided in upper-/mixed-case.
    - e.g. If a column was called "NAME", it would have previously been sent to the DB as "name", but will now remain as "NAME".

---
**OPT-IN FLAG:**
As per user input (in [issue 683](https://github.com/JetBrains/Exposed/issues/683), [issue 1658](https://github.com/JetBrains/Exposed/issues/1658), and related [EXPOSED 157](https://youtrack.jetbrains.com/issue/EXPOSED-157/Support-table-identifier-case-sensitivity-by-enabling-auto-quote)), a temporary flag has been introduced, `preserveKeywordCasing`. It is available in the `DatabaseConfig` block and defaults to `false`. Users can `@OptIn` and set this value to true to implement the fix.

A **warning** will also be logged for every identifier that is found to be a keyword when a table is created, if the user has not opt-in. The warning indicates that this fix may become the default with the implication that changes should be made to table identifiers if the new behavior clashes with any migration schema.

Internal functions that use the check are annotated as `@Deprecated` to prevent further internal use.

---

**BREAKING CHANGES in test suites (only with Oracle):**
- Test table objects that both use reserved keywords as table names (e.g. "public") and have an auto-increment column (any `IdTable` subclass) were failing with error `ORA-04043: Object "PUBLIC" does not exist`.
    - This is a [documented Oracle JDBC driver bug](https://stackoverflow.com/questions/58099523/ora-04043-on-insert/60115789) that only happens when such a table is used with an insert statement and `connection.prepareStatement(String, Array<String>)` and auto-generated keys are fetched.
    - *Solution A*: Update the Oracle JDBC driver version from the current 12.2.0.1 to at minimum 21.1.0.0. This should ideally be investigated in the future, but cannot currently be implemented. If updated, all tests that use `batchInsert()` or `statement.addBatch()` would fail with the error `Operation not allowed: DML Returning cannot be batched`.
    - *Solution B (implemented)*: Change all `IdTable` test tables to no longer use reserved keywords as table names.