### PR TITLE
fix: EXPOSED-162 SQLite generatedKeys exception

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -17,7 +17,7 @@ object Versions {
     const val oracle12 = "12.2.0.1"
     const val postgre = "42.6.0"
     const val postgreNG = "0.8.9"
-    const val sqlLite3 = "3.42.0.0"
+    const val sqlLite3 = "3.43.0.0"
     const val sqlserver = "9.4.1.jre8"
 
     /** Spring **/

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -59,7 +59,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 }
 
 public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl : org/jetbrains/exposed/sql/statements/api/PreparedStatementApi {
-	public fun <init> (Ljava/sql/PreparedStatement;Z)V
+	public fun <init> (Ljava/sql/PreparedStatement;ZZ)V
 	public fun addBatch ()V
 	public fun cancel ()V
 	public fun closeIfPossible ()V

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -74,11 +74,19 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
         } else {
             PreparedStatement.NO_GENERATED_KEYS
         }
-        return JdbcPreparedStatementImpl(connection.prepareStatement(sql, generated), returnKeys)
+        return JdbcPreparedStatementImpl(
+            connection.prepareStatement(sql, generated),
+            returnKeys,
+            connection.metaData.supportsGetGeneratedKeys()
+        )
     }
 
     override fun prepareStatement(sql: String, columns: Array<String>): PreparedStatementApi {
-        return JdbcPreparedStatementImpl(connection.prepareStatement(sql, columns), true)
+        return JdbcPreparedStatementImpl(
+            connection.prepareStatement(sql, columns),
+            true,
+            connection.metaData.supportsGetGeneratedKeys()
+        )
     }
 
     override fun executeInBatch(sqls: List<String>) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/MathFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/MathFunctionTests.kt
@@ -103,12 +103,17 @@ class MathFunctionTests : FunctionsTestBase() {
 
     @Test
     fun testRoundFunction() {
-        withTable {
+        withTable { testDb ->
             assertExpressionEqual(BigDecimal(10), RoundFunction(intLiteral(10), 0))
             assertExpressionEqual(BigDecimal("10.00"), RoundFunction(intLiteral(10), 2))
             assertExpressionEqual(BigDecimal(10), RoundFunction(doubleLiteral(10.455), 0))
             assertExpressionEqual(BigDecimal(11), RoundFunction(doubleLiteral(10.555), 0))
-            assertExpressionEqual(BigDecimal("10.56"), RoundFunction(doubleLiteral(10.555), 2))
+            if (testDb == TestDB.SQLITE) {
+                // Change this when this issue is resolved https://www.sqlite.org/forum/forumpost/2801f84063
+                assertExpressionEqual(BigDecimal("10.55"), RoundFunction(doubleLiteral(10.555), 2))
+            } else {
+                assertExpressionEqual(BigDecimal("10.56"), RoundFunction(doubleLiteral(10.555), 2))
+            }
         }
     }
 


### PR DESCRIPTION
Support for getGeneratedKeys() was [dropped](https://github.com/xerial/sqlite-jdbc/releases/tag/3.43.0.0#:~:text=%F0%9F%9A%A8%20remove%20support%20for%20Statement%23getGeneratedKeys%3A%20getGeneratedKeys%20is%20not%20supported%20anymore%20(712a8a5)%2C%20closes%20%23329) in the sqlite jdbc version 3.43.0.0. This caused a SQLFeatureNotSupportedException when using this version with Exposed, so the [old implementation](https://github.com/xerial/sqlite-jdbc/commit/f18a5bfad6fd95bc47fa0a41849573addbc75e2b#:~:text=getGeneratedKeys%20%3D%20conn.prepareStatement(%22select%20last_insert_rowid()%3B%22)%3B) of getGeneratedKeys() was used to retain the previous behaviour.