### PR TITLE
Version Notice for JVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Releases of Exposed are available in the Maven Central repository. You can decla
 
 #### Gradle Groovy and Kotlin DSL
 
-**Warning:** You might need to set your Kotlin JVM target to 8 and when using Spring to 11 in order for it to work properly
+**Warning:** You might need to set your Kotlin JVM target to 8 and when using Spring to 17 in order for it to work properly
 
 ```kotlin
 repositories {

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Releases of Exposed are available in the Maven Central repository. You can decla
 
 #### Gradle Groovy and Kotlin DSL
 
+**Warning:** You might need to set your Kotlin JVM target to 11 in order for it to work properly
+
 ```kotlin
 repositories {
     // Versions after 0.30.1

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Releases of Exposed are available in the Maven Central repository. You can decla
 
 #### Gradle Groovy and Kotlin DSL
 
-**Warning:** You might need to set your Kotlin JVM target to 11 in order for it to work properly
+**Warning:** You might need to set your Kotlin JVM target to 8 and when using Spring to 11 in order for it to work properly
 
 ```kotlin
 repositories {


### PR DESCRIPTION
I just had an issue on my Java 8 Kotlin Project where it wouldn't find Exposed. After I switched from JBR 17 to Coretto 19 and some other steps I forgot by now (was trying random stuff to be honest) Gradle finally gave me an Error pointing at that issue in a build. Maven found it, but other parts of my project wouldn't work for some reason. 

This PR solely exists to save other people a couple of hours.

Error:

![image](https://github.com/JetBrains/Exposed/assets/69903408/24da3df4-622d-4afe-b2fe-bd55036fd5cf)

