### PR TITLE
chore: Remove build file kotlinOptions languageVersion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import org.jetbrains.exposed.gradle.*
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     kotlin("jvm") apply true
@@ -40,14 +39,6 @@ subprojects {
         finalizedBy(reportMerge)
         reportMerge.configure {
             input.from(this@detekt.xmlReportFile)
-        }
-    }
-
-    tasks.withType<KotlinJvmCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = "1.8"
-            apiVersion = "1.6"
-            languageVersion = "1.6"
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import org.jetbrains.exposed.gradle.*
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     kotlin("jvm") apply true
@@ -40,12 +39,6 @@ subprojects {
         finalizedBy(reportMerge)
         reportMerge.configure {
             input.from(this@detekt.xmlReportFile)
-        }
-    }
-
-    tasks.withType<KotlinJvmCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = "1.8"
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 import org.jetbrains.exposed.gradle.*
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     kotlin("jvm") apply true
@@ -39,6 +40,12 @@ subprojects {
         finalizedBy(reportMerge)
         reportMerge.configure {
             input.from(this@detekt.xmlReportFile)
+        }
+    }
+
+    tasks.withType<KotlinJvmCompile>().configureEach {
+        kotlinOptions {
+            jvmTarget = "1.8"
         }
     }
 }

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1200,6 +1200,7 @@ public final class org/jetbrains/exposed/sql/JoinType : java/lang/Enum {
 	public static final field INNER Lorg/jetbrains/exposed/sql/JoinType;
 	public static final field LEFT Lorg/jetbrains/exposed/sql/JoinType;
 	public static final field RIGHT Lorg/jetbrains/exposed/sql/JoinType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/JoinType;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/JoinType;
 }
