### PR TITLE
fix: Add ArrayColumnType default override for datetime module types

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -160,6 +160,7 @@ public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exp
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
 	public final fun getDelegateType ()Ljava/lang/String;
 	public final fun getMaximumCardinality ()Ljava/lang/Integer;
+	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -1080,6 +1080,15 @@ class ArrayColumnType(
         else -> super.nonNullValueToString(value)
     }
 
+    override fun nonNullValueAsDefaultString(value: Any): String = when (value) {
+        is List<*> -> {
+            val prefix = if (currentDialect is H2Dialect) "ARRAY [" else "ARRAY["
+            value.joinToString(",", prefix, "]") { delegate.valueAsDefaultString(it) }
+        }
+        is Array<*> -> nonNullValueAsDefaultString(value.toList())
+        else -> super.nonNullValueAsDefaultString(value)
+    }
+
     override fun readObject(rs: ResultSet, index: Int): Any? = rs.getArray(index)
 
     override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -18,6 +18,7 @@ import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
@@ -472,6 +473,38 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             fakeTestTable.insert {}
 
             currentDbDateTime()
+        }
+    }
+
+    @Test
+    fun testDateTimeAsArray() {
+        val defaultDates = listOf(today)
+        val defaultDateTimes = listOf(LocalDateTime.now())
+        val tester = object : Table("array_tester") {
+            val dates = array<LocalDate>("dates", JavaLocalDateColumnType()).default(defaultDates)
+            val datetimes = array<LocalDateTime>("datetimes", JavaLocalDateTimeColumnType()).default(defaultDateTimes)
+        }
+
+        withTables(excludeSettings = TestDB.entries - TestDB.POSTGRESQL - TestDB.H2, tester) {
+            tester.insert { }
+            val result1 = tester.selectAll().single()
+            assertEqualLists(result1[tester.dates], defaultDates)
+            assertEqualLists(result1[tester.datetimes], defaultDateTimes)
+
+            val datesInput = List(3) { LocalDate.of(2020 + it, 5, 4) }
+            val datetimeInput = List(3) { LocalDateTime.of(2020 + it, 5, 4, 9, 9, 9) }
+            tester.insert {
+                it[dates] = datesInput
+                it[datetimes] = datetimeInput
+            }
+
+            val lastDate = tester.dates[3]
+            val firstTwoDatetimes = tester.datetimes.slice(1, 2)
+            val result2 = tester.select(lastDate, firstTwoDatetimes).where {
+                tester.dates[1].year() eq 2020
+            }.single()
+            assertEqualDateTime(datesInput.last(), result2[lastDate])
+            assertEqualLists(result2[firstTwoDatetimes], datetimeInput.take(2))
         }
     }
 }

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -384,7 +384,6 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
         }
 
         withTables(excludeSettings = TestDB.entries - TestDB.POSTGRESQL - TestDB.H2, tester) {
-            addLogger(StdOutSqlLogger)
             tester.insert { }
             val result1 = tester.selectAll().single()
             assertEqualLists(result1[tester.dates], defaultDates)

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -17,6 +17,7 @@ import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
@@ -370,6 +371,39 @@ open class JodaTimeBaseTest : DatabaseTestsBase() {
             fakeTestTable.insert {}
 
             currentDbDateTime()
+        }
+    }
+
+    @Test
+    fun testDateTimeAsArray() {
+        val defaultDates = listOf(today)
+        val defaultDateTimes = listOf(DateTime.now())
+        val tester = object : Table("array_tester") {
+            val dates = array<DateTime>("dates", DateColumnType(false)).default(defaultDates)
+            val datetimes = array<DateTime>("datetimes", DateColumnType(true)).default(defaultDateTimes)
+        }
+
+        withTables(excludeSettings = TestDB.entries - TestDB.POSTGRESQL - TestDB.H2, tester) {
+            addLogger(StdOutSqlLogger)
+            tester.insert { }
+            val result1 = tester.selectAll().single()
+            assertEqualLists(result1[tester.dates], defaultDates)
+            assertEqualLists(result1[tester.datetimes], defaultDateTimes)
+
+            val datesInput = List(3) { DateTime.parse("${2020 + it}-5-4") }
+            val datetimeInput = List(3) { DateTime(2020 + it, 5, 4, 9, 9, 9) }
+            tester.insert {
+                it[dates] = datesInput
+                it[datetimes] = datetimeInput
+            }
+
+            val lastDate = tester.dates[3]
+            val firstTwoDatetimes = tester.datetimes.slice(1, 2)
+            val result2 = tester.select(lastDate, firstTwoDatetimes).where {
+                tester.dates[1].year() eq 2020
+            }.single()
+            assertEqualDateTime(datesInput.last(), result2[lastDate])
+            assertEqualLists(result2[firstTwoDatetimes], datetimeInput.take(2))
         }
     }
 }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -14,6 +14,7 @@ import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
@@ -479,6 +480,38 @@ open class KotlinTimeBaseTest : DatabaseTestsBase() {
             }
             val row = tester.selectAll().where { tester.duration eq Duration.INFINITE }.single()
             assertEquals(Duration.INFINITE, row[tester.duration])
+        }
+    }
+
+    @Test
+    fun testDateTimeAsArray() {
+        val defaultDates = listOf(now().date)
+        val defaultDateTimes = listOf(now())
+        val tester = object : Table("array_tester") {
+            val dates = array<LocalDate>("dates", KotlinLocalDateColumnType()).default(defaultDates)
+            val datetimes = array<LocalDateTime>("datetimes", KotlinLocalDateTimeColumnType()).default(defaultDateTimes)
+        }
+
+        withTables(excludeSettings = TestDB.entries - TestDB.POSTGRESQL - TestDB.H2, tester) {
+            tester.insert { }
+            val result1 = tester.selectAll().single()
+            assertEqualLists(result1[tester.dates], defaultDates)
+            assertEqualLists(result1[tester.datetimes], defaultDateTimes)
+
+            val datesInput = List(3) { LocalDate(2020 + it, 5, 4) }
+            val datetimeInput = List(3) { LocalDateTime(2020 + it, 5, 4, 9, 9, 9) }
+            tester.insert {
+                it[dates] = datesInput
+                it[datetimes] = datetimeInput
+            }
+
+            val lastDate = tester.dates[3]
+            val firstTwoDatetimes = tester.datetimes.slice(1, 2)
+            val result2 = tester.select(lastDate, firstTwoDatetimes).where {
+                tester.dates[1].year() eq 2020
+            }.single()
+            assertEqualDateTime(datesInput.last(), result2[lastDate])
+            assertEqualLists(result2[firstTwoDatetimes], datetimeInput.take(2))
         }
     }
 }


### PR DESCRIPTION
1. Add column type override so default datetime lists are not treated as text type.
2. Add unit tests in the 3 datetime modules.