### PR TITLE
fix: EXPOSED-244 [PostgreSQL] Collate option on column not recognized

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2071,6 +2071,7 @@ public abstract class org/jetbrains/exposed/sql/StringColumnType : org/jetbrains
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	protected final fun escape (Ljava/lang/String;)Ljava/lang/String;
+	protected final fun escapeAndQuote (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getCollate ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -546,6 +546,12 @@ abstract class StringColumnType(
     /** Returns the specified [value] with special characters escaped. */
     protected fun escape(value: String): String = value.map { charactersToEscape[it] ?: it }.joinToString("")
 
+    /** Returns the specified [value] with special characters escaped and wrapped in quotations, if necessary. */
+    protected fun escapeAndQuote(value: String): String = when (currentDialect) {
+        is PostgreSQLDialect -> "\"${escape(value)}\""
+        else -> escape(value)
+    }
+
     override fun valueFromDB(value: Any): Any = when (value) {
         is Clob -> value.characterStream.readText()
         is ByteArray -> String(value)
@@ -597,7 +603,7 @@ open class CharColumnType(
     override fun sqlType(): String = buildString {
         append("CHAR($colLength)")
         if (collate != null) {
-            append(" COLLATE ${escape(collate)}")
+            append(" COLLATE ${escapeAndQuote(collate)}")
         }
     }
 
@@ -643,7 +649,7 @@ open class VarCharColumnType(
     override fun sqlType(): String = buildString {
         append(preciseType())
         if (collate != null) {
-            append(" COLLATE ${escape(collate)}")
+            append(" COLLATE ${escapeAndQuote(collate)}")
         }
     }
 
@@ -689,7 +695,7 @@ open class TextColumnType(
     override fun sqlType(): String = buildString {
         append(preciseType())
         if (collate != null) {
-            append(" COLLATE ${escape(collate)}")
+            append(" COLLATE ${escapeAndQuote(collate)}")
         }
     }
 


### PR DESCRIPTION
Unlike all other dialects, PostgreSQL column COLLATE clause requires that the option is quoted as part of the column definition.