### PR TITLE
feat: EXPOSED-255 Generate database migration script that can be used with any migration tool

### DIFF
--- a/docs/BREAKING_CHANGES.md
+++ b/docs/BREAKING_CHANGES.md
@@ -2,8 +2,10 @@
 
 ## 0.47.0
 
-The function `SchemaUtils.checkExcessiveIndices` used to check both excessive indices and excessive foreign key constraints. It now has a different behaviour and
-deals with excessive indices only. A new function, `SchemaUtils.checkExcessiveForeignKeyConstraints`, deals with excessive foreign key constraints.
+The function `SchemaUtils.checkExcessiveIndices` used to check both excessive indices and excessive foreign key
+constraints. It now has a different behaviour and deals with excessive indices only. Also, its return type is now
+`List<Index>` instead of `Unit`. A new function, `SchemaUtils.checkExcessiveForeignKeyConstraints`, deals with excessive
+foreign key constraints and has a return type `List<ForeignKeyConstraint>`.
 
 ## 0.46.0
 

--- a/docs/BREAKING_CHANGES.md
+++ b/docs/BREAKING_CHANGES.md
@@ -1,5 +1,10 @@
 # Breaking Changes
 
+## 0.47.0
+
+The function `SchemaUtils.checkExcessiveIndices` used to check both excessive indices and excessive foreign key constraints. It now has a different behaviour and
+deals with excessive indices only. A new function, `SchemaUtils.checkExcessiveForeignKeyConstraints`, deals with excessive foreign key constraints.
+
 ## 0.46.0
 
 * When an Exposed table object is created with a keyword identifier (a table or column name) it now retains the exact case used before being automatically quoted in generated SQL.

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -752,6 +752,9 @@ public final class org/jetbrains/exposed/sql/Exists : org/jetbrains/exposed/sql/
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
+public abstract interface annotation class org/jetbrains/exposed/sql/ExperimentalDatabaseMigrationApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class org/jetbrains/exposed/sql/ExperimentalKeywordApi : java/lang/annotation/Annotation {
 }
 
