### PR TITLE
fix: Exception when using RESTRICT reference option

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3245,9 +3245,12 @@ public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialec
 	public abstract fun getSupportsDualTableConcept ()Z
 	public abstract fun getSupportsIfNotExists ()Z
 	public abstract fun getSupportsMultipleGeneratedKeys ()Z
+	public abstract fun getSupportsOnUpdate ()Z
 	public abstract fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public abstract fun getSupportsOrderByNullsFirstLast ()Z
+	public abstract fun getSupportsRestrictReferenceOption ()Z
 	public abstract fun getSupportsSequenceAsGeneratedKeys ()Z
+	public abstract fun getSupportsSetDefaultReferenceOption ()Z
 	public abstract fun getSupportsSubqueryUnions ()Z
 	public abstract fun getSupportsTernaryAffectedRowValues ()Z
 	public abstract fun getSupportsWindowFrameGroupsMode ()Z
@@ -3285,9 +3288,12 @@ public final class org/jetbrains/exposed/sql/vendors/DatabaseDialect$DefaultImpl
 	public static fun getSupportsCreateSequence (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsDualTableConcept (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsIfNotExists (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
+	public static fun getSupportsOnUpdate (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsOnlyIdentifiersInGeneratedKeys (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsOrderByNullsFirstLast (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
+	public static fun getSupportsRestrictReferenceOption (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsSequenceAsGeneratedKeys (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
+	public static fun getSupportsSetDefaultReferenceOption (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsSubqueryUnions (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsTernaryAffectedRowValues (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsWindowFrameGroupsMode (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
@@ -3501,6 +3507,7 @@ public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbra
 	public fun getFunctionProvider ()Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;
 	public fun getName ()Ljava/lang/String;
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
+	public fun getSupportsSetDefaultReferenceOption ()Z
 }
 
 public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
@@ -3516,6 +3523,7 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	protected fun fillConstraintCacheForTables (Ljava/util/List;)V
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsSetDefaultReferenceOption ()Z
 	public fun getSupportsSubqueryUnions ()Z
 	public fun getSupportsTernaryAffectedRowValues ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
@@ -3542,8 +3550,11 @@ public class org/jetbrains/exposed/sql/vendors/OracleDialect : org/jetbrains/exp
 	public fun getSupportsDualTableConcept ()Z
 	public fun getSupportsIfNotExists ()Z
 	public fun getSupportsMultipleGeneratedKeys ()Z
+	public fun getSupportsOnUpdate ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRestrictReferenceOption ()Z
+	public fun getSupportsSetDefaultReferenceOption ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
@@ -3612,6 +3623,7 @@ public class org/jetbrains/exposed/sql/vendors/SQLServerDialect : org/jetbrains/
 	public fun getNeedsQuotesWhenSymbolsInNames ()Z
 	public fun getSupportsIfNotExists ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
+	public fun getSupportsRestrictReferenceOption ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
@@ -3677,9 +3689,12 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun getSupportsDualTableConcept ()Z
 	public fun getSupportsIfNotExists ()Z
 	public fun getSupportsMultipleGeneratedKeys ()Z
+	public fun getSupportsOnUpdate ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRestrictReferenceOption ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
+	public fun getSupportsSetDefaultReferenceOption ()Z
 	public fun getSupportsSubqueryUnions ()Z
 	public fun getSupportsTernaryAffectedRowValues ()Z
 	public fun getSupportsWindowFrameGroupsMode ()Z

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3556,10 +3556,13 @@ public final class org/jetbrains/exposed/sql/vendors/OracleDialect$Companion : o
 public class org/jetbrains/exposed/sql/vendors/PostgreSQLDialect : org/jetbrains/exposed/sql/vendors/VendorDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/PostgreSQLDialect$Companion;
 	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun createDatabase (Ljava/lang/String;)Ljava/lang/String;
 	protected fun createIndexWithType (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
 	public fun getSupportsWindowFrameGroupsMode ()Z

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -161,7 +161,7 @@ data class ForeignKeyConstraint(
             }
 
             if (updateRule != ReferenceOption.NO_ACTION) {
-                if (currentDialect is OracleDialect || currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+                if (currentDialect is OracleDialect) {
                     exposedLogger.warn("Oracle doesn't support FOREIGN KEY with ON UPDATE clause. Please check your $fromTableName table.")
                 } else if (currentDialect is SQLServerDialect && updateRule == ReferenceOption.RESTRICT) {
                     exposedLogger.warn(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -119,7 +119,12 @@ data class ForeignKeyConstraint(
             }
             append("FOREIGN KEY ($fromColumns) REFERENCES $targetTableName($targetColumns)")
             if (deleteRule != ReferenceOption.NO_ACTION) {
-                if (deleteRule == ReferenceOption.SET_DEFAULT) {
+                if (currentDialect is SQLServerDialect && deleteRule == ReferenceOption.RESTRICT) {
+                    exposedLogger.warn(
+                        "SQLServer doesn't support FOREIGN KEY with RESTRICT reference option with ON DELETE clause. " +
+                            "Please check your $fromTableName table."
+                    )
+                } else if (deleteRule == ReferenceOption.SET_DEFAULT) {
                     when (currentDialect) {
                         is MariaDBDialect -> exposedLogger.warn(
                             "MariaDB doesn't support FOREIGN KEY with SET DEFAULT reference option with ON DELETE clause. " +
@@ -142,6 +147,11 @@ data class ForeignKeyConstraint(
             if (updateRule != ReferenceOption.NO_ACTION) {
                 if (currentDialect is OracleDialect || currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
                     exposedLogger.warn("Oracle doesn't support FOREIGN KEY with ON UPDATE clause. Please check your $fromTableName table.")
+                } else if (currentDialect is SQLServerDialect && updateRule == ReferenceOption.RESTRICT) {
+                    exposedLogger.warn(
+                        "SQLServer doesn't support FOREIGN KEY with RESTRICT reference option with ON UPDATE clause. " +
+                            "Please check your $fromTableName table."
+                    )
                 } else if (updateRule == ReferenceOption.SET_DEFAULT) {
                     when (currentDialect) {
                         is MariaDBDialect -> exposedLogger.warn(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -112,7 +112,7 @@ class Database private constructor(
         }
 
         fun registerDialect(prefix: String, dialect: () -> DatabaseDialect) {
-            dialects[prefix] = dialect
+            dialects[prefix.lowercase()] = dialect
         }
 
         fun registerJdbcDriver(prefix: String, driverClassName: String, dialect: String) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -55,6 +55,12 @@ interface DatabaseDialect {
     /** Returns `true` if the dialect supports window function definitions with GROUPS mode in frame clause */
     val supportsWindowFrameGroupsMode: Boolean get() = false
 
+    val supportsOnUpdate: Boolean get() = true
+
+    val supportsSetDefaultReferenceOption: Boolean get() = true
+
+    val supportsRestrictReferenceOption: Boolean get() = true
+
     val likePatternSpecialChars: Map<Char, Char?> get() = defaultLikePatternSpecialChars
 
     /** Returns true if autoCommit should be enabled to create/drop database */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -163,7 +163,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
     private var delegatedDialect: DatabaseDialect? = null
 
     private fun resolveDelegatedDialect(): DatabaseDialect? {
-        return delegatedDialect ?: delegatedDialectNameProvider?.dialectName?.let {
+        return delegatedDialect ?: delegatedDialectNameProvider?.dialectName?.lowercase()?.let {
             val dialect = Database.dialects[it]?.invoke() ?: error("Can't resolve dialect for $it")
             delegatedDialect = dialect
             dialect
@@ -269,7 +269,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
 
     override fun dropDatabase(name: String) = "DROP SCHEMA IF EXISTS ${name.inProperCase()}"
 
-    companion object : DialectNameProvider("h2")
+    companion object : DialectNameProvider("H2")
 }
 
 val DatabaseDialect.h2Mode: H2Dialect.H2CompatibilityMode? get() = (this as? H2Dialect)?.h2Mode

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -37,6 +37,7 @@ class MariaDBDialect : MysqlDialect() {
     override val name: String = dialectName
     override val functionProvider: FunctionProvider = MariaDBFunctionProvider
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
+    override val supportsSetDefaultReferenceOption: Boolean = false
 
     override fun createIndex(index: Index): String {
         if (index.functions != null) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -48,5 +48,5 @@ class MariaDBDialect : MysqlDialect() {
         return super.createIndex(index)
     }
 
-    companion object : DialectNameProvider("mariadb")
+    companion object : DialectNameProvider("MariaDB")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -400,5 +400,5 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         }
     }
 
-    companion object : DialectNameProvider("mysql")
+    companion object : DialectNameProvider("MySQL")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -283,6 +283,8 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
 
     override val supportsOrderByNullsFirstLast: Boolean = false
 
+    override val supportsSetDefaultReferenceOption: Boolean = false
+
     fun isFractionDateTimeSupported(): Boolean = TransactionManager.current().db.isVersionCovers(BigDecimal("5.6"))
 
     // Available from MySQL 8.0.19

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -361,5 +361,5 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
         }
     }
 
-    companion object : DialectNameProvider("oracle")
+    companion object : DialectNameProvider("Oracle")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -310,6 +310,11 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
     override val supportsDualTableConcept: Boolean = true
     override val supportsOrderByNullsFirstLast: Boolean = true
+    override val supportsOnUpdate: Boolean = false
+    override val supportsSetDefaultReferenceOption: Boolean = false
+
+    // Preventing the deletion of a parent row if a child row references it is the default behaviour in Oracle.
+    override val supportsRestrictReferenceOption: Boolean = false
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -287,7 +287,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
 /**
  * PostgreSQL dialect implementation.
  */
-open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProvider, PostgreSQLFunctionProvider) {
+open class PostgreSQLDialect(override val name: String = dialectName) : VendorDialect(dialectName, PostgreSQLDataTypeProvider, PostgreSQLFunctionProvider) {
     override val supportsOrderByNullsFirstLast: Boolean = true
 
     override val requiresAutoCommitOnCreateDrop: Boolean = true
@@ -342,7 +342,7 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
         }
     }
 
-    companion object : DialectNameProvider("postgresql")
+    companion object : DialectNameProvider("PostgreSQL")
 }
 
 /**
@@ -350,8 +350,8 @@ open class PostgreSQLDialect : VendorDialect(dialectName, PostgreSQLDataTypeProv
  *
  * The driver accepts basic URLs in the following format : jdbc:pgsql://localhost:5432/db
  */
-open class PostgreSQLNGDialect : PostgreSQLDialect() {
+open class PostgreSQLNGDialect : PostgreSQLDialect(dialectName) {
     override val requiresAutoCommitOnCreateDrop: Boolean = true
 
-    companion object : DialectNameProvider("pgsql")
+    companion object : DialectNameProvider("PostgreSQLNG")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -347,7 +347,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15#arguments
     override val likePatternSpecialChars = sqlServerLikePatternSpecialChars
 
-    companion object : DialectNameProvider("sqlserver") {
+    companion object : DialectNameProvider("SQLServer") {
         private val sqlServerLikePatternSpecialChars = mapOf('%' to null, '_' to null, '[' to ']')
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -243,6 +243,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     override val needsQuotesWhenSymbolsInNames: Boolean = false
     override val supportsSequenceAsGeneratedKeys: Boolean = false
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
+    override val supportsRestrictReferenceOption: Boolean = false
 
     private val nonAcceptableDefaults = arrayOf("DEFAULT")
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -277,7 +277,7 @@ open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQ
 
     override fun dropDatabase(name: String) = "DETACH DATABASE ${name.inProperCase()}"
 
-    companion object : DialectNameProvider("sqlite") {
+    companion object : DialectNameProvider("SQLite") {
         val ENABLE_UPDATE_DELETE_LIMIT by lazy {
             var conn: Connection? = null
             var stmt: Statement? = null

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -502,7 +502,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
         withTables(parent, child) { testDb ->
             val t = TransactionManager.current()
-            val updateCascadePart = if (testDb !in listOf(TestDB.ORACLE, TestDB.H2_ORACLE)) " ON UPDATE CASCADE" else ""
+            val updateCascadePart = if (testDb != TestDB.ORACLE) " ON UPDATE CASCADE" else ""
             val expected = listOfNotNull(
                 child.autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
                     Sequence(

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
@@ -1,18 +1,15 @@
 package org.jetbrains.exposed.sql.tests.sqlite
 
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.Category
 import org.jetbrains.exposed.sql.tests.shared.DEFAULT_CATEGORY_ID
 import org.jetbrains.exposed.sql.tests.shared.Item
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Assume
 import org.junit.Test
@@ -70,5 +67,121 @@ class ForeignKeyConstraintTests : DatabaseTestsBase() {
             DEFAULT_CATEGORY_ID,
             Item.select { Item.id eq tabboulehId }.single()[Item.categoryId]
         )
+    }
+
+    @Test
+    fun `test ON DELETE RESTRICT for databases that support it without SQLite`() {
+        withDb(excludeSettings = listOf(TestDB.SQLITE, TestDB.SQLSERVER)) {
+            testOnDeleteRestrict()
+        }
+    }
+
+    @Test
+    fun `test ON DELETE RESTRICT for SQLite`() {
+        Assume.assumeTrue(TestDB.SQLITE in TestDB.enabledDialects())
+
+        transaction(Database.connect("jdbc:sqlite:file:test?mode=memory&cache=shared&foreign_keys=on", user = "root", driver = "org.sqlite.JDBC")) {
+            testOnDeleteRestrict()
+        }
+    }
+
+    private fun testOnDeleteRestrict() {
+        val country = object : Table("Country") {
+            val id = integer("id")
+            val name = varchar(name = "name", length = 20)
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val city = object : Table("City") {
+            val id = integer("id")
+            val name = varchar(name = "name", length = 20)
+            val countryId = integer("countryId")
+                .references(
+                    country.id,
+                    onDelete = ReferenceOption.RESTRICT
+                )
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        SchemaUtils.drop(country, city)
+        SchemaUtils.create(country, city)
+
+        val lebanonId = 0
+        country.insert {
+            it[id] = lebanonId
+            it[name] = "Lebanon"
+        }
+
+        val beirutId = 0
+        city.insert {
+            it[id] = beirutId
+            it[name] = "Beirut"
+            it[countryId] = 0
+        }
+
+        expectException<ExposedSQLException> {
+            country.deleteWhere { id eq lebanonId }
+        }
+    }
+
+    @Test
+    fun `test ON UPDATE RESTRICT for databases that support it without SQLite`() {
+        withDb(excludeSettings = listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)) {
+            testOnUpdateRestrict()
+        }
+    }
+
+    @Test
+    fun `test ON UPDATE RESTRICT for SQLite`() {
+        Assume.assumeTrue(TestDB.SQLITE in TestDB.enabledDialects())
+
+        transaction(Database.connect("jdbc:sqlite:file:test?mode=memory&cache=shared&foreign_keys=on", user = "root", driver = "org.sqlite.JDBC")) {
+            testOnUpdateRestrict()
+        }
+    }
+
+    private fun testOnUpdateRestrict() {
+        val country = object : Table("Country") {
+            val id = integer("id")
+            val name = varchar(name = "name", length = 20)
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val city = object : Table("City") {
+            val id = integer("id")
+            val name = varchar(name = "name", length = 20)
+            val countryId = integer("countryId")
+                .references(
+                    country.id,
+                    onUpdate = ReferenceOption.RESTRICT
+                )
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        SchemaUtils.drop(country, city)
+        SchemaUtils.create(country, city)
+
+        val lebanonId = 0
+        country.insert {
+            it[id] = lebanonId
+            it[name] = "Lebanon"
+        }
+
+        val beirutId = 0
+        city.insert {
+            it[id] = beirutId
+            it[name] = "Beirut"
+            it[countryId] = 0
+        }
+
+        expectException<ExposedSQLException> {
+            country.update({ country.id eq lebanonId }) {
+                it[id] = 1
+            }
+        }
     }
 }


### PR DESCRIPTION
The following exception is thrown because [SQLServer does not support RESTRICT reference option](https://www.sqlshack.com/commonly-used-sql-server-constraints-foreign-key-check-default): 

> com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near the keyword 'RESTRICT'.

----------------------------

The following exception is thrown because [Oracle does not have the RESTRICT reference option](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/cncpt/data-integrity.html?source=%3Aex%3Apw%3A%3A%3Arc_emmk180529p00117%3Atp3q1m8_defddeob&source=%3Aex%3Apw%3A%3A%3Arc_emmk180529p00117%3Atp3q1m8_defddeob&source=%3Aex%3Apw%3A%3A%3Arc_emmk180529p00117%3Atp3q1m8_defddeob#GUID-FB419C3E-7C1E-4881-B77D-D09A57C741A6):

> java.sql.SQLSyntaxErrorException: ORA-00905: missing keyword

Preventing the deletion of a parent row if a child row references it is the default behaviour.

----------------------------

All tests pass for H2 Oracle when allowing the ON UPDATE clause for it, so it seems like the ON UPDATE clause does work for H2 Oracle, but not for Oracle. [Documentation](http://www.h2database.com/html/grammar.html#references_specification).

----------------------------

I changed dialect names to make them more display-friendly. For `PostgreSQLNGDialect`, the name was previously taken from the parent class `PostgreSQLDialect`, so I changed that to show the correct name.

----------------------------

I added properties to DatabaseDialect to aid in simplifying the logic in `foreignKeyPart`.