### PR TITLE
deprecate: Raise deprecation level of currentScheme property

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2998,7 +2998,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun getVersion ()Ljava/math/BigDecimal;
 	public abstract fun resetCurrentScheme ()V
 	public abstract fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
-	public abstract fun tableNamesByCurrentSchema (Ljava/util/Map;)Lkotlin/Pair;
+	public abstract fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
 }
 
 public abstract class org/jetbrains/exposed/sql/statements/api/ExposedSavepoint {
@@ -3656,6 +3656,19 @@ public class org/jetbrains/exposed/sql/vendors/SQLiteDialect : org/jetbrains/exp
 
 public final class org/jetbrains/exposed/sql/vendors/SQLiteDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
 	public final fun getENABLE_UPDATE_DELETE_LIMIT ()Z
+}
+
+public final class org/jetbrains/exposed/sql/vendors/SchemaMetadata {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
+	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSchemaName ()Ljava/lang/String;
+	public final fun getTableNames ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetbrains/exposed/sql/vendors/DatabaseDialect {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2998,6 +2998,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun getVersion ()Ljava/math/BigDecimal;
 	public abstract fun resetCurrentScheme ()V
 	public abstract fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
+	public abstract fun tableNamesByCurrentSchema (Ljava/util/Map;)Lkotlin/Pair;
 }
 
 public abstract class org/jetbrains/exposed/sql/statements/api/ExposedSavepoint {
@@ -3532,8 +3533,8 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public final fun isFractionDateTimeSupported ()Z
 	public final fun isTimeZoneOffsetSupported ()Z
+	protected fun metadataMatchesTable (Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Table;)Z
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
-	public fun tableExists (Lorg/jetbrains/exposed/sql/Table;)Z
 }
 
 public final class org/jetbrains/exposed/sql/vendors/MysqlDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
@@ -3704,6 +3705,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun getSupportsWindowFrameGroupsMode ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
+	protected fun metadataMatchesTable (Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Table;)Z
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
 	protected final fun quoteIdentifierWhenWrongCaseOrNecessary (Ljava/lang/String;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun resetCaches ()V

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.sql.Index
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.vendors.ColumnMetadata
 import org.jetbrains.exposed.sql.vendors.PrimaryKeyMetadata
+import org.jetbrains.exposed.sql.vendors.SchemaMetadata
 import java.math.BigDecimal
 
 abstract class ExposedDatabaseMetadata(val database: String) {
@@ -30,7 +31,7 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     abstract val tableNames: Map<String, List<String>>
     abstract val schemaNames: List<String>
 
-    abstract fun tableNamesByCurrentSchema(tableNamesCache: Map<String, List<String>>?): Pair<String, List<String>>
+    abstract fun tableNamesByCurrentSchema(tableNamesCache: Map<String, List<String>>?): SchemaMetadata
 
     abstract fun columns(vararg tables: Table): Map<Table, List<ColumnMetadata>>
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -23,12 +23,14 @@ abstract class ExposedDatabaseMetadata(val database: String) {
 
     @Deprecated(
         message = "it's temporary solution which will be replaced in a future releases. Do not use it in your code",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     abstract val currentScheme: String
     abstract fun resetCurrentScheme()
     abstract val tableNames: Map<String, List<String>>
     abstract val schemaNames: List<String>
+
+    abstract fun tableNamesByCurrentSchema(tableNamesCache: Map<String, List<String>>?): Pair<String, List<String>>
 
     abstract fun columns(vararg tables: Table): Map<Table, List<ColumnMetadata>>
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -384,20 +384,13 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
 
     override fun dropSchema(schema: Schema, cascade: Boolean): String = "DROP SCHEMA IF EXISTS ${schema.identifier}"
 
-    override fun tableExists(table: Table): Boolean {
-        val tableScheme = table.schemaName
-        val scheme = tableScheme?.inProperCase() ?: TransactionManager.current().connection.metadata { currentScheme }
-        val allTables = getAllTableNamesCache().getValue(scheme)
-
-        return allTables.any {
-            when {
-                tableScheme != null -> it == table.nameInDatabaseCase()
-                scheme.isEmpty() -> it == table.nameInDatabaseCaseUnquoted()
-                else -> {
-                    val sanitizedTableName = table.tableNameWithoutScheme
-                    val nameInDb = "$scheme.$sanitizedTableName".inProperCase()
-                    it == nameInDb
-                }
+    override fun String.metadataMatchesTable(schema: String, table: Table): Boolean {
+        return when {
+            schema.isEmpty() -> this == table.nameInDatabaseCaseUnquoted()
+            else -> {
+                val sanitizedTableName = table.tableNameWithoutScheme
+                val nameInDb = "$schema.$sanitizedTableName".inProperCase()
+                this == nameInDb
             }
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SchemaMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SchemaMetadata.kt
@@ -1,0 +1,11 @@
+package org.jetbrains.exposed.sql.vendors
+
+/**
+ * Represents metadata information about the current schema and its associated tables.
+ */
+data class SchemaMetadata(
+    /** Name of the current schema. */
+    val schemaName: String,
+    /** Names of the existing tables in the current schema. */
+    val tableNames: List<String>
+)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
@@ -28,7 +28,7 @@ abstract class VendorDialect(
     val allTablesNames: List<String>
         get() {
             val connection = TransactionManager.current().connection
-            return getAllTableNamesCache().getValue(connection.metadata { currentScheme })
+            return connection.metadata { tableNamesByCurrentSchema(getAllTableNamesCache()) }.second
         }
 
     protected fun getAllTableNamesCache(): Map<String, List<String>> {
@@ -57,22 +57,31 @@ abstract class VendorDialect(
      * Using `allTablesNames` field is the preferred way.
      */
     override fun allTablesNames(): List<String> = TransactionManager.current().connection.metadata {
-        tableNames.getValue(currentScheme)
-    }
+        tableNamesByCurrentSchema(null)
+    }.second
 
     override fun tableExists(table: Table): Boolean {
-        val tableScheme = table.schemaName
-        val scheme = tableScheme?.inProperCase() ?: TransactionManager.current().connection.metadata { currentScheme }
-        val allTables = getAllTableNamesCache().getValue(scheme)
-        return allTables.any {
-            when {
-                tableScheme != null -> it == table.nameInDatabaseCase()
-                scheme.isEmpty() -> it == table.nameInDatabaseCaseUnquoted()
-                else -> {
-                    val sanitizedTableName = table.tableNameWithoutSchemeSanitized
-                    val nameInDb = "$scheme.$sanitizedTableName".inProperCase()
-                    it == nameInDb
-                }
+        return table.schemaName?.let { schema ->
+            getAllTableNamesCache().getValue(schema.inProperCase()).any {
+                it == table.nameInDatabaseCase()
+            }
+        } ?: run {
+            val (schema, allTables) = TransactionManager.current().connection.metadata {
+                tableNamesByCurrentSchema(getAllTableNamesCache())
+            }
+            allTables.any {
+                it.metadataMatchesTable(schema, table)
+            }
+        }
+    }
+
+    protected open fun String.metadataMatchesTable(schema: String, table: Table): Boolean {
+        return when {
+            schema.isEmpty() -> this == table.nameInDatabaseCaseUnquoted()
+            else -> {
+                val sanitizedTableName = table.tableNameWithoutSchemeSanitized
+                val nameInDb = "$schema.$sanitizedTableName".inProperCase()
+                this == nameInDb
             }
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
@@ -28,7 +28,7 @@ abstract class VendorDialect(
     val allTablesNames: List<String>
         get() {
             val connection = TransactionManager.current().connection
-            return connection.metadata { tableNamesByCurrentSchema(getAllTableNamesCache()) }.second
+            return connection.metadata { tableNamesByCurrentSchema(getAllTableNamesCache()).tableNames }
         }
 
     protected fun getAllTableNamesCache(): Map<String, List<String>> {
@@ -57,8 +57,8 @@ abstract class VendorDialect(
      * Using `allTablesNames` field is the preferred way.
      */
     override fun allTablesNames(): List<String> = TransactionManager.current().connection.metadata {
-        tableNamesByCurrentSchema(null)
-    }.second
+        tableNamesByCurrentSchema(null).tableNames
+    }
 
     override fun tableExists(table: Table): Boolean {
         return table.schemaName?.let { schema ->

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -53,7 +53,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun getVersion ()Ljava/math/BigDecimal;
 	public fun resetCurrentScheme ()V
 	public fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
-	public fun tableNamesByCurrentSchema (Ljava/util/Map;)Lkotlin/Pair;
+	public fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
 }
 
 public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl$Companion {

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -53,6 +53,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun getVersion ()Ljava/math/BigDecimal;
 	public fun resetCurrentScheme ()V
 	public fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
+	public fun tableNamesByCurrentSchema (Ljava/util/Map;)Lkotlin/Pair;
 }
 
 public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl$Companion {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -130,11 +130,12 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
     }
 
     /**
-     * Returns the default schema name and a list of its existing table names, as a pair,
+     * Returns the default schema name and a list of its existing table names, as [SchemaMetadata],
      * found either by reading metadata or from a cache of previously read metadata.
      */
-    override fun tableNamesByCurrentSchema(tableNamesCache: Map<String, List<String>>?): Pair<String, List<String>> {
-        return currentSchema!! to (tableNamesCache ?: tableNames).getValue(currentSchema!!)
+    override fun tableNamesByCurrentSchema(tableNamesCache: Map<String, List<String>>?): SchemaMetadata {
+        val tablesInSchema = (tableNamesCache ?: tableNames).getValue(currentSchema!!)
+        return SchemaMetadata(currentSchema!!, tablesInSchema)
     }
 
     private fun ResultSet.extractColumns(): List<ColumnMetadata> {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -38,7 +38,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
 
     private val databaseName
         get() = when (databaseDialectName) {
-            MysqlDialect.dialectName, MariaDBDialect.dialectName -> _currentScheme!!
+            MysqlDialect.dialectName, MariaDBDialect.dialectName -> currentSchema!!
             else -> database
         }
 
@@ -56,7 +56,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         }
     }
 
-    private var _currentScheme: String? = null
+    private var currentSchema: String? = null
         get() {
             if (field == null) {
                 field = try {
@@ -76,10 +76,10 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         message = "This will be removed when the interface property is fully deprecated",
         level = DeprecationLevel.ERROR
     )
-    override val currentScheme: String get() = _currentScheme!!
+    override val currentScheme: String get() = currentSchema!!
 
     override fun resetCurrentScheme() {
-        _currentScheme = null
+        currentSchema = null
     }
 
     private inner class CachableMapWithDefault<K, V>(
@@ -134,7 +134,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
      * found either by reading metadata or from a cache of previously read metadata.
      */
     override fun tableNamesByCurrentSchema(tableNamesCache: Map<String, List<String>>?): Pair<String, List<String>> {
-        return _currentScheme!! to (tableNamesCache ?: tableNames).getValue(_currentScheme!!)
+        return currentSchema!! to (tableNamesCache ?: tableNames).getValue(currentSchema!!)
     }
 
     private fun ResultSet.extractColumns(): List<ColumnMetadata> {
@@ -148,11 +148,11 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
     override fun columns(vararg tables: Table): Map<Table, List<ColumnMetadata>> {
         val result = mutableMapOf<Table, List<ColumnMetadata>>()
         val useSchemaInsteadOfDatabase = currentDialect is MysqlDialect
-        val tablesBySchema = tables.groupBy { identifierManager.inProperCase(it.schemaName ?: _currentScheme!!) }
+        val tablesBySchema = tables.groupBy { identifierManager.inProperCase(it.schemaName ?: currentSchema!!) }
 
         for ((schema, schemaTables) in tablesBySchema.entries) {
             for (table in schemaTables) {
-                val catalog = if (!useSchemaInsteadOfDatabase || schema == _currentScheme!!) databaseName else schema
+                val catalog = if (!useSchemaInsteadOfDatabase || schema == currentSchema!!) databaseName else schema
                 val rs = metadata.getColumns(catalog, schema, table.nameInDatabaseCaseUnquoted(), "%")
                 val columns = rs.extractColumns()
                 check(columns.isNotEmpty())
@@ -220,7 +220,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                     rs.close()
                     names
                 }
-                val storedIndexTable = if (tableSchema == _currentScheme!!) table.nameInDatabaseCase() else table.nameInDatabaseCaseUnquoted()
+                val storedIndexTable = if (tableSchema == currentSchema!!) table.nameInDatabaseCase() else table.nameInDatabaseCaseUnquoted()
                 val rs = metadata.getIndexInfo(catalog, tableSchema, storedIndexTable, false, false)
 
                 val tmpIndices = hashMapOf<Triple<String, Boolean, Op.TRUE?>, MutableList<String>>()
@@ -324,8 +324,8 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
      * metadata if 'my_schema' is used as the database name.
      */
     private fun tableCatalogAndSchema(table: Table): Pair<String, String> {
-        val tableSchema = identifierManager.inProperCase(table.schemaName ?: _currentScheme!!)
-        return if (currentDialect is MysqlDialect && tableSchema != _currentScheme!!) {
+        val tableSchema = identifierManager.inProperCase(table.schemaName ?: currentSchema!!)
+        return if (currentDialect is MysqlDialect && tableSchema != currentSchema!!) {
             tableSchema to tableSchema
         } else {
             databaseName to tableSchema

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
@@ -140,7 +140,7 @@ class SchemaTests : DatabaseTestsBase() {
 
         transaction {
             connection.metadata {
-                assertEquals("PUBLIC", tableNamesByCurrentSchema(null).first)
+                assertEquals("PUBLIC", tableNamesByCurrentSchema(null).schemaName)
             }
         }
 
@@ -154,13 +154,17 @@ class SchemaTests : DatabaseTestsBase() {
 
         transaction(db) {
             connection.metadata {
-                val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(tableNamesByCurrentSchema(null).first)
+                val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(
+                    tableNamesByCurrentSchema(null).schemaName
+                )
                 assertEquals(schema.identifier, currentScheme)
             }
             // Nested transaction
             transaction(db) {
                 connection.metadata {
-                    val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(tableNamesByCurrentSchema(null).first)
+                    val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(
+                        tableNamesByCurrentSchema(null).schemaName
+                    )
                     assertEquals(schema.identifier, currentScheme)
                 }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/SchemaTests.kt
@@ -140,7 +140,7 @@ class SchemaTests : DatabaseTestsBase() {
 
         transaction {
             connection.metadata {
-                assertEquals("PUBLIC", currentScheme)
+                assertEquals("PUBLIC", tableNamesByCurrentSchema(null).first)
             }
         }
 
@@ -154,13 +154,13 @@ class SchemaTests : DatabaseTestsBase() {
 
         transaction(db) {
             connection.metadata {
-                val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(currentScheme)
+                val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(tableNamesByCurrentSchema(null).first)
                 assertEquals(schema.identifier, currentScheme)
             }
             // Nested transaction
             transaction(db) {
                 connection.metadata {
-                    val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(currentScheme)
+                    val currentScheme = db.identifierManager.cutIfNecessaryAndQuote(tableNamesByCurrentSchema(null).first)
                     assertEquals(schema.identifier, currentScheme)
                 }
             }


### PR DESCRIPTION
Raise deprecation level of `ExposedDatabaseMetadata.currentScheme` from WARNING to ERROR.

This property was initially deprecated after [this PR](https://github.com/JetBrains/Exposed/pull/815) introduced the possibility to change the schema in runtime.

The goal of this fix is to keep the property private in `JdbcDatabaseMetadataImpl`, which has 2 complications:

1. **`VendorDialect` functions use it to filter existing table names:**
    - This is replaced by a new fun `tableNamesByCurrentSchema()`, which abstracts away the property from the core module. **Ideallly** this function should only return a `List<String>`, but it doesn't because of complication 2 (below).

2. **`VendorDialect.tableExists()` uses the property directly, as does 1 unit test:**
    - So `tableNamesByCurrentSchema()` instead returns a Pair, which maybe defeats the purpose of making it private.
    - **Alternatives:**
        - Put the entire `tableExists()` into `JdbcDatabaseMetadataImpl`. This would require refactoring of the cache in `VendorDialect` and `Table.exists()`.
        - `JdbcDatabaseMetadataImpl.schemaNames` could be refactored to always set the current schema name as the first list element, so it could be reliably found using the cache in `VendorDialect`. This seems prone to error if any future changes are made.