### PR TITLE
build: Fix compileKotlin task target in Spring modules

### DIFF
--- a/exposed-spring-boot-starter/build.gradle.kts
+++ b/exposed-spring-boot-starter/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.exposed.gradle.Versions
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") apply true
@@ -26,6 +27,12 @@ dependencies {
     // put in testImplementation so no hard dependency for those using the starter
     testImplementation("org.springframework.boot", "spring-boot-starter-webflux", Versions.springBoot)
     testImplementation("com.h2database", "h2", Versions.h2_v2)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/spring-transaction/build.gradle.kts
+++ b/spring-transaction/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.exposed.gradle.Versions
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") apply true
@@ -33,6 +34,12 @@ dependencies {
     testImplementation("junit", "junit", "4.12")
     testImplementation("org.hamcrest", "hamcrest-library", "1.3")
     testImplementation("com.h2database", "h2", Versions.h2)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
Gradle plugin was recently upgraded to 8.3, so warnings of compile task target compatibility became errors.

Tasks `:spring-transaction:compileKotlin` and `:exposed-spring-boot-starter:compileKotlin` failed with the following:
> 'compileJava' task (current target is 17) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
Consider using JVM toolchain:

Fixed by setting `compileKotlin` task to target jdk 17 in both modules.