### PR TITLE
fix: Remove false warning log

### DIFF
--- a/detekt/detekt-config.yml
+++ b/detekt/detekt-config.yml
@@ -18,6 +18,9 @@ formatting:
     NoMultipleSpaces:
         active: true
         autoCorrect: false
+    SpacingAroundUnaryOperator:
+        active: true
+        autoCorrect: true
 
 style:
     MaxLineLength:

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -267,7 +267,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
                     val isPKColumn = column.table.primaryKey?.columns?.contains(column) == true
 
                     if (column.columnType.nullable ||
-                        (defaultValue != null && column.defaultValueFun == null && ! currentDialect.isAllowedAsColumnDefault(defaultValue))
+                        (defaultValue != null && column.defaultValueFun == null && !currentDialect.isAllowedAsColumnDefault(defaultValue))
                     ) {
                         append(" NULL")
                     } else if (!isPKColumn) {

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testCompileOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
     compileOnly("com.h2database", "h2", Versions.h2)
     testCompileOnly("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
+    testImplementation("io.github.hakky54:logcaptor:2.9.0")
 }
 
 tasks.withType<Test>().configureEach {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
+import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
@@ -190,7 +191,10 @@ class JoinTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testNoWarningsOnLeftJoinRegression() {
+    @Test
+    fun testNoWarningsOnLeftJoinRegression() {
+        val logCaptor = LogCaptor.forName(exposedLogger.name)
+
         val MainTable = object : Table("maintable") {
             val id = integer("idCol")
         }
@@ -208,7 +212,9 @@ class JoinTests : DatabaseTestsBase() {
                 .single()
                 .getOrNull(JoinTable.data)
 
-            // Assert no logging took place. No idea how to.
+            // Assert no logging took place
+            assertTrue(logCaptor.warnLogs.isEmpty())
+            assertTrue(logCaptor.errorLogs.isEmpty())
         }
     }
 }


### PR DESCRIPTION
This [warning](https://github.com/JetBrains/Exposed/issues/1683) was first eliminated [here](https://github.com/JetBrains/Exposed/pull/541/files). Then it was accidentally introduced again [here](https://github.com/JetBrains/Exposed/commit/77f11a99adf18e7b0db863b58c68d2d9ab8cd1ff) because of the change made to the `getOrNull` function.

- To fix this, I moved the logic in the `get` function to a new function, `getInternal`, that has a Boolean parameter `checkNullability` which it uses to decide to whether or not to check for the column's nullability and log a warning.

- A new test dependency was added ([io.github.hakky54:logcaptor](https://github.com/Hakky54/log-captor)) to assert that no logging took place.