### PR TITLE
docs: [SQL Server, Oracle] Edit KDocs for Op.TRUE/FALSE

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -20,7 +20,12 @@ abstract class Op<T> : Expression<T>() {
 
     internal interface OpBoolean
 
-    /** Boolean operator corresponding to the SQL value `TRUE` */
+    /**
+     * Boolean operator that always evaluates to the SQL value `TRUE`.
+     *
+     * **Note** Some databases, like SQL Server and Oracle, do not support conditions like `WHERE 1` or `WHERE TRUE`.
+     * When using these databases, this operator will instead produce the condition `1 = 1`.
+     */
     object TRUE : Op<Boolean>(), OpBoolean {
         override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
             when {
@@ -32,7 +37,12 @@ abstract class Op<T> : Expression<T>() {
         }
     }
 
-    /** Boolean operator corresponding to the SQL value `FALSE` */
+    /**
+     * Boolean operator that always evaluates to the SQL value `FALSE`.
+     *
+     * **Note** Some databases, like SQL Server and Oracle, do not support conditions like `WHERE 0` or `WHERE FALSE`.
+     * When using these databases, this operator will instead produce the condition `1 = 0`.
+     */
     object FALSE : Op<Boolean>(), OpBoolean {
         override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
             when {


### PR DESCRIPTION
Current KDocs are misleading for the actual behavior of `Op.TRUE` and `Op.FALSE` as they make it seem like the objects simply translate to the SQL types for `true` and `false`.

This is technically correct for databases that support conventional boolean data types, so the objects can be used either as a stand-alone operator or as the left- or right-hand side of any comparison operator.

But for SQL Server and Oracle, which do not support syntax like `WHERE 1` or `WHERE TRUE`, the object's logic returns an operator that always evaluates to a boolean, like `1 = 1`. So attempting to use these objects as the left- or right-hand side of any comparison operator will cause a syntax error. `booleanLiteral()` or `booleanParam()` should be used in these situations.