### PR TITLE
docs: Add MIGRATION_GUIDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Releases of Exposed are available in the Maven Central repository. You can decla
 
 #### Gradle Groovy and Kotlin DSL
 
-**Warning:** You might need to set your Kotlin JVM target to 8 and when using Spring to 17 in order for it to work properly
+**Warning:** You might need to set your Kotlin JVM target to 8, and when using Spring to 17, in order for this to work properly:
 
 ```kotlin
 repositories {
@@ -264,7 +264,7 @@ fun main() {
             it.update(name, stringLiteral("   Prague   ").trim().substring(1, 2))
         }[Cities.id]
 
-        val pragueName = Cities.select { Cities.id eq pragueId }.single()[Cities.name]
+        val pragueName = Cities.selectAll().where { Cities.id eq pragueId }.single()[Cities.name]
         println("pragueName = $pragueName")
 
         Users.insert {
@@ -312,8 +312,8 @@ fun main() {
         println("Manual join:")
         
         (Users innerJoin Cities)
-            .slice(Users.name, Cities.name)
-            .select {
+            .select(Users.name, Cities.name)
+            .where {
                 (Users.id.eq("andrey") or Users.name.eq("Sergey")) and
                     Users.id.eq("sergey") and Users.cityId.eq(Cities.id)
             }.forEach { 
@@ -323,8 +323,8 @@ fun main() {
         println("Join with foreign key:")
 
         (Users innerJoin Cities)
-            .slice(Users.name, Users.cityId, Cities.name)
-            .select { Cities.name.eq("St. Petersburg") or Users.cityId.isNull() }
+            .select(Users.name, Users.cityId, Cities.name)
+            .where { Cities.name.eq("St. Petersburg") or Users.cityId.isNull() }
             .forEach { 
                 if (it[Users.cityId] != null) { 
                     println("${it[Users.name]} lives in ${it[Cities.name]}") 
@@ -337,8 +337,7 @@ fun main() {
         println("Functions and group by:")
 
         ((Cities innerJoin Users)
-            .slice(Cities.name, Users.id.count())
-            .selectAll()
+            .select(Cities.name, Users.id.count())
             .groupBy(Cities.name)
             ).forEach {
                 val cityName = it[Cities.name]

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,14 +1,15 @@
-# Migration Guide
+# Exposed Migration Guide
 
 ## Migrating from 0.45.0 to 0.46.0
 
-This guide provides instructions on how to migrate your Exposed application from version 0.45.0 to 0.46.0.
+While Exposed provides migration support in the code itself (by using the `@Deprecated` annotation), 
+this document serves as a reference point for the migration steps necessary to switch to the new query DSL.
 
 ### SELECT Query DSL
 
 Exposed's query DSL has been refactored to bring it closer to the syntax of a standard SQL `SELECT` statement.
 
-The `slice()` function has been deprecated in favor of a new `select()` function that accepts a variable amount of columns or expressions and creates a `Query` instance.
+The `slice()` function has been deprecated in favor of a new `select()` function that accepts a variable amount of columns or expressions and creates a `Query` instance. 
 The `Query` class now has the method `where()`, which can be chained to replace the old version of `select { }`.
 
 [Go to migration steps](#migration-steps)
@@ -51,8 +52,8 @@ TestTable
 TestTable.selectAll()
 ```
 
-To be consistent with these changes, the functions `selectBatched()` and `selectAllBatched()` have also been deprecated.
-A new `Query` method, `fetchBatchedResults()`, can be used instead as a terminal operation on an existing query instance:
+To be consistent with these changes, the functions `selectBatched()` and `selectAllBatched()` have also been deprecated. 
+A new `Query` method, `fetchBatchedResults()`, should be used instead as a terminal operation on an existing query instance:
 
 ```kotlin
 // Example 1
@@ -78,7 +79,7 @@ TestTable
     .fetchBatchedResults(50)
 ```
 
