### PR TITLE
refactor: EXPOSED-65 Change function declaration of adjustSelect

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -37,7 +37,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     override val queryToExecute: Statement<ResultSet> get() {
         val distinctExpressions = set.fields.distinct()
         return if (distinctExpressions.size < set.fields.size) {
-            copy().adjustSelect { select(distinctExpressions).set }
+            copy().adjustSelect { select(distinctExpressions) }
         } else {
             this
         }
@@ -80,7 +80,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * property used as the receiver and the current [set] as an argument.
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.AdjustQueryTests.testAdjustQuerySlice
      */
-    fun adjustSelect(body: ColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
+    fun adjustSelect(body: ColumnSet.(FieldSet) -> Query): Query = apply { set = set.source.body(set).set }
 
     /**
      * Assigns a new column set, either a [Table] or a [Join], by changing the `source` property of this query's [set],
@@ -90,7 +90,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.AdjustQueryTests.testAdjustQueryColumnSet
      */
     fun adjustColumnSet(body: ColumnSet.() -> ColumnSet): Query {
-        return adjustSelect { oldSlice -> body().select(oldSlice.fields).set }
+        return adjustSelect { oldSlice -> body().select(oldSlice.fields) }
     }
 
     /**
@@ -282,7 +282,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
                         originalSet.fields.map {
                             it as? ExpressionAlias<*> ?: ((it as? Column<*>)?.makeAlias() ?: it.alias("exp${expInx++}"))
                         }
-                    ).set
+                    )
                 }
 
                 alias("subquery").selectAll().count()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SetOperations.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SetOperations.kt
@@ -24,7 +24,7 @@ sealed class SetOperation(
                     else -> expression.alias("exp$index")
                 }
             }
-            _firstStatement.copy().adjustSelect { select(newSlice).set }
+            _firstStatement.copy().adjustSelect { select(newSlice) }
         }
         is SetOperation -> _firstStatement
         else -> error("Unsupported statement type ${_firstStatement::class.simpleName} in $operationName")

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -487,7 +487,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
             val finalQuery = if (parentTable.id in baseQuery.set.fields) {
                 baseQuery
             } else {
-                baseQuery.adjustSelect { select(fields + parentTable.id).set }
+                baseQuery.adjustSelect { select(fields + parentTable.id) }
                     .adjustColumnSet { innerJoin(parentTable, { refColumn }, { refColumn.referee!! }) }
             }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
@@ -24,7 +24,7 @@ class AdjustQueryTests : DatabaseTestsBase() {
             fun Query.sliceIt(): FieldSet = this.set.source.select(users.name, cities.name).set
             val oldSlice = queryAdjusted.set.fields
             val expectedSlice = queryAdjusted.sliceIt().fields
-            queryAdjusted.adjustSelect { select(users.name, cities.name).set }
+            queryAdjusted.adjustSelect { select(users.name, cities.name) }
             val actualSlice = queryAdjusted.set.fields
 
             assertFalse { oldSlice.size == actualSlice.size && oldSlice.all { it in actualSlice } }
@@ -39,7 +39,7 @@ class AdjustQueryTests : DatabaseTestsBase() {
             val originalQuery = cities.select(cities.name)
 
             assertFailsWith<IllegalArgumentException> {
-                originalQuery.adjustSelect { select(emptyList()).set }.toList()
+                originalQuery.adjustSelect { select(emptyList()) }.toList()
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -56,7 +56,7 @@ class SelectTests : DatabaseTestsBase() {
             cities.selectAll().fetchBatchedResults(50).toList()
 
             val originalQuery2 = cities.selectAll().where { cities.name eq "andrey" }.also { it.toList() }
-            originalQuery2.adjustSelect { select(cities.name).set }.toList()
+            originalQuery2.adjustSelect { select(cities.name) }.toList()
 
             val sqlLoggedWithNewDSL = logCaptor.debugLogs.toList()
             logCaptor.clearLogs()


### PR DESCRIPTION
As I was putting together the migration guide, it occurred to me that we're placing the responsibility on users to perform an extra step that could be avoided if the declaration of the new `adjustSelect()` is changed.

Since the new `select()` returns a `Query` instead of a `FieldSet`, users would need to access the query's `set` property to resolve type mismatch errors when migrating:
```kt
// before
originalQuery.adjustSlice { slice(TestTable.columnA) }

// after
originalQuery.adjustSelect { select(TestTable.columnA).set }
```

This would no longer be necessary by changing the return type of the `body` parameter in this PR:
```kt
originalQuery.adjustSelect { select(TestTable.columnA) }
```

The old `adjustSlice()` was recommended to be used with a `slice()` in the lambda, so majority of users should not be affected by the change.
Even if a user wanted to take the current selection of columns and add to it, they would still have needed to use `slice()`:
```kt
originalQuery.adjustSlice { oldSlice ->
    slice(oldSlice.fields + TestTable.newColumn)
}
```

The only edge case I can imagine being affected is if users are providing entire tables or joins (which extend `FieldSet`):
```kt
// this means take all columns from NewTable and use them as the selected columns in originalQuery
originalQuery.adjustSlice { NewTable }

// with the proposed changes, the user would need to do this now:
originalQuery.adjustSelect { NewTable.selectAll() }
```
This use case is very unlikely though as the tests I'm running show that it doesn't actually work 100%, probably because it's not meant to be used this way.

----
**Does this PR improve the new DSL experience or just introduce more room for problems?**