@@ -1843,7 +1846,6 @@ public final class org/jetbrains/exposed/sql/SchemaUtils {
 	public final fun addMissingColumnsStatements ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
 	public static synthetic fun addMissingColumnsStatements$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun checkCycle ([Lorg/jetbrains/exposed/sql/Table;)Z
-	public final fun checkExcessiveIndices ([Lorg/jetbrains/exposed/sql/Table;)V
 	public final fun checkMappingConsistence ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
 	public static synthetic fun checkMappingConsistence$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun create ([Lorg/jetbrains/exposed/sql/Table;Z)V
@@ -1867,11 +1869,15 @@ public final class org/jetbrains/exposed/sql/SchemaUtils {
 	public static synthetic fun dropSchema$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Schema;ZZILjava/lang/Object;)V
 	public final fun dropSequence ([Lorg/jetbrains/exposed/sql/Sequence;Z)V
 	public static synthetic fun dropSequence$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Sequence;ZILjava/lang/Object;)V
+	public final fun generateMigrationScript ([Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;Z)Ljava/io/File;
+	public static synthetic fun generateMigrationScript$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public final fun listDatabases ()Ljava/util/List;
 	public final fun listTables ()Ljava/util/List;
 	public final fun setSchema (Lorg/jetbrains/exposed/sql/Schema;Z)V
 	public static synthetic fun setSchema$default (Lorg/jetbrains/exposed/sql/SchemaUtils;Lorg/jetbrains/exposed/sql/Schema;ZILjava/lang/Object;)V
 	public final fun sortTablesByReferences (Ljava/lang/Iterable;)Ljava/util/List;
+	public final fun statementsRequiredForDatabaseMigration ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
+	public static synthetic fun statementsRequiredForDatabaseMigration$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun statementsRequiredToActualizeScheme ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
 	public static synthetic fun statementsRequiredToActualizeScheme$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun withDataBaseLock (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/jvm/functions/Function0;)V

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1846,6 +1846,8 @@ public final class org/jetbrains/exposed/sql/SchemaUtils {
 	public final fun addMissingColumnsStatements ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
 	public static synthetic fun addMissingColumnsStatements$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun checkCycle ([Lorg/jetbrains/exposed/sql/Table;)Z
+	public final fun checkExcessiveForeignKeyConstraints ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
+	public final fun checkExcessiveIndices ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
 	public final fun checkMappingConsistence ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
 	public static synthetic fun checkMappingConsistence$default (Lorg/jetbrains/exposed/sql/SchemaUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun create ([Lorg/jetbrains/exposed/sql/Table;Z)V

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -668,34 +668,32 @@ object SchemaUtils {
 
     /**
      * @param scriptName The name to be used for the generated migration script.
-     * @param scriptDirectory The directory in which to create the migration script.
+     * @param scriptDirectory The directory (path from repository root) in which to create the migration script.
      * @param withLogs By default, a description for each intermediate step, as well as its execution time, is logged at
      * the INFO level. This can be disabled by setting [withLogs] to `false`.
      *
      * @return The generated migration script.
      *
-     * This function simply generates the migration script without applying the migration. The purpose of it is to show
-     * the user what the migration script will look like before applying the migration.
+     * This function simply generates the migration script without applying the migration. Its purpose is to show what
+     * the migration script will look like before applying the migration.
+     * If a migration script with the same name already exists, its content will be overwritten.
      */
     @ExperimentalDatabaseMigrationApi
     fun generateMigrationScript(vararg tables: Table, scriptDirectory: String, scriptName: String, withLogs: Boolean = true): File {
         val allStatements = statementsRequiredForDatabaseMigration(*tables, withLogs = withLogs)
 
         val migrationScript = File("$scriptDirectory/$scriptName.sql")
-        val migrationScriptExists = if (migrationScript.exists()) true else migrationScript.createNewFile()
-        if (migrationScriptExists) {
-            // Clear existing content
-            migrationScript.writeText("")
+        migrationScript.createNewFile()
 
-            // Append statements
-            allStatements.forEach { statement ->
-                // Add semicolon only if it's not already there
-                val conditionalSemicolon = if (statement.last() == ';') "" else ";"
+        // Clear existing content
+        migrationScript.writeText("")
 
-                migrationScript.appendText("$statement$conditionalSemicolon\n")
-            }
-        } else {
-            throw NoSuchFileException(migrationScript, reason = "Failed to create/find migration script")
+        // Append statements
+        allStatements.forEach { statement ->
+            // Add semicolon only if it's not already there
+            val conditionalSemicolon = if (statement.last() == ';') "" else ";"
+
+            migrationScript.appendText("$statement$conditionalSemicolon\n")
         }
 
         return migrationScript

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -531,12 +531,13 @@ object SchemaUtils {
     }
 
     /**
-     * Checks all [tables] for any that have more than one defined index and logs the findings.
+     * Checks all [tables] for any that have more than one defined index and logs the findings. If found, this function
+     * also logs the SQL statements that can be used to drop these indices.
      *
-     * If found, this function also logs and returns the SQL statements that can be used to drop these constraints.
+     * @return List of indices that are excessive and can be dropped.
      */
     @Suppress("NestedBlockDepth")
-    private fun checkExcessiveIndices(vararg tables: Table, withLogs: Boolean): List<Index> {
+    fun checkExcessiveIndices(vararg tables: Table, withLogs: Boolean): List<Index> {
         val toDrop = HashSet<Index>()
 
         val excessiveIndices =
@@ -570,12 +571,13 @@ object SchemaUtils {
     }
 
     /**
-     * Checks all [tables] for any that have more than one defined foreign key constraint and logs the findings.
+     * Checks all [tables] for any that have more than one defined foreign key constraint and logs the findings. If
+     * found, this function also logs the SQL statements that can be used to drop these foreign key constraints.
      *
-     * If found, this function also logs and returns the SQL statements that can be used to drop these constraints.
+     * @return List of foreign key constraints that are excessive and can be dropped.
      */
     @Suppress("NestedBlockDepth")
-    private fun checkExcessiveForeignKeyConstraints(vararg tables: Table, withLogs: Boolean): List<ForeignKeyConstraint> {
+    fun checkExcessiveForeignKeyConstraints(vararg tables: Table, withLogs: Boolean): List<ForeignKeyConstraint> {
         val toDrop = HashSet<ForeignKeyConstraint>()
 
         val excessiveConstraints = currentDialect.columnConstraints(*tables).filter { (_, fkConstraints) -> fkConstraints.size > 1 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -675,6 +675,7 @@ object SchemaUtils {
     }
 
     /**
+     * @param tables The tables whose changes will be used to generate the migration script.
      * @param scriptName The name to be used for the generated migration script.
      * @param scriptDirectory The directory (path from repository root) in which to create the migration script.
      * @param withLogs By default, a description for each intermediate step, as well as its execution time, is logged at
@@ -682,12 +683,16 @@ object SchemaUtils {
      *
      * @return The generated migration script.
      *
+     * @throws IllegalArgumentException if no argument is passed for the [tables] parameter.
+     *
      * This function simply generates the migration script without applying the migration. Its purpose is to show what
      * the migration script will look like before applying the migration.
      * If a migration script with the same name already exists, its content will be overwritten.
      */
     @ExperimentalDatabaseMigrationApi
     fun generateMigrationScript(vararg tables: Table, scriptDirectory: String, scriptName: String, withLogs: Boolean = true): File {
+        require(tables.isNotEmpty()) { "Tables argument must not be empty" }
+
         val allStatements = statementsRequiredForDatabaseMigration(*tables, withLogs = withLogs)
 
         val migrationScript = File("$scriptDirectory/$scriptName.sql")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.sql.tests.inProperCase
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.PrimaryKeyMetadata
 import org.junit.Test
 import java.io.File
@@ -97,6 +98,15 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
             } finally {
                 assertTrue(File("$directory/$name.sql").delete())
                 SchemaUtils.drop(noPKTable)
+            }
+        }
+    }
+
+    @Test
+    fun testNoTablesPassedWhenGeneratingMigrationScript() {
+        withDb {
+            expectException<IllegalArgumentException> {
+                SchemaUtils.generateMigrationScript(scriptDirectory = "src/test/resources", scriptName = "V2__Test")
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -1,0 +1,166 @@
+package org.jetbrains.exposed.sql.tests.shared.ddl
+
+import org.jetbrains.exposed.sql.ExperimentalDatabaseMigrationApi
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.exists
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.inProperCase
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.vendors.PrimaryKeyMetadata
+import org.junit.Test
+import java.io.File
+import kotlin.properties.Delegates
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalDatabaseMigrationApi::class)
+class DatabaseMigrationTests : DatabaseTestsBase() {
+
+    @Test
+    fun testMigrationScriptDirectoryAndContent() {
+        val tableName = "tester"
+        val noPKTable = object : Table(tableName) {
+            val bar = integer("bar")
+        }
+
+        val singlePKTable = object : Table(tableName) {
+            val bar = integer("bar")
+
+            override val primaryKey = PrimaryKey(bar)
+        }
+
+        val scriptName = "V2__Add_primary_key"
+        val scriptDirectory = "src/test/resources"
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) {
+            try {
+                SchemaUtils.create(noPKTable)
+
+                val script = SchemaUtils.generateMigrationScript(singlePKTable, scriptDirectory = scriptDirectory, scriptName = scriptName)
+                assertTrue(script.exists())
+                assertEquals("src/test/resources/$scriptName.sql", script.path)
+
+                val expectedStatements: List<String> = SchemaUtils.statementsRequiredForDatabaseMigration(singlePKTable)
+                assertEquals(1, expectedStatements.size)
+
+                val fileStatements: List<String> = script.bufferedReader().readLines().map { it.trimEnd(';') }
+                expectedStatements.zip(fileStatements).forEach { (expected, actual) ->
+                    assertEquals(expected, actual)
+                }
+            } finally {
+                assertTrue(File("$scriptDirectory/$scriptName.sql").delete())
+            }
+        }
+    }
+
+    @Test
+    fun testAddNewPrimaryKeyOnExistingColumn() {
+        val tableName = "tester"
+        val noPKTable = object : Table(tableName) {
+            val bar = integer("bar")
+        }
+
+        val singlePKTable = object : Table(tableName) {
+            val bar = integer("bar")
+
+            override val primaryKey = PrimaryKey(bar)
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) {
+            try {
+                SchemaUtils.create(noPKTable)
+                val primaryKey: PrimaryKeyMetadata? = currentDialectTest.existingPrimaryKeys(singlePKTable)[singlePKTable]
+                assertNull(primaryKey)
+
+                val expected = "ALTER TABLE ${tableName.inProperCase()} ADD PRIMARY KEY (${noPKTable.bar.nameInDatabaseCase()})"
+                val statements = SchemaUtils.statementsRequiredForDatabaseMigration(singlePKTable)
+                assertEquals(expected, statements.single())
+            } finally {
+                SchemaUtils.drop(noPKTable)
+            }
+        }
+    }
+
+    @Test
+    fun `columns with default values that haven't changed shouldn't trigger change`() {
+        var table by Delegates.notNull<Table>()
+        withDb { testDb ->
+            try {
+                // MySQL doesn't support default values on text columns, hence excluded
+                table = if (testDb != TestDB.MYSQL) {
+                    object : Table("varchar_test") {
+                        val varchar = varchar("varchar_column", 255).default(" ")
+                        val text = text("text_column").default(" ")
+                    }
+                } else {
+                    object : Table("varchar_test") {
+                        val varchar = varchar("varchar_column", 255).default(" ")
+                    }
+                }
+
+                SchemaUtils.create(table)
+                val actual = SchemaUtils.statementsRequiredForDatabaseMigration(table)
+                assertEqualLists(emptyList(), actual)
+            } finally {
+                SchemaUtils.drop(table)
+            }
+        }
+    }
+
+    @Test
+    fun testCreateTableWithQuotedIdentifiers() {
+        val identifiers = listOf("\"IdentifierTable\"", "\"IDentiFierCoLUmn\"")
+        val quotedTable = object : Table(identifiers[0]) {
+            val column1 = varchar(identifiers[1], 32)
+        }
+
+        withDb {
+            try {
+                SchemaUtils.create(quotedTable)
+                assertTrue(quotedTable.exists())
+
+                val statements = SchemaUtils.statementsRequiredForDatabaseMigration(quotedTable)
+                assertTrue(statements.isEmpty())
+            } finally {
+                SchemaUtils.drop(quotedTable)
+            }
+        }
+    }
+
+    @Test
+    fun testDropExtraIndexOnSameColumn() {
+        val testTableWithTwoIndices = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+            val byName = index("test_table_by_name", false, name)
+            val byName2 = index("test_table_by_name_2", false, name)
+        }
+
+        val testTableWithOneIndex = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+            val byName = index("test_table_by_name", false, name)
+        }
+
+        // Oracle does not allow more than one index on a column
+        withTables(excludeSettings = listOf(TestDB.ORACLE), tables = arrayOf(testTableWithTwoIndices)) {
+            try {
+                SchemaUtils.create(testTableWithTwoIndices)
+                assertTrue(testTableWithTwoIndices.exists())
+
+                val statements = SchemaUtils.statementsRequiredForDatabaseMigration(testTableWithOneIndex)
+                assertEquals(1, statements.size)
+            } finally {
+                SchemaUtils.drop(testTableWithTwoIndices)
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,12 +33,11 @@ moneta = "1.4.3"
 hikariCP = "4.0.3"
 logcaptor = "2.9.2"
 
-
 [libraries]
 jvm = { group = "org.jetbrains.kotlin.jvm", name = "org.jetbrains.kotlin.jvm.gradle.plugin", version.ref = "kotlin" }
 docker-compose = { group = "com.avast.gradle", name = "gradle-docker-compose-plugin", version.ref = "docker-compose" }
 detekt = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
-detekt-formatting = {group = "io.gitlab.arturbosch.detekt", name="detekt-formatting", version.ref="detekt"}
+detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlinx-coroutines-debug = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-debug", version.ref = "kotlinCoroutines" }


### PR DESCRIPTION
Two new functions have been added:
-`SchemaUtils.statementsRequiredForDatabaseMigration`
-`SchemaUtils.generateMigrationScript` (marked as experimental)

The conditions of usage of the generated migration script:
-It has the .sql extension.
-Its name is decided by the user.
-The directory in which it is created is decided by the user.
-It is editable after it's generated.
-The user bears full responsibility for how the migration script is used. It should NOT be executed as regular SQL statements because there is no guarantee that it can be rolled back if a failure happens at any point. It should only be executed using a database migration tool like Flyway, for example, which is used in the tests for this feature.