### PR TITLE
chore: Bump Exposed version from 0.42.1 to 0.43.0, and add 0.43.0 changes to ChangeLog.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,52 +79,52 @@ repositories {
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-core</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-crypt</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-dao</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-java-time</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-jdbc</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-jodatime</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-json</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-kotlin-datetime</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-money</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-spring-boot-starter</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
 </dependencies>
 
@@ -134,20 +134,20 @@ repositories {
 
 ```groovy
 dependencies {
-    implementation 'org.jetbrains.exposed:exposed-core:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-crypt:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-dao:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-jdbc:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-core:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-crypt:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-dao:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-jdbc:0.43.0'
     
-    implementation 'org.jetbrains.exposed:exposed-jodatime:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-jodatime:0.43.0'
     // or
-    implementation 'org.jetbrains.exposed:exposed-java-time:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-java-time:0.43.0'
     // or
-    implementation 'org.jetbrains.exposed:exposed-kotlin-datetime:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-kotlin-datetime:0.43.0'
     
-    implementation 'org.jetbrains.exposed:exposed-json:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-money:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-json:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-money:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.43.0'
 }
 ```
 
@@ -178,7 +178,7 @@ dependencies {
 and in `gradle.properties`
 
 ```
-exposedVersion=0.42.1
+exposedVersion=0.43.0
 ```
 
 ## Samples

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,3 +1,34 @@
+# 0.43.0
+Infrastructure:
+* Kotlin 1.9.10
+
+Features:
+* feat: EXPOSED-85 Add support for changing default value in SQL Server by @joc-a in https://github.com/JetBrains/Exposed/pull/1812
+
+Bug fixes:
+* fix: EXPOSED-107 Inaccurate UByte column type mapping by @bog-walk in https://github.com/JetBrains/Exposed/pull/1808
+* fix: EXPOSED-108 Incorrect mapping for UInt data type by @bog-walk in https://github.com/JetBrains/Exposed/pull/1809
+* fix: Inaccurate drop database statement in Oracle by @bog-walk in https://github.com/JetBrains/Exposed/pull/1807
+* test: Fix failing datetime comparison tests in Oracle by @bog-walk in https://github.com/JetBrains/Exposed/pull/1813
+* fix: EXPOSED-111 Allow check constraint statements in MySQL8 by @bog-walk in https://github.com/JetBrains/Exposed/pull/1817
+* fix: EXPOSED-116 UUID conversion error with upsert in H2 by @bog-walk in https://github.com/JetBrains/Exposed/pull/1823
+* fix: EXPOSED-112 SchemaUtils fails to compare default CURRENT_TIMESTAMP by @bog-walk in https://github.com/JetBrains/Exposed/pull/1819
+* fix: EXPOSED-123 ExposedBlob.getBytes() fails on Oracle with IOException by @bog-walk in https://github.com/JetBrains/Exposed/pull/1824
+* fix: EXPOSED-128 Update with Join and Where clause fails in Oracle by @bog-walk in https://github.com/JetBrains/Exposed/pull/1825
+* fix: EXPOSED-135 Oracle does not use setSchema value as currentScheme by @bog-walk in https://github.com/JetBrains/Exposed/pull/1828
+* fix: EXPOSED-122 Fix timestampWithTimeZone tests in Oracle by @bog-walk in https://github.com/JetBrains/Exposed/pull/1829
+* fix: EXPOSED-137 SET DEFAULT reference option should not be supported in Oracle by @bog-walk in https://github.com/JetBrains/Exposed/pull/1830
+* test: Fix failing Oracle tests in exposed-tests by @bog-walk in https://github.com/JetBrains/Exposed/pull/1831
+* fix: EXPOSED-127 Default values for JSON columns are not quoted by @bog-walk in https://github.com/JetBrains/Exposed/pull/1827
+* fix: EXPOSED-145 Quoted table name breaks CREATE SEQUENCE in Oracle by @bog-walk in https://github.com/JetBrains/Exposed/pull/1836
+* fix: EXPOSED-130 Logger throws ClassCastException with JSON and ListSerializer by @bog-walk in https://github.com/JetBrains/Exposed/pull/1835
+* fix: EXPOSED-133 Suspend transactions blocking Hikari connection pool by @bog-walk in https://github.com/JetBrains/Exposed/pull/1837
+* fix: EXPOSED-151 Quoted identifiers cause incorrect schema validation by @bog-walk in https://github.com/JetBrains/Exposed/pull/1842
+* fix: Remove false warning log by @joc-a in https://github.com/JetBrains/Exposed/pull/1843
+
+Breaking changes:
+* [Breaking changes](BREAKING_CHANGES.md)
+
 # 0.42.1
 Infrastructure:
 * Kotlin 1.9.0

--- a/documentation-website/Writerside/topics/Getting-Started.md
+++ b/documentation-website/Writerside/topics/Getting-Started.md
@@ -18,17 +18,17 @@
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-core</artifactId>
-      <version>0.42.1</version>
+      <version>0.43.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-dao</artifactId>
-      <version>0.42.1</version>
+      <version>0.43.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-jdbc</artifactId>
-      <version>0.42.1</version>
+      <version>0.43.0</version>
     </dependency>
 </dependencies>
 ]]>
@@ -37,7 +37,7 @@
     <tab title="Gradle Kotlin Script">
         <code-block lang="kotlin">
 <![CDATA[
-val exposedVersion: String = "0.42.1"
+val exposedVersion: String = "0.43.0"
 
 dependencies {
 implementation("org.jetbrains.exposed:exposed-core", exposedVersion)

--- a/documentation-website/Writerside/topics/Modules-Documentation.md
+++ b/documentation-website/Writerside/topics/Modules-Documentation.md
@@ -95,52 +95,52 @@ Dependencies mapping listed below is similar (by functionality) to the previous 
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-core</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-crypt</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-dao</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-java-time</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-jdbc</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-jodatime</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-json</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-kotlin-datetime</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-money</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-spring-boot-starter</artifactId>
-        <version>0.42.1</version>
+        <version>0.43.0</version>
     </dependency>
 </dependencies>
 
@@ -150,20 +150,20 @@ Dependencies mapping listed below is similar (by functionality) to the previous 
 
 ```groovy
 dependencies {
-    implementation 'org.jetbrains.exposed:exposed-core:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-crypt:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-dao:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-jdbc:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-core:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-crypt:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-dao:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-jdbc:0.43.0'
     
-    implementation 'org.jetbrains.exposed:exposed-jodatime:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-jodatime:0.43.0'
     // or
-    implementation 'org.jetbrains.exposed:exposed-java-time:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-java-time:0.43.0'
     // or
-    implementation 'org.jetbrains.exposed:exposed-kotlin-datetime:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-kotlin-datetime:0.43.0'
     
-    implementation 'org.jetbrains.exposed:exposed-json:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-money:0.42.1'
-    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-json:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-money:0.43.0'
+    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.43.0'
 }
 ```
 
@@ -194,7 +194,7 @@ dependencies {
 and in `gradle.properties`
 
 ```
-exposedVersion=0.42.1
+exposedVersion=0.43.0
 ```
 
 ### JDBC driver and logging

--- a/exposed-bom/README.md
+++ b/exposed-bom/README.md
@@ -17,7 +17,7 @@ Bill of Materials for all Exposed modules
         <dependency>
             <groupId>org.jetbrains.exposed</groupId>
             <artifactId>exposed-bom</artifactId>
-            <version>0.42.1</version>
+            <version>0.43.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -51,7 +51,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.exposed:exposed-bom:0.42.1"))
+    implementation(platform("org.jetbrains.exposed:exposed-bom:0.43.0"))
     implementation("org.jetbrains.exposed", "exposed-core")
     implementation("org.jetbrains.exposed", "exposed-dao")
     implementation("org.jetbrains.exposed", "exposed-jdbc")

--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -18,7 +18,7 @@ This starter will give you the latest version of [Exposed](https://github.com/Je
   <dependency>
     <groupId>org.jetbrains.exposed</groupId>
     <artifactId>exposed-spring-boot-starter</artifactId>
-    <version>0.42.1</version>
+    <version>0.43.0</version>
   </dependency>
 </dependencies>
 ```
@@ -28,7 +28,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.42.1'
+    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.43.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 #
 group=org.jetbrains.exposed
-version=0.42.1
+version=0.43.0

--- a/samples/exposed-ktor/gradle.properties
+++ b/samples/exposed-ktor/gradle.properties
@@ -2,5 +2,5 @@ ktorVersion=2.3.1
 kotlinVersion=1.8.21
 logbackVersion=1.2.11
 kotlin.code.style=official
-exposedVersion=0.42.1
+exposedVersion=0.43.0
 h2Version=2.1.214


### PR DESCRIPTION
To be merged when the release is available on Maven.