### PR TITLE
[MySQL] Fix bug when inserted ids are not returned if `rewriteBatchedStatements` property set to true

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.vendors.currentDialect
 import java.io.InputStream
 import java.sql.PreparedStatement
 import java.sql.ResultSet
+import java.sql.Statement
 import java.sql.Types
 
 class JdbcPreparedStatementImpl(
@@ -60,7 +61,15 @@ class JdbcPreparedStatementImpl(
         if (!statement.isClosed) statement.close()
     }
 
-    override fun executeBatch(): List<Int> = statement.executeBatch().toList()
+    override fun executeBatch(): List<Int> {
+        return statement.executeBatch().map {
+            when (it) {
+                Statement.SUCCESS_NO_INFO -> 1
+                Statement.EXECUTE_FAILED -> 0
+                else -> it
+            }
+        }
+    }
 
     override fun cancel() {
         if (!statement.isClosed) statement.cancel()

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.apache.logging.log4j", "log4j-core", Versions.log4j2)
 
     implementation("com.zaxxer", "HikariCP", "4.0.3")
+    testCompileOnly("mysql", "mysql-connector-java", Versions.mysql80)
     testCompileOnly("org.postgresql", "postgresql", Versions.postgre)
     testCompileOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
     compileOnly("com.h2database", "h2", Versions.h2)

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -103,7 +103,7 @@ abstract class DatabaseTestsBase {
         withDb(dialect, statement)
     }
 
-    fun withTables(excludeSettings: List<TestDB>, vararg tables: Table, statement: Transaction.(TestDB) -> Unit) {
+    fun withTables(excludeSettings: Collection<TestDB>, vararg tables: Table, statement: Transaction.(TestDB) -> Unit) {
         Assume.assumeFalse(dialect in excludeSettings)
 
         withDb(dialect) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/mysql/MysqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/mysql/MysqlTests.kt
@@ -1,12 +1,18 @@
 package org.jetbrains.exposed.sql.tests.mysql
 
+import com.mysql.cj.conf.PropertyKey
+import com.mysql.cj.jdbc.ConnectionImpl
+import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.RepeatableTestRule
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 
 class MysqlTests : DatabaseTestsBase() {
 
@@ -17,6 +23,24 @@ class MysqlTests : DatabaseTestsBase() {
     fun testEmbeddedConnection() {
         withDb(TestDB.MYSQL) {
             assertFalse(TransactionManager.current().exec("SELECT VERSION();") { it.next(); it.getString(1) }.isNullOrEmpty())
+        }
+    }
+
+    @Test
+    fun testBatchInsertWithRewriteBatchedStatementsOn() {
+        val mysqlOnly = TestDB.enabledDialects() - TestDB.MYSQL
+        withTables(excludeSettings = mysqlOnly, DMLTestsData.Cities) {
+            val mysqlConnection = this.connection.connection as ConnectionImpl
+            mysqlConnection.propertySet.getBooleanProperty(PropertyKey.rewriteBatchedStatements).value = true
+            val cityNames = listOf("FooCity", "BarCity")
+            val generatedValues = DMLTestsData.Cities.batchInsert(cityNames) { city ->
+                this[DMLTestsData.Cities.name] = city
+            }
+
+            assertEquals(cityNames.size, generatedValues.size)
+            generatedValues.forEach {
+                assertNotNull(it.getOrNull(DMLTestsData.Cities.id))
+            }
         }
     }
 }


### PR DESCRIPTION
When rewriteBatchedStatements property is on mysql driver returns -2 as for each row returned by PreparedStatement.batchUpdate function. And when the whole array is summed up (https://github.com/JetBrains/Exposed/pull/1641) it results in negative value as nothing where inserted.