### PR TITLE
fix: EXPOSED-227 Slice() with empty list creates invalid SQL

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -105,6 +105,8 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     }
 
     override fun prepareSQL(builder: QueryBuilder): String {
+        require(set.fields.isNotEmpty()) { "Can't prepare SELECT statement without columns or expressions to retrieve" }
+
         builder {
             append("SELECT ")
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
@@ -8,6 +8,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 
@@ -30,6 +31,17 @@ class AdjustQueryTests : DatabaseTestsBase() {
             MatcherAssert.assertThat(oldSlice, Matchers.not(containsInAnyOrder(actualSlice)))
             MatcherAssert.assertThat(actualSlice, containsInAnyOrder(expectedSlice))
             assertQueryResultValid(queryAdjusted)
+        }
+    }
+
+    @Test
+    fun testAdjustQuerySliceWithEmptyListThrows() {
+        withCitiesAndUsers { cities, _, _ ->
+            val originalQuery = cities.slice(cities.name).selectAll()
+
+            assertFailsWith<IllegalArgumentException> {
+                originalQuery.adjustSlice { slice(emptyList()) }.toList()
+            }
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ConditionsTests.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.junit.Test
+import kotlin.test.assertFailsWith
 
 class ConditionsTests : DatabaseTestsBase() {
     @Test
@@ -76,6 +77,15 @@ class ConditionsTests : DatabaseTestsBase() {
             val row = city.slice(city.name, city.name, city.id).select { city.name eq "Munich" }.toList().single()
             assertEquals(2, row[city.id])
             assertEquals("Munich", row[city.name])
+        }
+    }
+
+    @Test
+    fun testSliceWithEmptyListThrows() {
+        withCitiesAndUsers { cities, _, _ ->
+            assertFailsWith<IllegalArgumentException> {
+                cities.slice(emptyList()).selectAll().toList()
+            }
         }
     }
 


### PR DESCRIPTION
Currently providing an empty list to `slice()` results in a SELECT statement without any columns defined, which returns syntax exceptions in all databases except PostgreSQL and H2 (these return empty results).

Adding a check to `Query.prepareSQL()` allows an early fail now.