### PR TITLE
chore: Configure detekt Gradle task to show its result in the terminal/IDE directly instead of generating an XML report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.report.ReportMergeTask
-import org.jetbrains.exposed.gradle.*
+import org.jetbrains.exposed.gradle.configureDetekt
+import org.jetbrains.exposed.gradle.configurePublishing
+import org.jetbrains.exposed.gradle.testDb
 
 plugins {
     kotlin("jvm") apply true
@@ -15,8 +15,6 @@ repositories {
 }
 
 allprojects {
-    configureDetekt()
-
     if (this.name != "exposed-tests" && this.name != "exposed-bom" && this != rootProject) {
         configurePublishing()
     }
@@ -26,19 +24,11 @@ apiValidation {
     ignoredProjects.addAll(listOf("exposed-tests", "exposed-bom"))
 }
 
-val reportMerge by tasks.registering(ReportMergeTask::class) {
-    output.set(rootProject.buildDir.resolve("reports/detekt/exposed.xml"))
-}
-
 subprojects {
+    configureDetekt()
+
     dependencies {
         detektPlugins(rootProject.libs.detekt.formatting)
-    }
-    tasks.withType<Detekt>().configureEach detekt@{
-        finalizedBy(reportMerge)
-        reportMerge.configure {
-            input.from(this@detekt.xmlReportFile)
-        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Detekt.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Detekt.kt
@@ -1,12 +1,10 @@
 package org.jetbrains.exposed.gradle
 
-import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektPlugin
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
 
 fun Project.configureDetekt() {
     apply<DetektPlugin>()
@@ -16,13 +14,5 @@ fun Project.configureDetekt() {
         buildUponDefaultConfig = true
         parallel = true
         config.setFrom("$rootDir/detekt/detekt-config.yml")
-    }
-    tasks.withType<Detekt>().configureEach {
-        reports {
-            xml.required.set(true)
-            html.required.set(false)
-            txt.required.set(false)
-            sarif.required.set(false)
-        }
     }
 }

--- a/detekt/detekt-config.yml
+++ b/detekt/detekt-config.yml
@@ -1,7 +1,7 @@
 # https://github.com/detekt/detekt/blob/main/detekt-core/src/main/resources/default-detekt-config.yml
 
 build:
-    maxIssues: 52
+    maxIssues: 0
 
 formatting:
     ArgumentListWrapping:


### PR DESCRIPTION
How to test:

1. Add code that would cause a **detekt** error (e.g: an unused import)
2. Run `./gradlew detekt` from the terminal
3. It should fail and point you to the problematic code