### PR TITLE
fix: EXPOSED-242 [PostgreSQL] Cannot change connection setting in middle of a transaction

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -97,6 +97,13 @@ class Database private constructor(
      */
     internal var dataSourceIsolationLevel: Int = -1
 
+    /**
+     * The read-only setting defined by a [DataSource] connection.
+     *
+     * This value should only be adjusted if [connectsViaDataSource] has been set to `true`.
+     */
+    internal var dataSourceReadOnly: Boolean = false
+
     companion object {
         internal val dialects = ConcurrentHashMap<String, () -> DatabaseDialect>()
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -126,14 +126,16 @@ class ThreadLocalTransactionManager(
                     if (db.connectsViaDataSource && loadDataSourceIsolationLevel && db.dataSourceIsolationLevel == -1) {
                         // retrieves the setting of the datasource connection & caches it
                         db.dataSourceIsolationLevel = transactionIsolation
+                        db.dataSourceReadOnly = readOnly
                     } else if (
                         !db.connectsViaDataSource ||
-                        db.dataSourceIsolationLevel != this@ThreadLocalTransaction.transactionIsolation
+                        db.dataSourceIsolationLevel != this@ThreadLocalTransaction.transactionIsolation ||
+                        db.dataSourceReadOnly != this@ThreadLocalTransaction.readOnly
                     ) {
                         // only set the level if there is no cached datasource value or if the value differs
                         transactionIsolation = this@ThreadLocalTransaction.transactionIsolation
+                        readOnly = this@ThreadLocalTransaction.readOnly
                     }
-                    readOnly = this@ThreadLocalTransaction.readOnly
                     autoCommit = false
                 }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
@@ -9,21 +9,14 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.LogDbInTestName
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
-import org.jetbrains.exposed.sql.tests.shared.assertTrue
-import org.jetbrains.exposed.sql.tests.shared.expectException
-import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.junit.Assert.assertFalse
 import org.junit.Assume
 import org.junit.Test
-import java.sql.Connection
-import kotlin.test.assertNotNull
 
 class ConnectionPoolTests : LogDbInTestName() {
     private val hikariDataSource1 by lazy {
@@ -63,85 +56,6 @@ class ConnectionPoolTests : LogDbInTestName() {
 
             SchemaUtils.drop(TestTable)
         }
-    }
-
-    private val hikariDataSourcePG by lazy {
-        HikariDataSource(
-            HikariConfig().apply {
-                jdbcUrl = TestDB.POSTGRESQL.connection.invoke()
-                username = TestDB.POSTGRESQL.user
-                password = TestDB.POSTGRESQL.pass
-                // sets the default schema for connections, which opens a database transaction before Exposed does
-                schema = "test_schema"
-                maximumPoolSize = 10
-                isAutoCommit = false
-                transactionIsolation = "TRANSACTION_SERIALIZABLE"
-                isReadOnly = true
-            }
-        )
-    }
-
-    private val hikariPG by lazy {
-        Database.connect(hikariDataSourcePG)
-    }
-
-    @Test
-    fun testSchemaAndConnectionsWithHikariAndPostgresql() {
-        Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
-
-        // setting schema directly in hikari config should not throw exception when Exposed creates
-        // a new transaction and checks if connection parameters need to be reset
-        transaction(db = hikariPG) {
-            val foundHikariSchema = exec("SELECT schema_name FROM information_schema.schemata;") {
-                var match = false
-                while (it.next()) {
-                    if (it.getString(1) == "test_schema") {
-                        match = true
-                        break
-                    }
-                }
-                match
-            }
-            assertNotNull(foundHikariSchema)
-            assertTrue(foundHikariSchema)
-        }
-
-        TransactionManager.closeAndUnregister(hikariPG)
-    }
-
-    @Test
-    fun testReadOnlyModeWithHikariAndPostgres() {
-        Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
-
-        fun Transaction.getReadOnlyMode(): Boolean {
-            val mode = exec("SHOW transaction_read_only;") {
-                it.next()
-                it.getBoolean(1)
-            }
-            assertNotNull(mode)
-            return mode
-        }
-
-        // read only mode should be set directly by hikari config
-        transaction(db = hikariPG) {
-            assertTrue(getReadOnlyMode())
-
-            // table cannot be created in read-only mode
-            expectException<ExposedSQLException> {
-                SchemaUtils.create(TestTable)
-            }
-        }
-
-        // transaction setting should override hikari config
-        transaction(transactionIsolation = Connection.TRANSACTION_SERIALIZABLE, readOnly = false, db = hikariPG) {
-            assertFalse(getReadOnlyMode())
-
-            // table can now be created and dropped
-            SchemaUtils.create(TestTable)
-            SchemaUtils.drop(TestTable)
-        }
-
-        TransactionManager.closeAndUnregister(hikariPG)
     }
 
     object TestTable : IntIdTable("HIKARI_TESTER") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
@@ -9,7 +9,8 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.tests.LogDbInTestName
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/ConnectionPoolTests.kt
@@ -9,15 +9,21 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.LogDbInTestName
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Assert.assertFalse
 import org.junit.Assume
 import org.junit.Test
+import java.sql.Connection
+import kotlin.test.assertNotNull
 
 class ConnectionPoolTests : LogDbInTestName() {
     private val hikariDataSource1 by lazy {
@@ -57,6 +63,85 @@ class ConnectionPoolTests : LogDbInTestName() {
 
             SchemaUtils.drop(TestTable)
         }
+    }
+
+    private val hikariDataSourcePG by lazy {
+        HikariDataSource(
+            HikariConfig().apply {
+                jdbcUrl = TestDB.POSTGRESQL.connection.invoke()
+                username = TestDB.POSTGRESQL.user
+                password = TestDB.POSTGRESQL.pass
+                // sets the default schema for connections, which opens a database transaction before Exposed does
+                schema = "test_schema"
+                maximumPoolSize = 10
+                isAutoCommit = false
+                transactionIsolation = "TRANSACTION_SERIALIZABLE"
+                isReadOnly = true
+            }
+        )
+    }
+
+    private val hikariPG by lazy {
+        Database.connect(hikariDataSourcePG)
+    }
+
+    @Test
+    fun testSchemaAndConnectionsWithHikariAndPostgresql() {
+        Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
+
+        // setting schema directly in hikari config should not throw exception when Exposed creates
+        // a new transaction and checks if connection parameters need to be reset
+        transaction(db = hikariPG) {
+            val foundHikariSchema = exec("SELECT schema_name FROM information_schema.schemata;") {
+                var match = false
+                while (it.next()) {
+                    if (it.getString(1) == "test_schema") {
+                        match = true
+                        break
+                    }
+                }
+                match
+            }
+            assertNotNull(foundHikariSchema)
+            assertTrue(foundHikariSchema)
+        }
+
+        TransactionManager.closeAndUnregister(hikariPG)
+    }
+
+    @Test
+    fun testReadOnlyModeWithHikariAndPostgres() {
+        Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
+
+        fun Transaction.getReadOnlyMode(): Boolean {
+            val mode = exec("SHOW transaction_read_only;") {
+                it.next()
+                it.getBoolean(1)
+            }
+            assertNotNull(mode)
+            return mode
+        }
+
+        // read only mode should be set directly by hikari config
+        transaction(db = hikariPG) {
+            assertTrue(getReadOnlyMode())
+
+            // table cannot be created in read-only mode
+            expectException<ExposedSQLException> {
+                SchemaUtils.create(TestTable)
+            }
+        }
+
+        // transaction setting should override hikari config
+        transaction(transactionIsolation = Connection.TRANSACTION_SERIALIZABLE, readOnly = false, db = hikariPG) {
+            assertFalse(getReadOnlyMode())
+
+            // table can now be created and dropped
+            SchemaUtils.create(TestTable)
+            SchemaUtils.drop(TestTable)
+        }
+
+        TransactionManager.closeAndUnregister(hikariPG)
     }
 
     object TestTable : IntIdTable("HIKARI_TESTER") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/ConnectionPoolTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/ConnectionPoolTests.kt
@@ -1,0 +1,97 @@
+package org.jetbrains.exposed.sql.tests.postgresql
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.tests.LogDbInTestName
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.Assert
+import org.junit.Assume
+import org.junit.Test
+import java.sql.Connection
+import kotlin.test.assertNotNull
+
+class ConnectionPoolTests : LogDbInTestName() {
+    private val hikariDataSourcePG by lazy {
+        HikariDataSource(
+            HikariConfig().apply {
+                jdbcUrl = TestDB.POSTGRESQL.connection.invoke()
+                username = TestDB.POSTGRESQL.user
+                password = TestDB.POSTGRESQL.pass
+                // sets the default schema for connections, which opens a database transaction before Exposed does
+                schema = "public"
+                maximumPoolSize = 10
+                isAutoCommit = false
+                transactionIsolation = "TRANSACTION_SERIALIZABLE"
+                isReadOnly = true
+            }
+        )
+    }
+
+    private val hikariPG by lazy {
+        Database.connect(hikariDataSourcePG)
+    }
+
+    @Test
+    fun testSchemaAndConnectionsWithHikariAndPostgresql() {
+        Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
+
+        // setting default schema directly in hikari config should not throw exception when Exposed creates
+        // a new transaction and checks if connection parameters need to be reset
+        transaction(db = hikariPG) {
+            val schema = exec("SELECT CURRENT_SCHEMA;") {
+                it.next()
+                it.getString(1)
+            }
+            assertEquals("public", schema)
+        }
+
+        TransactionManager.closeAndUnregister(hikariPG)
+    }
+
+    @Test
+    fun testReadOnlyModeWithHikariAndPostgres() {
+        Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
+
+        val testTable = object : IntIdTable("HIKARI_TESTER") { }
+
+        fun Transaction.getReadOnlyMode(): Boolean {
+            val mode = exec("SHOW transaction_read_only;") {
+                it.next()
+                it.getBoolean(1)
+            }
+            assertNotNull(mode)
+            return mode
+        }
+
+        // read only mode should be set directly by hikari config
+        transaction(db = hikariPG) {
+            assertTrue(getReadOnlyMode())
+
+            // table cannot be created in read-only mode
+            expectException<ExposedSQLException> {
+                SchemaUtils.create(testTable)
+            }
+        }
+
+        // transaction setting should override hikari config
+        transaction(transactionIsolation = Connection.TRANSACTION_SERIALIZABLE, readOnly = false, db = hikariPG) {
+            Assert.assertFalse(getReadOnlyMode())
+
+            // table can now be created and dropped
+            SchemaUtils.create(testTable)
+            SchemaUtils.drop(testTable)
+        }
+
+        TransactionManager.closeAndUnregister(hikariPG)
+    }
+}

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionManagerTest.kt
@@ -71,7 +71,7 @@ class SpringTransactionManagerTest {
         val tm = SpringTransactionManager(ds1)
         tm.executeAssert()
 
-        assertTrue(con1.verifyCallOrder("setReadOnly", "setAutoCommit", "commit", "close"))
+        assertTrue(con1.verifyCallOrder("setAutoCommit", "commit", "close"))
         assertEquals(1, con1.commitCallCount)
         assertEquals(1, con1.closeCallCount)
     }
@@ -178,7 +178,7 @@ class SpringTransactionManagerTest {
         val tm = SpringTransactionManager(transactionAwareDs)
         tm.executeAssert()
 
-        assertTrue(con1.verifyCallOrder("setReadOnly", "setAutoCommit", "commit"))
+        assertTrue(con1.verifyCallOrder("setAutoCommit", "commit"))
         assertEquals(1, con1.commitCallCount)
         assertTrue(con1.closeCallCount > 0)
     }
@@ -196,7 +196,7 @@ class SpringTransactionManagerTest {
             assertEquals(ex, e)
         }
 
-        assertTrue(con1.verifyCallOrder("setReadOnly", "setAutoCommit", "rollback"))
+        assertTrue(con1.verifyCallOrder("setAutoCommit", "rollback"))
         assertEquals(1, con1.rollbackCallCount)
         assertTrue(con1.closeCallCount > 0)
     }
@@ -211,7 +211,7 @@ class SpringTransactionManagerTest {
             tm.executeAssert()
         }
 
-        assertTrue(con1.verifyCallOrder("setReadOnly", "setAutoCommit", "commit", "isClosed", "rollback", "close"))
+        assertTrue(con1.verifyCallOrder("setAutoCommit", "commit", "isClosed", "rollback", "close"))
         assertEquals(1, con1.commitCallCount)
         assertEquals(1, con1.rollbackCallCount)
         assertEquals(1, con1.closeCallCount)
@@ -230,7 +230,7 @@ class SpringTransactionManagerTest {
             }
         }
 
-        assertTrue(con1.verifyCallOrder("setReadOnly", "setAutoCommit", "isClosed", "rollback", "close"))
+        assertTrue(con1.verifyCallOrder("setAutoCommit", "isClosed", "rollback", "close"))
         assertEquals(1, con1.rollbackCallCount)
         assertEquals(1, con1.closeCallCount)
     }


### PR DESCRIPTION
 The lazy property initializer of a new database connection attempts to reset parameters (like transaction isolation level and read only mode), regardless of whether connections are being reused from a connection pool instance.
This can be observed, for example, when schema settings are placed in `HikariConfig`, which opens a database transaction leading to thrown exceptions when Exposed later attempts to reset parameters:
> org.postgresql.util.PSQLException: Cannot change transaction read-only property in the middle of a transaction.

This PR builds on the changes introduced in PR #1943 by also retrieving and caching the `readOnly` mode set by the `DataSource`and avoiding redundant resets.

**Note:** To ensure that these resets are avoided and that the `DataSource` is the single source of truth, duplicate settings should not be placed in `DatabaseConfig` (otherwise Exposed will treat these as overrides, as it already does for per-transaction parameter settings).