### PR TITLE
test: Drop duplicate Spring tests using non-H2 Gradle tasks

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
@@ -65,7 +65,7 @@ fun Project.testDb(name: String, block: TestDb.() -> Unit) {
         if (db.ignoresSpringTests) {
             filter {
                 // exclude all test classes in (spring-transaction, exposed-spring-boot-starter) modules
-                exclude("org/jetbrains/exposed/spring/*", "org/jetbrains/exposed/jdbc_template/*")
+                exclude("org/jetbrains/exposed/spring/*", "org/jetbrains/exposed/jdbc-template/*")
                 isFailOnNoMatchingTests = false
             }
         }


### PR DESCRIPTION
Currently, both `spring-transaction` and `exposed-spring-boot-starter` modules are set up to not be database-specific, but to only test how Exposed generally integrates with Spring.
This means that all unit tests use an embedded H2 database and that these test classes do not extend `DatabaseTestsBase()` .

In spite of this, all Spring tests are run by every Gradle test task, resulting in multiple H2 duplicate tests when task `test` or TC build is run.

Duplicates can be confirmed by:
- Log `Transaction.db.vendor` or `Transaction.db.dialect` in any test while running a non-H2 test task:
    - Output will always be "H2" or "H2Dialect"
- Execute any H2-incompatible SQL in a test:
    - e.g. `exec("SELECT version();")` should work when included in any test run with `testPostgres`, but instead this is thrown: `org.h2.jdbc.JdbcSQLSyntaxErrorException: Function "VERSION" not found`

Excluding tests in the Spring packages confirmed locally and on TC build.
The total number of tests is still somehow 10071 but the only tasks with tests is `testH2` and build time dropped from 37-40 minutes to 32-35 minutes.
**Example before:**
![springtx_before_small](https://github.com/JetBrains/Exposed/assets/82039410/cb1cca9f-804a-4f21-b44f-bea9376227bc)

**Example after:**
![springtx_after_small](https://github.com/JetBrains/Exposed/assets/82039410/7bb67bf1-7c45-4203-a29a-2c1b9249cca5)