### PR TITLE
test: Change MySQL connector Driver class name and version

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -13,7 +13,7 @@ object Versions {
     const val mariaDB_v2 = "2.7.9"
     const val mariaDB_v3 = "3.1.4"
     const val mysql51 = "5.1.49"
-    const val mysql80 = "8.0.30"
+    const val mysql80 = "8.0.33"
     const val oracle12 = "12.2.0.1"
     const val postgre = "42.6.0"
     const val postgreNG = "0.8.9"

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
@@ -48,7 +48,7 @@ enum class TestDB(
         connection = {
             "jdbc:mysql://127.0.0.1:3001/testdb?useSSL=false&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull"
         },
-        driver = "com.mysql.jdbc.Driver"
+        driver = "com.mysql.cj.jdbc.Driver"
     ),
     POSTGRESQL(
         { "jdbc:postgresql://127.0.0.1:3004/postgres?lc_messages=en_US.UTF-8" },


### PR DESCRIPTION
Every MySQL test shows the following log when run:

![mysql_driver_log](https://github.com/JetBrains/Exposed/assets/82039410/36e50161-066f-4514-8308-24c9bdb82e81)

[Change notes](https://dev.mysql.com/doc/connector-j/8.1/en/connector-j-api-changes.html) confirm that the driver class name used in `exposed-tests` is deprecated.

The MySQL version used for testing is also bumped to 8.0.33.

**Note:** Could bump to latest 8.1.0, but it is fairly recent (2023-07-18, GA) and would require a [dependency change](https://dev.mysql.com/doc/relnotes/connector-j/8.1/en/news-8-1-0.html) (new `groupId` and `artifactId`) and refactoring of 1 unit test.

**Note:** I don't foresee complications, but please consider running MySQL tests locally to check that the new driver doesn't cause any issues.