### PR TITLE
fix: EXPOSED-272 [MySQL, Oracle] Unsupported type BIGINT UNSIGNED for auto-increment

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3251,7 +3251,9 @@ public abstract class org/jetbrains/exposed/sql/vendors/DataTypeProvider {
 	public fun timeType ()Ljava/lang/String;
 	public fun timestampWithTimeZoneType ()Ljava/lang/String;
 	public fun ubyteType ()Ljava/lang/String;
+	public fun uintegerAutoincType ()Ljava/lang/String;
 	public fun uintegerType ()Ljava/lang/String;
+	public fun ulongAutoincType ()Ljava/lang/String;
 	public fun ulongType ()Ljava/lang/String;
 	public fun untypedAndUnsizedArrayType ()Ljava/lang/String;
 	public fun ushortType ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -133,6 +133,8 @@ class AutoIncColumnType(
     private fun guessAutoIncTypeBy(sqlType: String): String? = when (sqlType) {
         currentDialect.dataTypeProvider.longType() -> currentDialect.dataTypeProvider.longAutoincType()
         currentDialect.dataTypeProvider.integerType() -> currentDialect.dataTypeProvider.integerAutoincType()
+        currentDialect.dataTypeProvider.ulongType() -> currentDialect.dataTypeProvider.ulongAutoincType()
+        currentDialect.dataTypeProvider.uintegerType() -> currentDialect.dataTypeProvider.uintegerAutoincType()
         else -> null
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -814,11 +814,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     // Auto-generated values
 
     /**
-     * Make @receiver column an auto-increment to generate its values in a database.
-     * Only integer and long columns supported.
-     * Some databases like a PostgreSQL supports auto-increment via sequences.
-     * In that case you should provide a name with [idSeqName] param and Exposed will create a sequence for you.
-     * If you already have a sequence in a database just use its name in [idSeqName].
+     * Make @receiver column an auto-increment column to generate its values in a database.
+     * **Note:** Only integer and long columns are supported (signed and unsigned types).
+     * Some databases, like PostgreSQL, support auto-increment via sequences.
+     * In this case a name should be provided using the [idSeqName] param and Exposed will create a sequence.
+     * If a sequence already exists in the database just use its name in [idSeqName].
      *
      * @param idSeqName an optional parameter to provide a sequence name
      */
@@ -826,11 +826,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         cloneWithAutoInc(idSeqName).also { replaceColumn(this, it) }
 
     /**
-     * Make @receiver column an auto-increment to generate its values in a database.
-     * Only integer and long columns supported.
-     * Some databases like a PostgreSQL supports auto-increment via sequences.
-     * In that case you should provide a name with [idSeqName] param and Exposed will create a sequence for you.
-     * If you already have a sequence in a database just use its name in [idSeqName].
+     * Make @receiver column an auto-increment column to generate its values in a database.
+     * **Note:** Only integer and long columns are supported (signed and unsigned types).
+     * Some databases, like PostgreSQL, support auto-increment via sequences.
+     * In this case a name should be provided using the [idSeqName] param and Exposed will create a sequence.
+     * If a sequence already exists in the database just use its name in [idSeqName].
      *
      * @param idSeqName an optional parameter to provide a sequence name
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
@@ -45,6 +45,12 @@ abstract class DataTypeProvider {
     /** Numeric type for storing 4-byte integers, marked as auto-increment. */
     open fun integerAutoincType(): String = "INT AUTO_INCREMENT"
 
+    /** Numeric type for storing 4-byte unsigned integers, marked as auto-increment.
+     *
+     * **Note:** If the database being used is not MySQL or MariaDB, this will represent the 8-byte integer type.
+     */
+    open fun uintegerAutoincType(): String = "BIGINT AUTO_INCREMENT"
+
     /** Numeric type for storing 8-byte integers. */
     open fun longType(): String = "BIGINT"
 
@@ -53,6 +59,9 @@ abstract class DataTypeProvider {
 
     /** Numeric type for storing 8-byte integers, and marked as auto-increment. */
     open fun longAutoincType(): String = "BIGINT AUTO_INCREMENT"
+
+    /** Numeric type for storing 8-byte unsigned integers, marked as auto-increment. */
+    open fun ulongAutoincType(): String = "BIGINT AUTO_INCREMENT"
 
     /** Numeric type for storing 4-byte (single precision) floating-point numbers. */
     open fun floatType(): String = "FLOAT"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -32,7 +32,11 @@ internal object MysqlDataTypeProvider : DataTypeProvider() {
 
     override fun uintegerType(): String = "INT UNSIGNED"
 
+    override fun uintegerAutoincType(): String = "INT UNSIGNED AUTO_INCREMENT"
+
     override fun ulongType(): String = "BIGINT UNSIGNED"
+
+    override fun ulongAutoincType(): String = "BIGINT UNSIGNED AUTO_INCREMENT"
 
     override fun textType(): String = "text"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.sql.DatabaseMetaData
 import java.util.*
 
+@Suppress("TooManyFunctions")
 internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun byteType(): String = "SMALLINT"
     override fun ubyteType(): String = "NUMBER(4)"
@@ -13,9 +14,11 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun integerType(): String = "NUMBER(12)"
     override fun integerAutoincType(): String = "NUMBER(12)"
     override fun uintegerType(): String = "NUMBER(13)"
+    override fun uintegerAutoincType(): String = "NUMBER(13)"
     override fun longType(): String = "NUMBER(19)"
     override fun longAutoincType(): String = "NUMBER(19)"
     override fun ulongType(): String = "NUMBER(20)"
+    override fun ulongAutoincType(): String = "NUMBER(20)"
     override fun varcharType(colLength: Int): String = "VARCHAR2($colLength CHAR)"
     override fun textType(): String = "CLOB"
     override fun mediumTextType(): String = textType()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -288,6 +288,30 @@ class DDLTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testAutoIncrementOnUnsignedColumns() {
+        // separate tables are necessary as some db only allow a single column to be auto-incrementing
+        val uIntTester = object : Table("u_int_tester") {
+            var id = uinteger("id").autoIncrement()
+            override val primaryKey = PrimaryKey(id)
+        }
+        val uLongTester = object : Table("u_long_tester") {
+            val id = ulong("id").autoIncrement()
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withDb {
+            SchemaUtils.drop(uIntTester, uLongTester)
+            SchemaUtils.create(uIntTester, uLongTester)
+
+            uIntTester.insert { }
+            assertEquals(1u, uIntTester.selectAll().single()[uIntTester.id])
+
+            uLongTester.insert { }
+            assertEquals(1u, uLongTester.selectAll().single()[uLongTester.id])
+        }
+    }
+
+    @Test
     fun tableWithMultiPKandAutoIncrement() {
         val foo = object : IdTable<Long>("FooTable") {
             val bar = integer("bar")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -300,7 +300,6 @@ class DDLTests : DatabaseTestsBase() {
         }
 
         withDb {
-            SchemaUtils.drop(uIntTester, uLongTester)
             SchemaUtils.create(uIntTester, uLongTester)
 
             uIntTester.insert { }
@@ -308,6 +307,8 @@ class DDLTests : DatabaseTestsBase() {
 
             uLongTester.insert { }
             assertEquals(1u, uLongTester.selectAll().single()[uLongTester.id])
+
+            SchemaUtils.drop(uIntTester, uLongTester)
         }
     }
 


### PR DESCRIPTION
With both Oracle and MySQL, attempting to create a table with an unsigned integer or long column that should auto-increment throws an `Unsupported type` exception.

This occurs because `AutoIncColumnType`, which delegates to the underlying type, is currently set up to only detect signed integer and long column types.

It is not possible to reuse the existing `integerAutoincType()` or `longAutoincType()` if the delegate is an unsigned column because of the type syntax differences between standard and auto-incrementing columns in some databases. So new types have been added to `DataTypeProvider`.