### PR TITLE
chore: EXPOSED-186 Replace JDK 1.7 support in exposed-jodatime classes

### DIFF
--- a/exposed-jodatime/api/exposed-jodatime.api
+++ b/exposed-jodatime/api/exposed-jodatime.api
@@ -16,7 +16,6 @@ public final class org/jetbrains/exposed/sql/jodatime/Date : org/jetbrains/expos
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/DateColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IDateColumnType {
-	public static final field Companion Lorg/jetbrains/exposed/sql/jodatime/DateColumnType$Companion;
 	public fun <init> (Z)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getHasTimePart ()Z
@@ -27,9 +26,6 @@ public final class org/jetbrains/exposed/sql/jodatime/DateColumnType : org/jetbr
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class org/jetbrains/exposed/sql/jodatime/DateColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/DateColumnTypeKt {
@@ -58,7 +54,6 @@ public final class org/jetbrains/exposed/sql/jodatime/DateFunctionsKt {
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IDateColumnType {
-	public static final field Companion Lorg/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
@@ -67,9 +62,6 @@ public final class org/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumn
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Lorg/joda/time/DateTime;
-}
-
-public final class org/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/Day : org/jetbrains/exposed/sql/Function {


### PR DESCRIPTION
Both column type classes in `exposed-jodatime` contain companion objects that check for `java.time` classes that were only introduced in JDK 1.8 (`LocalDateTime`, `OffsetDateTime`).

This was implemented because the module was expected to run on Java version 1.7 and to be compatible with legacy android versions.

Since the `jvmToolchain` has now been to set to 8, support for 1.7 is no longer needed and the classes can be referenced directly.