### PR TITLE
fix: Verbose logging in test module

### DIFF
--- a/exposed-tests/src/test/resources/logback-test.xml
+++ b/exposed-tests/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} [%thread] %level %logger{0}:%method:%line - %message %n</pattern>
+            <pattern>%date{HH:mm:ss.SSS} %level %thread %logger{0}:%method:%line - %message %n</pattern>
         </encoder>
     </appender>
     <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
@@ -18,4 +18,4 @@
     </logger>
 </configuration>
 
-<!-- 19:57:29.845 [Test worker] DEBUG Exposed - DROP TABLE jointable -->
+<!-- 19:57:29.845 DEBUG Test worker Exposed - DROP TABLE jointable -->

--- a/exposed-tests/src/test/resources/logback-test.xml
+++ b/exposed-tests/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS} [%thread] %level %logger{0}:%method:%line - %message %n</pattern>
+        </encoder>
+    </appender>
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="CONSOLE"/>
+        <includeCallerData>true</includeCallerData>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC" />
+    </root>
+    <logger name="Exposed" level="INFO" additivity="false">
+        <appender-ref ref="ASYNC"/>
+    </logger>
+</configuration>
+
+<!-- 19:57:29.845 [Test worker] DEBUG Exposed - DROP TABLE jointable -->


### PR DESCRIPTION
@joc-a I made an attempt to resolve the verbose logging. Which you also attempted to resolve in https://github.com/JetBrains/Exposed/pull/1849 I was not sure whether it is fully resolved. Can you maybe have a look at it? And what do you think of the changes? I just converted the XML configuration file with one that logback is able to understand. Logback is being used internally by logcaptor. Looking forward to your feedback 