### PR TITLE
Make Time function compatible with PostgreSQL

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.jetbrains.exposed.sql.vendors.h2Mode
@@ -22,7 +23,12 @@ class Date<T : Temporal?>(val expr: Expression<T>) : Function<LocalDate>(JavaLoc
 
 /** Represents an SQL function that extracts the time part from a given temporal [expr]. */
 class Time<T : Temporal?>(val expr: Expression<T>) : Function<LocalTime>(JavaLocalTimeColumnType.INSTANCE) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("Time(", expr, ")") }
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        when (currentDialect) {
+            is PostgreSQLDialect -> append(expr, "::time")
+            else -> append("Time(", expr, ")")
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Related issue on YouTrack (opened by me): https://youtrack.jetbrains.com/issue/EXPOSED-276/Time-class-is-not-compatible-with-PostgreSQL

Not sure what the practice for testing these are, if something needs to be added. I can't seem to run the relevant tests locally without running out of memory, presumably due to all the databases containers being started.