### PR TITLE
feat: EXPOSED-188 Support Propagation in SpringTransactionManager

### DIFF
--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
@@ -63,11 +63,13 @@ class SpringTransactionManager(
 
         return (currentManager.currentOrNull() as Any).apply {
             currentManager.bindTransactionToThread(null)
+            TransactionManager.resetCurrent(null)
         }
     }
 
     override fun doResume(transaction: Any?, suspendedResources: Any) {
         threadLocalTransactionManager.bindTransactionToThread(suspendedResources as Transaction?)
+        TransactionManager.resetCurrent(threadLocalTransactionManager)
     }
 
     override fun isExistingTransaction(transaction: Any): Boolean {
@@ -79,7 +81,7 @@ class SpringTransactionManager(
         val trxObject = transaction as ExposedTransactionObject
 
         val currentTransactionManager = trxObject.manager
-        TransactionManager.resetCurrent(currentTransactionManager)
+        TransactionManager.resetCurrent(threadLocalTransactionManager)
 
         currentTransactionManager.newTransaction(
             isolation = definition.isolationLevel, readOnly = definition.isReadOnly, outerTransaction = currentTransactionManager.currentOrNull()

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
@@ -61,7 +61,7 @@ class SpringTransactionManager(
         val trxObject = transaction as ExposedTransactionObject
         val currentManager = trxObject.manager
 
-        return (currentManager.currentOrNull() as Any).run {
+        return (currentManager.currentOrNull() as Any).apply {
             currentManager.bindTransactionToThread(null)
         }
     }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ConnectionSpy.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ConnectionSpy.kt
@@ -8,6 +8,7 @@ internal class ConnectionSpy(private val connection: Connection) : Connection by
     var commitCallCount: Int = 0
     var rollbackCallCount: Int = 0
     var closeCallCount: Int = 0
+    var releaseSavepointCallCount: Int = 0
     var mockReadOnly: Boolean = false
     var mockIsClosed: Boolean = false
     var mockAutoCommit: Boolean = false
@@ -25,6 +26,7 @@ internal class ConnectionSpy(private val connection: Connection) : Connection by
         commitCallCount = 0
         rollbackCallCount = 0
         closeCallCount = 0
+        releaseSavepointCallCount = 0
         mockAutoCommit = false
         mockReadOnly = false
         mockIsClosed = false
@@ -57,7 +59,17 @@ internal class ConnectionSpy(private val connection: Connection) : Connection by
         mockRollback()
     }
 
-    override fun rollback(savepoint: Savepoint?) = Unit
+    override fun rollback(savepoint: Savepoint?) {
+        callOrder.add("rollback")
+        rollbackCallCount++
+        mockRollback()
+    }
+
+    override fun releaseSavepoint(savepoint: Savepoint?) {
+        callOrder.add("releaseSavepoint")
+        releaseSavepointCallCount++
+    }
+
     override fun isClosed(): Boolean {
         callOrder.add("isClosed")
         return mockIsClosed

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -209,6 +209,46 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    @Test
+    @Repeat(5)
+    @Transactional
+    open fun testPropagationMandatoryWithTransaction() {
+        T1.insertRandom()
+        transactionManager.execute(TransactionDefinition.PROPAGATION_MANDATORY) {
+            T1.insertRandom()
+        }
+    }
+
+    @Test
+    @Repeat(5)
+    open fun testPropagationMandatoryWithoutTransaction() {
+        assertFailsWith<IllegalTransactionStateException> {
+            transactionManager.execute(TransactionDefinition.PROPAGATION_MANDATORY) {
+                T1.insertRandom()
+            }
+        }
+    }
+
+    @Test
+    @Repeat(5)
+    @Transactional
+    open fun testPropagationSupportWithTransaction() {
+        T1.insertRandom()
+        transactionManager.execute(TransactionDefinition.PROPAGATION_SUPPORTS) {
+            T1.insertRandom()
+        }
+    }
+
+    @Test
+    @Repeat(5)
+    open fun testPropagationSupportWithoutTransaction() {
+        transactionManager.execute(TransactionDefinition.PROPAGATION_SUPPORTS) {
+            assertFailsWith<IllegalStateException> { // No transaction exist
+                T1.insertRandom()
+            }
+        }
+    }
+
     @AfterTest
     fun afterTest() {
         transactionManager.execute {

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -70,7 +70,7 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         T1.insert {
             it[c1] = rnd
         }
-        Assert.assertEquals(T1.selectAll().single()[T1.c1], rnd)
+        Assert.assertEquals(rnd, T1.selectAll().single()[T1.c1])
     }
 
     @Test
@@ -82,7 +82,7 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
             T1.insert {
                 it[c1] = rnd
             }
-            Assert.assertEquals(T1.selectAll().single()[T1.c1], rnd)
+            Assert.assertEquals(rnd, T1.selectAll().single()[T1.c1])
 
             transactionManager.execute {
                 T1.insertRandom()
@@ -100,7 +100,7 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         T1.insert {
             it[c1] = rnd
         }
-        Assert.assertEquals(T1.selectAll().single()[T1.c1], rnd)
+        Assert.assertEquals(rnd, T1.selectAll().single()[T1.c1])
 
         transaction {
             T1.insertRandom()
@@ -168,7 +168,7 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
     }
 
     /**
-     * Test For Propagation.REQUIRED
+     * Test For Propagation.REQUIRES_NEW
      * Create a new transaction, and suspend the current transaction if one exists.
      */
     @Test
@@ -186,7 +186,7 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
     }
 
     /**
-     * Test For Propagation.REQUIRED with inner transaction roll-back
+     * Test For Propagation.REQUIRES_NEW with inner transaction roll-back
      * The inner transaction will be roll-back only inner transaction when the transaction marks as rollback.
      * And since isolation level is READ_COMMITTED, the inner transaction can't see the changes of outer transaction.
      */

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -11,6 +11,7 @@ import org.junit.Test
 import org.springframework.test.annotation.Commit
 import org.springframework.test.annotation.Repeat
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.util.*
@@ -128,5 +129,20 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
             Assert.assertEquals(2, T1.selectAll().count())
             SchemaUtils.drop(T1)
         }
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NESTED)
+    open fun testConnectionWithNestedTransaction() {
+        val pm = ctx.getBean(PlatformTransactionManager::class.java)
+        if (pm !is SpringTransactionManager) error("Wrong txManager instance: ${pm.javaClass.name}")
+
+        SchemaUtils.create(T1)
+        T1.insert {
+            it[c1] = "112"
+        }
+
+        Assert.assertEquals(T1.selectAll().count(), 1)
+        SchemaUtils.drop(T1)
     }
 }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -58,7 +58,7 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
     @Repeat(5)
     open fun testConnection() {
         T1.insertRandom()
-        Assert.assertEquals(T1.selectAll().count(), 1)
+        Assert.assertEquals(1, T1.selectAll().count())
     }
 
     @Test
@@ -140,18 +140,18 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
     fun testConnectionWithNestedTransactionOuterRollback() {
         transactionManager.execute {
             T1.insertRandom()
-            Assert.assertEquals(T1.selectAll().count(), 1)
+            Assert.assertEquals(1, T1.selectAll().count())
             it.setRollbackOnly()
 
             transactionManager.execute(TransactionDefinition.PROPAGATION_NESTED) {
                 T1.insertRandom()
-                Assert.assertEquals(T1.selectAll().count(), 2)
+                Assert.assertEquals(2, T1.selectAll().count())
             }
-            Assert.assertEquals(T1.selectAll().count(), 2)
+            Assert.assertEquals(2, T1.selectAll().count())
         }
 
         transactionManager.execute {
-            Assert.assertEquals(T1.selectAll().count(), 0)
+            Assert.assertEquals(0, T1.selectAll().count())
         }
     }
 
@@ -160,13 +160,13 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
     @Transactional
     open fun testConnectionWithRequiresNew() {
         T1.insertRandom()
-        Assert.assertEquals(T1.selectAll().count(), 1)
+        Assert.assertEquals(1, T1.selectAll().count())
         transactionManager.execute(TransactionDefinition.PROPAGATION_REQUIRES_NEW) {
-            Assert.assertEquals(T1.selectAll().count(), 0)
+            Assert.assertEquals(0, T1.selectAll().count())
             T1.insertRandom()
-            Assert.assertEquals(T1.selectAll().count(), 1)
+            Assert.assertEquals(1, T1.selectAll().count())
         }
-        Assert.assertEquals(T1.selectAll().count(), 2)
+        Assert.assertEquals(2, T1.selectAll().count())
     }
 
     @Test
@@ -174,17 +174,17 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
     fun testConnectionWithRequiresNewWithInnerTransactionRollback() {
         transactionManager.execute {
             T1.insertRandom()
-            Assert.assertEquals(T1.selectAll().count(), 1)
+            Assert.assertEquals(1, T1.selectAll().count())
             transactionManager.execute(TransactionDefinition.PROPAGATION_REQUIRES_NEW) {
                 T1.insertRandom()
-                Assert.assertEquals(T1.selectAll().count(), 1)
+                Assert.assertEquals(1, T1.selectAll().count())
                 it.setRollbackOnly()
             }
-            Assert.assertEquals(T1.selectAll().count(), 1)
+            Assert.assertEquals(1, T1.selectAll().count())
         }
 
         transactionManager.execute {
-            Assert.assertEquals(T1.selectAll().count(), 1)
+            Assert.assertEquals(1, T1.selectAll().count())
         }
     }
 

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -108,6 +108,10 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    /**
+     * Test For Propagation.NESTED
+     * Execute within a nested transaction if a current transaction exists, behave like REQUIRED otherwise.
+     */
     @Test
     @Repeat(5)
     @Transactional
@@ -121,6 +125,10 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         Assert.assertEquals(2, T1.selectAll().count())
     }
 
+    /**
+     * Test For Propagation.NESTED with inner roll-back
+     * The nested transaction will be roll-back only inner transaction when the transaction marks as rollback.
+     */
     @Test
     @Repeat(5)
     @Transactional
@@ -135,6 +143,10 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         Assert.assertEquals(1, T1.selectAll().count())
     }
 
