### PR TITLE
Improved code of functional logic in Exposed SQL Statement classes

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
@@ -151,7 +151,6 @@ fun StatementContext.expandArgs(transaction: Transaction): String {
     }
 }
 
-
 /** Represents the groups that are used to classify the purpose of an SQL statement. */
 enum class StatementGroup {
     /** Data definition language group. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
@@ -61,5 +61,4 @@ open class UpdateStatement(val targetsSet: ColumnSet, val limit: Int?, val where
         }
         if (args.isNotEmpty()) listOf(args) else emptyList()
     }
-
 }


### PR DESCRIPTION
### Type of PR

I have improved the readability of the internal implementation logic of SQL Statement-related classes. I noticed that some parts were implemented using `when` statements while others were implemented using `if` statements, so I improved readability by using `when` statements consistently.

Additionally, I added line breaks to the interface functions of the `StatementInterface` class, as it seemed like they were missing. The modified files are as follows: **Statement.kt**, **StatementInterceptor.kt**, and **UpdateStatement.kt**

---
### Commit Timeline

- 7e0480ed2f00f3ab517b489cd4e0cd23b67dc85f
Enhanced readability of the internal implementation of the `expandArgs` extension function in `StatementContext`.

- eda64ad11927cb2cc642bc1694003578ce92649b
Added line breaks to the interface functions of the `StatementInterceptor` class.

- dcccdb902dc857fa0ba98c5b836e2818a21ce3f5
Enhanced readability of the `arguments` function in the `UpdateStatement` class.

---

> I understand that code readability and conventions vary among teams and organizations. However, if you find my suggestions appealing, I would appreciate it if you could review this PR.