@@ -1679,6 +1680,7 @@ public final class org/jetbrains/exposed/sql/ReferenceOption : java/lang/Enum {
 	public static final field RESTRICT Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public static final field SET_DEFAULT Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public static final field SET_NULL Lorg/jetbrains/exposed/sql/ReferenceOption;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/ReferenceOption;
@@ -1917,6 +1919,7 @@ public final class org/jetbrains/exposed/sql/SortOrder : java/lang/Enum {
 	public static final field DESC_NULLS_FIRST Lorg/jetbrains/exposed/sql/SortOrder;
 	public static final field DESC_NULLS_LAST Lorg/jetbrains/exposed/sql/SortOrder;
 	public final fun getCode ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/SortOrder;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/SortOrder;
 }
@@ -2288,6 +2291,10 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 public final class org/jetbrains/exposed/sql/Transaction$Companion {
 }
 
+public synthetic class org/jetbrains/exposed/sql/Transaction$EntriesMappings {
+	public static final synthetic field entries$0 Lkotlin/enums/EnumEntries;
+}
+
 public final class org/jetbrains/exposed/sql/Trim : org/jetbrains/exposed/sql/Function {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;)V
 	public final fun getExpr ()Lorg/jetbrains/exposed/sql/Expression;
@@ -2432,6 +2439,7 @@ public final class org/jetbrains/exposed/sql/WindowFrameBound$Companion {
 public final class org/jetbrains/exposed/sql/WindowFrameBoundDirection : java/lang/Enum {
 	public static final field FOLLOWING Lorg/jetbrains/exposed/sql/WindowFrameBoundDirection;
 	public static final field PRECEDING Lorg/jetbrains/exposed/sql/WindowFrameBoundDirection;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/WindowFrameBoundDirection;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/WindowFrameBoundDirection;
 }
@@ -2446,6 +2454,7 @@ public final class org/jetbrains/exposed/sql/WindowFrameUnit : java/lang/Enum {
 	public static final field GROUPS Lorg/jetbrains/exposed/sql/WindowFrameUnit;
 	public static final field RANGE Lorg/jetbrains/exposed/sql/WindowFrameUnit;
 	public static final field ROWS Lorg/jetbrains/exposed/sql/WindowFrameUnit;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/WindowFrameUnit;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/WindowFrameUnit;
 }
@@ -2741,6 +2750,7 @@ public final class org/jetbrains/exposed/sql/statements/StatementContext {
 public final class org/jetbrains/exposed/sql/statements/StatementGroup : java/lang/Enum {
 	public static final field DDL Lorg/jetbrains/exposed/sql/statements/StatementGroup;
 	public static final field DML Lorg/jetbrains/exposed/sql/statements/StatementGroup;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/statements/StatementGroup;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/statements/StatementGroup;
 }
@@ -2785,6 +2795,7 @@ public final class org/jetbrains/exposed/sql/statements/StatementType : java/lan
 	public static final field SHOW Lorg/jetbrains/exposed/sql/statements/StatementType;
 	public static final field TRUNCATE Lorg/jetbrains/exposed/sql/statements/StatementType;
 	public static final field UPDATE Lorg/jetbrains/exposed/sql/statements/StatementType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getGroup ()Lorg/jetbrains/exposed/sql/statements/StatementGroup;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/statements/StatementType;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/statements/StatementType;
@@ -2920,6 +2931,7 @@ protected final class org/jetbrains/exposed/sql/statements/api/IdentifierManager
 	public static final field Oracle11g Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi$OracleVersion;
 	public static final field Oracle12_1g Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi$OracleVersion;
 	public static final field Oracle12plus Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi$OracleVersion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi$OracleVersion;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi$OracleVersion;
 }
@@ -3283,6 +3295,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreS
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE : java/lang/Enum {
 	public static final field NO_WAIT Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 	public static final field SKIP_LOCKED Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getStatement ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
@@ -3377,6 +3390,7 @@ public final class org/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMo
 	public static final field Oracle Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
 	public static final field PostgreSQL Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
 	public static final field SQLServer Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
 }

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2291,10 +2291,6 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 public final class org/jetbrains/exposed/sql/Transaction$Companion {
 }
 
-public synthetic class org/jetbrains/exposed/sql/Transaction$EntriesMappings {
-	public static final synthetic field entries$0 Lkotlin/enums/EnumEntries;
-}
-
 public final class org/jetbrains/exposed/sql/Trim : org/jetbrains/exposed/sql/Function {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;)V
 	public final fun getExpr ()Lorg/jetbrains/exposed/sql/Expression;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -519,7 +519,7 @@ class CharacterColumnType : ColumnType() {
     override fun sqlType(): String = "CHAR"
     override fun valueFromDB(value: Any): Char = when (value) {
         is Char -> value
-        is Number -> value.toChar()
+        is Number -> value.toInt().toChar()
         is String -> value.single()
         else -> error("Unexpected value of type Char: $value of ${value::class.qualifiedName}")
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -119,7 +119,7 @@ open class Transaction(
         if (stmt.isEmpty()) return null
 
         val type = explicitStatementType
-            ?: StatementType.entries.find { stmt.trim().startsWith(it.name, true) }
+            ?: StatementType.values().find { stmt.trim().startsWith(it.name, true) }
             ?: StatementType.OTHER
 
         return exec(object : Statement<T>(type, emptyList()) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -119,7 +119,7 @@ open class Transaction(
         if (stmt.isEmpty()) return null
 
         val type = explicitStatementType
-            ?: StatementType.values().find { stmt.trim().startsWith(it.name, true) }
+            ?: StatementType.entries.find { stmt.trim().startsWith(it.name, true) }
             ?: StatementType.OTHER
 
         return exec(object : Statement<T>(type, emptyList()) {

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -106,6 +106,7 @@ public final class org/jetbrains/exposed/dao/EntityChangeType : java/lang/Enum {
 	public static final field Created Lorg/jetbrains/exposed/dao/EntityChangeType;
 	public static final field Removed Lorg/jetbrains/exposed/dao/EntityChangeType;
 	public static final field Updated Lorg/jetbrains/exposed/dao/EntityChangeType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/dao/EntityChangeType;
 	public static fun values ()[Lorg/jetbrains/exposed/dao/EntityChangeType;
 }

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -31,6 +31,10 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl 
 	public fun setTransactionIsolation (I)V
 }
 
+public synthetic class org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl$EntriesMappings {
+	public static final synthetic field entries$0 Lkotlin/enums/EnumEntries;
+}
+
 public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl : org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata {
 	public static final field Companion Lorg/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/sql/DatabaseMetaData;)V

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -31,10 +31,6 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl 
 	public fun setTransactionIsolation (I)V
 }
 
-public synthetic class org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl$EntriesMappings {
-	public static final synthetic field entries$0 Lkotlin/enums/EnumEntries;
-}
-
 public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl : org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata {
 	public static final field Companion Lorg/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/sql/DatabaseMetaData;)V

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -94,7 +94,7 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
 
     override fun executeInBatch(sqls: List<String>) {
         val types = sqls.map { stmt ->
-            StatementType.values().find {
+            StatementType.entries.find {
                 stmt.startsWith(it.name, true)
             } ?: StatementType.OTHER
         }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -94,7 +94,7 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
 
     override fun executeInBatch(sqls: List<String>) {
         val types = sqls.map { stmt ->
-            StatementType.entries.find {
+            StatementType.values().find {
                 stmt.startsWith(it.name, true)
             } ?: StatementType.OTHER
         }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -150,7 +150,7 @@ class JsonColumnTests : DatabaseTestsBase() {
         }
     }
 
-    private val jsonContainsNotSupported = TestDB.entries -
+    private val jsonContainsNotSupported = TestDB.values().toList() -
         listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.MYSQL, TestDB.MARIADB)
 
     @Test

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -150,7 +150,7 @@ class JsonColumnTests : DatabaseTestsBase() {
         }
     }
 
-    private val jsonContainsNotSupported = TestDB.values().toList() -
+    private val jsonContainsNotSupported = TestDB.entries -
         listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.MYSQL, TestDB.MARIADB)
 
     @Test

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -34,7 +34,6 @@ import java.time.ZoneOffset
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
@@ -210,9 +209,9 @@ class DefaultsTest : DatabaseTestsBase() {
         val dateTimeConstValue = instConstValue.toLocalDateTime(TimeZone.UTC)
         val dLiteral = dateLiteral(dateConstValue)
         val dtLiteral = dateTimeLiteral(dateTimeConstValue)
-        val tsConstValue = instConstValue.plus(Duration.seconds(42))
+        val tsConstValue = instConstValue.plus(42.toDuration(DurationUnit.SECONDS))
         val tsLiteral = timestampLiteral(tsConstValue)
-        val durConstValue = Duration.milliseconds(tsConstValue.toEpochMilliseconds())
+        val durConstValue = tsConstValue.toEpochMilliseconds().toDuration((DurationUnit.MILLISECONDS))
         val durLiteral = durationLiteral(durConstValue)
         val tmConstValue = LocalTime(12, 0)
         val tLiteral = timeLiteral(tmConstValue)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
@@ -27,7 +27,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 "enumColumn", sql,
                 { value ->
                     when {
-                        currentDialectTest is H2Dialect && value is Int -> DDLTests.Foo.entries[value]
+                        currentDialectTest is H2Dialect && value is Int -> DDLTests.Foo.values()[value]
                         else -> DDLTests.Foo.valueOf(value as String)
                     }
                 },

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
@@ -27,7 +27,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 "enumColumn", sql,
                 { value ->
                     when {
-                        currentDialectTest is H2Dialect && value is Int -> DDLTests.Foo.values()[value]
+                        currentDialectTest is H2Dialect && value is Int -> DDLTests.Foo.entries[value]
                         else -> DDLTests.Foo.valueOf(value as String)
                     }
                 },

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
@@ -6,7 +6,6 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.transactions.TransactionManager
-import org.junit.Assert
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
+import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
@@ -27,8 +28,8 @@ class AdjustQueryTests : DatabaseTestsBase() {
             val actualSlice = queryAdjusted.set.fields
             fun containsInAnyOrder(list: List<*>) = Matchers.containsInAnyOrder(*list.toTypedArray())
 
-            Assert.assertThat(oldSlice, Matchers.not(containsInAnyOrder(actualSlice)))
-            Assert.assertThat(actualSlice, containsInAnyOrder(expectedSlice))
+            MatcherAssert.assertThat(oldSlice, Matchers.not(containsInAnyOrder(actualSlice)))
+            MatcherAssert.assertThat(actualSlice, containsInAnyOrder(expectedSlice))
             assertQueryResultValid(queryAdjusted)
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -77,7 +77,7 @@ class DeleteTests : DatabaseTestsBase() {
 
     @Test
     fun testDeleteWithLimit02() {
-        val dialects = TestDB.values().toList() - notSupportLimit
+        val dialects = TestDB.entries - notSupportLimit
         withCitiesAndUsers(dialects) { _, _, userData ->
             expectException<UnsupportedByDialectException> {
                 userData.deleteWhere(limit = 1) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -77,7 +77,7 @@ class DeleteTests : DatabaseTestsBase() {
 
     @Test
     fun testDeleteWithLimit02() {
-        val dialects = TestDB.entries - notSupportLimit
+        val dialects = TestDB.values().toList() - notSupportLimit
         withCitiesAndUsers(dialects) { _, _, userData ->
             expectException<UnsupportedByDialectException> {
                 userData.deleteWhere(limit = 1) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -56,7 +56,7 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    private val insertIgnoreUnsupportedDB = TestDB.values().toList() -
+    private val insertIgnoreUnsupportedDB = TestDB.entries -
         listOf(TestDB.SQLITE, TestDB.MYSQL, TestDB.H2_MYSQL, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.H2_PSQL)
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -56,7 +56,7 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    private val insertIgnoreUnsupportedDB = TestDB.entries -
+    private val insertIgnoreUnsupportedDB = TestDB.values().toList() -
         listOf(TestDB.SQLITE, TestDB.MYSQL, TestDB.H2_MYSQL, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.H2_PSQL)
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -12,7 +12,7 @@ import java.util.*
 class ReplaceTests : DatabaseTestsBase() {
 
     private val mysqlLikeDialects = listOf(TestDB.MYSQL, TestDB.MARIADB, TestDB.H2_MYSQL, TestDB.H2_MARIADB)
-    private val replaceNotSupported = TestDB.entries - mysqlLikeDialects - TestDB.SQLITE
+    private val replaceNotSupported = TestDB.values().toList() - mysqlLikeDialects - TestDB.SQLITE
 
     private object NewAuth : Table("new_auth") {
         val username = varchar("username", 16)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -12,7 +12,7 @@ import java.util.*
 class ReplaceTests : DatabaseTestsBase() {
 
     private val mysqlLikeDialects = listOf(TestDB.MYSQL, TestDB.MARIADB, TestDB.H2_MYSQL, TestDB.H2_MARIADB)
-    private val replaceNotSupported = TestDB.values().toList() - mysqlLikeDialects - TestDB.SQLITE
+    private val replaceNotSupported = TestDB.entries - mysqlLikeDialects - TestDB.SQLITE
 
     private object NewAuth : Table("new_auth") {
         val username = varchar("username", 16)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
@@ -60,7 +60,7 @@ class UpdateTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdateWithLimit02() {
-        val dialects = TestDB.values().toList() - notSupportLimit
+        val dialects = TestDB.entries - notSupportLimit
         withCitiesAndUsers(dialects) { _, users, _ ->
             expectException<UnsupportedByDialectException> {
                 users.update({ users.id like "a%" }, 1) {
@@ -112,7 +112,7 @@ class UpdateTests : DatabaseTestsBase() {
             val tableAId = reference("table_a_id", tableA)
         }
 
-        val supportWhere = TestDB.values().toList() - TestDB.allH2TestDB - TestDB.SQLITE + TestDB.H2_ORACLE
+        val supportWhere = TestDB.entries - TestDB.allH2TestDB - TestDB.SQLITE + TestDB.H2_ORACLE
 
         withTables(tableA, tableB) { testingDb ->
             val aId = tableA.insertAndGetId { it[foo] = "foo" }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
@@ -60,7 +60,7 @@ class UpdateTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdateWithLimit02() {
-        val dialects = TestDB.entries - notSupportLimit
+        val dialects = TestDB.values().toList() - notSupportLimit
         withCitiesAndUsers(dialects) { _, users, _ ->
             expectException<UnsupportedByDialectException> {
                 users.update({ users.id like "a%" }, 1) {
@@ -112,7 +112,7 @@ class UpdateTests : DatabaseTestsBase() {
             val tableAId = reference("table_a_id", tableA)
         }
 
-        val supportWhere = TestDB.entries - TestDB.allH2TestDB - TestDB.SQLITE + TestDB.H2_ORACLE
+        val supportWhere = TestDB.values().toList() - TestDB.allH2TestDB - TestDB.SQLITE + TestDB.H2_ORACLE
 
         withTables(tableA, tableB) { testingDb ->
             val aId = tableA.insertAndGetId { it[foo] = "foo" }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
@@ -99,7 +99,7 @@ class `Text id loosed on insert issue 1379` : DatabaseTestsBase() {
 
     @Test
     fun testRegression() {
-        val runTests = TestDB.entries - TestDB.POSTGRESQL
+        val runTests = TestDB.values().toList() - TestDB.POSTGRESQL
         withTables(runTests, Table1, Table2) {
             val obj1 = Obj1.new {
                 a = "hello world!"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
@@ -99,7 +99,7 @@ class `Text id loosed on insert issue 1379` : DatabaseTestsBase() {
 
     @Test
     fun testRegression() {
-        val runTests = TestDB.values().toList() - TestDB.POSTGRESQL
+        val runTests = TestDB.entries - TestDB.POSTGRESQL
         withTables(runTests, Table1, Table2) {
             val obj1 = Obj1.new {
                 a = "hello world!"


### PR DESCRIPTION
`kotlinOptions.languageVersion` was set to 1.6, preventing the use of Kotlin 1.9 features, namely switching to `Enum.entries`.

Removing this tasks block allowed the switch and the following **deprecations** also had to be dealt with:
- Direct use of `toChar()`
- `Assert.assertThat()`
- `Duration` constructor using extension functions