### PR TITLE
fix: Unable to download required toolchain on MAC

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,3 +19,17 @@ pluginManagement {
         id("org.jetbrains.kotlin.plugin.serialization") version "1.9.10"
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver") version "0.7.0"
+}
+
+toolchainManagement {
+    jvm {
+        javaRepositories {
+            repository("foojay") {
+                resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
+            }
+        }
+    }
+}


### PR DESCRIPTION
For devices that don't already have JVM 8 installed, the project failed to find it and use it. Foojay Toolchains Plugin resolves this by providing a repository for downloading JVMs.