### PR TITLE
fix: EXPOSED-263 Null arg parameter in exec() throws if logger enabled

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -206,7 +206,11 @@ open class Transaction(
 
             override fun prepareSQL(transaction: Transaction, prepared: Boolean): String = stmt
 
-            override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = listOf(args)
+            override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = listOf(
+                args.map { (columnType, value) ->
+                    columnType.apply { nullable = true } to value
+                }
+            )
         })
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/SequencesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/SequencesTests.kt
@@ -86,7 +86,6 @@ class SequencesTests : DatabaseTestsBase() {
     fun `test insert LongIdTable with auth-increment with sequence`() {
         withDb {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
-                addLogger(StdOutSqlLogger)
                 try {
                     SchemaUtils.create(DeveloperWithAutoIncrementBySequence)
                     val developerId = DeveloperWithAutoIncrementBySequence.insertAndGetId {


### PR DESCRIPTION
The type for `exec()` parameterized arguments is declared as `args: Iterable<Pair<IColumnType, Any?>>`, so passing `null` as the second element correctly sets the statement parameter to SQL NULL.
But if a logger is enabled, this exception is thrown instead:
> java.lang.IllegalStateException: NULL in non-nullable column.

This is because all `IColumnType` default to being not nullable and fail the check in `ColumnType.valueToString()` when attempting to parse the null parameter value.

This exception can be avoided by always providing SQL NULL directly, via `Op.nullOp<T>()`.
But given the type hints, the accepted parameter values should match what would be accepted by any other DSL statement.

Even if the column in the Exposed table object is declared as being `nullable()`, the column type in `exec()` has no knowledge of this because it is meant to accept plain SQL using an anonymous `Statement` object.
This fix sets the nullable parameter of any column type in `args` to `true` so that no exception will be thrown when the logger invokes `valueToString()`.