### PR TITLE
docs: EXPOSED-132 Add annotations to spring-boot-starter README samples

### DIFF
--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -1,9 +1,9 @@
 # Exposed Spring Boot Starter
 
-This is a starter for [Spring Boot](https://spring.io/projects/spring-boot) to utilize [Exposed](https://github.com/JetBrains/Exposed) as the ORM instead of [Hibernate](https://hibernate.org/)
+This is a starter for [Spring Boot](https://spring.io/projects/spring-boot) to utilize [Exposed](https://github.com/JetBrains/Exposed) as the ORM instead of [Hibernate](https://hibernate.org/).
 
 ## Getting Started
-This starter will give you the latest version of [Exposed](https://github.com/JetBrains/Exposed) and the spring-transaction library along with [Spring Boot Data Starter JDBC](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jdbc)
+This starter will give you the latest version of [Exposed](https://github.com/JetBrains/Exposed) and its `spring-transaction` library along with the [Spring Boot Starter Data JDBC](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jdbc).
 ### Maven
 ```mxml
 <repositories>
@@ -22,7 +22,7 @@ This starter will give you the latest version of [Exposed](https://github.com/Je
   </dependency>
 </dependencies>
 ```
-### Gradle
+### Gradle Groovy
 ```groovy
 repositories {
     mavenCentral()
@@ -31,9 +31,24 @@ dependencies {
     implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.43.0'
 }
 ```
+### Gradle Kotlin DSL
+In `build.gradle.kts`:
+```kotlin
+val exposedVersion: String by project
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation("org.jetbrains.exposed:exposed-spring-boot-starter:$exposedVersion")
+}
+```
+In `gradle.properties`
+```properties
+exposedVersion=0.43.0
+```
 
 ## Setting up a database connection
-This starter utilizes spring-boot-starter-data-jdbc so all properties that you are used to for setting up a database in spring are applicable here.
+This starter utilizes `spring-boot-starter-data-jdbc` so that all properties usually used for setting up a database in Spring are applicable here.
 
 ### application.properties (h2 example)
 ```properties
@@ -43,8 +58,8 @@ spring.datasource.username=sa
 spring.datasource.password=password
 ```
 
-### Configuring Exposed 
-When using this starter, you can customize typical Exposed configuration by registering a [DatabaseConfig](https://github.com/JetBrains/Exposed/blob/master/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt). See the class itself for available configuration options.
+## Configuring Exposed 
+When using this starter, you can customize the default Exposed configuration by registering a [DatabaseConfig](https://github.com/JetBrains/Exposed/blob/master/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt). See the class itself for available configuration options.
 
 Example:
 
@@ -72,10 +87,16 @@ See the [official documentation](https://docs.spring.io/spring-boot/docs/current
 ## Automatic Schema Creation
 This starter will create the database schema if enabled automatically using any class that extends `org.jetbrains.exposed.sql.Table`
 
-Sometimes you will want to exclude packages from that list, we have included the property `spring.exposed.excluded-packages` which will exclude everything under the provided package
+Sometimes you will want to exclude packages from the list of auto-created schema. In this event, the property `spring.exposed.excluded-packages` can be used to exclude everything under the provided packages.
 
 ### application.properties
 ```properties
-spring.exposed.generate-ddl = true
-spring.exposed.excluded-packages = com.example.models.ignore,com.example.utils
+spring.exposed.generate-ddl=true
+spring.exposed.excluded-packages=com.example.models.ignore,com.example.utils
 ```
+
+## Sample
+
+Check out the [Exposed - Spring Boot sample](../samples/exposed-spring/README.md) for more details, for example:
+- How to set up [a controller](../samples/exposed-spring/src/main/kotlin/controller/UserController.kt) to handle web requests
+- How to implement [a service layer](../samples/exposed-spring/src/main/kotlin/service/UserService.kt) for database access logic

--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -112,7 +112,7 @@ See the [official documentation](https://docs.spring.io/spring-boot/docs/current
 ## Automatic Schema Creation
 This starter will create the database schema if enabled automatically using any class that extends `org.jetbrains.exposed.sql.Table`
 
-Sometimes you will want to exclude packages from the list of auto-created schema. In this event, the property `spring.exposed.excluded-packages` can be used to exclude everything under the provided packages.
+Sometimes you will want to exclude packages from the list of auto-created schemas. In this event, the property `spring.exposed.excluded-packages` can be used to exclude everything under the provided packages.
 
 ### application.properties
 ```properties

--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -64,8 +64,18 @@ When using this starter, you can customize the default Exposed configuration by 
 Example:
 
 ```kotlin
+import org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration
+import org.jetbrains.exposed.sql.DatabaseConfig
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
 @Configuration
-@EnableAutoConfiguration(exclude = [DataSourceTransactionManagerAutoConfiguration::class])
+@ImportAutoConfiguration(
+    value = [ExposedAutoConfiguration::class],
+    exclude = [DataSourceTransactionManagerAutoConfiguration::class]
+)
 class ExposedConfig {
     @Bean
     fun databaseConfig() = DatabaseConfig {
@@ -73,13 +83,28 @@ class ExposedConfig {
     }
 }
 ```
-It is recommended that the `DataSourceTransactionManagerAutoConfiguration` class be excluded from auto-configuration, which can be done in a custom configuration, as shown above.
+In addition to applying the `ExposedAutoConfiguration` class, it is recommended that the `DataSourceTransactionManagerAutoConfiguration` class be excluded from auto-configuration.
+This can be done as part of a custom configuration, as shown above.
 
-Alternatively, the class can be disabled using the `exclude` attribute of `@SpringBootApplication`:
+Alternatively, auto-configuration can be detailed directly on the Spring configuration class that is annotated using `@SpringBootApplication`:
 
 ```kotlin
-@SpringBootApplication(exclude = [DataSourceTransactionManagerAutoConfiguration::class])
+import org.jetbrains.exposed.spring.autoconfigure.ExposedAutoConfiguration
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+@ImportAutoConfiguration(
+    value = [ExposedAutoConfiguration::class],
+    exclude = [DataSourceTransactionManagerAutoConfiguration::class]
+)
 class MyApplication
+
+fun main(args: Array<String>) {
+    runApplication<MyApplication>(*args)
+}
 ```
 
 See the [official documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.auto-configuration.disabling-specific) for more options to exclude auto-configuration classes.


### PR DESCRIPTION
Edit code blocks to show auto-configuration annotations.

Add links to spring boot sample project.

Add Gradle dsl dependency block.