### PR TITLE
chore!: EXPOSED-239 Set preserveKeywordCasing flag to true by default

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -111,10 +111,10 @@ class DatabaseConfig private constructor(
         var logTooMuchResultSetsThreshold: Int = 0,
         /**
          * Toggle whether table and column identifiers that are also keywords should retain their case sensitivity.
-         * Keeping user-defined case sensitivity (value set to `true`) may become the default in future releases.
+         * Keeping user-defined case sensitivity (value set to `true`) is the default setting.
          */
         @ExperimentalKeywordApi
-        var preserveKeywordCasing: Boolean = false,
+        var preserveKeywordCasing: Boolean = true,
     )
 
     companion object {
@@ -143,8 +143,8 @@ class DatabaseConfig private constructor(
 }
 
 @RequiresOptIn(
-    message = "This API is experimental and the behavior defined by setting this value to 'true' may become the default " +
-        "in future releases. Its usage must be marked with '@OptIn(org.jetbrains.exposed.sql.ExperimentalKeywordApi::class)' " +
+    message = "This API is experimental and the behavior defined by setting this value to 'true' is now the default. " +
+        "Its usage must be marked with '@OptIn(org.jetbrains.exposed.sql.ExperimentalKeywordApi::class)' " +
         "or '@org.jetbrains.exposed.sql.ExperimentalKeywordApi'."
 )
 @Target(AnnotationTarget.PROPERTY)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1289,21 +1289,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         }
     }
 
-    @Deprecated(
-        message = "This will be removed in future releases when the check becomes default in IdentifierManagerApi",
-        level = DeprecationLevel.WARNING
-    )
-    private fun String.warnIfUnflaggedKeyword() {
-        val warn = TransactionManager.currentOrNull()?.db?.identifierManager?.isUnflaggedKeyword(this) == true
-        if (warn) {
-            exposedLogger.warn(
-                "Keyword identifier used: '$this'. Case sensitivity may not be kept when quoted by default: '${inProperCase()}'. " +
-                    "To keep case sensitivity, opt-in and set 'preserveKeywordCasing' to true in DatabaseConfig block."
-            )
-        }
-    }
-
-    @Suppress("CyclomaticComplexMethod")
     override fun createStatement(): List<String> {
         val createSequence = autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
             Sequence(
@@ -1323,10 +1308,10 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
             if (currentDialect.supportsIfNotExists) {
                 append("IF NOT EXISTS ")
             }
-            append(TransactionManager.current().identity(this@Table).also { tableName.warnIfUnflaggedKeyword() })
+            append(TransactionManager.current().identity(this@Table))
             if (columns.isNotEmpty()) {
                 columns.joinTo(this, prefix = " (") { column ->
-                    column.descriptionDdl(false).also { column.name.warnIfUnflaggedKeyword() }
+                    column.descriptionDdl(false)
                 }
 
                 if (columns.any { it.isPrimaryConstraintWillBeDefined }) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
@@ -72,13 +72,7 @@ abstract class IdentifierManagerApi {
     }
 
     @Deprecated(
-        message = "This will be removed in future releases when the behavior becomes default in IdentifierManagerApi",
-        level = DeprecationLevel.WARNING
-    )
-    internal fun isUnflaggedKeyword(identity: String): Boolean = identity.isAKeyword() && !shouldPreserveKeywordCasing
-
-    @Deprecated(
-        message = "This will be removed in future releases when the behavior becomes default in IdentifierManagerApi",
+        message = "This will be removed in future releases when the opt-out flag is removed in DatabaseConfig",
         level = DeprecationLevel.WARNING
     )
     private val shouldPreserveKeywordCasing by lazy {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -12,7 +12,7 @@ import java.sql.Types
 class ConnectionTests : DatabaseTestsBase() {
 
     object People : LongIdTable() {
-        val name = varchar("name", 80).nullable()
+        val firstName = varchar("firstname", 80).nullable()
         val lastName = varchar("lastname", 42).default("Doe")
         val age = integer("age").default(18)
     }
@@ -28,13 +28,13 @@ class ConnectionTests : DatabaseTestsBase() {
             val expected = when ((db.dialect as H2Dialect).isSecondVersion) {
                 false -> setOf(
                     ColumnMetadata("ID", Types.BIGINT, false, 19, true, null),
-                    ColumnMetadata("NAME", Types.VARCHAR, true, 80, false, null),
+                    ColumnMetadata("FIRSTNAME", Types.VARCHAR, true, 80, false, null),
                     ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
                     ColumnMetadata("AGE", Types.INTEGER, false, 10, false, "18"),
                 )
                 true -> setOf(
                     ColumnMetadata("ID", Types.BIGINT, false, 64, true, null),
-                    ColumnMetadata("NAME", Types.VARCHAR, true, 80, false, null),
+                    ColumnMetadata("FIRSTNAME", Types.VARCHAR, true, 80, false, null),
                     ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
                     ColumnMetadata("AGE", Types.INTEGER, false, 32, false, "18"),
                 )


### PR DESCRIPTION
The opt-in flag `preserveKeywordCasing` was introduced 3 versions ago (PR #1841 ).

This PR sets the goal behavior (that keywords retain user-defined casing before being quoted) to `true` by default.

The flag temporarily remains in the event that users want to opt-out of the now default behavior by setting it to `false`.

Tests have been refactored to account for new behavior.