+    /**
+     * Test For Propagation.NESTED with outer roll-back
+     * The nested transaction will be roll-back entire transaction when the transaction marks as rollback.
+     */
     @Test
     @Repeat(5)
     fun testConnectionWithNestedTransactionOuterRollback() {
@@ -155,6 +167,10 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    /**
+     * Test For Propagation.REQUIRED
+     * Create a new transaction, and suspend the current transaction if one exists.
+     */
     @Test
     @Repeat(5)
     @Transactional
@@ -169,6 +185,11 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         Assert.assertEquals(2, T1.selectAll().count())
     }
 
+    /**
+     * Test For Propagation.REQUIRED with inner transaction roll-back
+     * The inner transaction will be roll-back only inner transaction when the transaction marks as rollback.
+     * And since isolation level is READ_COMMITTED, the inner transaction can't see the changes of outer transaction.
+     */
     @Test
     @Repeat(5)
     fun testConnectionWithRequiresNewWithInnerTransactionRollback() {
@@ -188,15 +209,23 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    /**
+     * Test For Propagation.NEVER
+     * Execute non-transactionally, throw an exception if a transaction exists.
+     */
     @Test
     @Repeat(5)
     @Transactional(propagation = Propagation.NEVER)
     open fun testPropagationNever() {
-        assertFailsWith<IllegalStateException> {
+        assertFailsWith<IllegalStateException> { // Should Be "No transaction exist"
             T1.insertRandom()
         }
     }
 
+    /**
+     * Test For Propagation.NEVER
+     * Throw an exception cause outer transaction exists.
+     */
     @Test
     @Repeat(5)
     @Transactional
@@ -209,6 +238,10 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    /**
+     * Test For Propagation.MANDATORY
+     * Support a current transaction, throw an exception if none exists.
+     */
     @Test
     @Repeat(5)
     @Transactional
@@ -219,6 +252,10 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    /**
+     * Test For Propagation.MANDATORY
+     * Throw an exception cause no transaction exists.
+     */
     @Test
     @Repeat(5)
     open fun testPropagationMandatoryWithoutTransaction() {
@@ -229,6 +266,10 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    /**
+     * Test For Propagation.SUPPORTS
+     * Support a current transaction, execute non-transactionally if none exists.
+     */
     @Test
     @Repeat(5)
     @Transactional
@@ -239,11 +280,15 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
+    /**
+     * Test For Propagation.SUPPORTS
+     * Execute non-transactionally if none exists.
+     */
     @Test
     @Repeat(5)
     open fun testPropagationSupportWithoutTransaction() {
         transactionManager.execute(TransactionDefinition.PROPAGATION_SUPPORTS) {
-            assertFailsWith<IllegalStateException> { // No transaction exist
+            assertFailsWith<IllegalStateException> { // Should Be "No transaction exist"
                 T1.insertRandom()
             }
         }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionManagerTest.kt
@@ -297,6 +297,27 @@ class SpringTransactionManagerTest {
         assertEquals(2, con1.closeCallCount)
     }
 
+    @Test
+    fun `not support with required transaction`() {
+        val tm = SpringTransactionManager(ds1)
+        tm.executeAssert {
+            assertTrue(it.isNewTransaction)
+            tm.executeAssert(
+                initializeConnection = false,
+                propagationBehavior = TransactionDefinition.PROPAGATION_NOT_SUPPORTED
+            ) {
+                assertFailsWith<IllegalStateException> {
+                    TransactionManager.current().connection
+                }
+            }
+            assertTrue(it.isNewTransaction)
+            TransactionManager.current().connection
+        }
+
+        assertEquals(1, con1.commitCallCount)
+        assertEquals(1, con1.closeCallCount)
+    }
+
     private fun SpringTransactionManager.executeAssert(
         initializeConnection: Boolean = true,
         propagationBehavior: Int = TransactionDefinition.PROPAGATION_REQUIRED,

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionTestBase.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionTestBase.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.spring
 
+import org.jetbrains.exposed.sql.DatabaseConfig
 import org.junit.FixMethodOrder
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
@@ -22,10 +23,15 @@ import org.springframework.transaction.annotation.TransactionManagementConfigure
 open class TestConfig : TransactionManagementConfigurer {
 
     @Bean
-    open fun ds(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName("embeddedTest").setType(EmbeddedDatabaseType.H2).build()
+    open fun ds(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName(
+        "embeddedTest"
+    ).setType(EmbeddedDatabaseType.H2).build()
 
     @Bean
-    override fun annotationDrivenTransactionManager(): PlatformTransactionManager = SpringTransactionManager(ds())
+    override fun annotationDrivenTransactionManager(): PlatformTransactionManager = SpringTransactionManager(
+        ds(),
+        DatabaseConfig { useNestedTransactions = true }
+    )
 
     @Bean
     open fun service(): Service = Service()

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionTestBase.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionTestBase.kt
@@ -48,4 +48,7 @@ abstract class SpringTransactionTestBase {
 
     @Autowired
     lateinit var ctx: ApplicationContext
+
+    @Autowired
+    lateinit var transactionManager: PlatformTransactionManager
 }


### PR DESCRIPTION
Implemented the Propagation policy in SpringTransactionManager.

In addition to REQUIRED, we now support SUPPORTS, MANDATORY, REQUIRES_NEW, NOT_SUPPORTED, NEVER, and NESTED.

The changes are as follows

- NESTED is implemented to use the ThreadLocalTransactionManager's savepoint. So Spring's SavePointManager is not implemented.
- Implemented doSuspend and doResume methods for support, mandatory, etc. Saves the current transaction, changes the current TransactionManager to null, etc.