### PR TITLE
docs: Add missing KDocs for exposed-core transactions API

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionScope.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionScope.kt
@@ -5,10 +5,25 @@ import org.jetbrains.exposed.sql.Transaction
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
+/**
+ * Returns the result of reading/writing transaction data stored within the scope of the current transaction.
+ *
+ * If no data is found, the specified [init] block is called with the current transaction as its receiver and
+ * the result is returned.
+ */
 @Suppress("UNCHECKED_CAST")
 fun <T : Any> transactionScope(init: Transaction.() -> T) = TransactionStore(init) as ReadWriteProperty<Any?, T>
+
+/**
+ * Returns the result of reading/writing transaction data stored within the scope of the current transaction,
+ * or `null` if no data is found.
+ */
 fun <T : Any> nullableTransactionScope() = TransactionStore<T>()
 
+/**
+ * Class responsible for implementing property delegates of read-write properties in
+ * the current transaction's [UserDataHolder].
+ */
 class TransactionStore<T : Any>(val init: (Transaction.() -> T)? = null) : ReadWriteProperty<Any?, T?> {
 
     private val key = Key<T>()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
@@ -56,10 +56,13 @@ internal class TransactionCoroutineElement(
 }
 
 /**
- * Creates a new `TransactionScope` then calls the specified suspending [statement], suspends until it completes, and returns the result.
+ * Creates a new `TransactionScope` then calls the specified suspending [statement], suspends until it completes,
+ * and returns the result.
  *
  * The `TransactionScope` is derived from a new `Transaction` and a given coroutine [context],
- * or the current `coroutineContext` if no [context] is provided.
+ * or the current [CoroutineContext] if no [context] is provided.
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.CoroutineTests.suspendedTx
  */
 suspend fun <T> newSuspendedTransaction(
     context: CoroutineContext? = null,
@@ -74,8 +77,10 @@ suspend fun <T> newSuspendedTransaction(
 /**
  * Calls the specified suspending [statement], suspends until it completes, and returns the result.
  *
- * The resulting `TransactionScope` is derived from the current `coroutineContext` if the latter already holds [this] `Transaction`;
- * otherwise, a new scope is created using [this] `Transaction` and a given coroutine [context].
+ * The resulting `TransactionScope` is derived from the current [CoroutineContext] if the latter already holds
+ * [this] `Transaction`; otherwise, a new scope is created using [this] `Transaction` and a given coroutine [context].
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.CoroutineTests.suspendedTx
  */
 suspend fun <T> Transaction.withSuspendTransaction(
     context: CoroutineContext? = null,
@@ -86,10 +91,12 @@ suspend fun <T> Transaction.withSuspendTransaction(
     }
 
 /**
- * Creates a new `TransactionScope` and returns its future result as an implementation of `Deferred`.
+ * Creates a new `TransactionScope` and returns its future result as an implementation of [Deferred].
  *
  * The `TransactionScope` is derived from a new `Transaction` and a given coroutine [context],
- * or the current `coroutineContext` if no [context] is provided.
+ * or the current [CoroutineContext] if no [context] is provided.
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.CoroutineTests.suspendTxAsync
  */
 suspend fun <T> suspendedTransactionAsync(
     context: CoroutineContext? = null,


### PR DESCRIPTION
Covers files in the `transactions` package in the `exposed-core` module.

All public API elements now show a KDoc when hovered over by a mouse in IDE or when _Quick Documentation_ shortcut is used (`F1 | Ctrl+Q`).