### PR TITLE
fix: EXPOSED-151 Quoted identifiers cause incorrect schema validation

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -353,6 +353,7 @@ public final class org/jetbrains/exposed/sql/Column : org/jetbrains/exposed/sql/
 	public fun modifyStatement ()Ljava/util/List;
 	public final fun modifyStatements (Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
 	public final fun nameInDatabaseCase ()Ljava/lang/String;
+	public final fun nameUnquoted ()Ljava/lang/String;
 	public final fun referee ()Lorg/jetbrains/exposed/sql/Column;
 	public final fun setDefaultValueFun (Lkotlin/jvm/functions/Function0;)V
 	public final fun setForeignKey (Lorg/jetbrains/exposed/sql/ForeignKeyConstraint;)V
@@ -2258,6 +2259,7 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public static synthetic fun mediumText$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public fun modifyStatement ()Ljava/util/List;
 	public final fun nameInDatabaseCase ()Ljava/lang/String;
+	public final fun nameInDatabaseCaseUnquoted ()Ljava/lang/String;
 	public final fun nullable (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun nullable (Lorg/jetbrains/exposed/sql/CompositeColumn;)Lorg/jetbrains/exposed/sql/CompositeColumn;
 	public final fun optReference (Ljava/lang/String;Lorg/jetbrains/exposed/dao/id/IdTable;Lorg/jetbrains/exposed/sql/ReferenceOption;Lorg/jetbrains/exposed/sql/ReferenceOption;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
@@ -44,7 +45,16 @@ class Column<T>(
     /** Returns the list of DDL statements that create this column. */
     val ddl: List<String> get() = createStatement()
 
+    /** Returns the column name in proper case. */
     fun nameInDatabaseCase(): String = name.inProperCase()
+
+    /**
+     * Returns the column name with wrapping double-quotation characters removed.
+     *
+     * **Note** If used with MySQL or MariaDB, the column name is returned unchanged, since these databases use a
+     * backtick character as the identifier quotation.
+     */
+    fun nameUnquoted(): String = if (currentDialect is MysqlDialect) name else name.trim('\"')
 
     private val isLastColumnInPK: Boolean
         get() = this == table.primaryKey?.columns?.last()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -241,7 +241,7 @@ object SchemaUtils {
             // create columns
             val thisTableExistingColumns = existingTablesColumns[table].orEmpty()
             val existingTableColumns = table.columns.mapNotNull { column ->
-                val existingColumn = thisTableExistingColumns.find { column.name.equals(it.name, true) }
+                val existingColumn = thisTableExistingColumns.find { column.nameUnquoted().equals(it.name, true) }
                 if (existingColumn != null) column to existingColumn else null
             }.toMap()
             val missingTableColumns = table.columns.filter { it !in existingTableColumns }
@@ -266,7 +266,7 @@ object SchemaUtils {
                         val incorrectDefaults = existingCol.defaultDbValue != col.dbDefaultValue?.let {
                             dataTypeProvider.dbDefaultToString(col, it)
                         }
-                        val incorrectCaseSensitiveName = existingCol.name.inProperCase() != col.nameInDatabaseCase()
+                        val incorrectCaseSensitiveName = existingCol.name.inProperCase() != col.nameUnquoted().inProperCase()
                         ColumnDiff(incorrectNullability, incorrectAutoInc, incorrectDefaults, incorrectCaseSensitiveName)
                     }
                     .filterValues { it.hasDifferences() }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -368,6 +368,18 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      */
     fun nameInDatabaseCase(): String = tableName.inProperCase()
 
+    /**
+     * Returns the table name, in proper case, with wrapping single- and double-quotation characters removed.
+     *
+     * **Note** If used with MySQL or MariaDB, the column name is returned unchanged, since these databases use a
+     * backtick character as the identifier quotation.
+     */
+    fun nameInDatabaseCaseUnquoted(): String = if (currentDialect is MysqlDialect) {
+        nameInDatabaseCase()
+    } else {
+        nameInDatabaseCase().trim('\"', '\'')
+    }
+
     override fun describe(s: Transaction, queryBuilder: QueryBuilder): Unit = queryBuilder { append(s.identity(this@Table)) }
 
     // Join operations

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/Default.kt
@@ -1145,8 +1145,15 @@ abstract class VendorDialect(
         return allTables.any {
             when {
                 tableScheme != null -> it == table.nameInDatabaseCase()
-                scheme.isEmpty() -> it == table.nameInDatabaseCase()
-                else -> it == "$scheme.${table.tableNameWithoutScheme}".inProperCase()
+                scheme.isEmpty() -> it == table.nameInDatabaseCaseUnquoted()
+                else -> {
+                    val sanitizedTableName = if (currentDialect is MysqlDialect) {
+                        table.tableNameWithoutScheme
+                    } else {
+                        table.tableNameWithoutSchemeSanitized
+                    }
+                    it == "$scheme.$sanitizedTableName".inProperCase()
+                }
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -625,4 +625,24 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
         }
     }
+
+    @Test
+    fun testCreateTableWithQuotedIdentifiers() {
+        val identifiers = listOf("\"IdentifierTable\"", "\"IDentiFierCoLUmn\"")
+        val quotedTable = object : Table(identifiers[0]) {
+            val column1 = varchar(identifiers[1], 32)
+        }
+
+        withDb {
+            try {
+                SchemaUtils.createMissingTablesAndColumns(quotedTable)
+                assertTrue(quotedTable.exists())
+
+                val statements = SchemaUtils.statementsRequiredToActualizeScheme(quotedTable)
+                assertTrue(statements.isEmpty())
+            } finally {
+                SchemaUtils.drop(quotedTable)
+            }
+        }
+    }
 }


### PR DESCRIPTION
If a table object is created with user-quoted table and/or column names, attempting to validate it using either `SchemaUtils.createMissingTablesAndColumns()` or `SchemaUtils.statementsRequiredToActualizeScheme()` incorrectly generates CREATE and ALTER statements.

This happens because metadata returned by the database does not generally include quotes.
So any comparison check with the cached identifiers (which do include quotes) in `Table.exists()` or `SchemaUtils` functions causes false negative results.

Table and column functions that process/unquote the respective names are introduced to ensure a more accurate equality check with metadata.