### PR TITLE
fix: EXPOSED-292 Explicit nulls in insert with databaseGenerated()

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -162,6 +162,7 @@ class Column<T>(
         it.foreignKey = this.foreignKey
         it.defaultValueFun = this.defaultValueFun
         it.dbDefaultValue = this.dbDefaultValue
+        it.isDatabaseGenerated = this.isDatabaseGenerated
     }
 
     override fun compareTo(other: Column<*>): Int = comparator.compare(this, other)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1112,6 +1112,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         newColumn.defaultValueFun = defaultValueFun
         @Suppress("UNCHECKED_CAST")
         newColumn.dbDefaultValue = dbDefaultValue as Expression<T?>?
+        newColumn.isDatabaseGenerated = isDatabaseGenerated
         newColumn.columnType.nullable = true
         return replaceColumn(this, newColumn)
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BaseBatchInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BaseBatchInsertStatement.kt
@@ -88,7 +88,9 @@ abstract class BaseBatchInsertStatement(
 
     override var arguments: List<List<Pair<Column<*>, Any?>>>? = null
         get() = field ?: run {
-            val nullableColumns by lazy { allColumnsInDataSet().filter { it.columnType.nullable } }
+            val nullableColumns by lazy {
+                allColumnsInDataSet().filter { it.columnType.nullable && !it.isDatabaseGenerated }
+            }
             data.map { single ->
                 val valuesAndDefaults = super.valuesAndDefaults(single) as MutableMap
                 val nullableMap = (nullableColumns - valuesAndDefaults.keys).associateWith { null }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -201,7 +201,7 @@ open class InsertStatement<Key : Any>(
 
     protected open var arguments: List<List<Pair<Column<*>, Any?>>>? = null
         get() = field ?: run {
-            val nullableColumns = table.columns.filter { it.columnType.nullable }
+            val nullableColumns = table.columns.filter { it.columnType.nullable && !it.isDatabaseGenerated }
             val valuesAndDefaults = valuesAndDefaults() as MutableMap
             valuesAndDefaults.putAll((nullableColumns - valuesAndDefaults.keys).associateWith { null })
             val result = valuesAndDefaults.toList().sortedBy { it.first }


### PR DESCRIPTION
If a generated/computed column is marked as such using `databaseGenerated()`, but it is also `nullable()`, an exception is thrown even when the field is correctly excluded from an `insert()` block.

This occurs because a NULL value is still being auto-included for that column in the prepared insert statement.

**Additional:**
- Add `isDatabaseGenerated` property to places where `Column` is copied, so that, for example, switching the chain order leads to equivalent results: `.nullable().databaseGenerated()` vs `.databaseGenerated().nullable()`