### PR TITLE
chore: Bump Exposed version from 0.45.0 to 0.46.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,52 +81,52 @@ repositories {
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-core</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-crypt</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-dao</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-java-time</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-jdbc</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-jodatime</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-json</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-kotlin-datetime</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-money</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-spring-boot-starter</artifactId>
-        <version>0.45.0</version>
+        <version>0.46.0</version>
     </dependency>
 </dependencies>
 
@@ -136,20 +136,20 @@ repositories {
 
 ```groovy
 dependencies {
-    implementation 'org.jetbrains.exposed:exposed-core:0.45.0'
-    implementation 'org.jetbrains.exposed:exposed-crypt:0.45.0'
-    implementation 'org.jetbrains.exposed:exposed-dao:0.45.0'
-    implementation 'org.jetbrains.exposed:exposed-jdbc:0.45.0'
+    implementation 'org.jetbrains.exposed:exposed-core:0.46.0'
+    implementation 'org.jetbrains.exposed:exposed-crypt:0.46.0'
+    implementation 'org.jetbrains.exposed:exposed-dao:0.46.0'
+    implementation 'org.jetbrains.exposed:exposed-jdbc:0.46.0'
     
-    implementation 'org.jetbrains.exposed:exposed-jodatime:0.45.0'
+    implementation 'org.jetbrains.exposed:exposed-jodatime:0.46.0'
     // or
-    implementation 'org.jetbrains.exposed:exposed-java-time:0.45.0'
+    implementation 'org.jetbrains.exposed:exposed-java-time:0.46.0'
     // or
-    implementation 'org.jetbrains.exposed:exposed-kotlin-datetime:0.45.0'
+    implementation 'org.jetbrains.exposed:exposed-kotlin-datetime:0.46.0'
     
-    implementation 'org.jetbrains.exposed:exposed-json:0.45.0'
-    implementation 'org.jetbrains.exposed:exposed-money:0.45.0'
-    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.45.0'
+    implementation 'org.jetbrains.exposed:exposed-json:0.46.0'
+    implementation 'org.jetbrains.exposed:exposed-money:0.46.0'
+    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.46.0'
 }
 ```
 
@@ -180,7 +180,7 @@ dependencies {
 and in `gradle.properties`
 
 ```
-exposedVersion=0.45.0
+exposedVersion=0.46.0
 ```
 
 ## Samples

--- a/docs/BREAKING_CHANGES.md
+++ b/docs/BREAKING_CHANGES.md
@@ -1,5 +1,35 @@
 # Breaking Changes
 
+## 0.46.0
+
+* When an Exposed table object is created with a keyword identifier (a table or column name) it now retains the exact case used before being automatically quoted in generated SQL.
+  This primarily affects H2 and Oracle, both of which support folding identifiers to uppercase, and PostgreSQL, which folds identifiers to lower case.
+
+  If `preserveKeywordCasing = true` had been previously set in `DatabaseConfig` to remove logged warnings about any keyword identifiers, this can now be removed as the property is `true` by default.
+
+  To temporarily opt-out of this behavior and to not keep the defined casing of keyword identifiers, please set `preserveKeywordCasing = false` in `DatabaseConfig`:
+```kotlin
+object TestTable : Table("table") {
+    val col = integer("select")
+}
+
+// default behavior (preserveKeywordCasing is by default set to true)
+// H2 generates SQL -> CREATE TABLE IF NOT EXISTS "table" ("select" INT NOT NULL)
+
+// with opt-out
+Database.connect(
+    url = "jdbc:h2:mem:test",
+    driver = "org.h2.Driver",
+    databaseConfig = DatabaseConfig {
+        @OptIn(ExperimentalKeywordApi::class)
+        preserveKeywordCasing = false
+    }
+)
+// H2 generates SQL -> CREATE TABLE IF NOT EXISTS "TABLE" ("SELECT" INT NOT NULL)
+```
+
+**Note:** `preserveKeywordCasing` is an experimental flag and requires `@OptIn`. It may become deprecated in future releases.
+
 ## 0.44.0
 
 * `SpringTransactionManager` no longer extends `DataSourceTransactionManager`; instead, it directly extends `AbstractPlatformTransactionManager` while retaining the previous basic functionality.

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,3 +1,43 @@
+# 0.46.0
+Infrastructure:
+* Kotlinx Datetime JVM 0.5.0
+* Joda Time 2.12.5
+* Kotlinx Serialization Json 1.6.2
+* log4j2 2.22.0
+* slf4j 2.0.9
+* MariaDB (V3) driver 3.3.1
+* PostgreSQL driver 42.7.1
+* h2-database (V2) driver 2.2.224
+* SQLite driver 3.44.1.0
+* Spring Framework 6.1.2
+* Spring Boot 3.2.0
+* Spring Security Crypto 5.8.8
+
+Breaking changes:
+* chore!: EXPOSED-239 Set `preserveKeywordCasing` flag to true by default by @bog-walk in https://github.com/JetBrains/Exposed/pull/1948
+* More details at [Breaking changes](BREAKING_CHANGES.md#0460)
+
+Features:
+* feat: EXPOSED-65 Design query DSL consistent with SQL language by @bog-walk in https://github.com/JetBrains/Exposed/pull/1916
+* More details in the [Migration guide](MIGRATION_GUIDE.md#migrating-from-0450-to-0460)
+
+Bug fixes:
+* perf: EXPOSED-204 Performance problem with getConnection() by @bog-walk in https://github.com/JetBrains/Exposed/pull/1943
+* fix: EXPOSED-242 [PostgreSQL] Cannot change connection setting in middle of a transaction by @bog-walk in https://github.com/JetBrains/Exposed/pull/1949
+
+Build:
+* build: Add dependencies to Version Catalog by @pank-su in https://github.com/JetBrains/Exposed/pull/1887
+
+Docs:
+* docs: Add KDoc for `databaseGenerated` feature by @joc-a in https://github.com/JetBrains/Exposed/pull/1904
+* WRS-3621 Update project configuration by @e5l in https://github.com/JetBrains/Exposed/pull/1911
+* docs: Add missing Wiki documentation by @bog-walk in https://github.com/JetBrains/Exposed/pull/1910
+* docs: Apply query DSL changes to writerside docs by @bog-walk in https://github.com/JetBrains/Exposed/pull/1926
+* docs: Add missing KDocs for exposed-core queries API by @bog-walk in https://github.com/JetBrains/Exposed/pull/1941
+* docs: Add missing KDocs for exposed-core database API by @bog-walk in https://github.com/JetBrains/Exposed/pull/1945
+* docs: Add missing KDocs for exposed-core table API by @bog-walk in https://github.com/JetBrains/Exposed/pull/1946
+* docs: Add MIGRATION_GUIDE by @bog-walk in https://github.com/JetBrains/Exposed/pull/1933
+
 # 0.45.0
 Infrastructure:
 * Kotlin 1.9.21

--- a/documentation-website/Writerside/topics/Getting-Started.md
+++ b/documentation-website/Writerside/topics/Getting-Started.md
@@ -18,17 +18,17 @@
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-core</artifactId>
-      <version>0.45.0</version>
+      <version>0.46.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-dao</artifactId>
-      <version>0.45.0</version>
+      <version>0.46.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-jdbc</artifactId>
-      <version>0.45.0</version>
+      <version>0.46.0</version>
     </dependency>
 </dependencies>
 ]]>
@@ -37,7 +37,7 @@
     <tab title="Gradle Kotlin Script">
         <code-block lang="kotlin">
 <![CDATA[
-val exposedVersion: String = "0.45.0"
+val exposedVersion: String = "0.46.0"
 
 dependencies {
 implementation("org.jetbrains.exposed:exposed-core", exposedVersion)

--- a/documentation-website/Writerside/topics/Modules-Documentation.md
+++ b/documentation-website/Writerside/topics/Modules-Documentation.md
@@ -61,7 +61,7 @@ Dependencies mapping listed below is similar (by functionality) to the previous 
 <tabs>
   <tab title="Kotlin Gradle">
     <code-block lang="kotlin">
-      val exposedVersion: String = "0.45.0"
+      val exposedVersion: String = "0.46.0"
       dependencies {
           implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
           implementation("org.jetbrains.exposed:exposed-crypt:$exposedVersion")
@@ -88,59 +88,59 @@ Dependencies mapping listed below is similar (by functionality) to the previous 
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-core&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-crypt&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-dao&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-java-time&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-jdbc&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-jodatime&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-json&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-kotlin-datetime&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-money&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.jetbrains.exposed&lt;/groupId&gt;
         &lt;artifactId&gt;exposed-spring-boot-starter&lt;/artifactId&gt;
-        &lt;version&gt;0.45.0&lt;/version&gt;
+        &lt;version&gt;0.46.0&lt;/version&gt;
     &lt;/dependency&gt;
 &lt;/dependencies&gt;
     </code-block>
   </tab>
   <tab title="Groovy Gradle">
     <code-block lang="groovy">
-      def exposedVersion = "0.45.0"
+      def exposedVersion = "0.46.0"
       dependencies {
           implementation "org.jetbrains.exposed:exposed-core:$exposedVersion"
           implementation "org.jetbrains.exposed:exposed-crypt:$exposedVersion"

--- a/exposed-bom/README.md
+++ b/exposed-bom/README.md
@@ -17,7 +17,7 @@ Bill of Materials for all Exposed modules
         <dependency>
             <groupId>org.jetbrains.exposed</groupId>
             <artifactId>exposed-bom</artifactId>
-            <version>0.45.0</version>
+            <version>0.46.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -51,7 +51,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.jetbrains.exposed:exposed-bom:0.45.0"))
+    implementation(platform("org.jetbrains.exposed:exposed-bom:0.46.0"))
     implementation("org.jetbrains.exposed", "exposed-core")
     implementation("org.jetbrains.exposed", "exposed-dao")
     implementation("org.jetbrains.exposed", "exposed-jdbc")

--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -18,7 +18,7 @@ This starter will give you the latest version of [Exposed](https://github.com/Je
   <dependency>
     <groupId>org.jetbrains.exposed</groupId>
     <artifactId>exposed-spring-boot-starter</artifactId>
-    <version>0.45.0</version>
+    <version>0.46.0</version>
   </dependency>
 </dependencies>
 ```
@@ -28,7 +28,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.45.0'
+    implementation 'org.jetbrains.exposed:exposed-spring-boot-starter:0.46.0'
 }
 ```
 ### Gradle Kotlin DSL
@@ -44,7 +44,7 @@ dependencies {
 ```
 In `gradle.properties`
 ```properties
-exposedVersion=0.45.0
+exposedVersion=0.46.0
 ```
 
 ## Setting up a database connection

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.configuration.cache=true
 org.gradle.caching=true
 
 group=org.jetbrains.exposed
-version=0.45.0
+version=0.46.0

--- a/samples/exposed-ktor/gradle.properties
+++ b/samples/exposed-ktor/gradle.properties
@@ -2,5 +2,5 @@ ktorVersion=2.3.4
 kotlinVersion=1.8.10
 logbackVersion=1.2.11
 kotlin.code.style=official
-exposedVersion=0.45.0
+exposedVersion=0.46.0
 h2Version=2.1.214

--- a/samples/exposed-spring/gradle.properties
+++ b/samples/exposed-spring/gradle.properties
@@ -1,2 +1,2 @@
-exposedVersion=0.45.0
+exposedVersion=0.46.0
 kotlinVersion=1.8.21


### PR DESCRIPTION
Update BREAKING_CHANGES and CHANGELOG files.

Wiki will be updated with new DSL changes as well.