### PR TITLE
fix: Verbose logging introduced by LogCaptor

### DIFF
--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     testCompileOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
     compileOnly("com.h2database", "h2", Versions.h2)
     testCompileOnly("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
-    testImplementation("io.github.hakky54:logcaptor:2.9.0")
 }
 
 tasks.withType<Test>().configureEach {

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestAppender.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestAppender.kt
@@ -1,24 +1,32 @@
 package org.jetbrains.exposed.sql.tests
 
-import org.apache.logging.log4j.core.Filter
+import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.core.Layout
 import org.apache.logging.log4j.core.LogEvent
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.Property
 import org.apache.logging.log4j.core.config.plugins.Plugin
-import org.apache.logging.log4j.core.config.plugins.PluginAttribute
-import org.apache.logging.log4j.core.config.plugins.PluginElement
 import org.apache.logging.log4j.core.config.plugins.PluginFactory
 import java.io.Serializable
 
+/**
+ * Appends log events of a specified level to a list using a layout.
+ */
 @Plugin(name = "TestAppender", category = "Core", elementType = "appender", printObject = false)
 class TestAppender
-private constructor(name: String, filter: Filter?, layout: Layout<out Serializable>) :
-    AbstractAppender(name, filter, layout, true, Property.EMPTY_ARRAY) {
+private constructor(layout: Layout<out Serializable>, val level: Level) : AbstractAppender(
+    "TestAppender",
+    null,
+    layout,
+    true,
+    Property.EMPTY_ARRAY
+) {
     private val log: MutableList<LogEvent> = mutableListOf()
 
     override fun append(event: LogEvent) {
-        log.add(event.toImmutable())
+        if (event.level == level) { // add events of the specified level only
+            log.add(event.toImmutable())
+        }
     }
 
     fun getLog(): List<LogEvent> {
@@ -29,11 +37,10 @@ private constructor(name: String, filter: Filter?, layout: Layout<out Serializab
         @PluginFactory
         @JvmStatic
         fun createAppender(
-            @PluginAttribute("name") name: String,
-            @PluginElement("Layout") layout: Layout<out Serializable>,
-            @PluginElement("Filter") filter: Filter?
+            layout: Layout<out Serializable>,
+            level: Level
         ): TestAppender {
-            return TestAppender(name, filter, layout)
+            return TestAppender(layout, level)
         }
     }
 }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestAppender.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestAppender.kt
@@ -1,0 +1,39 @@
+package org.jetbrains.exposed.sql.tests
+
+import org.apache.logging.log4j.core.Filter
+import org.apache.logging.log4j.core.Layout
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.config.Property
+import org.apache.logging.log4j.core.config.plugins.Plugin
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute
+import org.apache.logging.log4j.core.config.plugins.PluginElement
+import org.apache.logging.log4j.core.config.plugins.PluginFactory
+import java.io.Serializable
+
+@Plugin(name = "TestAppender", category = "Core", elementType = "appender", printObject = false)
+class TestAppender
+private constructor(name: String, filter: Filter?, layout: Layout<out Serializable>) :
+    AbstractAppender(name, filter, layout, true, Property.EMPTY_ARRAY) {
+    private val log: MutableList<LogEvent> = mutableListOf()
+
+    override fun append(event: LogEvent) {
+        log.add(event.toImmutable())
+    }
+
+    fun getLog(): List<LogEvent> {
+        return log
+    }
+
+    companion object {
+        @PluginFactory
+        @JvmStatic
+        fun createAppender(
+            @PluginAttribute("name") name: String,
+            @PluginElement("Layout") layout: Layout<out Serializable>,
+            @PluginElement("Filter") filter: Filter?
+        ): TestAppender {
+            return TestAppender(name, filter, layout)
+        }
+    }
+}

--- a/exposed-tests/src/main/resources/log4j2.xml
+++ b/exposed-tests/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="info">
+<Configuration status="info" packages="org.jetbrains.exposed.sql.tests">
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{ABSOLUTE} %5p %t %c{1}:%M:%L - %m%n"/>
@@ -7,13 +7,18 @@
         <Async name="ASYNC" includeLocation="true">
             <AppenderRef ref="CONSOLE"/>
         </Async>
+        <TestAppender name="TestAppender">
+            <PatternLayout pattern="%d{ABSOLUTE} %5p %t %c{1}:%M:%L - %m%n"/>
+        </TestAppender>
     </Appenders>
     <Loggers>
         <Root level="info">
             <AppenderRef ref="ASYNC"/>
+            <AppenderRef ref="TestAppender"/>
         </Root>
         <Logger name="Exposed" level="info" additivity="false">
             <AppenderRef ref="ASYNC"/>
+            <AppenderRef ref="TestAppender"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/exposed-tests/src/main/resources/log4j2.xml
+++ b/exposed-tests/src/main/resources/log4j2.xml
@@ -7,18 +7,13 @@
         <Async name="ASYNC" includeLocation="true">
             <AppenderRef ref="CONSOLE"/>
         </Async>
-        <TestAppender name="TestAppender">
-            <PatternLayout pattern="%d{ABSOLUTE} %5p %t %c{1}:%M:%L - %m%n"/>
-        </TestAppender>
     </Appenders>
     <Loggers>
         <Root level="info">
             <AppenderRef ref="ASYNC"/>
-            <AppenderRef ref="TestAppender"/>
         </Root>
         <Logger name="Exposed" level="info" additivity="false">
             <AppenderRef ref="ASYNC"/>
-            <AppenderRef ref="TestAppender"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
@@ -1,8 +1,11 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
 import org.apache.logging.log4j.Level
-import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.Filter
 import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.config.Configuration
+import org.apache.logging.log4j.core.layout.PatternLayout
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
@@ -10,6 +13,7 @@ import org.jetbrains.exposed.sql.tests.TestAppender
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.junit.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class JoinTests : DatabaseTestsBase() {
@@ -196,9 +200,7 @@ class JoinTests : DatabaseTestsBase() {
 
     @Test
     fun testNoWarningsOnLeftJoinRegression() {
-        val loggerContext = LogManager.getContext(false) as LoggerContext
-        val appenders = loggerContext.configuration.appenders
-        val testAppender = appenders["TestAppender"] as TestAppender
+        val testAppender = addAppender(Level.WARN)
 
         val MainTable = object : Table("maintable") {
             val id = integer("idCol")
@@ -217,13 +219,45 @@ class JoinTests : DatabaseTestsBase() {
                 .single()
                 .getOrNull(JoinTable.data)
 
-            // Assert no logging took place
-            println("Printing ${testAppender.getLog().size} logevents")
-            testAppender.getLog().forEachIndexed { index, logEvent ->
-                println("LogEvent $index: level ${logEvent.level}, message ${logEvent.message}, $logEvent")
-            }
-            println("End of logevents")
-            assertTrue(testAppender.getLog().none { it.level == Level.WARN })
+            // Assert no logging took place whose source is the ResultRow.getInternal method because that is where the
+            // warning comes from
+            assertFalse(testAppender.getLog().any { it.source.methodName == "getInternal" })
         }
+
+        removeAppender(testAppender)
+    }
+
+    private fun addAppender(level: Level): TestAppender {
+        val context = LoggerContext.getContext(false)
+        val config = context.configuration
+        val layout = PatternLayout.createDefaultLayout(config)
+        val testAppender = TestAppender.createAppender(layout, level)
+        testAppender.start()
+        config.addAppender(testAppender)
+        updateLoggers(testAppender, config, level)
+        return testAppender
+    }
+
+    private fun updateLoggers(appender: Appender, config: Configuration, level: Level, remove: Boolean = false) {
+        val filter: Filter? = null
+        for (loggerConfig in config.loggers.values) {
+            if (remove) {
+                loggerConfig.removeAppender(appender.name)
+            } else {
+                loggerConfig.addAppender(appender, level, filter)
+            }
+        }
+        if (remove) {
+            config.rootLogger.removeAppender(appender.name)
+        } else {
+            config.rootLogger.addAppender(appender, level, filter)
+        }
+    }
+
+    private fun removeAppender(testAppender: TestAppender) {
+        val context = LoggerContext.getContext(false)
+        val config = context.configuration
+        testAppender.stop()
+        updateLoggers(testAppender, config, testAppender.level, remove = true)
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
@@ -218,6 +218,11 @@ class JoinTests : DatabaseTestsBase() {
                 .getOrNull(JoinTable.data)
 
             // Assert no logging took place
+            println("Printing ${testAppender.getLog().size} logevents")
+            testAppender.getLog().forEachIndexed { index, logEvent ->
+                println("LogEvent $index: level ${logEvent.level}, message ${logEvent.message}, $logEvent")
+            }
+            println("End of logevents")
             assertTrue(testAppender.getLog().none { it.level == Level.WARN })
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
@@ -1,9 +1,12 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
-import nl.altindag.log.LogCaptor
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.LoggerContext
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestAppender
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.junit.Test
@@ -193,7 +196,9 @@ class JoinTests : DatabaseTestsBase() {
 
     @Test
     fun testNoWarningsOnLeftJoinRegression() {
-        val logCaptor = LogCaptor.forName(exposedLogger.name)
+        val loggerContext = LogManager.getContext(false) as LoggerContext
+        val appenders = loggerContext.configuration.appenders
+        val testAppender = appenders["TestAppender"] as TestAppender
 
         val MainTable = object : Table("maintable") {
             val id = integer("idCol")
@@ -213,8 +218,7 @@ class JoinTests : DatabaseTestsBase() {
                 .getOrNull(JoinTable.data)
 
             // Assert no logging took place
-            assertTrue(logCaptor.warnLogs.isEmpty())
-            assertTrue(logCaptor.errorLogs.isEmpty())
+            assertTrue(testAppender.getLog().none { it.level == Level.WARN })
         }
     }
 }


### PR DESCRIPTION
Adding the LogCaptor dependency caused the logging level to be DEBUG instead of INFO, even though it is configured to be INFO in `log4j2.xml`. This is a known issue (https://github.com/Hakky54/log-captor/issues/8) because LogCaptor uses a different appender than the one configured in `log4j2.xml`. More details in this comment: https://github.com/Hakky54/log-captor/issues/8#issuecomment-850676609.

The solution is to remove the dependency and create a custom appender which is used to test the logs.

Partially inspired by [this](https://logging.apache.org/log4j/2.x/manual/customconfig.html#appending-log-events-to-writers-and-outputstreams-programmatical).