### PR TITLE
test: EXPOSED-233 Add additional SpringTransactionManager isolation test

### DIFF
--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -321,7 +321,8 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
                SELECT N+1 FROM T WHERE N<10000000
                )
                SELECT * FROM T;
-                    """.trimIndent(), explicitStatementType = StatementType.SELECT
+                    """.trimIndent(),
+                    explicitStatementType = StatementType.SELECT
                 )
                 fail("Should have thrown a timeout exception")
             } catch (cause: ExposedSQLException) {

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedTransactionManagerTest.kt
@@ -39,20 +39,6 @@ open class ExposedTransactionManagerTest : SpringTransactionTestBase() {
         }
     }
 
-    private fun PlatformTransactionManager.execute(
-        propagationBehavior: Int = TransactionDefinition.PROPAGATION_REQUIRED,
-        timeout: Int? = null,
-        block: (TransactionStatus) -> Unit
-    ) {
-        if (this !is SpringTransactionManager) error("Wrong txManager instance: ${this.javaClass.name}")
-        val tt = TransactionTemplate(this)
-        tt.propagationBehavior = propagationBehavior
-        if (timeout != null) tt.timeout = timeout
-        tt.executeWithoutResult {
-            block(it)
-        }
-    }
-
     @BeforeTest
     fun beforeTest() {
         transactionManager.execute {

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionSingleConnectionTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionSingleConnectionTest.kt
@@ -1,0 +1,93 @@
+package org.jetbrains.exposed.spring
+
+import org.jetbrains.exposed.sql.DatabaseConfig
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.selectAll
+import org.junit.Test
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.datasource.DataSourceUtils
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import javax.sql.DataSource
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+
+class SpringTransactionIsolationTest {
+    object T1 : Table() {
+        val c1 = varchar("c1", Int.MIN_VALUE.toString().length)
+    }
+
+    val singleConnectionH2TestContainer = AnnotationConfigApplicationContext(SingleConnectionH2TestConfig::class.java)
+    val transactionManager = singleConnectionH2TestContainer.getBean(PlatformTransactionManager::class.java)
+    val dataSource = singleConnectionH2TestContainer.getBean(DataSource::class.java)
+
+    @BeforeTest
+    fun beforeTest() {
+        transactionManager.execute {
+            SchemaUtils.create(T1)
+        }
+    }
+
+    @Test
+    fun `start transaction with non default isolation level`() {
+        transactionManager.execute(
+            isolationLevel = TransactionDefinition.ISOLATION_SERIALIZABLE,
+        ) {
+            T1.selectAll().toList()
+        }
+    }
+
+    @Test
+    fun `nested transaction with non default isolation level`() {
+        transactionManager.execute(
+            isolationLevel = TransactionDefinition.ISOLATION_SERIALIZABLE,
+        ) {
+            T1.selectAll().toList()
+
+            // Nested transaction will inherit isolation level from parent transaction because is use the same connection
+            transactionManager.execute(
+                isolationLevel = TransactionDefinition.ISOLATION_READ_UNCOMMITTED,
+            ) {
+                DataSourceUtils.getConnection(dataSource).use { connection ->
+                    assertEquals(connection.transactionIsolation, TransactionDefinition.ISOLATION_SERIALIZABLE)
+                }
+                T1.selectAll().toList()
+            }
+            T1.selectAll().toList()
+        }
+    }
+
+    @AfterTest
+    fun afterTest() {
+        transactionManager.execute {
+            SchemaUtils.drop(T1)
+        }
+    }
+}
+
+@Configuration
+@EnableTransactionManagement(proxyTargetClass = true)
+open class SingleConnectionH2TestConfig {
+
+    @Bean
+    open fun singleConnectionH2DataSource(): DataSource = SingleConnectionDataSource().apply {
+        setDriverClassName("org.h2.Driver")
+        setUrl("jdbc:h2:mem:regular;DB_CLOSE_DELAY=-1;")
+        setUsername("sa")
+        setPassword("")
+        setSuppressClose(true)
+    }
+
+    @Bean
+    open fun singleConnectionH2TransactionManager(
+        @Qualifier("singleConnectionH2DataSource") dataSource: DataSource
+    ): PlatformTransactionManager = SpringTransactionManager(dataSource = dataSource, DatabaseConfig { useNestedTransactions = true })
+}
+

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionSingleConnectionTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionSingleConnectionTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 
-class SpringTransactionIsolationTest {
+class SpringTransactionSingleConnectionTest {
     object T1 : Table() {
         val c1 = varchar("c1", Int.MIN_VALUE.toString().length)
     }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionSingleConnectionTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionSingleConnectionTest.kt
@@ -90,4 +90,3 @@ open class SingleConnectionH2TestConfig {
         @Qualifier("singleConnectionH2DataSource") dataSource: DataSource
     ): PlatformTransactionManager = SpringTransactionManager(dataSource = dataSource, DatabaseConfig { useNestedTransactions = true })
 }
-

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionTestBase.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionTestBase.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.jdbc.datasource.DataSourceUtils
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
@@ -20,8 +19,6 @@ import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import org.springframework.transaction.annotation.TransactionManagementConfigurer
 import org.springframework.transaction.support.TransactionTemplate
-import java.sql.Connection
-import javax.sql.DataSource
 
 @Configuration
 @EnableTransactionManagement
@@ -54,9 +51,6 @@ abstract class SpringTransactionTestBase {
 
     @Autowired
     lateinit var transactionManager: PlatformTransactionManager
-
-    @Autowired
-    lateinit var dataSource: DataSource
 }
 
 fun PlatformTransactionManager.execute(


### PR DESCRIPTION
Sorry for the late PR!
Added some tests to test the isolation level of SpringTransactionManager.

1. Write test code in `SpringTransactionSingleConnectionTest` to check if the issue that when there is only one connection, the connection cannot be obtained unless the default isolation level is set is fixed in the latest version.

2. Add test code to check if the isolation level is set well in the existing test

Discussion

1. I have confirmed that the problem encountered in this issue is resolved in the current version. I wonder if additional isolation tests are needed?

2. The `readOnly` test was tested with a spy test to make sure the value is set correctly. Unfortunately, H2 does not seem to support readOnly properly, so I was unable to test it.

3. May spring test also need to test real database