### PR TITLE
Regression for unsigned column changes

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -21,6 +21,10 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
         val unsignedShort = ushort("ushort")
     }
 
+    object UShortTable2 : Table("ushort_table2") {
+        val unsignedShort = ushort("ushort")
+    }
+
     object UIntTable : Table("uint_table") {
         val unsignedInt = uinteger("uint")
     }
@@ -146,6 +150,11 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
                 exec("""INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)""")
             }
         }
+    }
+
+    @Test
+    fun testCheckConstraintsCanCoexist() {
+        withTables(UShortTable, UShortTable2) {}
     }
 
     @Test


### PR DESCRIPTION
It seems that since #1799 it is no longer possible to have multiple tables with unsigned columns since check constraints are not scoped to a table but in a global namespace.

I have created a failing test case that fails with following exception:
```
org.jetbrains.exposed.exceptions.ExposedSQLException: org.h2.jdbc.JdbcSQLSyntaxErrorException: Constraint "CHK_UNSIGNED_USHORT" already exists; SQL statement:
CREATE TABLE IF NOT EXISTS USHORT_TABLE2 (USHORT INT NOT NULL, CONSTRAINT chk_unsigned_ushort CHECK (USHORT BETWEEN 0 AND 65535)) [90045-220]
SQL: [CREATE TABLE IF NOT EXISTS USHORT_TABLE2 (USHORT INT NOT NULL, CONSTRAINT chk_unsigned_ushort CHECK (USHORT BETWEEN 0 AND 65535))]
```