### PR TITLE
test: Refactor time tests

### DIFF
--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -347,6 +347,21 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
             }
         }
     }
+
+    @Test
+    fun testCurrentDateTimeFunction() {
+        val fakeTestTable = object : IntIdTable("fakeTable") {}
+
+        withTables(fakeTestTable) {
+            fun currentDbDateTime(): DateTime {
+                return fakeTestTable.slice(CurrentDateTime).selectAll().first()[CurrentDateTime]
+            }
+
+            fakeTestTable.insert {}
+
+            currentDbDateTime()
+        }
+    }
 }
 
 fun assertEqualDateTime(d1: DateTime?, d2: DateTime?) {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -16,7 +16,7 @@ import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.constraintNamePart
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.inProperCase
-import org.jetbrains.exposed.sql.tests.shared.Category.defaultExpression
+import org.jetbrains.exposed.sql.tests.insertAndWait
 import org.jetbrains.exposed.sql.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
@@ -455,6 +455,35 @@ class DefaultsTest : DatabaseTestsBase() {
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
             }
+        }
+    }
+
+    @Test
+    fun testDefaultCurrentDateTime() {
+        val testDate = object : IntIdTable("TestDate") {
+            val time = datetime("time").defaultExpression(CurrentDateTime)
+        }
+
+        fun LocalDateTime.millis(): Long = this.toJavaLocalDateTime().toEpochSecond(ZoneOffset.UTC) * 1000
+
+        withTables(testDate) {
+            val duration: Long = 2000
+
+            repeat(2) {
+                testDate.insertAndWait(duration)
+            }
+
+            Thread.sleep(duration)
+
+            repeat(2) {
+                testDate.insertAndWait(duration)
+            }
+
+            val sortedEntries: List<LocalDateTime> = testDate.selectAll().map { it[testDate.time] }.sorted()
+
+            assertTrue(sortedEntries[1].millis() - sortedEntries[0].millis() >= 2000)
+            assertTrue(sortedEntries[2].millis() - sortedEntries[0].millis() >= 6000)
+            assertTrue(sortedEntries[3].millis() - sortedEntries[0].millis() >= 8000)
         }
     }
 }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestUtils.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestUtils.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.exposed.sql.tests
 
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.DatabaseDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
@@ -10,10 +12,11 @@ fun String.inProperCase(): String = TransactionManager.currentOrNull()?.db?.iden
 
 val currentDialectTest: DatabaseDialect get() = TransactionManager.current().db.dialect
 
-val currentDialectIfAvailableTest: DatabaseDialect? get() =
-    if (TransactionManager.isInitialized() && TransactionManager.currentOrNull() != null) {
-        currentDialectTest
-    } else null
+val currentDialectIfAvailableTest: DatabaseDialect?
+    get() =
+        if (TransactionManager.isInitialized() && TransactionManager.currentOrNull() != null) {
+            currentDialectTest
+        } else null
 
 inline fun <reified E : Enum<E>> enumSetOf(vararg elements: E): EnumSet<E> =
     elements.toCollection(EnumSet.noneOf(E::class.java))
@@ -21,3 +24,9 @@ inline fun <reified E : Enum<E>> enumSetOf(vararg elements: E): EnumSet<E> =
 fun <T> Column<T>.constraintNamePart() = (currentDialectTest as? SQLServerDialect)?.let {
     " CONSTRAINT DF_${table.tableName}_$name"
 } ?: ""
+
+fun Table.insertAndWait(duration: Long) {
+    this.insert { }
+    TransactionManager.current().commit()
+    Thread.sleep(duration)
+}


### PR DESCRIPTION
- Move `testCurrentDateTimeFunction` from `JodaTimeDefaultsTest` to `JodaTimeTests`
- Rewrite `testDefaultCurrentDateTime` in `JodaTimeDefaultsTest`
- Add `testDefaultCurrentDateTime` to Java and Kotlin tests