### PR TITLE
fix: EXPOSED-270 Crash when `Duration.INFINITE` is used for duration column type

### DIFF
--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -384,6 +384,7 @@ class KotlinDurationColumnType : ColumnType() {
     }
 
     override fun valueFromDB(value: Any): Duration = when (value) {
+        Duration.INFINITE.inWholeNanoseconds -> Duration.INFINITE
         is Long -> value.nanoseconds
         is Number -> value.toLong().nanoseconds
         is String -> Duration.parse(value)

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -26,6 +26,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import kotlin.test.assertEquals
+import kotlin.time.Duration
 
 open class KotlinTimeBaseTest : DatabaseTestsBase() {
 
@@ -462,6 +463,20 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
             fakeTestTable.insert {}
 
             currentDbDateTime()
+        }
+    }
+
+    @Test
+    fun testInfiniteDuration() {
+        val tester = object : Table("tester") {
+            val duration = duration("duration")
+        }
+        withTables(tester) {
+            tester.insert {
+                it[duration] = Duration.INFINITE
+            }
+            val row = tester.selectAll().where { tester.duration eq Duration.INFINITE }.single()
+            assertEquals(Duration.INFINITE, row[tester.duration])
         }
     }
 }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
@@ -1224,69 +1224,6 @@ class MiscTableTest : DatabaseTestsBase() {
         }
     }
 
-    @Test
-    fun testInfiniteDuration() {
-        val tbl = Misc
-        val date = today
-        val dateTime = now()
-        val time = dateTime.time
-        val timestamp = Clock.System.now()
-        val duration = Duration.INFINITE
-        val eOne = MiscTable.E.ONE
-        val dec = BigDecimal("123.45")
-        withTables(tbl) {
-            tbl.insert {
-                it[by] = 7
-                it[sm] = -2
-                it[n] = 14
-                it[c] = "1234"
-                it[s] = "123456789"
-                it[d] = date
-                it[t] = time
-                it[dt] = dateTime
-                it[ts] = timestamp
-                it[dr] = duration
-                it[e] = eOne
-                it[es] = eOne
-                it[dc] = dec
-            }
-
-            val row = tbl.selectAll().where { tbl.dr eq Duration.INFINITE }.single()
-
-            tbl.checkRowFull(
-                row,
-                by = 7,
-                byn = null,
-                sm = -2,
-                smn = null,
-                n = 14,
-                nn = null,
-                d = date,
-                dn = null,
-                t = time,
-                tn = null,
-                dt = dateTime,
-                dtn = null,
-                ts = timestamp,
-                tsn = null,
-                dr = duration,
-                drn = null,
-                e = eOne,
-                en = null,
-                es = eOne,
-                esn = null,
-                c = "1234",
-                cn = null,
-                s = "123456789",
-                sn = null,
-                dc = dec,
-                dcn = null,
-                fcn = null,
-                dblcn = null
-            )
-        }
-    }
-
     private object ZeroDateTimeTable : Table("zerodatetimetable") {
         val id = integer("id")
 

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
@@ -1224,6 +1224,69 @@ class MiscTableTest : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testInfiniteDuration() {
+        val tbl = Misc
+        val date = today
+        val dateTime = now()
+        val time = dateTime.time
+        val timestamp = Clock.System.now()
+        val duration = Duration.INFINITE
+        val eOne = MiscTable.E.ONE
+        val dec = BigDecimal("123.45")
+        withTables(tbl) {
+            tbl.insert {
+                it[by] = 7
+                it[sm] = -2
+                it[n] = 14
+                it[c] = "1234"
+                it[s] = "123456789"
+                it[d] = date
+                it[t] = time
+                it[dt] = dateTime
+                it[ts] = timestamp
+                it[dr] = duration
+                it[e] = eOne
+                it[es] = eOne
+                it[dc] = dec
+            }
+
+            val row = tbl.selectAll().where { tbl.dr eq Duration.INFINITE }.single()
+
+            tbl.checkRowFull(
+                row,
+                by = 7,
+                byn = null,
+                sm = -2,
+                smn = null,
+                n = 14,
+                nn = null,
+                d = date,
+                dn = null,
+                t = time,
+                tn = null,
+                dt = dateTime,
+                dtn = null,
+                ts = timestamp,
+                tsn = null,
+                dr = duration,
+                drn = null,
+                e = eOne,
+                en = null,
+                es = eOne,
+                esn = null,
+                c = "1234",
+                cn = null,
+                s = "123456789",
+                sn = null,
+                dc = dec,
+                dcn = null,
+                fcn = null,
+                dblcn = null
+            )
+        }
+    }
+
     private object ZeroDateTimeTable : Table("zerodatetimetable") {
         val id = integer("id")
 


### PR DESCRIPTION
Fix [EXPOSED-270](https://youtrack.jetbrains.com/issue/EXPOSED-270).

Exposed converts Duration to its nanoseconds value when writing to database, and uses the kotlin `Long.nanoseconds` function to convert Long to Duration when reading from database. If inserting the `Duration.INFINITE` value, the saving value in database is 9223372036854775807(`Long.MAX_VALUE`). However, the  kotlin `Long.nanoseconds` function checks `Long.MAX_VALUE` exceeding the nanosecond range and then converts it to millisecond unit, causing the ignoring of last few digits of the value. Therefore, the reading value does not equal to `Duration.INFINITE` anymore.

This bug can be fixed by first checking the equality of the value and `Duration.INFINITE.inWholeNanoseconds`, then return `Duration.INFINITE` directly if equals.