### PR TITLE
feat: EXPOSED-65 Design query DSL consistent with SQL language

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -400,6 +400,8 @@ public abstract class org/jetbrains/exposed/sql/ColumnSet : org/jetbrains/expose
 	public static synthetic fun join$default (Lorg/jetbrains/exposed/sql/ColumnSet;Lorg/jetbrains/exposed/sql/ColumnSet;Lorg/jetbrains/exposed/sql/JoinType;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Join;
 	public abstract fun leftJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public abstract fun rightJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
+	public final fun select (Ljava/util/List;)Lorg/jetbrains/exposed/sql/Query;
+	public final fun select (Lorg/jetbrains/exposed/sql/Expression;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun slice (Ljava/util/List;)Lorg/jetbrains/exposed/sql/FieldSet;
 	public final fun slice (Lorg/jetbrains/exposed/sql/Expression;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/FieldSet;
 }
@@ -1579,6 +1581,7 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 	public fun <init> (Lorg/jetbrains/exposed/sql/FieldSet;Lorg/jetbrains/exposed/sql/Op;)V
 	public final fun adjustColumnSet (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun adjustHaving (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
+	public final fun adjustSelect (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun adjustSlice (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun adjustWhere (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public fun copy ()Lorg/jetbrains/exposed/sql/Query;
@@ -1587,6 +1590,8 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 	public fun empty ()Z
 	public synthetic fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/Object;
 	public fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/sql/ResultSet;
+	public final fun fetchBatchedResults (I)Ljava/lang/Iterable;
+	public static synthetic fun fetchBatchedResults$default (Lorg/jetbrains/exposed/sql/Query;IILjava/lang/Object;)Ljava/lang/Iterable;
 	public fun forUpdate (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/Query;
 	public synthetic fun forUpdate (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun getDistinct ()Z
@@ -1604,6 +1609,8 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/QueryBuilder;)Ljava/lang/String;
 	protected final fun setDistinct (Z)V
 	public fun setSet (Lorg/jetbrains/exposed/sql/FieldSet;)V
+	public final fun where (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
+	public final fun where (Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
 	public synthetic fun withDistinct (Z)Lorg/jetbrains/exposed/sql/AbstractQuery;
 	public fun withDistinct (Z)Lorg/jetbrains/exposed/sql/Query;
 }

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1564,11 +1564,17 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static final fun replace (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/ReplaceStatement;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
+	public static final fun select (Lorg/jetbrains/exposed/sql/Query;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
+	public static final fun select (Lorg/jetbrains/exposed/sql/Query;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun selectAll (Lorg/jetbrains/exposed/sql/FieldSet;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun selectAllBatched (Lorg/jetbrains/exposed/sql/FieldSet;I)Ljava/lang/Iterable;
+	public static final fun selectAllBatched (Lorg/jetbrains/exposed/sql/Query;I)Ljava/lang/Iterable;
 	public static synthetic fun selectAllBatched$default (Lorg/jetbrains/exposed/sql/FieldSet;IILjava/lang/Object;)Ljava/lang/Iterable;
+	public static synthetic fun selectAllBatched$default (Lorg/jetbrains/exposed/sql/Query;IILjava/lang/Object;)Ljava/lang/Iterable;
 	public static final fun selectBatched (Lorg/jetbrains/exposed/sql/FieldSet;ILkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
+	public static final fun selectBatched (Lorg/jetbrains/exposed/sql/Query;ILkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
 	public static synthetic fun selectBatched$default (Lorg/jetbrains/exposed/sql/FieldSet;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Iterable;
+	public static synthetic fun selectBatched$default (Lorg/jetbrains/exposed/sql/Query;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Iterable;
 	public static final fun update (Lorg/jetbrains/exposed/sql/Join;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;)I
 	public static final fun update (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;)I
 	public static synthetic fun update$default (Lorg/jetbrains/exposed/sql/Join;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -36,6 +36,13 @@ fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
 )
 fun Query.select(where: Op<Boolean>): Query = this
 
+/**
+ * Creates a [Query] by selecting all columns from this [ColumnSet].
+ *
+ * The column set selected from may be either a [Table] or a [Join].
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testSelect
+ */
 fun FieldSet.selectAll(): Query = Query(this, null)
 
 @Deprecated(
@@ -62,12 +69,15 @@ fun Query.selectBatched(
     batchSize: Int = 1000,
     where: SqlExpressionBuilder.() -> Op<Boolean>
 ): Iterable<Iterable<ResultRow>> {
-    return fetchBatchedResults(batchSize)
+    return where { SqlExpressionBuilder.where() }.fetchBatchedResults(batchSize)
 }
 
 @Deprecated(
     message = "As part of SELECT DSL design changes, this will be removed in future releases.",
-    replaceWith = ReplaceWith("selectAll().fetchBatchedResults(batchSize)", "import org.jetbrains.exposed.sql.selectAll"),
+    replaceWith = ReplaceWith(
+        "selectAll().fetchBatchedResults(batchSize)",
+        "import org.jetbrains.exposed.sql.selectAll"
+    ),
     level = DeprecationLevel.WARNING
 )
 fun FieldSet.selectAllBatched(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -13,14 +13,28 @@ import kotlin.sequences.Sequence
     replaceWith = ReplaceWith("selectAll().where { where.invoke() }", "import org.jetbrains.exposed.sql.selectAll"),
     level = DeprecationLevel.WARNING
 )
-inline fun FieldSet.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = selectAll().where(SqlExpressionBuilder.where())
+inline fun FieldSet.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = Query(this, SqlExpressionBuilder.where())
+
+@Deprecated(
+    message = "This method only exists as part of the migration for SELECT DSL design changes.",
+    replaceWith = ReplaceWith("where { where.invoke() }"),
+    level = DeprecationLevel.ERROR
+)
+inline fun Query.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = this
 
 @Deprecated(
     message = "As part of SELECT DSL design changes, this will be removed in future releases.",
-    replaceWith = ReplaceWith("selectAll().where(predicate = where", "import org.jetbrains.exposed.sql.selectAll"),
+    replaceWith = ReplaceWith("selectAll().where(predicate = where)", "import org.jetbrains.exposed.sql.selectAll"),
     level = DeprecationLevel.WARNING
 )
 fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
+
+@Deprecated(
+    message = "This method only exists as part of the migration for SELECT DSL design changes.",
+    replaceWith = ReplaceWith("where(where)"),
+    level = DeprecationLevel.ERROR
+)
+fun Query.select(where: Op<Boolean>): Query = this
 
 fun FieldSet.selectAll(): Query = Query(this, null)
 
@@ -40,6 +54,18 @@ fun FieldSet.selectBatched(
 }
 
 @Deprecated(
+    message = "This method only exists as part of the migration for SELECT DSL design changes.",
+    replaceWith = ReplaceWith("where { where.invoke() }.fetchBatchedResults(batchSize)"),
+    level = DeprecationLevel.ERROR
+)
+fun Query.selectBatched(
+    batchSize: Int = 1000,
+    where: SqlExpressionBuilder.() -> Op<Boolean>
+): Iterable<Iterable<ResultRow>> {
+    return fetchBatchedResults(batchSize)
+}
+
+@Deprecated(
     message = "As part of SELECT DSL design changes, this will be removed in future releases.",
     replaceWith = ReplaceWith("selectAll().fetchBatchedResults(batchSize)", "import org.jetbrains.exposed.sql.selectAll"),
     level = DeprecationLevel.WARNING
@@ -48,6 +74,17 @@ fun FieldSet.selectAllBatched(
     batchSize: Int = 1000
 ): Iterable<Iterable<ResultRow>> {
     return selectBatched(batchSize, Op.TRUE)
+}
+
+@Deprecated(
+    message = "This method only exists as part of the migration for SELECT DSL design changes.",
+    replaceWith = ReplaceWith("fetchBatchedResults(batchSize)"),
+    level = DeprecationLevel.ERROR
+)
+fun Query.selectAllBatched(
+    batchSize: Int = 1000
+): Iterable<Iterable<ResultRow>> {
+    return fetchBatchedResults(batchSize)
 }
 
 /**
@@ -386,7 +423,7 @@ private fun FieldSet.selectBatched(
                 var lastOffset = 0L
                 while (true) {
                     val query =
-                        select { whereOp and (autoIncColumn greater lastOffset) }
+                        selectAll().where { whereOp and (autoIncColumn greater lastOffset) }
                             .limit(batchSize)
                             .orderBy(autoIncColumn, SortOrder.ASC)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -8,26 +8,30 @@ import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import kotlin.sequences.Sequence
 
-/**
- * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testSelect01
- */
-inline fun FieldSet.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = select(SqlExpressionBuilder.where())
+@Deprecated(
+    message = "As part of SELECT DSL design changes, this will be removed in future releases.",
+    replaceWith = ReplaceWith("selectAll().where { where.invoke() }", "import org.jetbrains.exposed.sql.selectAll"),
+    level = DeprecationLevel.WARNING
+)
+inline fun FieldSet.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = selectAll().where(SqlExpressionBuilder.where())
 
+@Deprecated(
+    message = "As part of SELECT DSL design changes, this will be removed in future releases.",
+    replaceWith = ReplaceWith("selectAll().where(predicate = where", "import org.jetbrains.exposed.sql.selectAll"),
+    level = DeprecationLevel.WARNING
+)
 fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
 
-/**
- * @sample org.jetbrains.exposed.sql.tests.shared.DMLTests.testSelectDistinct
- */
 fun FieldSet.selectAll(): Query = Query(this, null)
 
-/**
- * That function will make multiple queries with limit equals to [batchSize]
- * and return result as a collection of [ResultRow] sub-collections.
- * [FieldSet] will be sorted by the first auto-increment column and then returned in batches.
- *
- * @param batchSize Size of a sub-collections to return
- * @param where Where condition to be applied
- */
+@Deprecated(
+    message = "As part of SELECT DSL design changes, this will be removed in future releases.",
+    replaceWith = ReplaceWith(
+        "selectAll().where { where.invoke() }.fetchBatchedResults(batchSize)",
+        "import org.jetbrains.exposed.sql.selectAll"
+    ),
+    level = DeprecationLevel.WARNING
+)
 fun FieldSet.selectBatched(
     batchSize: Int = 1000,
     where: SqlExpressionBuilder.() -> Op<Boolean>
@@ -35,13 +39,11 @@ fun FieldSet.selectBatched(
     return selectBatched(batchSize, SqlExpressionBuilder.where())
 }
 
-/**
- * That function will make multiple queries with limit equals to [batchSize]
- * and return result as a collection of [ResultRow] sub-collections.
- * [FieldSet] will be sorted by the first auto-increment column and then returned in batches.
- *
- * @param batchSize Size of a sub-collections to return
- */
+@Deprecated(
+    message = "As part of SELECT DSL design changes, this will be removed in future releases.",
+    replaceWith = ReplaceWith("selectAll().fetchBatchedResults(batchSize)", "import org.jetbrains.exposed.sql.selectAll"),
+    level = DeprecationLevel.WARNING
+)
 fun FieldSet.selectAllBatched(
     batchSize: Int = 1000
 ): Iterable<Iterable<ResultRow>> {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -24,7 +24,7 @@ inline fun Query.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = 
 
 @Deprecated(
     message = "As part of SELECT DSL design changes, this will be removed in future releases.",
-    replaceWith = ReplaceWith("selectAll().where(predicate = where)", "import org.jetbrains.exposed.sql.selectAll"),
+    replaceWith = ReplaceWith("selectAll().where(where)", "import org.jetbrains.exposed.sql.selectAll"),
     level = DeprecationLevel.WARNING
 )
 fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
@@ -37,7 +37,7 @@ fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
 fun Query.select(where: Op<Boolean>): Query = this
 
 /**
- * Creates a [Query] by selecting all columns from this [ColumnSet].
+ * Creates a `SELECT` [Query] by selecting all columns from this [ColumnSet].
  *
  * The column set selected from may be either a [Table] or a [Join].
  *

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -15,6 +15,7 @@ import kotlin.sequences.Sequence
 )
 inline fun FieldSet.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = Query(this, SqlExpressionBuilder.where())
 
+@Suppress("UnusedParameter")
 @Deprecated(
     message = "This method only exists as part of the migration for SELECT DSL design changes.",
     replaceWith = ReplaceWith("where { where.invoke() }"),
@@ -29,6 +30,7 @@ inline fun Query.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = 
 )
 fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
 
+@Suppress("UnusedParameter")
 @Deprecated(
     message = "This method only exists as part of the migration for SELECT DSL design changes.",
     replaceWith = ReplaceWith("where(where)"),

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -2,7 +2,6 @@ package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.greater
-import org.jetbrains.exposed.sql.Table.Dual.source
 import org.jetbrains.exposed.sql.statements.Statement
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.ForUpdateOption
@@ -31,6 +30,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
 
     private var forUpdate: ForUpdateOption? = null
 
+    /** The stored condition for a `WHERE` clause in this query. */
     var where: Op<Boolean>? = where
         private set
 
@@ -72,11 +72,21 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     )
     fun adjustSlice(body: ColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
 
+    /**
+     * Assigns a new selection of columns, by changing the `fields` property of this query's [set],
+     * while preserving its `source` property.
+     *
+     * @param body Builder for the new column set defined using `select()`, with the current [set]'s `source`
+     * property used as the receiver and the current [set] as an argument.
+     * @sample org.jetbrains.exposed.sql.tests.shared.dml.AdjustQueryTests.testAdjustQuerySlice
+     */
     fun adjustSelect(body: ColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
 
     /**
-     * Changes [set.source] field of a Query, [set.fields] will be preserved
-     * @param body builder for new column set, previous value used as a receiver
+     * Assigns a new column set, either a [Table] or a [Join], by changing the `source` property of this query's [set],
+     * while preserving its `fields` property.
+     *
+     * @param body Builder for the new column set, with the previous column set value as the receiver.
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.AdjustQueryTests.testAdjustQueryColumnSet
      */
     fun adjustColumnSet(body: ColumnSet.() -> ColumnSet): Query {
@@ -183,8 +193,18 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
         return this
     }
 
+    /**
+     * Appends a `WHERE` clause with the specified [predicate] to this query.
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testSelect
+     */
     fun where(predicate: SqlExpressionBuilder.() -> Op<Boolean>): Query = where(SqlExpressionBuilder.predicate())
 
+    /**
+     * Appends a `WHERE` clause with the specified [predicate] to this query.
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.dml.ExistsTests.testExists01
+     */
     fun where(predicate: Op<Boolean>): Query {
         where?.let {
             error("WHERE clause is specified twice. Old value = '$it', new value = '$predicate'")
@@ -193,11 +213,21 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
         return this
     }
 
+    /**
+     * Iterates over multiple executions of this query with its `LIMIT` clause set to [batchSize]
+     * until the amount of results retrieved from the database is less than [batchSize].
+     *
+     * This query's [FieldSet] will be ordered by the first auto-increment column.
+     *
+     * @param batchSize Size of each sub-collection to return.
+     * @return Retrieved results as a collection of batched [ResultRow] sub-collections.
+     * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectBatchedTests.testFetchBatchedResultsWithWhereAndSetBatchSize
+     */
     fun fetchBatchedResults(batchSize: Int = 1000): Iterable<Iterable<ResultRow>> {
         require(batchSize > 0) { "Batch size should be greater than 0." }
-        require(limit == null) { "A manual LIMIT clause should not be set. By default, batchSize will be used." }
+        require(limit == null) { "A manual `LIMIT` clause should not be set. By default, `batchSize` will be used." }
         require(orderByExpressions.isEmpty()) {
-            "A manual ORDER BY clause should not be set. By default, the auto-incrementing column will be used."
+            "A manual `ORDER BY` clause should not be set. By default, the auto-incrementing column will be used."
         }
 
         val autoIncColumn = try {
@@ -218,7 +248,6 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
                             whereOp and (autoIncColumn greater lastOffset)
                         }
 
-                        // query.iterator() executes the query
                         val results = query.iterator().asSequence().toList()
 
                         if (results.isNotEmpty()) {
@@ -249,9 +278,11 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
             try {
                 var expInx = 0
                 adjustSelect {
-                    select(originalSet.fields.map {
-                        it as? ExpressionAlias<*> ?: ((it as? Column<*>)?.makeAlias() ?: it.alias("exp${expInx++}"))
-                    }).set
+                    select(
+                        originalSet.fields.map {
+                            it as? ExpressionAlias<*> ?: ((it as? Column<*>)?.makeAlias() ?: it.alias("exp${expInx++}"))
+                        }
+                    ).set
                 }
 
                 alias("subquery").selectAll().count()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -67,15 +67,11 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
 
     @Deprecated(
         message = "As part of SELECT DSL design changes, this will be removed in future releases.",
+        replaceWith = ReplaceWith("adjustSelect { body.invoke() }"),
         level = DeprecationLevel.WARNING
     )
     fun adjustSlice(body: ColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
 
-    /**
-     * Changes [set.fields] field of a Query, [set.source] will be preserved
-     * @param body builder for new column set, current [set.source] used as a receiver and current [set] as an argument, you are expected to slice it
-     * @sample org.jetbrains.exposed.sql.tests.shared.dml.AdjustQueryTests.testAdjustQuerySlice
-     */
     fun adjustSelect(body: ColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -30,7 +30,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
 
     private var forUpdate: ForUpdateOption? = null
 
-    /** The stored condition for a `WHERE` clause in this query. */
+    /** The stored condition for a `WHERE` clause in this `SELECT` query. */
     var where: Op<Boolean>? = where
         private set
 
@@ -194,14 +194,14 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     }
 
     /**
-     * Appends a `WHERE` clause with the specified [predicate] to this query.
+     * Appends a `WHERE` clause with the specified [predicate] to this `SELECT` query.
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testSelect
      */
     fun where(predicate: SqlExpressionBuilder.() -> Op<Boolean>): Query = where(SqlExpressionBuilder.predicate())
 
     /**
-     * Appends a `WHERE` clause with the specified [predicate] to this query.
+     * Appends a `WHERE` clause with the specified [predicate] to this `SELECT` query.
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.ExistsTests.testExists01
      */
@@ -214,7 +214,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     }
 
     /**
-     * Iterates over multiple executions of this query with its `LIMIT` clause set to [batchSize]
+     * Iterates over multiple executions of this `SELECT` query with its `LIMIT` clause set to [batchSize]
      * until the amount of results retrieved from the database is less than [batchSize].
      *
      * This query's [FieldSet] will be ordered by the first auto-increment column.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SetOperations.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SetOperations.kt
@@ -24,7 +24,7 @@ sealed class SetOperation(
                     else -> expression.alias("exp$index")
                 }
             }
-            _firstStatement.copy().adjustSlice { slice(newSlice) }
+            _firstStatement.copy().adjustSelect { select(newSlice).set }
         }
         is SetOperation -> _firstStatement
         else -> error("Unsupported statement type ${_firstStatement::class.simpleName} in $operationName")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1,4 +1,4 @@
-@file:Suppress("internal", "INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 
 package org.jetbrains.exposed.sql
 
@@ -22,6 +22,7 @@ import kotlin.reflect.full.primaryConstructor
 /** Pair of expressions used to match rows from two joined tables. */
 typealias JoinCondition = Pair<Expression<*>, Expression<*>>
 
+/** Represents a subset of fields from a given source. */
 typealias Select = Slice
 
 /**
@@ -115,10 +116,23 @@ abstract class ColumnSet : FieldSet {
     )
     fun slice(columns: List<Expression<*>>): FieldSet = Slice(this, columns)
 
+    /**
+     * Creates a [Query] by selecting either a single [column], or a subset of [columns], from this [ColumnSet].
+     *
+     * The column set selected from may be either a [Table] or a [Join].
+     * Arguments provided to [column] and [columns] may be table object columns or function expressions.
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.AliasesTests.testJoinSubQuery01
+     */
     @LowPriorityInOverloadResolution
     fun select(column: Expression<*>, vararg columns: Expression<*>): Query =
         Query(Select(this, listOf(column) + columns), null)
 
+    /**
+     * Creates a [Query] using a list of [columns] or expressions from this [ColumnSet].
+     *
+     * The column set selected from may be either a [Table] or a [Join].
+     */
     @LowPriorityInOverloadResolution
     fun select(columns: List<Expression<*>>): Query = Query(Select(this, columns), null)
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -117,7 +117,7 @@ abstract class ColumnSet : FieldSet {
     fun slice(columns: List<Expression<*>>): FieldSet = Slice(this, columns)
 
     /**
-     * Creates a [Query] by selecting either a single [column], or a subset of [columns], from this [ColumnSet].
+     * Creates a `SELECT` [Query] by selecting either a single [column], or a subset of [columns], from this [ColumnSet].
      *
      * The column set selected from may be either a [Table] or a [Join].
      * Arguments provided to [column] and [columns] may be table object columns or function expressions.
@@ -129,7 +129,7 @@ abstract class ColumnSet : FieldSet {
         Query(Select(this, listOf(column) + columns), null)
 
     /**
-     * Creates a [Query] using a list of [columns] or expressions from this [ColumnSet].
+     * Creates a `SELECT` [Query] using a list of [columns] or expressions from this [ColumnSet].
      *
      * The column set selected from may be either a [Table] or a [Join].
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -19,6 +19,8 @@ import kotlin.reflect.full.primaryConstructor
 /** Pair of expressions used to match rows from two joined tables. */
 typealias JoinCondition = Pair<Expression<*>, Expression<*>>
 
+typealias Select = Slice
+
 /**
  * Represents a set of expressions, contained in the given column set.
  */
@@ -96,11 +98,24 @@ abstract class ColumnSet : FieldSet {
     /** Creates a cross join relation with [otherTable]. */
     abstract fun crossJoin(otherTable: ColumnSet): Join
 
-    /** Specifies a subset of [columns] of this [ColumnSet]. */
+    @Deprecated(
+        message = "As part of SELECT DSL design changes, this will be removed in future releases.",
+        replaceWith = ReplaceWith("select(column, *columns)"),
+        level = DeprecationLevel.WARNING
+    )
     fun slice(column: Expression<*>, vararg columns: Expression<*>): FieldSet = Slice(this, listOf(column) + columns)
 
-    /** Specifies a subset of [columns] of this [ColumnSet]. */
+    @Deprecated(
+        message = "As part of SELECT DSL design changes, this will be removed in future releases.",
+        replaceWith = ReplaceWith("select(columns)"),
+        level = DeprecationLevel.WARNING
+    )
     fun slice(columns: List<Expression<*>>): FieldSet = Slice(this, columns)
+
+    fun select(column: Expression<*>, vararg columns: Expression<*>): Query =
+        Query(Select(this, listOf(column) + columns), null)
+
+    fun select(columns: List<Expression<*>>): Query = Query(Select(this, columns), null)
 }
 
 /** Creates an inner join relation with [otherTable] using [onColumn] and [otherColumn] as the join condition. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1,3 +1,5 @@
+@file:Suppress("internal", "INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.dao.id.EntityID
@@ -9,6 +11,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
 import java.math.BigDecimal
 import java.util.*
+import kotlin.internal.LowPriorityInOverloadResolution
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KParameter
@@ -112,9 +115,11 @@ abstract class ColumnSet : FieldSet {
     )
     fun slice(columns: List<Expression<*>>): FieldSet = Slice(this, columns)
 
+    @LowPriorityInOverloadResolution
     fun select(column: Expression<*>, vararg columns: Expression<*>): Query =
         Query(Select(this, listOf(column) + columns), null)
 
+    @LowPriorityInOverloadResolution
     fun select(columns: List<Expression<*>>): Query = Query(Select(this, columns), null)
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -236,7 +236,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
             listOfNotNull(it.first, it.second as? Expression<*>)
         }.mapIndexed { index, expression -> expression to expression.alias("c$index") }.toMap()
 
-        val subQuery = targets.slice(columnsToSelect.values.toList()).selectAll()
+        val subQuery = targets.select(columnsToSelect.values.toList())
         where?.let {
             subQuery.adjustWhere { it }
         }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -45,7 +45,8 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
     val readValues: ResultRow
         get() = _readValues ?: run {
             val table = klass.table
-            _readValues = klass.searchQuery(Op.build { table.id eq id }).firstOrNull() ?: table.select { table.id eq id }.first()
+            _readValues = klass.searchQuery(Op.build { table.id eq id }).firstOrNull()
+                ?: table.selectAll().where { table.id eq id }.first()
             _readValues!!
         }
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
@@ -60,7 +60,7 @@ class InnerTableLink<SID : Comparable<SID>, Source : Entity<SID>, ID : Comparabl
 
         val (columns, entityTables) = columnsAndTables
 
-        val query = { target.wrapRows(entityTables.slice(columns).select { sourceColumn eq o.id }) }
+        val query = { target.wrapRows(entityTables.select(columns).where { sourceColumn eq o.id }) }
         return transaction.entityCache.getOrPutReferrers(o.id, sourceColumn, query).also {
             o.storeReferenceInCache(sourceColumn, it)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectBatchedTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectBatchedTests.kt
@@ -8,7 +8,7 @@ import java.util.*
 
 class SelectBatchedTests : DatabaseTestsBase() {
     @Test
-    fun `selectBatched should respect 'where' expression and the provided batch size`() {
+    fun testFetchBatchedResultsWithWhereAndSetBatchSize() {
         val cities = DMLTestsData.Cities
         withTables(cities) {
             val names = List(100) { UUID.randomUUID().toString() }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
+import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.crypt.Algorithms
 import org.jetbrains.exposed.crypt.encryptedBinary
 import org.jetbrains.exposed.crypt.encryptedVarchar
@@ -10,10 +11,62 @@ import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.entities.EntityTests
 import org.junit.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertNull
 
 class SelectTests : DatabaseTestsBase() {
-    // select expressions
+    @Test
+    fun testMigrationToNewQueryDSL() {
+        withCitiesAndUsers { cities, _, _ ->
+            val logCaptor = LogCaptor.forName(exposedLogger.name)
+            logCaptor.setLogLevelToDebug()
+
+            // old query dsl
+            cities.slice(cities.name).select { cities.name eq "andrey" }.toList()
+            cities.slice(cities.name).select(Op.TRUE).toList()
+            cities.slice(cities.name).selectAll().toList()
+
+            cities.select { cities.name eq "andrey" }.toList()
+            cities.select(Op.TRUE).toList()
+            cities.selectAll().toList()
+
+            cities.slice(cities.name).selectBatched(50) { cities.name eq "andrey" }.toList()
+            cities.slice(cities.name).selectAllBatched(50).toList()
+            cities.selectBatched(50) { cities.name eq "andrey" }.toList()
+            cities.selectAllBatched(50).toList()
+
+            val originalQuery1 = cities.select { cities.name eq "andrey" }.also { it.toList() }
+            originalQuery1.adjustSlice { slice(cities.name) }.toList()
+
+            val sqlLoggedWithOldDSL = logCaptor.debugLogs.toList()
+            logCaptor.clearLogs()
+
+            // new query dsl
+            cities.select(cities.name).where { cities.name eq "andrey" }.toList()
+            cities.select(cities.name).where(Op.TRUE).toList()
+            cities.select(cities.name).toList()
+
+            cities.selectAll().where { cities.name eq "andrey" }.toList()
+            cities.selectAll().where(Op.TRUE).toList()
+            cities.selectAll().toList()
+
+            cities.select(cities.name).where { cities.name eq "andrey" }.fetchBatchedResults(50).toList()
+            cities.select(cities.name).fetchBatchedResults(50).toList()
+            cities.selectAll().where { cities.name eq "andrey" }.fetchBatchedResults(50).toList()
+            cities.selectAll().fetchBatchedResults(50).toList()
+
+            val originalQuery2 = cities.selectAll().where { cities.name eq "andrey" }.also { it.toList() }
+            originalQuery2.adjustSelect { select(cities.name).set }.toList()
+
+            val sqlLoggedWithNewDSL = logCaptor.debugLogs.toList()
+            logCaptor.clearLogs()
+            logCaptor.resetLogLevel()
+            logCaptor.close()
+
+            assertContentEquals(sqlLoggedWithOldDSL, sqlLoggedWithNewDSL)
+        }
+    }
+
     @Test
     fun testSelect() {
         withCitiesAndUsers { _, users, _ ->


### PR DESCRIPTION
**Before:**
```kt
1. TestTable.slice(TestTable.columnA).select { TestTable.columnA eq 1 }
2. TestTable.slice(TestTable.columnA).select(Op.TRUE)
3. TestTable.slice(TestTable.columnA).selectAll()

4. TestTable.select { TestTable.columnA eq 1 }
5. TestTable.select(Op.TRUE)
6. TestTable.selectAll()

7. TestTable.slice(TestTable.columnA).selectBatched(50) { TestTable.columnA eq 1 }
8. TestTable.slice(TestTable.columnA).selectAllBatched(50)
9. TestTable.selectBatched(50) { TestTable.columnA eq 1 }
10.TestTable.selectAllBatched(50)
        
11. val originalQuery = TestTable.select { TestTable.columnA eq 1 }
12. originalQuery.adjustSlice { slice(TestTable.columnA) }
```

**After:**
```kt
1. TestTable.select(TestTable.columnA).where { TestTable.columnA eq 1 }
2. TestTable.select(TestTable.columnA).where(Op.TRUE)
3. TestTable.select(TestTable.columnA)

4. TestTable.selectAll().where { TestTable.columnA eq 1 }
5. TestTable.selectAll().where(Op.TRUE)
6. TestTable.selectAll()

7. TestTable.select(TestTable.columnA).where { TestTable.columnA eq 1 }.fetchBatchedResults(50)
8. TestTable.select(TestTable.columnA).fetchBatchedResults(50)
9. TestTable.selectAll().where { TestTable.columnA eq 1 }.fetchBatchedResults(50)
10. TestTable.selectAll().fetchBatchedResults(50)

11. val originalQuery = TestTable.selectAll().where { TestTable.columnA eq 1 }
12. originalQuery.adjustSelect { select(TestTable.columnA).set }
```
-------
This PR only affects the `src` codebase.
All deprecated methods in tests have been left to confirm that all tests still pass.
A PR with all changes applied to the tests will follow this one being merged.