### PR TITLE
feat: EXPOSED-290 Support ANY and ALL operators using array column expressions

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1790,9 +1790,11 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun CustomLongFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomStringFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
+	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun allFrom ([Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
+	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom ([Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun avg (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/Avg;
@@ -2689,6 +2691,12 @@ public abstract class org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp : org/jetbr
 	public final fun isAny ()Z
 	public abstract fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/ops/AllAnyFromExpressionOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {
+	public fun <init> (ZLorg/jetbrains/exposed/sql/Expression;)V
+	public synthetic fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
+	public fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Expression;)V
 }
 
 public final class org/jetbrains/exposed/sql/ops/AllAnyFromSubQueryOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -122,6 +122,9 @@ fun <T> anyFrom(array: Array<T>): Op<T> = AllAnyFromArrayOp(true, array)
 /** Returns this table wrapped in the `ANY` operator. This function is only supported by MySQL, PostgreSQL, and H2 dialects. */
 fun <T> anyFrom(table: Table): Op<T> = AllAnyFromTableOp(true, table)
 
+/** Returns this expression wrapped in the `ANY` operator. This function is only supported by PostgreSQL and H2 dialects. */
+fun <E, T : List<E>?> anyFrom(expression: Expression<T>): Op<E> = AllAnyFromExpressionOp(true, expression)
+
 /** Returns this subquery wrapped in the `ALL` operator. This function is not supported by the SQLite dialect. */
 fun <T> allFrom(subQuery: AbstractQuery<*>): Op<T> = AllAnyFromSubQueryOp(false, subQuery)
 
@@ -130,6 +133,9 @@ fun <T> allFrom(array: Array<T>): Op<T> = AllAnyFromArrayOp(false, array)
 
 /** Returns this table wrapped in the `ALL` operator. This function is only supported by MySQL, PostgreSQL, and H2 dialects. */
 fun <T> allFrom(table: Table): Op<T> = AllAnyFromTableOp(false, table)
+
+/** Returns this expression wrapped in the `ALL` operator. This function is only supported by PostgreSQL and H2 dialects. */
+fun <E, T : List<E>?> allFrom(expression: Expression<T>): Op<E> = AllAnyFromExpressionOp(false, expression)
 
 /**
  * Returns the array element stored at the one-based [index] position, or `null` if the stored array itself is null.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.ops
 
 import org.jetbrains.exposed.sql.AbstractQuery
+import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.QueryBuilder
 import org.jetbrains.exposed.sql.Table
@@ -61,5 +62,20 @@ class AllAnyFromTableOp<T>(isAny: Boolean, table: Table) : AllAnyFromBaseOp<T, T
     override fun QueryBuilder.registerSubSearchArgument(subSearch: Table) {
         +"TABLE "
         +subSearch.tableName
+    }
+}
+
+/**
+ * Represents an SQL operator that checks a value, based on the preceding comparison operator,
+ * against a collection of values returned by the provided expression.
+ *
+ * **Note** This operation is only supported by PostgreSQL and H2 dialects.
+ */
+class AllAnyFromExpressionOp<E, T : List<E>?>(
+    isAny: Boolean,
+    expression: Expression<T>
+) : AllAnyFromBaseOp<E, Expression<T>>(isAny, expression) {
+    override fun QueryBuilder.registerSubSearchArgument(subSearch: Expression<T>) {
+        append(subSearch)
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -258,4 +258,30 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             assertContentEquals(doublesInput, ArrayTestDao.all().single().doubles)
         }
     }
+
+    @Test
+    fun testArrayColumnWithAllAnyOps() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val numInput = listOf(1, 2, 3)
+            val id1 = ArrayTestTable.insertAndGetId {
+                it[numbers] = numInput
+                it[doubles] = null
+            }
+
+            val result1 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id eq anyFrom(ArrayTestTable.numbers)
+            }
+            assertEquals(id1, result1.single()[ArrayTestTable.id])
+
+            val result2 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id eq anyFrom(ArrayTestTable.numbers.slice(2, 3))
+            }
+            assertTrue(result2.toList().isEmpty())
+
+            val result3 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id lessEq allFrom(ArrayTestTable.numbers)
+            }
+            assertEquals(id1, result3.single()[ArrayTestTable.id])
+        }
+    }
 }


### PR DESCRIPTION
Support using `ANY` and `ALL` operators with new array column from PR #1986 , as well as any expression that returns a new array value, so the following is possible:
```kt
Table
    .selectAll()
    .where { Table.number eq anyFrom(Table.numbers) }

Table
    .selectAll()
    .where { Table.number less allFrom(Table.numbers.slice(1, 5)) }
```

**Next step:**
- Replace `UntypedAndUnsizedArrayColumnType` from PR #1886  with `ArrayColumnType` and refactor existing functions to use base column type reflection.