### PR TITLE
fix: EXPOSED-260 [Oracle] Pair.inList() fails if list contains single element

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/InListOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/InListOps.kt
@@ -4,6 +4,8 @@ import org.jetbrains.exposed.sql.ComplexExpression
 import org.jetbrains.exposed.sql.ExpressionWithColumnType
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.vendors.OracleDialect
+import org.jetbrains.exposed.sql.vendors.currentDialectIfAvailable
 
 /**
  * Represents an SQL operator that checks if [expr] is equals to any element from [list].
@@ -38,7 +40,7 @@ abstract class InListOrNotInListBaseOp<V> (
 
             val firstValue = iterator.next()
 
-            if (!iterator.hasNext()) {
+            if (!iterator.hasNext() && currentDialectIfAvailable !is OracleDialect) {
                 when {
                     isInList -> append(" = ")
                     else -> append(" != ")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -172,7 +172,7 @@ class SelectTests : DatabaseTestsBase() {
 
     @Test
     fun testInList04() {
-        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)) { _, users, _ ->
+        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER)) { _, users, _ ->
             val r = users.selectAll().where { users.id to users.name inList listOf("andrey" to "Andrey") }.toList()
 
             assertEquals(1, r.size)
@@ -182,7 +182,7 @@ class SelectTests : DatabaseTestsBase() {
 
     @Test
     fun testInList05() {
-        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)) { _, users, _ ->
+        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER)) { _, users, _ ->
             val r = users.selectAll().where { users.id to users.name inList emptyList() }.toList()
 
             assertEquals(0, r.size)
@@ -191,7 +191,7 @@ class SelectTests : DatabaseTestsBase() {
 
     @Test
     fun testInList06() {
-        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)) { _, users, _ ->
+        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER)) { _, users, _ ->
             val r = users.selectAll().where { users.id to users.name notInList emptyList() }.toList()
 
             assertEquals(users.selectAll().count().toInt(), r.size)
@@ -200,7 +200,7 @@ class SelectTests : DatabaseTestsBase() {
 
     @Test
     fun testInList07() {
-        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)) { _, users, _ ->
+        withCitiesAndUsers(listOf(TestDB.SQLITE, TestDB.SQLSERVER)) { _, users, _ ->
             val r = users.selectAll().where {
                 Triple(users.id, users.name, users.cityId) notInList listOf(Triple("alex", "Alex", null))
             }.toList()


### PR DESCRIPTION
If a `Pair`/`Triple` is used with `inList()`/`notInList()` and the right-side list contains multiple elements, the SQL generated is:
```sql
WHERE (col1, col2) IN ((?, ?), (?, ?), ...)
```
If the right-side list only contains a single element, the SQL generated is:
```sql
WHERE (col1, col2) = (?, ?)
```
The latter works correctly for all supported databases except Oracle, which throws:
> java.sql.SQLSyntaxErrorException: ORA-00920: invalid relational operator

This fix ensures that the `IN` and `NOT IN` operators are always used with Oracle regardless of the number of list elements.

Existing tests that excluded Oracle for this reason have been adjusted.