-Lastly, `adjustSlice()` has been renamed to `adjustSelect()`. Since the new `select()` returns a `Query` instead of a `FieldSet`,
+Lastly, `adjustSlice()` has been renamed to `adjustSelect()`. Since the new `select()` returns a `Query` instead of a `FieldSet`, 
 the property `set` should be accessed within the lambda expression of `adjustSelect()` to retrieve the query's `FieldSet`:
 
 ```kotlin

--- a/documentation-website/Writerside/topics/Migration-Guide.md
+++ b/documentation-website/Writerside/topics/Migration-Guide.md
@@ -2,13 +2,16 @@
 
 ## Migrating from 0.45.0 to 0.46.0
 
-This guide provides instructions on how to migrate your Exposed application from version 0.45.0 to 0.46.0.
+While Exposed provides migration support in the code itself (by using the `@Deprecated` annotation and `ReplaceWith` quickfix),
+this document serves as a reference point for the migration steps necessary to switch to the new query DSL.
 
 ### SELECT Query DSL
 
 Exposed's query DSL has been refactored to bring it closer to the syntax of a standard SQL `SELECT` statement.
 
-The `slice()` function has been deprecated in favor of a new `select()` function that accepts a variable amount of columns or expressions and creates a `Query` instance.
+The `slice()` function has been deprecated in favor of a new `select()` function that accepts the same variable amount of columns and creates a `Query` instance.
+If all columns should be selected, use `selectAll()` to create a `Query` instance.
+
 The `Query` class now has the method `where()`, which can be chained to replace the old version of `select { }`.
 
 [Go to migration steps](#migration-steps)
@@ -52,7 +55,7 @@ TestTable.selectAll()
 ```
 
 To be consistent with these changes, the functions `selectBatched()` and `selectAllBatched()` have also been deprecated.
-A new `Query` method, `fetchBatchedResults()`, can be used instead as a terminal operation on an existing query instance:
+A new `Query` method, `fetchBatchedResults()`, should be used instead as a terminal operation on an existing `Query`:
 
 ```kotlin
 // Example 1
@@ -78,8 +81,7 @@ TestTable
     .fetchBatchedResults(50)
 ```
 
-Lastly, `adjustSlice()` has been renamed to `adjustSelect()`. Since the new `select()` returns a `Query` instead of a `FieldSet`,
-the property `set` should be accessed within the lambda expression of `adjustSelect()` to retrieve the query's `FieldSet`:
+Lastly, `adjustSlice()` has been renamed to `adjustSelect()`:
 
 ```kotlin
 // before
@@ -88,15 +90,15 @@ originalQuery.adjustSlice { slice(TestTable.columnA) }
 
 // after
 val originalQuery = TestTable.selectAll().where { TestTable.columnA eq 1 }
-originalQuery.adjustSelect { select(TestTable.columnA).set }
+originalQuery.adjustSelect { select(TestTable.columnA) }
 ```
 
 ### Migration Steps
 
-1. Use *Edit > Find > Find in Files...* to find any use of `adjustSlice`, and use the `Alt+Enter` quickfix with "Replace usages of '...' in whole project".
+1. Use *Edit > Find > Find in Files...* to find any use of `adjustSlice`, then use the `Alt+Enter` quickfix with "Replace usages of '...' in whole project".
 2. Repeat step 1 with all the deprecated methods in the following list:
     * `slice`
-    * `Query.select`: enter `select\(((\s*.+\s*)\)(\s*)\.select` in the search bar (with the regex tab enabled) to find this method easily
+    * `Query.select`: enter `select\((\s*.+\s*)\)(\s*)\.select` in the search bar (with the regex tab enabled) to find this method easily
     * `select`
     * `selectBatched`
     * `selectAllBatched`
@@ -104,6 +106,4 @@ originalQuery.adjustSelect { select(TestTable.columnA).set }
     * Enter `select\((\s*.+\s*)\)(\s*)\.selectAll\(\)` in the search bar (with the regex tab enabled)
     * Enter `select\($1\)` in the replace bar
     * Confirm the results and select "Replace All"
-4. Use *Edit > Find > Find in Files...* to find any use of `adjustSelect` and resolve type mismatch errors by accessing the `set` property:
-    * `adjustSelect { select(TestTable.columnA).set }`
-5. Rebuild the project
+4. Rebuild the project


### PR DESCRIPTION
The 2 docs are duplicates for now, but, in the future, the library doc could just hold a link to the live writerside page, like what's done in Ktor.

Includes new DSL changes in README.