### PR TITLE
docs: Add details about @EnableTransactionManagement to spring-boot-starter docs

### DIFF
--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -109,6 +109,12 @@ fun main(args: Array<String>) {
 
 See the [official documentation](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using.auto-configuration.disabling-specific) for more options to exclude auto-configuration classes.
 
+**Note:** The `ExposedAutoConfiguration` class adds `@EnableTransactionManagement` without setting any attributes. 
+This means that all attributes have their default values, including `mode = AdviceMode.PROXY` and `proxyTargetClass = false`. 
+If the type of [proxying mechanism](https://docs.spring.io/spring-framework/reference/core/aop/proxying.html)  is unexpected, 
+the attributes can be set to the required values in a separate `@EnableTransactionManagement` on the main configuration class 
+or in the `application.properties` file using the property `spring.aop.proxy-target-class`.
+
 ### Configuring Additional Transaction Managers
 
 Once Exposed has been configured as shown [above](#configuring-exposed), other transaction managers can also be registered by creating their own `@Configuration` class containing a declared transaction manager bean.

--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
@@ -19,6 +19,12 @@ import javax.sql.DataSource
  * This should be applied on a Spring configuration class using:
  * `@ImportAutoConfiguration(ExposedAutoConfiguration::class)`
  *
+ * **Note** As part of the configuration, `@EnableTransactionManagement` is added without setting any attributes.
+ * This means that all attributes have their default values, including `mode = AdviceMode.PROXY` and
+ * `proxyTargetClass = false`. If the type of proxy mechanism is unexpected, the attributes can be set to the
+ * required values in a separate `@EnableTransactionManagement` on the main configuration class or in a configuration
+ * file using `spring.aop.proxy-target-class`.
+ *
  * @property applicationContext The Spring ApplicationContext container responsible for managing beans.
  */
 @AutoConfiguration(after = [DataSourceAutoConfiguration::class])


### PR DESCRIPTION
Users of `exposed-spring-boot-starter` might not expect the starter to set certain configuration attributes to their Spring defaults because it is necessary for the inclusion and configuration of Exposed's `SpringTransactionManager`.

This provides a warning regarding the default attribute settings included when `@ExposedAutoConfiguration` is automatically configured, as well as options for how to adjust the default proxy target settings, if required.