### PR TITLE
fix: Incorrect SQL statements when creating a table with a dot in its name

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -355,7 +355,14 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     internal val tableNameWithoutScheme: String
         get() = if (!tableName.isAlreadyQuoted()) tableName.substringAfterLast(".") else tableName
 
-    // Table name may contain quotes, remove those before appending
+    /**
+     * Returns the table name without schema, with all quotes removed.
+     *
+     * Used for two purposes:
+     * 1. Forming primary and foreign key names
+     * 2. Comparing table names from database metadata (except MySQL and MariaDB)
+     * @see org.jetbrains.exposed.sql.vendors.VendorDialect.metadataMatchesTable
+     */
     internal val tableNameWithoutSchemeSanitized: String
         get() = tableNameWithoutScheme
             .replace("\"", "")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1192,8 +1192,10 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     private fun <T> Column<T>.cloneWithAutoInc(idSeqName: String?): Column<T> = when (columnType) {
         is AutoIncColumnType -> this
         is ColumnType -> {
+            val q = if (tableName.contains('.')) "\"" else ""
+            val fallbackSeqName = "$q${tableName.replace("\"", "")}_${name}_seq$q"
             this.withColumnType(
-                AutoIncColumnType(columnType, idSeqName, "${tableName?.replace("\"", "")}_${name}_seq")
+                AutoIncColumnType(columnType, idSeqName, fallbackSeqName)
             )
         }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -352,6 +352,12 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         null
     }
 
+    /**
+     * Returns the table name without schema.
+     *
+     * If the table is quoted, a dot in the name is considered part of the table name and the whole string is taken to
+     * be the table name as is. If it is not quoted, whatever is after the dot is considered to be the table name.
+     */
     internal val tableNameWithoutScheme: String
         get() = if (!tableName.isAlreadyQuoted()) tableName.substringAfterLast(".") else tableName
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -345,7 +345,12 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         else -> javaClass.name.removePrefix("${javaClass.`package`.name}.").substringAfter('$').removeSuffix("Table")
     }
 
-    /** Returns the schema name, or null if one does not exist for this table. */
+    /** Returns the schema name, or null if one does not exist for this table.
+     *
+     * If the table is quoted, a dot in the name is considered part of the table name and the whole string is taken to
+     * be the table name as is, so there would be no schema. If it is not quoted, whatever is after the dot is
+     * considered to be the table name, and whatever is before the dot is considered to be the schema.
+     */
     val schemaName: String? = if (name.contains(".") && !name.isAlreadyQuoted()) {
         name.substringBeforeLast(".")
     } else {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
@@ -97,7 +97,7 @@ abstract class IdentifierManagerApi {
     }
 
     fun quoteIfNecessary(identity: String): String {
-        return if (identity.contains('.')) {
+        return if (identity.contains('.') && !identity.isAlreadyQuoted()) {
             identity.split('.').joinToString(".") { quoteTokenIfNecessary(it) }
         } else {
             quoteTokenIfNecessary(identity)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -388,7 +388,7 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         return when {
             schema.isEmpty() -> this == table.nameInDatabaseCaseUnquoted()
             else -> {
-                val sanitizedTableName = table.tableNameWithoutSchemeSanitized
+                val sanitizedTableName = table.tableNameWithoutScheme.replace("`", "")
                 val nameInDb = "$schema.$sanitizedTableName".inProperCase()
                 this == nameInDb
             }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -388,7 +388,7 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
         return when {
             schema.isEmpty() -> this == table.nameInDatabaseCaseUnquoted()
             else -> {
-                val sanitizedTableName = table.tableNameWithoutScheme
+                val sanitizedTableName = table.tableNameWithoutSchemeSanitized
                 val nameInDb = "$schema.$sanitizedTableName".inProperCase()
                 this == nameInDb
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -445,7 +445,7 @@ class CreateTableTests : DatabaseTestsBase() {
     fun createTableWithExplicitForeignKeyName4() {
         val fkName = "MyForeignKey4"
         val parent = object : LongIdTable() {
-            override val tableName = "parent4"
+            override val tableName get() = "parent4"
             val uniqueId = uuid("uniqueId").clientDefault { UUID.randomUUID() }.uniqueIndex()
         }
         val child = object : LongIdTable("child4") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -631,6 +631,15 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    /**
+     * Note on Oracle exclusion in this test:
+     * Oracle names are not case-sensitive. They can be made case-sensitive by using quotes around them. The Oracle JDBC
+     * driver converts the entire SQL INSERT statement to upper case before extracting the table name from it. This
+     * happens regardless of whether there is a dot in the name. Even when a name is quoted, the driver converts
+     * it to upper case. Therefore, the INSERT statement fails when it contains a quoted table name because it attempts
+     * to insert into a table that does not exist (“SOMENAMESPACE.SOMETABLE” is not found) . It does not fail when the
+     * table name is not quoted because the case would not matter in that scenario.
+     */
     @Test
     fun `create table with dot in name without creating schema beforehand`() {
         withDb(excludeSettings = listOf(TestDB.ORACLE)) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -652,6 +652,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
             try {
                 SchemaUtils.create(tester)
+                assertTrue(tester.exists())
 
                 val id = tester.insertAndGetId { it[text_col] = "Inserted text" }
                 tester.update({ tester.id eq id }) { it[text_col] = "Updated text" }


### PR DESCRIPTION
When providing a table with a dot in its name, it's necessary to quote it so that the part before the dot is not treated as a schema name. If it is treated like a schema name, it fails to find that schema and throws an error. Adding quotes previously caused the name to be broken apart. The fix is to only break the name apart if is NOT already quoted.

**Old behaviour:**
Provided table name = "SomeNamespace.SomeTable"
Name in SQL statements = "SomeNamespace"."SomeTable"

**New behaviour:**
Provided table name = "SomeNamespace.SomeTable"
Name in SQL statements = "SomeNamespace.SomeTable"

Oracle is excluded from this fix because it throws this error:
> java.sql.SQLSyntaxErrorException: ORA-04043: object "SOMENAMESPACE.SOMETABLE" does not exist

A problem with casing for table names is suspected with INSERT statements. Needs further investigation.

**Post-investigation**:
Oracle names are not case-sensitive. They can be made case-sensitive by using quotes around them. The Oracle JDBC driver converts the entire SQL INSERT statement to upper case before extracting the table name from it. This happens regardless of whether there is a dot in the name. Even when a name is quoted, the driver converts it to upper case. Therefore, the INSERT statement fails when it contains a quoted table name because it attempts to insert into a table that does not exist (“SOMENAMESPACE.SOMETABLE” is not found) . It does not fail when the table name is not quoted because the case would not matter in that scenario.

Created an [issue](https://youtrack.jetbrains.com/issue/EXPOSED-200) to further investigate case sensitivity in the Oracle driver.