### PR TITLE
fix: EXPOSED-93 Error when using `with`

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -472,7 +472,8 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
                 distinctRefIds.forEach { id ->
                     cache.getOrPutReferrers(id, refColumn) { result[id]?.let { SizedCollection(it) } ?: emptySized() }.also {
                         if (keepLoadedReferenceOutOfTransaction) {
-                            findById(id)?.storeReferenceInCache(refColumn, it)
+                            val childEntity = find { refColumn eq id }.firstOrNull()
+                            childEntity?.storeReferenceInCache(refColumn, it)
                         }
                     }
                 }


### PR DESCRIPTION
Previously, the following line in `EntityClass.kt` was causing a crash:
`findById(id)?.storeReferenceInCache(refColumn, it)`
`findById` was being invoked on `this`, which is the child entity, using `id` (from looping over `distinctRefIds`) which is for the parent entity. This causes a crash as reported [here](https://youtrack.jetbrains.com/issue/EXPOSED-93).

The fix is to find the child entity by using `refColumn`, which is the column in the child table that references the `id` in the parent table.

I suspect this bug was never detected because our tests did not cover the case where the parent would have a String id, so the auto-generated Int id happened to be the same for the child entities and they were found using `findById(id)`.