### PR TITLE
feat: EXPOSED-78 Support database-generated values for columns

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2215,6 +2215,7 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public fun crossJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public final fun customEnumeration (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun customEnumeration$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun dbGenerated (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun decimal (Ljava/lang/String;II)Lorg/jetbrains/exposed/sql/Column;
 	public final fun default (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun default (Lorg/jetbrains/exposed/sql/CompositeColumn;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/CompositeColumn;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2215,7 +2215,7 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public fun crossJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public final fun customEnumeration (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun customEnumeration$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
-	public final fun dbGenerated (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun databaseGenerated (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun decimal (Ljava/lang/String;II)Lorg/jetbrains/exposed/sql/Column;
 	public final fun default (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun default (Lorg/jetbrains/exposed/sql/CompositeColumn;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/CompositeColumn;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -39,6 +39,8 @@ class Column<T>(
 
     fun defaultValueInDb() = dbDefaultValue
 
+    internal var isGeneratedInDb: Boolean = false
+
     /** Appends the SQL representation of this column to the specified [queryBuilder]. */
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = TransactionManager.current().fullIdentity(this@Column, queryBuilder)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -39,7 +39,7 @@ class Column<T>(
 
     fun defaultValueInDb() = dbDefaultValue
 
-    internal var isGeneratedInDb: Boolean = false
+    internal var isDatabaseGenerated: Boolean = false
 
     /** Appends the SQL representation of this column to the specified [queryBuilder]. */
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = TransactionManager.current().fullIdentity(this@Column, queryBuilder)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -726,8 +726,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     }
 
     // Potential names: readOnly, generatable, dbGeneratable, dbGenerated, generated, generatedDefault, generatedInDb
-    fun <T> Column<T>.dbGenerated(): Column<T> = apply {
-        isGeneratedInDb = true
+    fun <T> Column<T>.databaseGenerated(): Column<T> = apply {
+        isDatabaseGenerated = true
     }
 
     /** UUID column will auto generate its value on a client side just before an insert. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -725,6 +725,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         defaultValueFun = defaultValue
     }
 
+    // Potential names: readOnly, generatable, dbGeneratable, dbGenerated, generated, generatedDefault, generatedInDb
+    fun <T> Column<T>.dbGenerated(): Column<T> = apply {
+        isGeneratedInDb = true
+    }
+
     /** UUID column will auto generate its value on a client side just before an insert. */
     fun Column<UUID>.autoGenerate(): Column<UUID> = clientDefault { UUID.randomUUID() }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BaseBatchInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BaseBatchInsertStatement.kt
@@ -18,7 +18,7 @@ abstract class BaseBatchInsertStatement(
 
     internal val data = ArrayList<MutableMap<Column<*>, Any?>>()
 
-    private fun Column<*>.isDefaultable() = columnType.nullable || defaultValueFun != null || isGeneratedInDb
+    private fun Column<*>.isDefaultable() = columnType.nullable || defaultValueFun != null || isDatabaseGenerated
 
     override operator fun <S> set(column: Column<S>, value: S) {
         if (data.size > 1 && column !in data[data.size - 2] && !column.isDefaultable()) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BaseBatchInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BaseBatchInsertStatement.kt
@@ -18,7 +18,7 @@ abstract class BaseBatchInsertStatement(
 
     internal val data = ArrayList<MutableMap<Column<*>, Any?>>()
 
-    private fun Column<*>.isDefaultable() = columnType.nullable || defaultValueFun != null
+    private fun Column<*>.isDefaultable() = columnType.nullable || defaultValueFun != null || isGeneratedInDb
 
     override operator fun <S> set(column: Column<S>, value: S) {
         if (data.size > 1 && column !in data[data.size - 2] && !column.isDefaultable()) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -1403,7 +1403,7 @@ class EntityTests : DatabaseTestsBase() {
 
     object CreditCards : IntIdTable("CreditCards") {
         val number = varchar("number", 16)
-        val spendingLimit = ulong("spendingLimit").dbGenerated()
+        val spendingLimit = ulong("spendingLimit").databaseGenerated()
     }
 
     class CreditCard(id: EntityID<Int>) : IntEntity(id) {
@@ -1414,9 +1414,8 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testDbGeneratedDefault() {
+    fun testDatabaseGeneratedValues() {
         withTables(excludeSettings = listOf(TestDB.SQLITE), CreditCards) { testDb ->
-            addLogger(StdOutSqlLogger)
             when (testDb) {
                 TestDB.POSTGRESQL, TestDB.POSTGRESQLNG -> {
                     // The value can also be set using a SQL trigger
@@ -1446,10 +1445,10 @@ class EntityTests : DatabaseTestsBase() {
                 }
                 else -> {
                     // This table is only used to get the statement that adds the DEFAULT value, and use it with exec
-                    val CreditCards2 = object : IntIdTable("CreditCards") {
+                    val creditCards2 = object : IntIdTable("CreditCards") {
                         val spendingLimit = ulong("spendingLimit").default(10000uL)
                     }
-                    val missingStatements = SchemaUtils.addMissingColumnsStatements(CreditCards2)
+                    val missingStatements = SchemaUtils.addMissingColumnsStatements(creditCards2)
                     missingStatements.forEach {
                         exec(it)
                     }


### PR DESCRIPTION
This feature will enable marking a column as `databaseGenerated` to be able to omit setting it when inserting a new record without getting an error. The value for the column can be set with TRIGGER or DEFAULT, for example.