### PR TITLE
test: Remove hamcrest dependency usage

### DIFF
--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/sqlserver/SQLServerDefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/sqlserver/SQLServerDefaultsTest.kt
@@ -1,8 +1,5 @@
 package org.jetbrains.exposed.sqlserver
 
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.MatcherAssert.assertThat
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.javatime.*
@@ -10,6 +7,8 @@ import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.junit.Test
 import java.time.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class SQLServerDefaultsTest : DatabaseTestsBase() {
 
@@ -48,9 +47,9 @@ class SQLServerDefaultsTest : DatabaseTestsBase() {
                     }
                 val id = batchInsert.first()[temporalTable.id]
                 val result = temporalTable.selectAll().where { temporalTable.id eq id }.single()
-                assertThat(result[temporalTable.name], `is`("name"))
-                assertThat(result[temporalTable.sysStart], notNullValue())
-                assertThat(result[temporalTable.sysEnd], notNullValue())
+                assertEquals("name", result[temporalTable.name])
+                assertNotNull(result[temporalTable.sysStart])
+                assertNotNull(result[temporalTable.sysEnd])
             } finally {
                 SchemaUtils.drop(temporalTable)
             }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/sqlserver/SQLServerDefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/sqlserver/SQLServerDefaultsTest.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.exposed.sql.kotlin.datetime.sqlserver
 
 import kotlinx.datetime.LocalDateTime
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.MatcherAssert.assertThat
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.kotlin.datetime.KotlinLocalDateTimeColumnType
@@ -11,6 +8,8 @@ import org.jetbrains.exposed.sql.kotlin.datetime.datetime
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class SQLServerDefaultsTest : DatabaseTestsBase() {
 
@@ -49,9 +48,9 @@ class SQLServerDefaultsTest : DatabaseTestsBase() {
                     }
                 val id = batchInsert.first()[temporalTable.id]
                 val result = temporalTable.selectAll().where { temporalTable.id eq id }.single()
-                assertThat(result[temporalTable.name], `is`("name"))
-                assertThat(result[temporalTable.sysStart], notNullValue())
-                assertThat(result[temporalTable.sysEnd], notNullValue())
+                assertEquals("name", result[temporalTable.name])
+                assertNotNull(result[temporalTable.sysStart])
+                assertNotNull(result[temporalTable.sysEnd])
             } finally {
                 SchemaUtils.drop(temporalTable)
             }

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
 
     implementation(kotlin("test-junit"))
     implementation(libs.junit)
-    implementation(libs.hamcrest)
 
     implementation(project(":exposed-core"))
     implementation(project(":exposed-jdbc"))

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionExceptions.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionExceptions.kt
@@ -1,7 +1,5 @@
 package org.jetbrains.exposed.sql.tests.shared
 
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.transactions.TransactionManager
@@ -13,6 +11,7 @@ import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.SQLException
 import java.sql.SQLTransientException
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -76,7 +75,7 @@ class ConnectionExceptions {
             }
             fail("Should have thrown an exception")
         } catch (e: SQLException) {
-            MatcherAssert.assertThat(e.toString(), Matchers.containsString("BROKEN_SQL_THAT_CAUSES_EXCEPTION"))
+            assertContains(e.toString(), "BROKEN_SQL_THAT_CAUSES_EXCEPTION", ignoreCase = false)
             assertEquals(5, wrappingDataSource.connections.size)
             wrappingDataSource.connections.forEach {
                 assertFalse(it.commitCalled)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
@@ -1,14 +1,14 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 
@@ -26,10 +26,9 @@ class AdjustQueryTests : DatabaseTestsBase() {
             val expectedSlice = queryAdjusted.sliceIt().fields
             queryAdjusted.adjustSelect { select(users.name, cities.name).set }
             val actualSlice = queryAdjusted.set.fields
-            fun containsInAnyOrder(list: List<*>) = Matchers.containsInAnyOrder(*list.toTypedArray())
 
-            MatcherAssert.assertThat(oldSlice, Matchers.not(containsInAnyOrder(actualSlice)))
-            MatcherAssert.assertThat(actualSlice, containsInAnyOrder(expectedSlice))
+            assertFalse { oldSlice.size == actualSlice.size && oldSlice.all { it in actualSlice } }
+            assertEqualLists(expectedSlice, actualSlice)
             assertQueryResultValid(queryAdjusted)
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ junit = "4.13.2"
 kotlinx-datetime = "0.4.0"
 javax-money = "1.1"
 moneta = "1.4.2"
-hamcrest = "2.2"
 hikariCP = "4.0.3"
 logcaptor = "2.9.1"
 
@@ -64,8 +63,6 @@ spring-test = { group = "org.springframework", name = "spring-test", version.ref
 
 h2 = { group = "com.h2database", name = "h2", version.ref = "h2_v2" }
 h1 = { group = "com.h2database", name = "h2", version.ref = "h2" }
-
-hamcrest = { group = "org.hamcrest", name = "hamcrest-library", version.ref = "hamcrest" }
 
 log4j-slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version.ref = "log4j2" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j2" }

--- a/spring-transaction/build.gradle.kts
+++ b/spring-transaction/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     testImplementation(libs.log4j.api)
     testImplementation(libs.log4j.core)
     testImplementation(libs.junit)
-    testImplementation(libs.hamcrest)
     testImplementation(libs.h2)
 }
 


### PR DESCRIPTION
Hamcrest dependency is only used in 4 tests in the entire codebase and all its usages can be replaced with less verbose and more clear `kotlin.test` assertions.