### PR TITLE
fix: EXPOSED-257 Upsert incorrectly parameterizes non-literal WHERE arguments

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2963,6 +2963,8 @@ public class org/jetbrains/exposed/sql/statements/UpdateStatement : org/jetbrain
 
 public class org/jetbrains/exposed/sql/statements/UpsertStatement : org/jetbrains/exposed/sql/statements/InsertStatement {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Lorg/jetbrains/exposed/sql/Op;)V
+	public synthetic fun arguments ()Ljava/lang/Iterable;
+	public fun arguments ()Ljava/util/List;
 	public final fun getKeys ()[Lorg/jetbrains/exposed/sql/Column;
 	public final fun getOnUpdate ()Ljava/util/List;
 	public final fun getWhere ()Lorg/jetbrains/exposed/sql/Op;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -209,7 +209,7 @@ open class InsertStatement<Key : Any>(
         }
 
     override fun arguments(): List<Iterable<Pair<IColumnType, Any?>>> {
-        return arguments!!.map { args ->
+        return arguments?.map { args ->
             val builder = QueryBuilder(true)
             args.filter { (_, value) ->
                 value != DefaultValueMarker
@@ -217,6 +217,6 @@ open class InsertStatement<Key : Any>(
                 builder.registerArgument(column, value)
             }
             builder.args
-        }
+        } ?: emptyList()
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -30,4 +30,17 @@ open class UpsertStatement<Key : Any>(
         }
         return functionProvider.upsert(table, arguments!!.first(), onUpdate, where, transaction, keys = keys)
     }
+
+    override fun arguments(): List<Iterable<Pair<IColumnType, Any?>>> {
+        return arguments!!.map { args ->
+            val builder = QueryBuilder(true)
+            args.filter { (_, value) ->
+                value != DefaultValueMarker
+            }.forEach { (column, value) ->
+                builder.registerArgument(column, value)
+            }
+            where?.toQueryBuilder(builder)
+            builder.args
+        }
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -32,7 +32,7 @@ open class UpsertStatement<Key : Any>(
     }
 
     override fun arguments(): List<Iterable<Pair<IColumnType, Any?>>> {
-        return arguments!!.map { args ->
+        return arguments?.map { args ->
             val builder = QueryBuilder(true)
             args.filter { (_, value) ->
                 value != DefaultValueMarker
@@ -41,6 +41,6 @@ open class UpsertStatement<Key : Any>(
             }
             where?.toQueryBuilder(builder)
             builder.args
-        }
+        } ?: emptyList()
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
@@ -13,7 +13,6 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
 import org.jetbrains.exposed.sql.statements.BatchUpsertStatement
 import org.jetbrains.exposed.sql.tests.*
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
-import org.jetbrains.exposed.sql.tests.shared.entities.UUIDTables.Addresses.address
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.junit.Test
 import java.util.*


### PR DESCRIPTION
Currently when using `upsert()` with a `where` argument, only column expressions and literal values are being handled correctly in the `PreparedStatement` SQL.

Attempting to use a value that should be parameterized (by using `param()` functions or primitive types) results in an exception stating that the provided parameter count is incorrect. 
This occurs because the `where` arguments are not correctly added to the list of statement arguments in the super class `InsertStatement`.

An `arguments()` override that includes these `where` arguments has now been added to the `UpsertStatement` class.