### PR TITLE
fix: EXPOSED-182 Schema name breaks Create Table with default column [SQLServer]

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -127,7 +127,7 @@ class Column<T>(
             } else {
                 if (currentDialect is SQLServerDialect) {
                     // Create a DEFAULT constraint with an explicit name to facilitate removing it later if needed
-                    val tableName = column.table.tableName
+                    val tableName = column.table.tableNameWithoutScheme
                     val columnName = column.name
                     val constraintName = "DF_${tableName}_$columnName"
                     append(" CONSTRAINT $constraintName DEFAULT $expressionSQL")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -673,8 +673,10 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         val schemaName = "my_schema"
         val schema = Schema(schemaName)
         // index and foreign key both use table name to auto-generate their own names & to compare metadata
+        // default columns in SQL Server requires a named constraint that uses table name
         val parentTable = object : IntIdTable("$schemaName.parent_table") {
             val secondId = integer("second_id").uniqueIndex()
+            val column1 = varchar("column_1", 32).default("TEST")
         }
         val childTable = object : LongIdTable("$schemaName.child_table") {
             val parent = reference("my_parent", parentTable)


### PR DESCRIPTION
Attempting to create the following table throws `com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near '.'`:
```kt
object ParentTable : IntIdTable("my_schema.parent_table") {
    val column1 = varchar("column_1", 32).default("TEST")
}

// generated SQL
// CREATE TABLE my_schema.parent_table (
//       id INT IDENTITY(1,1) PRIMARY KEY,
//       column_1 VARCHAR(32) CONSTRAINT DF_my_schema.parent_table_column_1 DEFAULT 'TEST' NOT NULL
// ) 
```

When using SQL Server, a default column auto-generates a named-constraint for the default value using the full table name.

Using the table name without schema resolves this.