### PR TITLE
fix: EXPOSED-179 Unsigned column check constraint is not unique to table

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -375,7 +375,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     private val checkConstraints = mutableListOf<Pair<String, Op<Boolean>>>()
 
-    private val generatedCheckPrefix = "chk_unsigned_"
+    private val generatedCheckPrefix = "chk_${tableName}_unsigned_"
 
     /**
      * Returns the table name in proper case.

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -309,22 +309,25 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             val unsigned2 = ushort(col2)
             val unsigned3 = uinteger(col3)
         }
+
         withDb {
-            SchemaUtils.create(tester1, tester2)
+            try {
+                SchemaUtils.create(tester1, tester2)
 
-            val (byte, short, integer) = Triple(191.toUByte(), 49151.toUShort(), 3_221_225_471u)
-            tester1.insert {
-                it[unsigned1] = byte
-                it[unsigned2] = short
-                it[unsigned3] = integer
+                val (byte, short, integer) = Triple(191.toUByte(), 49151.toUShort(), 3_221_225_471u)
+                tester1.insert {
+                    it[unsigned1] = byte
+                    it[unsigned2] = short
+                    it[unsigned3] = integer
+                }
+                tester2.insert {
+                    it[unsigned1] = byte
+                    it[unsigned2] = short
+                    it[unsigned3] = integer
+                }
+            } finally {
+                SchemaUtils.drop(tester1, tester2)
             }
-            tester2.insert {
-                it[unsigned1] = byte
-                it[unsigned2] = short
-                it[unsigned3] = integer
-            }
-
-            SchemaUtils.drop(tester1, tester2)
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -295,4 +295,36 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             SchemaUtils.drop(UByteTable, UShortTable, UIntTable, ULongTable)
         }
     }
+
+    @Test
+    fun testCheckConstraintNameAcrossMultipleTables() {
+        val (col1, col2, col3) = listOf("num1", "num2", "num3")
+        val tester1 = object : Table("tester_1") {
+            val unsigned1 = ubyte(col1)
+            val unsigned2 = ushort(col2)
+            val unsigned3 = uinteger(col3)
+        }
+        val tester2 = object : Table("tester_2") {
+            val unsigned1 = ubyte(col1)
+            val unsigned2 = ushort(col2)
+            val unsigned3 = uinteger(col3)
+        }
+        withDb {
+            SchemaUtils.create(tester1, tester2)
+
+            val (byte, short, integer) = Triple(191.toUByte(), 49151.toUShort(), 3_221_225_471u)
+            tester1.insert {
+                it[unsigned1] = byte
+                it[unsigned2] = short
+                it[unsigned3] = integer
+            }
+            tester2.insert {
+                it[unsigned1] = byte
+                it[unsigned2] = short
+                it[unsigned3] = integer
+            }
+
+            SchemaUtils.drop(tester1, tester2)
+        }
+    }
 }


### PR DESCRIPTION
If multiple tables have the same unsigned column types with the same column names, creating these tables throws `JdbcSQLSyntaxErrorException` with a message like `Name already used by existing constraint`.

Affected databases: H2 (+ compatibility modes), SQL Server, Oracle.

To avoid these naming clashes, the name of the auto-generated check constraint for the unsigned column types now includes the table name in the prefix, with the original column type and name appended to it.