### PR TITLE
fix: Parsing failure when selecting CURRENT_TIMESTAMP using CurrentDateTime function

### DIFF
--- a/exposed-java-time/api/exposed-java-time.api
+++ b/exposed-java-time/api/exposed-java-time.api
@@ -116,6 +116,7 @@ public final class org/jetbrains/exposed/sql/javatime/JavaLocalDateTimeColumnTyp
 	public fun getHasTimePart ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -453,6 +453,21 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             }
         }
     }
+
+    @Test
+    fun testCurrentDateTimeFunction() {
+        val fakeTestTable = object : IntIdTable("fakeTable") {}
+
+        withTables(fakeTestTable) {
+            fun currentDbDateTime(): LocalDateTime {
+                return fakeTestTable.slice(CurrentDateTime).selectAll().first()[CurrentDateTime]
+            }
+
+            fakeTestTable.insert {}
+
+            currentDbDateTime()
+        }
+    }
 }
 
 fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -282,6 +282,21 @@ class JodaTimeDefaultsTest : JodaTimeBaseTest() {
     }
 
     @Test
+    fun testCurrentDateTimeFunction() {
+        val fakeTestTable = object : IntIdTable("fakeTable") {}
+
+        withTables(fakeTestTable) {
+            fun currentDbDateTime(): DateTime {
+                return fakeTestTable.slice(CurrentDateTime).selectAll().first()[CurrentDateTime]
+            }
+
+            fakeTestTable.insert {}
+
+            currentDbDateTime()
+        }
+    }
+
+    @Test
     fun testDefaultCurrentDateTime() {
         val testDate = object : IntIdTable("TestDate") {
             val time = datetime("time").defaultExpression(CurrentDateTime)

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -136,6 +136,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalDateTime
 	public fun getHasTimePart ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -449,6 +449,21 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
             }
         }
     }
+
+    @Test
+    fun testCurrentDateTimeFunction() {
+        val fakeTestTable = object : IntIdTable("fakeTable") {}
+
+        withTables(fakeTestTable) {
+            fun currentDbDateTime(): LocalDateTime {
+                return fakeTestTable.slice(CurrentDateTime).selectAll().first()[CurrentDateTime]
+            }
+
+            fakeTestTable.insert {}
+
+            currentDbDateTime()
+        }
+    }
 }
 
 fun <T> assertEqualDateTime(d1: T?, d2: T?) {


### PR DESCRIPTION
- For H2, the type of the value returned from the database for CurrentDateTime function is OffsetDateTime, which was not being handled correctly in `valueFromDB` function.
- For Oracle, the type of the value returned from the database for CurrentDateTime function is oracle.sql.TIMESTAMPTZ, which was not being handled correctly in `valueFromDB` function. The fix for this is to call `rs.getObject(index, java.sql.Timestamp::class.java)` in readObject, which then results in the type being java.sql.Timestamp which is already handled properly in `valueFromDB` function.