### PR TITLE
fix: EXPOSED-161 SQL Server syntax incorrectly allows CASCADE with dropSchema 

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -653,12 +653,12 @@ object SchemaUtils {
      * **Note** that when you are using Mysql or MariaDB, this will fail if you try to drop a schema that
      * contains a table that is referenced by a table in another schema.
      *
-     * @sample org.jetbrains.exposed.sql.tests.shared.SchemaTests
+     * @sample org.jetbrains.exposed.sql.tests.shared.SchemaTests.testDropSchemaWithCascade
      *
      * @param schemas the names of the schema
      * @param cascade flag to drop schema and all of its objects and all objects that depend on those objects.
-     * You don't have to specify this option when you are using Mysql or MariaDB
-     * because whether you specify it or not, all objects in the schema will be dropped.
+     * **Note** This option is not supported by MySQL, MariaDB, or SQL Server, so all objects in the schema will be
+     * dropped regardless of the flag's value.
      * @param inBatch flag to perform schema creation in a single batch
      */
     fun dropSchema(vararg schemas: Schema, cascade: Boolean = false, inBatch: Boolean = false) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -312,13 +312,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
         appendIfNotNull(" AUTHORIZATION ", schema.authorization)
     }
 
-    override fun dropSchema(schema: Schema, cascade: Boolean): String = buildString {
-        append("DROP SCHEMA ", schema.identifier)
-
-        if (cascade) {
-            append(" CASCADE")
-        }
-    }
+    override fun dropSchema(schema: Schema, cascade: Boolean): String = "DROP SCHEMA ${schema.identifier}"
 
     override fun createIndex(index: Index): String {
         if (index.functions != null) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
@@ -6,7 +6,6 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.junit.Assume

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
@@ -57,6 +57,20 @@ class SchemaTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testDropSchemaWithCascade() {
+        withDb {
+            if (currentDialect.supportsCreateSchema) {
+                val schema = Schema("TEST_SCHEMA")
+                SchemaUtils.createSchema(schema)
+                assertTrue(schema.exists())
+
+                SchemaUtils.dropSchema(schema, cascade = true)
+                assertFalse(schema.exists())
+            }
+        }
+    }
+
+    @Test
     fun `table references table with same name in other database in mysql`() {
         withDb(listOf(TestDB.MYSQL, TestDB.MARIADB)) {
             val schema = Schema("MYSCHEMA")


### PR DESCRIPTION
When `SchemaUtils.dropSchema(schema, cascade = true)` is used with SQL Server it fails with the error:
```
Incorrect syntax near the keyword 'CASCADE'..
Statement(s): DROP SCHEMA TEST_SCHEMA CASCADE
```

[Documentation](https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-schema-transact-sql?view=sql-server-2016) shows that CASCADE is not supported in this statement (from version 2016 upwards).
In fact, other uses of `dropSchema()` with cascade make sure to exclude SQL Server:
- [DatabaseTestsBase](https://github.com/JetBrains/Exposed/blob/main/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt#L260)
- [CreateTableTests](https://github.com/JetBrains/Exposed/blob/main/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt#L593)