### PR TITLE
fix: EXPOSED-266 Between() accepts arguments of different type than column type

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -894,6 +894,7 @@ public abstract interface class org/jetbrains/exposed/sql/IDateColumnType {
 
 public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder {
 	public abstract fun asLiteral (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public abstract fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Between;
 	public abstract fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public abstract fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/AndBitOp;
 	public abstract fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/AndBitOp;
@@ -1014,6 +1015,7 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 
 public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls {
 	public static fun asLiteral (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public static fun between (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Between;
 	public static fun between (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public static fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/AndBitOp;
 	public static fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/AndBitOp;
@@ -1988,6 +1990,7 @@ public final class org/jetbrains/exposed/sql/SortOrder : java/lang/Enum {
 public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrains/exposed/sql/ISqlExpressionBuilder {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/SqlExpressionBuilder;
 	public fun asLiteral (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Between;
 	public fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/AndBitOp;
 	public fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/AndBitOp;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -396,7 +396,10 @@ interface ISqlExpressionBuilder {
     // Comparison Predicates
 
     /** Returns `true` if this expression is between the values [from] and [to], `false` otherwise. */
-    fun <T, S : T?> ExpressionWithColumnType<S>.between(from: T, to: T): Between = Between(this, wrap(from), wrap(to))
+    fun <T, S : T?> ExpressionWithColumnType<in S>.between(from: T, to: T): Between = Between(this, wrap(from), wrap(to))
+
+    /** Returns `true` if this [EntityID] expression is between the values [from] and [to], `false` otherwise. */
+    fun <T : Comparable<T>, E : EntityID<T>?> ExpressionWithColumnType<E>.between(from: T, to: T): Between = Between(this, wrap(from), wrap(to))
 
     /** Returns `true` if this expression is null, `false` otherwise. */
     fun <T> Expression<T>.isNull(): IsNullOp = IsNullOp(this)

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -359,8 +359,8 @@ class DefaultsTest : DatabaseTestsBase() {
         withTables(foo) {
             val d2020 = LocalDate(2020, 1, 1)
             val dt2020 = d2020.atTime(0, 0, 0)
-            val dt2020m1w = d2020.minus(DateTimeUnit.WEEK).atTime(0, 0, 0)
-            val dt2020p1w = d2020.plus(DateTimeUnit.WEEK).atTime(0, 0, 0)
+            val dt2020m1w = d2020.minus(1, DateTimeUnit.WEEK).atTime(0, 0, 0)
+            val dt2020p1w = d2020.plus(1, DateTimeUnit.WEEK).atTime(0, 0, 0)
 
             foo.insert { it[dt] = LocalDateTime(2019, 1, 1, 1, 1) }
             foo.insert { it[dt] = dt2020 }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -97,8 +97,8 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
             val dateTime = Instant.parse("2023-05-04T05:04:00.000Z") // has 0 nanoseconds
             val nanos = DateTimeUnit.NANOSECOND * 111111
             // insert 2 separate constants to ensure test's rounding mode matches DB precision
-            val dateTimeWithFewNanos = dateTime.plus(nanos).toLocalDateTime(TimeZone.currentSystemDefault())
-            val dateTimeWithManyNanos = dateTime.plus(nanos * 7).toLocalDateTime(TimeZone.currentSystemDefault())
+            val dateTimeWithFewNanos = dateTime.plus(1, nanos).toLocalDateTime(TimeZone.currentSystemDefault())
+            val dateTimeWithManyNanos = dateTime.plus(7, nanos).toLocalDateTime(TimeZone.currentSystemDefault())
             testDate.insert {
                 it[testDate.time] = dateTimeWithFewNanos
             }


### PR DESCRIPTION
`between()` currently accepts arguments of types that do not match the type stored in the column on which it is called.
This means that the following is technically possible to compile:
```kt
object TestTable : Table() {
    val number = integer("number")
}

TestTable
    .selectAll()
    .where { TestTable.number.between("hello", "there") }
```

In the event that this is being taken advantage of by users (for example with numeric or UUID types), rather than introducing an immediate breaking change, the upper bounds have been restricted to highlight the offending function and show a compiler warning.

> Type argument for a type parameter S can't be inferred because it has incompatible upper bounds: Int, String (multiple incompatible classes). This will become an error in Kotlin 2.0

A function overload has also been introduced to ensure that this warning does not show when invoked on an `EntityID` column with appropriate literal arguments.

**Note:** No tests have been added and all tests for `between()` in the datetime modules provide matching argument types with no warnings.

**Additional:**
- Replace some datetime functions with deprecation warnings.
