### PR TITLE
fix: EXPOSED-173 UPDATE_RULE read incorrectly for Oracle

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -287,7 +287,9 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                 val targetColumn = allTables[targetTableName]?.columns?.firstOrNull {
                     identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(it.nameInDatabaseCase()) == targetColumnName
                 } ?: return@iterate null // Do not crash if there are missing fields in Exposed's tables
-                val constraintUpdateRule = ReferenceOption.resolveRefOptionFromJdbc(getInt("UPDATE_RULE"))
+                val constraintUpdateRule = getObject("UPDATE_RULE")?.toString()?.toIntOrNull()?.let {
+                    ReferenceOption.resolveRefOptionFromJdbc(it)
+                }
                 val constraintDeleteRule = ReferenceOption.resolveRefOptionFromJdbc(getInt("DELETE_RULE"))
                 ForeignKeyConstraint(
                     target = targetColumn,


### PR DESCRIPTION
Although the documentation of the driver mentions `UPDATE_RULE` [here](https://javadoc.io/static/com.oracle.database.jdbc/ojdbc8/12.2.0.1/oracle/jdbc/OracleDatabaseMetaData.html#getImportedKeys-java.lang.String-java.lang.String-java.lang.String-), it is missing from the `ALL_CONSTRAINTS` view [here](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/refrn/ALL_CONSTRAINTS.html#GUID-9C96DA92-CFE0-4A3F-9061-C5ED17B43EFE). Only `DELETE_RULE` is mentioned.

This is part of the SQL that runs when `OracleDatabaseMetadata.getImportedKeys()` is invoked:
```
SELECT NULL AS pktable_cat,
p.owner as pktable_schem,
p.table_name as pktable_name,
pc.column_name as pkcolumn_name,
NULL as fktable_cat,
f.owner as fktable_schem,
f.table_name as fktable_name,
fc.column_name as fkcolumn_name,
fc.position as key_seq,
NULL as update_rule,
decode (f.delete_rule, 'CASCADE', 0, 'SET NULL', 2, 1) as delete_rule
...
```

`update_rule` is hardcoded to `NULL`, which gets converted to 0 when using `getInt("UPDATE_RULE")`, and is then mistakenly taken to represent `DatabaseMetaData.importedKeyCascade = 0`.