### PR TITLE
fix: EXPOSED-261 [H2] JSON column throws when setting nullable parameters

### DIFF
--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
@@ -54,11 +54,13 @@ open class JsonColumnType<T : Any>(
 
     override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
         val parameterValue = when (currentDialect) {
-            is PostgreSQLDialect -> PGobject().apply {
-                type = sqlType()
-                this.value = value as String?
+            is PostgreSQLDialect -> value?.let {
+                PGobject().apply {
+                    type = sqlType()
+                    this.value = value as? String
+                }
             }
-            is H2Dialect -> (value as String).encodeToByteArray()
+            is H2Dialect -> (value as? String)?.encodeToByteArray()
             else -> value
         }
         super.setParameter(stmt, index, parameterValue)


### PR DESCRIPTION
When using **H2**, attempting to insert `null` into a nullable JSON column results in an NPE that states: 
> null cannot be cast to non-null type kotlin.String

When using **PostgreSQL-NG**, attempting to retrieve a null value stored in a JSON column results in a deserialization error because a non-null object is read with string value `'null'`.

Both these issues occur because the `JsonColumnType` override for `setParameter()` does not handle null values correctly.
In the case of PostgreSQL-NG, this meant that a null value was being stored as a string literal instead of SQL NULL.

If null values are passed, the dialect overrides now ensure that they are sent to the super implementation so they can be handled as SQL NULL.