### PR TITLE
fix: EXPOSED-280 Comparison operators show incorrect compiler warning with datetime columns

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -263,8 +263,8 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.eq(
-        other: ExpressionWithColumnType<in E>
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.eq(
+        other: ExpressionWithColumnType<E>
     ): Op<Boolean> = other eq this
 
     // NOT EQUAL
@@ -297,8 +297,8 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is not equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.neq(
-        other: ExpressionWithColumnType<in E>
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.neq(
+        other: ExpressionWithColumnType<E>
     ): Op<Boolean> = other neq this
 
     // LESS THAN
@@ -320,8 +320,8 @@ interface ISqlExpressionBuilder {
     ): LessOp = LessOp(this, other)
 
     /** Checks if this expression is less than some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.less(
-        other: ExpressionWithColumnType<in E>
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.less(
+        other: ExpressionWithColumnType<E>
     ): LessOp = LessOp(this, other)
 
     // LESS THAN OR EQUAL
@@ -343,8 +343,8 @@ interface ISqlExpressionBuilder {
     ): LessEqOp = LessEqOp(this, other)
 
     /** Checks if this expression is less than or equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.lessEq(
-        other: ExpressionWithColumnType<in E>
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.lessEq(
+        other: ExpressionWithColumnType<E>
     ): LessEqOp = LessEqOp(this, other)
 
     // GREATER THAN
@@ -366,8 +366,8 @@ interface ISqlExpressionBuilder {
     ): GreaterOp = GreaterOp(this, other)
 
     /** Checks if this expression is greater than some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.greater(
-        other: ExpressionWithColumnType<in E>
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.greater(
+        other: ExpressionWithColumnType<E>
     ): GreaterOp = GreaterOp(this, other)
 
     // GREATER THAN OR EQUAL
@@ -389,8 +389,8 @@ interface ISqlExpressionBuilder {
     ): GreaterEqOp = GreaterEqOp(this, other)
 
     /** Checks if this expression is greater than or equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.greaterEq(
-        other: ExpressionWithColumnType<in E>
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.greaterEq(
+        other: ExpressionWithColumnType<E>
     ): GreaterEqOp = GreaterEqOp(this, other)
 
     // Comparison Predicates


### PR DESCRIPTION
I came across this warning while scanning the datetime modules for PR #1983 .

A strange compiler warning is flagged for the following code in `exposed-jodatime` and `exposed-java-time` modules:
```kt
object TestTable : Table() {
    val created = date("created")
    val deleted = date("deleted")
}
TestTable
    .selectAll()
    .where { TestTable.created eq TestTable.deleted }
```
>  Type argument for a type parameter E can't be inferred because it has incompatible upper bounds: LocalDate, EntityID (multiple incompatible classes). This will become an error in Kotlin 2.0

The same warning doesn't appear in the `exposed-kotlin-datetime` module.
But a user has already reported that they are seeing the warning with regular (non-entity id) UUID columns, suggesting a pattern only involving objects that aren't part of the Kotlin standard library.

This occurs because this convenience overload (introduced by PR #1961 ) is being incorrectly chosen:
```kt
infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.eq(
    other: ExpressionWithColumnType<in E>
): Op<Boolean> = other eq this
```
These overloads incorrectly make the `ExpressionWithColumnType` argument's type parameter contravariant, when this annotation should instead be set on the calling `Expression` object's type parameter.

**Note:** No tests have been added but there are multiple examples of the highlighted warning in `JodaTimeTests/testlocalDateComparison` and `testLocalDateTimeComparison`. Switching between branches confirms the warning is resolved by this fix.