### PR TITLE
fix!: EXPOSED-288 Extend ANY and ALL operators to use ArrayColumnType

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1208,6 +1208,9 @@ public final class org/jetbrains/exposed/sql/IntegerColumnType : org/jetbrains/e
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public abstract interface annotation class org/jetbrains/exposed/sql/InternalApi : java/lang/annotation/Annotation {
+}
+
 public final class org/jetbrains/exposed/sql/Intersect : org/jetbrains/exposed/sql/SetOperation {
 	public fun <init> (Lorg/jetbrains/exposed/sql/AbstractQuery;Lorg/jetbrains/exposed/sql/AbstractQuery;)V
 	public fun copy ()Lorg/jetbrains/exposed/sql/Intersect;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1803,10 +1803,8 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun CustomLongFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomStringFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
-	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
-	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun avg (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/Avg;
 	public static synthetic fun avg$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;IILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Avg;
@@ -2704,12 +2702,6 @@ public abstract class org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp : org/jetbr
 	public final fun isAny ()Z
 	public abstract fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
-}
-
-public final class org/jetbrains/exposed/sql/ops/AllAnyFromExpressionOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {
-	public fun <init> (ZLorg/jetbrains/exposed/sql/Expression;)V
-	public synthetic fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
-	public fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Expression;)V
 }
 
 public final class org/jetbrains/exposed/sql/ops/AllAnyFromSubQueryOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -450,6 +450,8 @@ public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/expos
 public final class org/jetbrains/exposed/sql/ColumnTypeKt {
 	public static final fun getAutoIncColumnType (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/AutoIncColumnType;
 	public static final fun isAutoInc (Lorg/jetbrains/exposed/sql/IColumnType;)Z
+	public static final fun resolveColumnType (Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/ColumnType;
+	public static synthetic fun resolveColumnType$default (Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/ColumnType;
 }
 
 public abstract class org/jetbrains/exposed/sql/ComparisonOp : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {
@@ -1535,8 +1537,6 @@ public final class org/jetbrains/exposed/sql/OpKt {
 	public static final fun andIfNotNull (Lorg/jetbrains/exposed/sql/Op;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun andIfNotNull (Lorg/jetbrains/exposed/sql/Op;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun andNot (Lorg/jetbrains/exposed/sql/Expression;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Op;
-	public static final fun arrayLiteral (Ljava/util/List;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/LiteralOp;
-	public static final fun arrayParam (Ljava/util/List;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun blobParam (Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;Z)Lorg/jetbrains/exposed/sql/Expression;
 	public static synthetic fun blobParam$default (Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun booleanLiteral (Z)Lorg/jetbrains/exposed/sql/LiteralOp;
@@ -1805,11 +1805,9 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
-	public static final fun allFrom ([Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
-	public static final fun anyFrom ([Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun avg (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/Avg;
 	public static synthetic fun avg$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;IILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Avg;
 	public static final fun castTo (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/IColumnType;)Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;
@@ -2694,7 +2692,8 @@ public final class org/jetbrains/exposed/sql/functions/math/TanFunction : org/je
 }
 
 public final class org/jetbrains/exposed/sql/ops/AllAnyFromArrayOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {
-	public fun <init> (Z[Ljava/lang/Object;)V
+	public fun <init> (Z[Ljava/lang/Object;Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;)V
+	public synthetic fun <init> (Z[Ljava/lang/Object;Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
 	public fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;[Ljava/lang/Object;)V
 }
@@ -3317,7 +3316,6 @@ public abstract class org/jetbrains/exposed/sql/vendors/DataTypeProvider {
 	public fun uintegerType ()Ljava/lang/String;
 	public fun ulongAutoincType ()Ljava/lang/String;
 	public fun ulongType ()Ljava/lang/String;
-	public fun untypedAndUnsizedArrayType ()Ljava/lang/String;
 	public fun ushortType ()Ljava/lang/String;
 	public fun uuidToDB (Ljava/util/UUID;)Ljava/lang/Object;
 	public fun uuidType ()Ljava/lang/String;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1803,8 +1803,10 @@ public final class org/jetbrains/exposed/sql/SQLExpressionBuilderKt {
 	public static final fun CustomLongFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomStringFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
+	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun allFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Op;
+	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun anyFrom (Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/Op;
 	public static final fun avg (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;I)Lorg/jetbrains/exposed/sql/Avg;
 	public static synthetic fun avg$default (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;IILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Avg;
@@ -2690,8 +2692,7 @@ public final class org/jetbrains/exposed/sql/functions/math/TanFunction : org/je
 }
 
 public final class org/jetbrains/exposed/sql/ops/AllAnyFromArrayOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {
-	public fun <init> (Z[Ljava/lang/Object;Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;)V
-	public synthetic fun <init> (Z[Ljava/lang/Object;Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Z[Ljava/lang/Object;Lorg/jetbrains/exposed/sql/ColumnType;)V
 	public synthetic fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
 	public fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;[Ljava/lang/Object;)V
 }
@@ -2702,6 +2703,12 @@ public abstract class org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp : org/jetbr
 	public final fun isAny ()Z
 	public abstract fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/ops/AllAnyFromExpressionOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {
+	public fun <init> (ZLorg/jetbrains/exposed/sql/Expression;)V
+	public synthetic fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/Object;)V
+	public fun registerSubSearchArgument (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Expression;)V
 }
 
 public final class org/jetbrains/exposed/sql/ops/AllAnyFromSubQueryOp : org/jetbrains/exposed/sql/ops/AllAnyFromBaseOp {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Annotations.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Annotations.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.exposed.sql
+
+/**
+ * API marked with this annotation is experimental.
+ * Any behavior associated with its use is not guaranteed to be stable.
+ */
+@RequiresOptIn(
+    message = "This database migration API is experimental. " +
+        "Its usage must be marked with '@OptIn(org.jetbrains.exposed.sql.ExperimentalDatabaseMigrationApi::class)' " +
+        "or '@org.jetbrains.exposed.sql.ExperimentalDatabaseMigrationApi'."
+)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ExperimentalDatabaseMigrationApi
+
+/**
+ * API marked with this annotation is experimental.
+ * Any behavior associated with its use is not guaranteed to be stable.
+ */
+@RequiresOptIn(
+    message = "This API is experimental and the behavior defined by setting this value to 'true' is now the default. " +
+        "Its usage must be marked with '@OptIn(org.jetbrains.exposed.sql.ExperimentalKeywordApi::class)' " +
+        "or '@org.jetbrains.exposed.sql.ExperimentalKeywordApi'."
+)
+@Target(AnnotationTarget.PROPERTY)
+annotation class ExperimentalKeywordApi
+
+/**
+ * API marked with this annotation is internal and should not be used outside Exposed.
+ * It may be changed or removed in the future without notice.
+ * Using it outside Exposed may result in undefined and unexpected behaviour.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is internal in Exposed and should not be used. It may be changed or removed in the future without notice."
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.TYPEALIAS
+)
+annotation class InternalApi

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -1114,6 +1114,7 @@ interface JsonColumnMarker {
  *
  * @throws IllegalStateException If no column type mapping is found and a [defaultType] is not provided.
  */
+@InternalApi
 fun <T : Any> resolveColumnType(
     klass: KClass<T>,
     defaultType: ColumnType? = null

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -1130,7 +1130,10 @@ fun <T : Any> resolveColumnType(
     Float::class -> FloatColumnType()
     Double::class -> DoubleColumnType()
     String::class -> TextColumnType()
+    Char::class -> CharacterColumnType()
     ByteArray::class -> BasicBinaryColumnType()
+    BigDecimal::class -> DecimalColumnType.INSTANCE
+    UUID::class -> UUIDColumnType()
     else -> defaultType ?: error(
         "A column type could not be associated with ${klass.qualifiedName}. Provide an explicit column type argument."
     )

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -141,11 +141,3 @@ class DatabaseConfig private constructor(
         }
     }
 }
-
-@RequiresOptIn(
-    message = "This API is experimental and the behavior defined by setting this value to 'true' is now the default. " +
-        "Its usage must be marked with '@OptIn(org.jetbrains.exposed.sql.ExperimentalKeywordApi::class)' " +
-        "or '@org.jetbrains.exposed.sql.ExperimentalKeywordApi'."
-)
-@Target(AnnotationTarget.PROPERTY)
-annotation class ExperimentalKeywordApi

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -691,7 +691,7 @@ fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(Decimal
  * internal mapping of the element's type in [resolveColumnType].
  */
 inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType? = null): LiteralOp<List<T>> =
-    LiteralOp(ArrayColumnType(resolveColumnType(T::class, delegateType)), value)
+    LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class)), value)
 
 // Query Parameters
 
@@ -766,7 +766,7 @@ fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Express
  * internal mapping of the element's type in [resolveColumnType].
  */
 inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType? = null): Expression<List<T>> =
-    QueryParameter(value, ArrayColumnType(resolveColumnType(T::class, delegateType)))
+    QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class)))
 
 // Misc.
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -689,6 +689,8 @@ fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(Decimal
  *
  * **Note** If [delegateType] is left `null`, the associated column type will be resolved according to the
  * internal mapping of the element's type in [resolveColumnType].
+ *
+ * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
 inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType? = null): LiteralOp<List<T>> =
     LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class)), value)
@@ -764,6 +766,8 @@ fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Express
  *
  * **Note** If [delegateType] is left `null`, the associated column type will be resolved according to the
  * internal mapping of the element's type in [resolveColumnType].
+ *
+ * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
 inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType? = null): Expression<List<T>> =
     QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class)))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -684,9 +684,14 @@ fun stringLiteral(value: String): LiteralOp<String> = LiteralOp(TextColumnType()
 /** Returns the specified [value] as a decimal literal. */
 fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(DecimalColumnType(value.precision(), value.scale()), value)
 
-/** Returns the specified [value] as an array literal, with elements parsed by the [delegateType]. */
-fun <T> arrayLiteral(value: List<T>, delegateType: ColumnType): LiteralOp<List<T>> =
-    LiteralOp(ArrayColumnType(delegateType), value)
+/**
+ * Returns the specified [value] as an array literal, with elements parsed by the [delegateType] if provided.
+ *
+ * **Note** If [delegateType] is left `null`, the associated column type will be resolved according to the
+ * internal mapping of the element's type in [resolveColumnType].
+ */
+inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType? = null): LiteralOp<List<T>> =
+    LiteralOp(ArrayColumnType(resolveColumnType(T::class, delegateType)), value)
 
 // Query Parameters
 
@@ -754,9 +759,14 @@ fun decimalParam(value: BigDecimal): Expression<BigDecimal> = QueryParameter(val
 fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Expression<ExposedBlob> =
     QueryParameter(value, BlobColumnType(useObjectIdentifier))
 
-/** Returns the specified [value] as an array query parameter, with elements parsed by the [delegateType]. */
-fun <T> arrayParam(value: List<T>, delegateType: ColumnType): Expression<List<T>> =
-    QueryParameter(value, ArrayColumnType(delegateType))
+/**
+ * Returns the specified [value] as an array query parameter, with elements parsed by the [delegateType] if provided.
+ *
+ * **Note** If [delegateType] is left `null`, the associated column type will be resolved according to the
+ * internal mapping of the element's type in [resolveColumnType].
+ */
+inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType? = null): Expression<List<T>> =
+    QueryParameter(value, ArrayColumnType(resolveColumnType(T::class, delegateType)))
 
 // Misc.
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -692,8 +692,10 @@ fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(Decimal
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType? = null): LiteralOp<List<T>> =
-    LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class)), value)
+inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType? = null): LiteralOp<List<T>> {
+    @OptIn(InternalApi::class)
+    return LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class)), value)
+}
 
 // Query Parameters
 
@@ -769,8 +771,10 @@ fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Express
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType? = null): Expression<List<T>> =
-    QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class)))
+inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType? = null): Expression<List<T>> {
+    @OptIn(InternalApi::class)
+    return QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class)))
+}
 
 // Misc.
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -128,9 +128,6 @@ inline fun <reified T : Any> anyFrom(array: Array<T>, delegateType: ColumnType? 
 /** Returns this table wrapped in the `ANY` operator. This function is only supported by MySQL, PostgreSQL, and H2 dialects. */
 fun <T> anyFrom(table: Table): Op<T> = AllAnyFromTableOp(true, table)
 
-/** Returns this expression wrapped in the `ANY` operator. This function is only supported by PostgreSQL and H2 dialects. */
-fun <E, T : List<E>?> anyFrom(expression: Expression<T>): Op<E> = AllAnyFromExpressionOp(true, expression)
-
 /** Returns this subquery wrapped in the `ALL` operator. This function is not supported by the SQLite dialect. */
 fun <T> allFrom(subQuery: AbstractQuery<*>): Op<T> = AllAnyFromSubQueryOp(false, subQuery)
 
@@ -145,9 +142,6 @@ inline fun <reified T : Any> allFrom(array: Array<T>, delegateType: ColumnType? 
 
 /** Returns this table wrapped in the `ALL` operator. This function is only supported by MySQL, PostgreSQL, and H2 dialects. */
 fun <T> allFrom(table: Table): Op<T> = AllAnyFromTableOp(false, table)
-
-/** Returns this expression wrapped in the `ALL` operator. This function is only supported by PostgreSQL and H2 dialects. */
-fun <E, T : List<E>?> allFrom(expression: Expression<T>): Op<E> = AllAnyFromExpressionOp(false, expression)
 
 /**
  * Returns the array element stored at the one-based [index] position, or `null` if the stored array itself is null.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -116,8 +116,14 @@ fun <T : Any?> ExpressionWithColumnType<T>.varSamp(scale: Int = 2): VarSamp<T> =
 /** Returns this subquery wrapped in the `ANY` operator. This function is not supported by the SQLite dialect. */
 fun <T> anyFrom(subQuery: AbstractQuery<*>): Op<T> = AllAnyFromSubQueryOp(true, subQuery)
 
-/** Returns this array of data wrapped in the `ANY` operator. This function is only supported by PostgreSQL and H2 dialects. */
-fun <T> anyFrom(array: Array<T>): Op<T> = AllAnyFromArrayOp(true, array)
+/**
+ * Returns this array of data wrapped in the `ANY` operator. This function is only supported by PostgreSQL and H2 dialects.
+ *
+ * **Note** If [delegateType] is left `null`, the base column type associated with storing elements of type [T] will be
+ * resolved according to the internal mapping of the element's type in [resolveColumnType].
+ */
+inline fun <reified T : Any> anyFrom(array: Array<T>, delegateType: ColumnType? = null): Op<T> =
+    AllAnyFromArrayOp(true, array, T::class, delegateType)
 
 /** Returns this table wrapped in the `ANY` operator. This function is only supported by MySQL, PostgreSQL, and H2 dialects. */
 fun <T> anyFrom(table: Table): Op<T> = AllAnyFromTableOp(true, table)
@@ -128,8 +134,14 @@ fun <E, T : List<E>?> anyFrom(expression: Expression<T>): Op<E> = AllAnyFromExpr
 /** Returns this subquery wrapped in the `ALL` operator. This function is not supported by the SQLite dialect. */
 fun <T> allFrom(subQuery: AbstractQuery<*>): Op<T> = AllAnyFromSubQueryOp(false, subQuery)
 
-/** Returns this array of data wrapped in the `ALL` operator. This function is only supported by PostgreSQL and H2 dialects. */
-fun <T> allFrom(array: Array<T>): Op<T> = AllAnyFromArrayOp(false, array)
+/**
+ * Returns this array of data wrapped in the `ALL` operator. This function is only supported by PostgreSQL and H2 dialects.
+ *
+ * **Note** If [delegateType] is left `null`, the base column type associated with storing elements of type [T] will be
+ * resolved according to the internal mapping of the element's type in [resolveColumnType].
+ */
+inline fun <reified T : Any> allFrom(array: Array<T>, delegateType: ColumnType? = null): Op<T> =
+    AllAnyFromArrayOp(false, array, T::class, delegateType)
 
 /** Returns this table wrapped in the `ALL` operator. This function is only supported by MySQL, PostgreSQL, and H2 dialects. */
 fun <T> allFrom(table: Table): Op<T> = AllAnyFromTableOp(false, table)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -2,7 +2,6 @@
 
 package org.jetbrains.exposed.sql
 
-import kotlinx.coroutines.scheduling.DefaultIoScheduler.default
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -126,6 +126,7 @@ fun <T> anyFrom(subQuery: AbstractQuery<*>): Op<T> = AllAnyFromSubQueryOp(true, 
  */
 inline fun <reified T : Any> anyFrom(array: Array<T>, delegateType: ColumnType? = null): Op<T> {
     // emptyArray() without type info generates ARRAY[]
+    @OptIn(InternalApi::class)
     val columnType = delegateType ?: resolveColumnType(T::class, if (array.isEmpty()) TextColumnType() else null)
     return AllAnyFromArrayOp(true, array, columnType)
 }
@@ -149,6 +150,7 @@ fun <T> allFrom(subQuery: AbstractQuery<*>): Op<T> = AllAnyFromSubQueryOp(false,
  */
 inline fun <reified T : Any> allFrom(array: Array<T>, delegateType: ColumnType? = null): Op<T> {
     // emptyArray() without type info generates ARRAY[]
+    @OptIn(InternalApi::class)
     val columnType = delegateType ?: resolveColumnType(T::class, if (array.isEmpty()) TextColumnType() else null)
     return AllAnyFromArrayOp(false, array, columnType)
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -888,11 +888,3 @@ object SchemaUtils {
         }
     }
 }
-
-@RequiresOptIn(
-    message = "This database migration API is experimental. " +
-        "Its usage must be marked with '@OptIn(org.jetbrains.exposed.sql.ExperimentalDatabaseMigrationApi::class)' " +
-        "or '@org.jetbrains.exposed.sql.ExperimentalDatabaseMigrationApi'."
-)
-@Target(AnnotationTarget.FUNCTION)
-annotation class ExperimentalDatabaseMigrationApi

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -844,8 +844,10 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      * @throws IllegalStateException If no column type mapping is found.
      */
-    inline fun <reified T : Any> array(name: String, maximumCardinality: Int? = null): Column<List<T>> =
-        array(name, resolveColumnType(T::class), maximumCardinality)
+    inline fun <reified T : Any> array(name: String, maximumCardinality: Int? = null): Column<List<T>> {
+        @OptIn(InternalApi::class)
+        return array(name, resolveColumnType(T::class), maximumCardinality)
+    }
 
     // Auto-generated values
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -836,7 +836,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      *
      * **Note** The base column type associated with storing elements of type [T] will be resolved according to
      * the internal mapping in [resolveColumnType]. To avoid this type reflection, or if a mapping does not exist
-     * for the elements being stored, please provide an explicit column type to the [array] overload.
+     * for the elements being stored, please provide an explicit column type to the [array] overload. If the elements
+     * to be stored are nullable, an explicit column type will also need to be provided.
      *
      * @param name Name of the column.
      * @param maximumCardinality The maximum amount of allowed elements. **Note** Providing an array size limit

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -829,6 +829,23 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <T> array(name: String, columnType: ColumnType, maximumCardinality: Int? = null): Column<List<T>> =
         registerColumn(name, ArrayColumnType(columnType.apply { nullable = true }, maximumCardinality))
 
+    /**
+     * Creates an array column, with the specified [name], for storing elements of a `List`.
+     *
+     * **Note** This column type is only supported by H2 and PostgreSQL dialects.
+     *
+     * **Note** The base column type associated with storing elements of type [T] will be resolved according to
+     * the internal mapping in [resolveColumnType]. To avoid this type reflection, or if a mapping does not exist
+     * for the elements being stored, please provide an explicit column type to the [array] overload.
+     *
+     * @param name Name of the column.
+     * @param maximumCardinality The maximum amount of allowed elements. **Note** Providing an array size limit
+     * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
+     * @throws IllegalStateException If no column type mapping is found.
+     */
+    inline fun <reified T : Any> array(name: String, maximumCardinality: Int? = null): Column<List<T>> =
+        array(name, resolveColumnType(T::class), maximumCardinality)
+
     // Auto-generated values
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
@@ -50,8 +50,10 @@ class AllAnyFromArrayOp<T : Any>(
     private val delegateType: ColumnType? = null
 ) : AllAnyFromBaseOp<T, Array<T>>(isAny, array) {
     override fun QueryBuilder.registerSubSearchArgument(subSearch: Array<T>) {
+        // emptyArray() without type info generates ARRAY[]
+        val default = if (subSearch.isEmpty()) TextColumnType() else null
         registerArgument(
-            ArrayColumnType(delegateType ?: resolveColumnType(klass, TextColumnType())),
+            ArrayColumnType(delegateType ?: resolveColumnType(klass, default)),
             subSearch
         )
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
@@ -71,18 +71,3 @@ class AllAnyFromTableOp<T>(isAny: Boolean, table: Table) : AllAnyFromBaseOp<T, T
         +subSearch.tableName
     }
 }
-
-/**
- * Represents an SQL operator that checks a value, based on the preceding comparison operator,
- * against a collection of values returned by the provided expression.
- *
- * **Note** This operation is only supported by PostgreSQL and H2 dialects.
- */
-class AllAnyFromExpressionOp<E, T : List<E>?>(
-    isAny: Boolean,
-    expression: Expression<T>
-) : AllAnyFromBaseOp<E, Expression<T>>(isAny, expression) {
-    override fun QueryBuilder.registerSubSearchArgument(subSearch: Expression<T>) {
-        append(subSearch)
-    }
-}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
@@ -1,11 +1,7 @@
 package org.jetbrains.exposed.sql.ops
 
-import org.jetbrains.exposed.sql.AbstractQuery
-import org.jetbrains.exposed.sql.Expression
-import org.jetbrains.exposed.sql.Op
-import org.jetbrains.exposed.sql.QueryBuilder
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.UntypedAndUnsizedArrayColumnType
+import org.jetbrains.exposed.sql.*
+import kotlin.reflect.KClass
 
 /**
  * Represents an SQL operator that checks a value, based on the preceding comparison operator,
@@ -47,9 +43,18 @@ class AllAnyFromSubQueryOp<T>(
  *
  * **Note** This operation is only supported by PostgreSQL and H2 dialects.
  */
-class AllAnyFromArrayOp<T>(isAny: Boolean, array: Array<T>) : AllAnyFromBaseOp<T, Array<T>>(isAny, array) {
-    override fun QueryBuilder.registerSubSearchArgument(subSearch: Array<T>) =
-        registerArgument(UntypedAndUnsizedArrayColumnType, subSearch)
+class AllAnyFromArrayOp<T : Any>(
+    isAny: Boolean,
+    array: Array<T>,
+    private val klass: KClass<T>,
+    private val delegateType: ColumnType? = null
+) : AllAnyFromBaseOp<T, Array<T>>(isAny, array) {
+    override fun QueryBuilder.registerSubSearchArgument(subSearch: Array<T>) {
+        registerArgument(
+            ArrayColumnType(delegateType ?: resolveColumnType(klass, TextColumnType())),
+            subSearch
+        )
+    }
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
@@ -137,11 +137,6 @@ abstract class DataTypeProvider {
     open fun jsonBType(): String =
         throw UnsupportedByDialectException("This vendor does not support binary JSON data type", currentDialect)
 
-    /** Data type for arrays with no specified size or element type, used only as types of [QueryParameter]s for PostgreSQL and H2.
-     * An array with no element type cannot be used for storing arrays in a column in either PostgreSQL or H2. */
-    open fun untypedAndUnsizedArrayType(): String =
-        throw UnsupportedByDialectException("This vendor does not support array data type", currentDialect)
-
     // Misc.
 
     /** Returns the SQL representation of the specified expression, for it to be used as a column default value. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -19,7 +19,6 @@ internal object H2DataTypeProvider : DataTypeProvider() {
     override fun timestampWithTimeZoneType(): String = "TIMESTAMP(9) WITH TIME ZONE"
 
     override fun jsonBType(): String = "JSON"
-    override fun untypedAndUnsizedArrayType(): String = "ARRAY[]"
 
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -21,8 +21,6 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun dateTimeType(): String = "TIMESTAMP"
     override fun jsonBType(): String = "JSONB"
 
-    override fun untypedAndUnsizedArrayType(): String = "ARRAY"
-
     override fun processForDefaultValue(e: Expression<*>): String = when {
         e is LiteralOp<*> && e.columnType is JsonColumnMarker && (currentDialect as? H2Dialect) == null -> {
             val cast = if (e.columnType.usesBinaryFormat) "::jsonb" else "::json"

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
@@ -44,6 +44,7 @@ inline fun <reified T : Any> ExpressionWithColumnType<*>.extract(
     vararg path: String,
     toScalar: Boolean = true
 ): Extract<T> {
+    @OptIn(InternalApi::class)
     val columnType = resolveColumnType(
         T::class,
         defaultType = JsonColumnType(

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
@@ -44,22 +44,12 @@ inline fun <reified T : Any> ExpressionWithColumnType<*>.extract(
     vararg path: String,
     toScalar: Boolean = true
 ): Extract<T> {
-    val columnType = when (T::class) {
-        String::class -> TextColumnType()
-        Boolean::class -> BooleanColumnType()
-        Long::class -> LongColumnType()
-        Int::class -> IntegerColumnType()
-        Short::class -> ShortColumnType()
-        Byte::class -> ByteColumnType()
-        Double::class -> DoubleColumnType()
-        Float::class -> FloatColumnType()
-        ByteArray::class -> BasicBinaryColumnType()
-        else -> {
-            JsonColumnType(
-                { Json.Default.encodeToString(serializer<T>(), it) },
-                { Json.Default.decodeFromString(serializer<T>(), it) }
-            )
-        }
-    }
+    val columnType = resolveColumnType(
+        T::class,
+        defaultType = JsonColumnType(
+            { Json.Default.encodeToString(serializer<T>(), it) },
+            { Json.Default.decodeFromString(serializer<T>(), it) }
+        )
+    )
     return Extract(this, path = path, toScalar, this.columnType, columnType)
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -354,8 +354,7 @@ class SelectTests : DatabaseTestsBase() {
         withDb(testDBsSupportingAnyAndAllFromArrays) {
             withSales { _, sales ->
                 val amounts = arrayOf(100, 1000).map { it.toBigDecimal() }.toTypedArray()
-                val r = sales.selectAll()
-                    .where { sales.amount greaterEq anyFrom(amounts) }
+                val r = sales.selectAll().where { sales.amount greaterEq anyFrom(amounts) }
                     .orderBy(sales.amount)
                     .map { it[sales.product] }
                 assertEquals(6, r.size)
@@ -405,8 +404,7 @@ class SelectTests : DatabaseTestsBase() {
         withDb(testDBsSupportingAnyAndAllFromArrays) {
             withSales { _, sales ->
                 val amounts = arrayOf(100, 1000).map { it.toBigDecimal() }.toTypedArray()
-                val r = sales.selectAll()
-                    .where { sales.amount greaterEq allFrom(amounts) }.toList()
+                val r = sales.selectAll().where { sales.amount greaterEq allFrom(amounts) }.toList()
                 assertEquals(3, r.size)
                 r.forEach { assertEquals("coffee", it[sales.product]) }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -354,7 +354,8 @@ class SelectTests : DatabaseTestsBase() {
         withDb(testDBsSupportingAnyAndAllFromArrays) {
             withSales { _, sales ->
                 val amounts = arrayOf(100, 1000).map { it.toBigDecimal() }.toTypedArray()
-                val r = sales.selectAll().where { sales.amount greaterEq anyFrom(amounts) }
+                val r = sales.selectAll()
+                    .where { sales.amount greaterEq anyFrom(amounts, DecimalColumnType(2, 2)) }
                     .orderBy(sales.amount)
                     .map { it[sales.product] }
                 assertEquals(6, r.size)
@@ -404,7 +405,8 @@ class SelectTests : DatabaseTestsBase() {
         withDb(testDBsSupportingAnyAndAllFromArrays) {
             withSales { _, sales ->
                 val amounts = arrayOf(100, 1000).map { it.toBigDecimal() }.toTypedArray()
-                val r = sales.selectAll().where { sales.amount greaterEq allFrom(amounts) }.toList()
+                val r = sales.selectAll()
+                    .where { sales.amount greaterEq allFrom(amounts, DecimalColumnType(2, 2)) }.toList()
                 assertEquals(3, r.size)
                 r.forEach { assertEquals("coffee", it[sales.product]) }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -355,7 +355,7 @@ class SelectTests : DatabaseTestsBase() {
             withSales { _, sales ->
                 val amounts = arrayOf(100, 1000).map { it.toBigDecimal() }.toTypedArray()
                 val r = sales.selectAll()
-                    .where { sales.amount greaterEq anyFrom(amounts, DecimalColumnType(2, 2)) }
+                    .where { sales.amount greaterEq anyFrom(amounts) }
                     .orderBy(sales.amount)
                     .map { it[sales.product] }
                 assertEquals(6, r.size)
@@ -406,7 +406,7 @@ class SelectTests : DatabaseTestsBase() {
             withSales { _, sales ->
                 val amounts = arrayOf(100, 1000).map { it.toBigDecimal() }.toTypedArray()
                 val r = sales.selectAll()
-                    .where { sales.amount greaterEq allFrom(amounts, DecimalColumnType(2, 2)) }.toList()
+                    .where { sales.amount greaterEq allFrom(amounts) }.toList()
                 assertEquals(3, r.size)
                 r.forEach { assertEquals("coffee", it[sales.product]) }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -201,14 +201,14 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             assertEquals(id1, result1.single()[ArrayTestTable.id])
 
             val result2 = ArrayTestTable.select(ArrayTestTable.id).where {
-                ArrayTestTable.doubles eq arrayParam(doublesInput, DoubleColumnType())
+                ArrayTestTable.doubles eq arrayParam(doublesInput)
             }
             assertEquals(id1, result2.single()[ArrayTestTable.id])
 
             if (currentDialectTest is PostgreSQLDialect) {
                 val lastStrings = ArrayTestTable.strings.slice(lower = 4) // strings[4:]
                 val result3 = ArrayTestTable.select(ArrayTestTable.id).where {
-                    lastStrings eq arrayLiteral(listOf("hello"), TextColumnType())
+                    lastStrings eq arrayLiteral(listOf("hello"))
                 }
                 assertEquals(id1, result3.single()[ArrayTestTable.id])
             }
@@ -282,6 +282,11 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
                 ArrayTestTable.id lessEq allFrom(ArrayTestTable.numbers)
             }
             assertEquals(id1, result3.single()[ArrayTestTable.id])
+
+            val result4 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id greater allFrom(arrayParam(numInput))
+            }
+            assertTrue(result4.toList().isEmpty())
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -23,9 +23,9 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
     private val arrayTypeUnsupportedDb = TestDB.entries - (TestDB.postgreSQLRelatedDB + TestDB.H2 + TestDB.H2_PSQL).toSet()
 
     object ArrayTestTable : IntIdTable("array_test_table") {
-        val numbers = array<Int>("numbers", IntegerColumnType()).default(listOf(5))
+        val numbers = array<Int>("numbers").default(listOf(5))
         val strings = array<String?>("strings", TextColumnType()).default(emptyList())
-        val doubles = array<Double>("doubles", DoubleColumnType()).nullable()
+        val doubles = array<Double>("doubles").nullable()
     }
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -258,4 +258,35 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             assertContentEquals(doublesInput, ArrayTestDao.all().single().doubles)
         }
     }
+
+    @Test
+    fun testArrayColumnWithAllAnyOps() {
+        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
+            val numInput = listOf(1, 2, 3)
+            val id1 = ArrayTestTable.insertAndGetId {
+                it[numbers] = numInput
+                it[doubles] = null
+            }
+
+            val result1 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id eq anyFrom(ArrayTestTable.numbers)
+            }
+            assertEquals(id1, result1.single()[ArrayTestTable.id])
+
+            val result2 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id eq anyFrom(ArrayTestTable.numbers.slice(2, 3))
+            }
+            assertTrue(result2.toList().isEmpty())
+
+            val result3 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id lessEq allFrom(ArrayTestTable.numbers)
+            }
+            assertEquals(id1, result3.single()[ArrayTestTable.id])
+
+            val result4 = ArrayTestTable.select(ArrayTestTable.id).where {
+                ArrayTestTable.id greater allFrom(arrayParam(numInput))
+            }
+            assertTrue(result4.toList().isEmpty())
+        }
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -258,35 +258,4 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             assertContentEquals(doublesInput, ArrayTestDao.all().single().doubles)
         }
     }
-
-    @Test
-    fun testArrayColumnWithAllAnyOps() {
-        withTables(excludeSettings = arrayTypeUnsupportedDb, ArrayTestTable) {
-            val numInput = listOf(1, 2, 3)
-            val id1 = ArrayTestTable.insertAndGetId {
-                it[numbers] = numInput
-                it[doubles] = null
-            }
-
-            val result1 = ArrayTestTable.select(ArrayTestTable.id).where {
-                ArrayTestTable.id eq anyFrom(ArrayTestTable.numbers)
-            }
-            assertEquals(id1, result1.single()[ArrayTestTable.id])
-
-            val result2 = ArrayTestTable.select(ArrayTestTable.id).where {
-                ArrayTestTable.id eq anyFrom(ArrayTestTable.numbers.slice(2, 3))
-            }
-            assertTrue(result2.toList().isEmpty())
-
-            val result3 = ArrayTestTable.select(ArrayTestTable.id).where {
-                ArrayTestTable.id lessEq allFrom(ArrayTestTable.numbers)
-            }
-            assertEquals(id1, result3.single()[ArrayTestTable.id])
-
-            val result4 = ArrayTestTable.select(ArrayTestTable.id).where {
-                ArrayTestTable.id greater allFrom(arrayParam(numInput))
-            }
-            assertTrue(result4.toList().isEmpty())
-        }
-    }
 }


### PR DESCRIPTION
1. Replace `UntypedAndUnsizedArrayColumnType` from PR #1886   with `ArrayColumnType` from PR #1986 
    - Remove unused dialect data types
2. Introduce function `resolveColumnType()` that returns an appropriate column type based on type reflection
    - Refactor existing array and json functions to use this so that users don't need to manually provide a base column type
    - Provide a nullable override so that the base column type can be explicitly defined

**Note** This is a potentially breaking change in the (unlikely) event that users were providing an array of non-primitive or unsupported types to `anyFrom()` or `allFrom()`, for example: `anyFrom(arrayOf<BigInteger>())`. The recommendation will be to provide the best match or custom column type to the new parameter.