### PR TITLE
feat: EXPOSED-225 Support transaction timeout in SpringTransactionManager

### DIFF
--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     testCompileOnly("mysql", "mysql-connector-java", Versions.mysql80)
     testCompileOnly("org.postgresql", "postgresql", Versions.postgre)
     testCompileOnly("com.impossibl.pgjdbc-ng", "pgjdbc-ng", Versions.postgreNG)
+    testCompileOnly("com.microsoft.sqlserver", "mssql-jdbc", Versions.sqlserver)
     compileOnly("com.h2database", "h2", Versions.h2)
     testCompileOnly("org.xerial", "sqlite-jdbc", Versions.sqlLite3)
     testImplementation("io.github.hakky54:logcaptor:2.9.0")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/QueryTimeoutTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/QueryTimeoutTest.kt
@@ -8,6 +8,8 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.junit.Assert.fail
 import org.junit.Test
 import org.postgresql.util.PSQLException
+import java.sql.SQLException
+import java.sql.SQLSyntaxErrorException
 import java.sql.SQLTimeoutException
 
 /**
@@ -54,6 +56,41 @@ class QueryTimeoutTest : DatabaseTestsBase() {
             TransactionManager.current().exec(
                 generateTimeoutStatements(it, 1)
             )
+        }
+    }
+
+    @Test
+    fun timeoutZeroWithTimeoutStatement() {
+        withDb(timeoutTestDBList) {
+            this.queryTimeout = 0
+            TransactionManager.current().exec(
+                generateTimeoutStatements(it, 1)
+            )
+        }
+    }
+
+    @Test
+    fun timeoutMinusWithTimeoutStatement() {
+        withDb(timeoutTestDBList) { testDB ->
+            this.queryTimeout = -1
+            try {
+                TransactionManager.current().exec(
+                    generateTimeoutStatements(testDB, 1)
+                )
+                fail("Should have thrown a timeout or cancelled statement exception")
+            } catch (cause: ExposedSQLException) {
+                when (testDB) {
+                    // PostgreSQL throws a regular PSQLException with a minus timeout value
+                    TestDB.POSTGRESQL -> assertTrue(cause.cause is PSQLException)
+                    // MySQL, POSTGRESQLNG throws a regular SQLException with a minus timeout value
+                    TestDB.MYSQL, TestDB.POSTGRESQLNG -> assertTrue(cause.cause is SQLException)
+                    // MariaDB throws a regular SQLSyntaxErrorException with a minus timeout value
+                    TestDB.MARIADB -> assertTrue(cause.cause is SQLSyntaxErrorException)
+                    // SqlServer throws a regular SQLServerException with a minus timeout value
+                    TestDB.SQLSERVER -> assertTrue(true)
+                    else -> throw NotImplementedError()
+                }
+            }
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/QueryTimeoutTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/QueryTimeoutTest.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.tests.shared
 
 import com.impossibl.postgres.jdbc.PGSQLSimpleException
+import com.microsoft.sqlserver.jdbc.SQLServerException
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
@@ -87,7 +88,7 @@ class QueryTimeoutTest : DatabaseTestsBase() {
                     // MariaDB throws a regular SQLSyntaxErrorException with a minus timeout value
                     TestDB.MARIADB -> assertTrue(cause.cause is SQLSyntaxErrorException)
                     // SqlServer throws a regular SQLServerException with a minus timeout value
-                    TestDB.SQLSERVER -> assertTrue(true)
+                    TestDB.SQLSERVER -> assertTrue(cause.cause is SQLServerException)
                     else -> throw NotImplementedError()
                 }
             }

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/SpringTransactionManager.kt
@@ -107,6 +107,10 @@ class SpringTransactionManager(
             readOnly = definition.isReadOnly,
             outerTransaction = currentTransactionManager.currentOrNull()
         ).apply {
+            if (definition.timeout != TransactionDefinition.TIMEOUT_DEFAULT) {
+                queryTimeout = definition.timeout
+            }
+
             if (showSql) {
                 addLogger(StdOutSqlLogger)
             }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -35,13 +35,11 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
 
     private fun PlatformTransactionManager.execute(
         propagationBehavior: Int = TransactionDefinition.PROPAGATION_REQUIRED,
-        timeout: Int? = null,
         block: (TransactionStatus) -> Unit
     ) {
         if (this !is SpringTransactionManager) error("Wrong txManager instance: ${this.javaClass.name}")
         val tt = TransactionTemplate(this)
         tt.propagationBehavior = propagationBehavior
-        if (timeout != null) tt.timeout = timeout
         tt.executeWithoutResult {
             block(it)
         }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -35,11 +35,13 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
 
     private fun PlatformTransactionManager.execute(
         propagationBehavior: Int = TransactionDefinition.PROPAGATION_REQUIRED,
+        timeout: Int? = null,
         block: (TransactionStatus) -> Unit
     ) {
         if (this !is SpringTransactionManager) error("Wrong txManager instance: ${this.javaClass.name}")
         val tt = TransactionTemplate(this)
         tt.propagationBehavior = propagationBehavior
+        if (timeout != null) tt.timeout = timeout
         tt.executeWithoutResult {
             block(it)
         }


### PR DESCRIPTION
related issue #1671 

Simply changed the Spring Transaction's timeout to apply. Change the implementation to use the timeout implemented in the previous PR.

The test code for SpringTransactionManager is not database-specific, so I think we need to implement a module like `withDB` in the exposed-test module to test the actual behaviour. So I'm going to change the existing SpringTransactionManagerTest to be more extensible, at which point I'll add a real DB test for queryTimeout.

I wonder if the tests included in this PR are sufficient for this feature to be deployed. 