### PR TITLE
feat: EXPOSED-248 Support array column type

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1801,9 +1801,8 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun charLength (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CharLength;
 	public static final fun count (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Count;
 	public static final fun countDistinct (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Count;
-	public static final fun elementAt (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/functions/array/ArrayElementAt;
 	public static final fun function (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/CustomFunction;
-	public static final fun get (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/functions/array/ArrayElementAt;
+	public static final fun get (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/functions/array/ArrayGet;
 	public static final fun groupConcat (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ZLkotlin/Pair;)Lorg/jetbrains/exposed/sql/GroupConcat;
 	public static final fun groupConcat (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Z[Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/GroupConcat;
 	public static synthetic fun groupConcat$default (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ZLkotlin/Pair;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/GroupConcat;
@@ -2590,7 +2589,7 @@ public final class org/jetbrains/exposed/sql/XorBitOp : org/jetbrains/exposed/sq
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/functions/array/ArrayElementAt : org/jetbrains/exposed/sql/Function {
+public final class org/jetbrains/exposed/sql/functions/array/ArrayGet : org/jetbrains/exposed/sql/Function {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;ILorg/jetbrains/exposed/sql/IColumnType;)V
 	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
 	public final fun getIndex ()I

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -154,6 +154,20 @@ public final class org/jetbrains/exposed/sql/AndOp : org/jetbrains/exposed/sql/C
 	public fun <init> (Ljava/util/List;)V
 }
 
+public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exposed/sql/ColumnType {
+	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
+	public final fun getDelegateType ()Ljava/lang/String;
+	public final fun getMaximumCardinality ()Ljava/lang/Integer;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
+	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
+	public fun sqlType ()Ljava/lang/String;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueToString (Ljava/lang/Object;)Ljava/lang/String;
+}
+
 public final class org/jetbrains/exposed/sql/AutoIncColumnType : org/jetbrains/exposed/sql/IColumnType {
 	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/String;Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -1509,6 +1523,8 @@ public final class org/jetbrains/exposed/sql/OpKt {
 	public static final fun andIfNotNull (Lorg/jetbrains/exposed/sql/Op;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun andIfNotNull (Lorg/jetbrains/exposed/sql/Op;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun andNot (Lorg/jetbrains/exposed/sql/Expression;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Op;
+	public static final fun arrayLiteral (Ljava/util/List;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public static final fun arrayParam (Ljava/util/List;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun blobParam (Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun booleanLiteral (Z)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun booleanParam (Z)Lorg/jetbrains/exposed/sql/Expression;
@@ -1785,6 +1801,7 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun charLength (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CharLength;
 	public static final fun count (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Count;
 	public static final fun countDistinct (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Count;
+	public static final fun elementAt (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/functions/array/ArrayElementAt;
 	public static final fun function (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun groupConcat (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ZLkotlin/Pair;)Lorg/jetbrains/exposed/sql/GroupConcat;
 	public static final fun groupConcat (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Z[Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/GroupConcat;
@@ -1796,6 +1813,8 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun min (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Min;
 	public static final fun nextIntVal (Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/NextVal;
 	public static final fun nextLongVal (Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/NextVal;
+	public static final fun slice (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Integer;Ljava/lang/Integer;)Lorg/jetbrains/exposed/sql/functions/array/ArraySlice;
+	public static synthetic fun slice$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/functions/array/ArraySlice;
 	public static final fun stdDevPop (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/StdDevPop;
 	public static synthetic fun stdDevPop$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;IILjava/lang/Object;)Lorg/jetbrains/exposed/sql/StdDevPop;
 	public static final fun stdDevSamp (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/StdDevSamp;
@@ -2174,6 +2193,8 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun array (Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;)Lorg/jetbrains/exposed/sql/Column;
+	public static synthetic fun array$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoGenerate (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoIncrement (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun autoIncrement$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
@@ -2565,6 +2586,21 @@ public final class org/jetbrains/exposed/sql/XorBitOp : org/jetbrains/exposed/sq
 	public fun getColumnType ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public final fun getExpr1 ()Lorg/jetbrains/exposed/sql/Expression;
 	public final fun getExpr2 ()Lorg/jetbrains/exposed/sql/Expression;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/functions/array/ArrayElementAt : org/jetbrains/exposed/sql/Function {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;ILorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getIndex ()I
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/functions/array/ArraySlice : org/jetbrains/exposed/sql/Function {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getExpression ()Lorg/jetbrains/exposed/sql/Expression;
+	public final fun getLower ()Ljava/lang/Integer;
+	public final fun getUpper ()Ljava/lang/Integer;
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
@@ -3092,6 +3128,7 @@ public abstract interface class org/jetbrains/exposed/sql/statements/api/Prepare
 	public abstract fun getResultSet ()Ljava/sql/ResultSet;
 	public abstract fun getTimeout ()Ljava/lang/Integer;
 	public abstract fun set (ILjava/lang/Object;)V
+	public abstract fun setArray (ILjava/lang/String;[Ljava/lang/Object;)V
 	public abstract fun setFetchSize (Ljava/lang/Integer;)V
 	public abstract fun setInputStream (ILjava/io/InputStream;)V
 	public abstract fun setNull (ILorg/jetbrains/exposed/sql/IColumnType;)V
@@ -3455,6 +3492,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	protected final fun appendInsertToUpsertClause (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lorg/jetbrains/exposed/sql/Transaction;)V
 	protected final fun appendJoinPartForUpdateClause (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Join;Lorg/jetbrains/exposed/sql/Transaction;)V
 	protected final fun appendUpdateToUpsertClause (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/exposed/sql/Transaction;Z)V
+	public fun arraySlice (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun cast (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun charLength (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun concat (Ljava/lang/String;Lorg/jetbrains/exposed/sql/QueryBuilder;[Lorg/jetbrains/exposed/sql/Expression;)V

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1803,6 +1803,7 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun countDistinct (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Count;
 	public static final fun elementAt (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/functions/array/ArrayElementAt;
 	public static final fun function (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/CustomFunction;
+	public static final fun get (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/functions/array/ArrayElementAt;
 	public static final fun groupConcat (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ZLkotlin/Pair;)Lorg/jetbrains/exposed/sql/GroupConcat;
 	public static final fun groupConcat (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;Z[Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/GroupConcat;
 	public static synthetic fun groupConcat$default (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;ZLkotlin/Pair;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/GroupConcat;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -682,6 +682,10 @@ fun stringLiteral(value: String): LiteralOp<String> = LiteralOp(TextColumnType()
 /** Returns the specified [value] as a decimal literal. */
 fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(DecimalColumnType(value.precision(), value.scale()), value)
 
+/** Returns the specified [value] as an array literal, with elements parsed by the [delegateType]. */
+fun <T> arrayLiteral(value: List<T>, delegateType: ColumnType): LiteralOp<List<T>> =
+    LiteralOp(ArrayColumnType(delegateType), value)
+
 // Query Parameters
 
 /**
@@ -741,6 +745,10 @@ fun decimalParam(value: BigDecimal): Expression<BigDecimal> = QueryParameter(val
 
 /** Returns the specified [value] as a blob query parameter. */
 fun blobParam(value: ExposedBlob): Expression<ExposedBlob> = QueryParameter(value, BlobColumnType())
+
+/** Returns the specified [value] as an array query parameter, with elements parsed by the [delegateType]. */
+fun <T> arrayParam(value: List<T>, delegateType: ColumnType): Expression<List<T>> =
+    QueryParameter(value, ArrayColumnType(delegateType))
 
 // Misc.
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -5,7 +5,7 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
-import org.jetbrains.exposed.sql.functions.array.ArrayElementAt
+import org.jetbrains.exposed.sql.functions.array.ArrayGet
 import org.jetbrains.exposed.sql.functions.array.ArraySlice
 import org.jetbrains.exposed.sql.ops.*
 import org.jetbrains.exposed.sql.vendors.FunctionProvider
@@ -134,18 +134,10 @@ fun <T> allFrom(table: Table): Op<T> = AllAnyFromTableOp(false, table)
 /**
  * Returns the array element stored at the one-based [index] position, or `null` if the stored array itself is null.
  *
- * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArrayElementAt
+ * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArrayGet
  */
-fun <E, T : List<E>?> ExpressionWithColumnType<T>.elementAt(index: Int): ArrayElementAt<E, T> =
-    ArrayElementAt(this, index, (this.columnType as ArrayColumnType).delegate)
-
-/**
- * Returns the array element stored at the one-based [index] position, or `null` if the stored array itself is null.
- *
- * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArrayElementAt
- */
-infix operator fun <E, T : List<E>?> ExpressionWithColumnType<T>.get(index: Int): ArrayElementAt<E, T> =
-    ArrayElementAt(this, index, (this.columnType as ArrayColumnType).delegate)
+infix operator fun <E, T : List<E>?> ExpressionWithColumnType<T>.get(index: Int): ArrayGet<E, T> =
+    ArrayGet(this, index, (this.columnType as ArrayColumnType).delegate)
 
 /**
  * Returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -140,6 +140,14 @@ fun <E, T : List<E>?> ExpressionWithColumnType<T>.elementAt(index: Int): ArrayEl
     ArrayElementAt(this, index, (this.columnType as ArrayColumnType).delegate)
 
 /**
+ * Returns the array element stored at the one-based [index] position, or `null` if the stored array itself is null.
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArrayElementAt
+ */
+infix operator fun <E, T : List<E>?> ExpressionWithColumnType<T>.get(index: Int): ArrayElementAt<E, T> =
+    ArrayElementAt(this, index, (this.columnType as ArrayColumnType).delegate)
+
+/**
  * Returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),
  * or `null` if the stored array itself is null.
  * **Note** If either bounds is left `null`, the database will use the stored array's respective lower or upper limit.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -132,8 +132,9 @@ fun <T> allFrom(array: Array<T>): Op<T> = AllAnyFromArrayOp(false, array)
 fun <T> allFrom(table: Table): Op<T> = AllAnyFromTableOp(false, table)
 
 /**
- * Returns the array element stored at the one-based [index] position,
- * or `null` if the stored array itself is null or if [index] is out of bounds.
+ * Returns the array element stored at the one-based [index] position, or `null` if the stored array itself is null.
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArrayElementAt
  */
 fun <E, T : List<E>?> ExpressionWithColumnType<T>.elementAt(index: Int): ArrayElementAt<E, T> =
     ArrayElementAt(this, index, (this.columnType as ArrayColumnType).delegate)
@@ -142,6 +143,8 @@ fun <E, T : List<E>?> ExpressionWithColumnType<T>.elementAt(index: Int): ArrayEl
  * Returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),
  * or `null` if the stored array itself is null.
  * **Note** If either bounds is left `null`, the database will use the stored array's respective lower or upper limit.
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArraySlice
  */
 fun <E, T : List<E>?> ExpressionWithColumnType<T>.slice(lower: Int? = null, upper: Int? = null): ArraySlice<E, T> =
     ArraySlice(this, lower, upper, ArrayColumnType((this.columnType as ArrayColumnType).delegate))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -5,6 +5,8 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.functions.array.ArrayElementAt
+import org.jetbrains.exposed.sql.functions.array.ArraySlice
 import org.jetbrains.exposed.sql.ops.*
 import org.jetbrains.exposed.sql.vendors.FunctionProvider
 import org.jetbrains.exposed.sql.vendors.currentDialect
@@ -128,6 +130,21 @@ fun <T> allFrom(array: Array<T>): Op<T> = AllAnyFromArrayOp(false, array)
 
 /** Returns this table wrapped in the `ALL` operator. This function is only supported by MySQL, PostgreSQL, and H2 dialects. */
 fun <T> allFrom(table: Table): Op<T> = AllAnyFromTableOp(false, table)
+
+/**
+ * Returns the array element stored at the one-based [index] position,
+ * or `null` if the stored array itself is null or if [index] is out of bounds.
+ */
+fun <E, T : List<E>?> ExpressionWithColumnType<T>.elementAt(index: Int): ArrayElementAt<E, T> =
+    ArrayElementAt(this, index, (this.columnType as ArrayColumnType).delegate)
+
+/**
+ * Returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),
+ * or `null` if the stored array itself is null.
+ * **Note** If either bounds is left `null`, the database will use the stored array's respective lower or upper limit.
+ */
+fun <E, T : List<E>?> ExpressionWithColumnType<T>.slice(lower: Int? = null, upper: Int? = null): ArraySlice<E, T> =
+    ArraySlice(this, lower, upper, ArrayColumnType((this.columnType as ArrayColumnType).delegate))
 
 // Sequence Manipulation Functions
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql
 
 import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.asLiteral
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
 import java.io.File
@@ -202,6 +203,20 @@ object SchemaUtils {
                                 is MysqlDialect -> "_utf8mb4\\'${processed.trim('(', ')', '\'')}\\"
                                 else -> processed.trim('\'')
                             }
+                        } else if (column.columnType is ArrayColumnType && dialect is PostgreSQLDialect) {
+                            (value as List<*>)
+                                .takeIf { it.isNotEmpty() }
+                                ?.run {
+                                    val delegate = column.withColumnType(column.columnType.delegate)
+                                    val processed = map {
+                                        if (delegate.columnType is StringColumnType) {
+                                            "'$it'::text"
+                                        } else {
+                                            dbDefaultToString(delegate, delegate.asLiteral(it))
+                                        }
+                                    }
+                                    "ARRAY$processed"
+                                } ?: processForDefaultValue(exp)
                         } else {
                             processForDefaultValue(exp)
                         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -811,6 +811,21 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         toDb: (T) -> Any
     ): Column<T> = registerColumn(name, CustomEnumerationColumnType(name, sql, fromDb, toDb))
 
+    // Array columns
+
+    /**
+     * Creates an array column, with the specified [name], for storing elements of a `List` using a base [columnType].
+     *
+     * **Note** This column type is only supported by H2 and PostgreSQL dialects.
+     *
+     * @param name Name of the column.
+     * @param columnType Base column type for the individual elements.
+     * @param maximumCardinality The maximum amount of allowed elements. **Note** Providing an array size limit
+     * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
+     */
+    fun <T> array(name: String, columnType: ColumnType, maximumCardinality: Int? = null): Column<List<T>> =
+        registerColumn(name, ArrayColumnType(columnType.apply { nullable = true }, maximumCardinality))
+
     // Auto-generated values
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
@@ -14,7 +14,7 @@ import org.jetbrains.exposed.sql.vendors.h2Mode
  * Represents an SQL function that returns the array element stored at the one-based [index] position,
  * or `null` if the stored array itself is null.
  */
-class ArrayElementAt<E, T : List<E>?>(
+class ArrayGet<E, T : List<E>?>(
     /** The array expression that is accessed. */
     val expression: Expression<T>,
     /** The one-based index position at which the stored array is accessed. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
@@ -5,11 +5,14 @@ import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.IColumnType
 import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.append
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
 import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.jetbrains.exposed.sql.vendors.h2Mode
 
 /**
  * Represents an SQL function that returns the array element stored at the one-based [index] position,
- * or `null` if the stored array itself is null or if [index] is out of bounds.
+ * or `null` if the stored array itself is null.
  */
 class ArrayElementAt<E, T : List<E>?>(
     /** The array expression that is accessed. */
@@ -39,6 +42,10 @@ class ArraySlice<E, T : List<E>?>(
     columnType: IColumnType
 ) : Function<T>(columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        currentDialect.functionProvider.arraySlice(expression, lower, upper, queryBuilder)
+        val functionProvider = when (currentDialect.h2Mode) {
+            H2Dialect.H2CompatibilityMode.PostgreSQL -> H2FunctionProvider
+            else -> currentDialect.functionProvider
+        }
+        functionProvider.arraySlice(expression, lower, upper, queryBuilder)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.exposed.sql.functions.array
+
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.Function
+import org.jetbrains.exposed.sql.IColumnType
+import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.append
+import org.jetbrains.exposed.sql.vendors.currentDialect
+
+/**
+ * Represents an SQL function that returns the array element stored at the one-based [index] position,
+ * or `null` if the stored array itself is null or if [index] is out of bounds.
+ */
+class ArrayElementAt<E, T : List<E>?>(
+    /** The array expression that is accessed. */
+    val expression: Expression<T>,
+    /** The one-based index position at which the stored array is accessed. */
+    val index: Int,
+    columnType: IColumnType
+) : Function<E?>(columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        queryBuilder {
+            append(expression, "[", index.toString(), "]")
+        }
+    }
+}
+
+/**
+ * Represents an SQL function that returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),
+ * or `null` if the stored array itself is null.
+ */
+class ArraySlice<E, T : List<E>?>(
+    /** The array expression from which the subarray is returned. */
+    val expression: Expression<T>,
+    /** The lower bounds (inclusive) of a subarray. If left `null`, the database will use the stored array's lower limit. */
+    val lower: Int?,
+    /** The upper bounds (inclusive) of a subarray. If left `null`, the database will use the stored array's upper limit. */
+    val upper: Int?,
+    columnType: IColumnType
+) : Function<T>(columnType) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        currentDialect.functionProvider.arraySlice(expression, lower, upper, queryBuilder)
+    }
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
@@ -64,6 +64,9 @@ interface PreparedStatementApi {
     /** Sets the statement parameter at the [index] position to the provided [inputStream]. */
     fun setInputStream(index: Int, inputStream: InputStream)
 
+    /** Sets the statement parameter at the [index] position to the provided [array] of SQL [type]. */
+    fun setArray(index: Int, type: String, array: Array<*>)
+
     /** Closes the statement, if still open, and releases any of its database and/or driver resources. */
     fun closeIfPossible()
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -309,6 +309,24 @@ abstract class FunctionProvider {
         append("VAR_SAMP(", expression, ")")
     }
 
+    // Array Functions
+
+    /**
+     * SQL function that returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),
+     * or `null` if the stored array itself is null.
+     *
+     * @param expression Array expression from which the subarray is returned.
+     * @param lower Lower bounds (inclusive) of a subarray.
+     * @param upper Upper bounds (inclusive) of a subarray.
+     * **Note** If either bounds is left `null`, the database will use the stored array's respective lower or upper limit.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
+    open fun <T> arraySlice(expression: Expression<T>, lower: Int?, upper: Int?, queryBuilder: QueryBuilder) {
+        throw UnsupportedByDialectException(
+            "There's no generic SQL for ARRAY_SLICE. There must be a vendor specific implementation", currentDialect
+        )
+    }
+
     // JSON Functions
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -36,6 +36,12 @@ internal object H2FunctionProvider : FunctionProvider() {
             }
         }
 
+    override fun <T> arraySlice(expression: Expression<T>, lower: Int?, upper: Int?, queryBuilder: QueryBuilder) {
+        queryBuilder {
+            append("ARRAY_SLICE(", expression, ",$lower,$upper)")
+        }
+    }
+
     override fun insert(
         ignore: Boolean,
         table: Table,

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -75,6 +75,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStateme
 	public fun getTimeout ()Ljava/lang/Integer;
 	public final fun getWasGeneratedKeysRequested ()Z
 	public fun set (ILjava/lang/Object;)V
+	public fun setArray (ILjava/lang/String;[Ljava/lang/Object;)V
 	public fun setFetchSize (Ljava/lang/Integer;)V
 	public fun setInputStream (ILjava/io/InputStream;)V
 	public fun setNull (ILorg/jetbrains/exposed/sql/IColumnType;)V

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
@@ -83,6 +83,10 @@ class JdbcPreparedStatementImpl(
         statement.setBinaryStream(index, inputStream, inputStream.available())
     }
 
+    override fun setArray(index: Int, type: String, array: Array<*>) {
+        statement.setArray(index, statement.connection.createArrayOf(type, array))
+    }
+
     override fun closeIfPossible() {
         if (!statement.isClosed) statement.close()
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -1,0 +1,42 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.junit.Test
+
+class ArrayColumnTypeTests : DatabaseTestsBase() {
+    private val arrayTypeUnsupportedDb = TestDB.entries - (TestDB.postgreSQLRelatedDB + TestDB.H2 + TestDB.H2_PSQL).toSet()
+
+    object ArrayTestTable : IntIdTable("array_test_table") {
+        val numbers = array<Int>("numbers", IntegerColumnType()).default(listOf(5))
+        val strings = array<String?>("strings", TextColumnType()).default(emptyList())
+        val doubles = array<Double>("doubles", DoubleColumnType()).nullable()
+    }
+
+    @Test
+    fun testCreateAndDropArrayColumns() {
+        withDb(excludeSettings = arrayTypeUnsupportedDb) {
+            try {
+                SchemaUtils.create(ArrayTestTable)
+                assertTrue(ArrayTestTable.exists())
+            } finally {
+                SchemaUtils.drop(ArrayTestTable)
+            }
+        }
+    }
+
+    @Test
+    fun testCreateMissingColumnsWithDefaults() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            try {
+                SchemaUtils.createMissingTablesAndColumns(ArrayTestTable)
+                assertTrue(SchemaUtils.statementsRequiredToActualizeScheme(ArrayTestTable).isEmpty())
+            } finally {
+                SchemaUtils.drop(ArrayTestTable)
+            }
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -1,11 +1,23 @@
 package org.jetbrains.exposed.sql.tests.shared.types
 
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.junit.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNull
 
 class ArrayColumnTypeTests : DatabaseTestsBase() {
     private val arrayTypeUnsupportedDb = TestDB.entries - (TestDB.postgreSQLRelatedDB + TestDB.H2 + TestDB.H2_PSQL).toSet()
@@ -29,7 +41,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testCreateMissingColumnsWithDefaults() {
+    fun testCreateMissingColumnsWithArrayDefaults() {
         withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
             try {
                 SchemaUtils.createMissingTablesAndColumns(ArrayTestTable)
@@ -37,6 +49,213 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             } finally {
                 SchemaUtils.drop(ArrayTestTable)
             }
+        }
+    }
+
+    @Test
+    fun testArrayColumnInsertAndSelect() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val numInput = listOf(1, 2, 3)
+            val stringInput = listOf<String?>("hi", "hey", "hello")
+            val doubleInput = listOf(1.0, 2.0, 3.0)
+            val id1 = ArrayTestTable.insertAndGetId {
+                it[numbers] = numInput
+                it[strings] = stringInput
+                it[doubles] = doubleInput
+            }
+
+            val result1 = ArrayTestTable.selectAll().where { ArrayTestTable.id eq id1 }.single()
+            assertContentEquals(numInput, result1[ArrayTestTable.numbers])
+            assertContentEquals(stringInput, result1[ArrayTestTable.strings])
+            assertContentEquals(doubleInput, result1[ArrayTestTable.doubles])
+
+            val id2 = ArrayTestTable.insertAndGetId {
+                it[numbers] = emptyList()
+                it[strings] = emptyList()
+                it[doubles] = emptyList()
+            }
+
+            val result2: ResultRow = ArrayTestTable.selectAll().where { ArrayTestTable.id eq id2 }.single()
+            assertTrue(result2[ArrayTestTable.numbers].isEmpty())
+            assertTrue(result2[ArrayTestTable.strings].isEmpty())
+            assertEquals(true, result2[ArrayTestTable.doubles]?.isEmpty())
+
+            val id3 = ArrayTestTable.insertAndGetId {
+                it[strings] = listOf(null, null, null, "null")
+                it[doubles] = null
+            }
+
+            val result3 = ArrayTestTable.selectAll().where { ArrayTestTable.id eq id3 }.single()
+            assertEquals(5, result3[ArrayTestTable.numbers].single())
+            assertTrue(result3[ArrayTestTable.strings].take(3).all { it == null })
+            assertEquals("null", result3[ArrayTestTable.strings].last())
+            assertNull(result3[ArrayTestTable.doubles])
+        }
+    }
+
+    @Test
+    fun testArrayMaxSize() {
+        val maxArraySize = 5
+        val sizedTester = object : Table("sized_tester") {
+            val numbers = array<Int>("numbers", IntegerColumnType(), maxArraySize).default(emptyList())
+        }
+
+        withTables(excludeSettings = arrayTypeUnsupportedDb, sizedTester) {
+            val tooLongList = List(maxArraySize + 1) { i -> i + 1 }
+            if (currentDialectTest is PostgreSQLDialect) {
+                // PostgreSQL ignores any max cardinality value
+                sizedTester.insert {
+                    it[numbers] = tooLongList
+                }
+                assertContentEquals(tooLongList, sizedTester.selectAll().single()[sizedTester.numbers])
+            } else {
+                // H2 throws 'value too long for column' exception
+                expectException<ExposedSQLException> {
+                    sizedTester.insert {
+                        it[numbers] = tooLongList
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testSelectUsingArrayElementAt() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val numInput = listOf(1, 2, 3)
+            ArrayTestTable.insert {
+                it[numbers] = numInput
+                it[strings] = listOf<String?>("hi", "hello")
+                it[doubles] = null
+            }
+
+            // SQL array indexes are one-based
+            val secondNumber = ArrayTestTable.numbers.elementAt(2)
+            val result1 = ArrayTestTable.select(secondNumber).single()[secondNumber]
+            assertEquals(numInput[1], result1)
+
+            val result2 = ArrayTestTable.selectAll().where { ArrayTestTable.strings.elementAt(2) eq "hello" }
+            assertNull(result2.single()[ArrayTestTable.doubles])
+
+            val result3 = ArrayTestTable.selectAll().where {
+                ArrayTestTable.numbers.elementAt(1) greaterEq ArrayTestTable.numbers.elementAt(3)
+            }
+            assertTrue(result3.toList().isEmpty())
+
+            val nullArray = ArrayTestTable.doubles.elementAt(1)
+            val result4 = ArrayTestTable.select(nullArray).single()[nullArray]
+            assertNull(result4)
+        }
+    }
+
+    @Test
+    fun testSelectUsingArraySlice() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val numInput = listOf(1, 2, 3)
+            ArrayTestTable.insert {
+                it[numbers] = numInput
+                it[strings] = listOf(null, null, null, "hello")
+                it[doubles] = null
+            }
+
+            val lastTwoNumbers = ArrayTestTable.numbers.slice(2, 3) // numbers[2:3]
+            val result1 = ArrayTestTable.select(lastTwoNumbers).single()[lastTwoNumbers]
+            assertContentEquals(numInput.takeLast(2), result1)
+
+            val firstThreeStrings = ArrayTestTable.strings.slice(upper = 3) // strings[:3]
+            val result2 = ArrayTestTable.select(firstThreeStrings).single()[firstThreeStrings]
+            if (currentDialect is H2Dialect) { // H2 returns SQL NULL if any parameter in ARRAY_SLICE is null
+                assertNull(result2)
+            } else {
+                assertTrue(result2.filterNotNull().isEmpty())
+            }
+
+            val allNumbers = ArrayTestTable.numbers.slice() // numbers[:]
+            val result3 = ArrayTestTable.select(allNumbers).single()[allNumbers]
+            if (currentDialect is H2Dialect) {
+                assertNull(result3)
+            } else {
+                assertContentEquals(numInput, result3)
+            }
+
+            val nullArray = ArrayTestTable.doubles.slice(1, 3)
+            val result4 = ArrayTestTable.select(nullArray).single()[nullArray]
+            assertNull(result4)
+        }
+    }
+
+    @Test
+    fun testArrayLiteralAndArrayParam() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val numInput = listOf(1, 2, 3)
+            val doublesInput = List(5) { i -> (i + 1).toDouble() }
+            val id1 = ArrayTestTable.insertAndGetId {
+                it[numbers] = numInput
+                it[strings] = listOf(null, null, null, "hello")
+                it[doubles] = doublesInput
+            }
+
+            val result1 = ArrayTestTable.select(ArrayTestTable.id).where {
+                (ArrayTestTable.numbers eq numInput) and (ArrayTestTable.strings neq emptyList())
+            }
+            assertEquals(id1, result1.single()[ArrayTestTable.id])
+
+            val result2 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.doubles eq arrayParam(doublesInput, DoubleColumnType())
+            }
+            assertEquals(id1, result2.single()[ArrayTestTable.id])
+
+            if (currentDialectTest is PostgreSQLDialect) {
+                val lastStrings = ArrayTestTable.strings.slice(lower = 4) // strings[4:]
+                val result3 = ArrayTestTable.select(ArrayTestTable.id).where {
+                    lastStrings eq arrayLiteral(listOf("hello"), TextColumnType())
+                }
+                assertEquals(id1, result3.single()[ArrayTestTable.id])
+            }
+        }
+    }
+
+    @Test
+    fun testArrayColumnUpdate() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val id1 = ArrayTestTable.insertAndGetId {
+                it[doubles] = null
+            }
+
+            assertNull(ArrayTestTable.selectAll().single()[ArrayTestTable.doubles])
+
+            val updatedDoubles = listOf(9.0)
+            ArrayTestTable.update({ ArrayTestTable.id eq id1 }) {
+                it[doubles] = updatedDoubles
+            }
+
+            assertContentEquals(updatedDoubles, ArrayTestTable.selectAll().single()[ArrayTestTable.doubles])
+        }
+    }
+
+    class ArrayTestDao(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<ArrayTestDao>(ArrayTestTable)
+
+        var numbers by ArrayTestTable.numbers
+        var strings by ArrayTestTable.strings
+        var doubles by ArrayTestTable.doubles
+    }
+
+    @Test
+    fun testArrayColumnWithDAOFunctions() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val numInput = listOf(1, 2, 3)
+            val entity1 = ArrayTestDao.new {
+                numbers = numInput
+                doubles = null
+            }
+            assertContentEquals(numInput, entity1.numbers)
+            assertTrue(entity1.strings.isEmpty())
+
+            val doublesInput = listOf(9.0)
+            entity1.doubles = doublesInput
+
+            assertContentEquals(doublesInput, ArrayTestDao.all().single().doubles)
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -120,7 +120,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testSelectUsingArrayElementAt() {
+    fun testSelectUsingArrayGet() {
         withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
             val numInput = listOf(1, 2, 3)
             ArrayTestTable.insert {
@@ -134,7 +134,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             val result1 = ArrayTestTable.select(secondNumber).single()[secondNumber]
             assertEquals(numInput[1], result1)
 
-            val result2 = ArrayTestTable.selectAll().where { ArrayTestTable.strings.elementAt(2) eq "hello" }
+            val result2 = ArrayTestTable.selectAll().where { ArrayTestTable.strings[2] eq "hello" }
             assertNull(result2.single()[ArrayTestTable.doubles])
 
             val result3 = ArrayTestTable.selectAll().where {
@@ -142,7 +142,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             }
             assertTrue(result3.toList().isEmpty())
 
-            val nullArray = ArrayTestTable.doubles.elementAt(1)
+            val nullArray = ArrayTestTable.doubles[2]
             val result4 = ArrayTestTable.select(nullArray).single()[nullArray]
             assertNull(result4)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -130,7 +130,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             }
 
             // SQL array indexes are one-based
-            val secondNumber = ArrayTestTable.numbers.elementAt(2)
+            val secondNumber = ArrayTestTable.numbers[2]
             val result1 = ArrayTestTable.select(secondNumber).single()[secondNumber]
             assertEquals(numInput[1], result1)
 
@@ -138,7 +138,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             assertNull(result2.single()[ArrayTestTable.doubles])
 
             val result3 = ArrayTestTable.selectAll().where {
-                ArrayTestTable.numbers.elementAt(1) greaterEq ArrayTestTable.numbers.elementAt(3)
+                ArrayTestTable.numbers[1] greaterEq ArrayTestTable.numbers[3]
             }
             assertTrue(result3.toList().isEmpty())
 


### PR DESCRIPTION
Adds a new `ArrayColumnType` that accepts and returns elements of a List:
```kt
object TestTable : Table() {
    val amounts: Column<List<Int>?> = array<Int>("amounts", IntegerColumnType()).nullable()
    val items: Column<List<String?>> = array<String?>("amounts", TextColumnType()).default(emptyList())
    val prices: Column<List<Double>> = array<Double>("prices", DoubleColumnType())
}
```
**Note:**
- The `ARRAY` data type is supported by H2 and PostgreSQL (and their variants). See below for other possible supporting DB.
- Even though it is an `array()` column, the expected input/output is `List`. Type casting with List and Java `ArrayList` is more simple when retrieving `java.sql.Array` from the DB. Avoiding class cast exceptions when converting back to a `kotlin.Array` is possible but would require iterating over contents of the `java.sql.Array.resultSet` instead of using the array directly. Since `Array` and `List` don't share a type, there would also need to be adequate differences to prevent clashing overrides:
```kt
fun <T> array(name: String, columnType: ColumnType, length: Int? = null): Column<Array<T>> =
        registerColumn(name, ArrayColumnType(columnType.apply { nullable = true }, false, length))

fun <T> arrayList(name: String, columnType: ColumnType, length: Int? = null): Column<List<T>> =
        registerColumn(name, ArrayColumnType(columnType.apply { nullable = true }, true, length))
```
And all functions would need to be duplicated or given less restrictive type parameters. If there are any opinions about whether `Array` should be used instead (or add both), please let me know.
- To ensure that each element in the array is processed properly, the user has to supply a delegate column type (on column declaration and in some column functions). This could be seen as too verbose, so functions could be altered to use reflection and assign a column type for primitives, so that the user could choose to omit this argument.

---

Allows maximum array size to be set on column declaration.
Allows array column getter (via index reference) and slicing:
```kt
val somePrices = TestTable.prices.slice(3, 7)
TestTable.select(somePrices).where { TestTable.items.elementAt(2) eq "Item B" }
```

---

**Features not supported:**
- **Update using index reference**: `UPDATE ... SET array_column[2] = new_value`. This would require changes to the behavior of `UpdateBuilder` class.
- **Multi-dimensional support** (PostgreSQL): `INTEGER[][]`.
- **Oracle & SQL Server**: While they don't support ARRAY data type, there are ways to simulate array storage by creating a custom SQL type (using VARRAY or table-value parameters). Support could be investigated if requested, but there might be driver-specific  issues with how arrays are created and provided to `PreparedStatement` (for Oracle at least).

**Next steps:**
1. Add support for new column type with ANY and ALL operators.
2. Refactor existing ANY and ALL operators to use `ArrayColumnType`.
3. Consider using reflection and reified versions of column functions to resolve an appropriate column type, so users don't need to manually provide this value.
4. The new column works with datetime types as long as a default array is not used on table creation. Tests for these modules can be added once the datetime default issue is resolved.
5. Add documentation examples and update Wiki once complete.