### PR TITLE
fix: EXPOSED-158 avoid SQL syntax error of CASE WHEN using nested CASE

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -393,14 +393,14 @@ class CaseWhenElse<T, R : T>(
 
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder {
-            append("CASE ")
+            append("CASE")
             if (caseWhen.value != null) {
-                +caseWhen.value
                 +" "
+                +caseWhen.value
             }
 
             for ((first, second) in caseWhen.cases) {
-                append("WHEN ", first, " THEN ", second)
+                append(" WHEN ", first, " THEN ", second)
             }
 
             append(" ELSE ", elseResult, " END")

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -26,7 +26,6 @@ import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.h2Mode
 import org.junit.Test
 import java.time.*
-import java.time.temporal.ChronoUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -401,7 +400,7 @@ class DefaultsTest : DatabaseTestsBase() {
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
         assertEquals("UTC", ZoneId.systemDefault().id)
 
-        val nowWithTimeZone = OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS)
+        val nowWithTimeZone = OffsetDateTime.now()
         val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
 
         val testTable = object : IntIdTable("t") {

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -26,6 +26,7 @@ import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.h2Mode
 import org.junit.Test
 import java.time.*
+import java.time.temporal.ChronoUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -400,7 +401,7 @@ class DefaultsTest : DatabaseTestsBase() {
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
         assertEquals("UTC", ZoneId.systemDefault().id)
 
-        val nowWithTimeZone = OffsetDateTime.now()
+        val nowWithTimeZone = OffsetDateTime.now().truncatedTo(ChronoUnit.MICROS)
         val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
 
         val testTable = object : IntIdTable("t") {


### PR DESCRIPTION
`toQueryBuilder` of `CaseWhenElse` doesn't write a space before `WHEN`
and the second and subsequent `WHEN` s are concatenated with the previous terms,
resulting in syntax error when the previous ones are, e.g.,  `END` of the nested `CASE` as concatenated `ENDWHEN`.
So fixed it back with the preceding space.