### PR TITLE
docs: Add details about ArrayColumnType and ANY/ALL operators

### DIFF
--- a/documentation-website/Writerside/topics/Asynchronous-Support.md
+++ b/documentation-website/Writerside/topics/Asynchronous-Support.md
@@ -70,7 +70,7 @@ This function will accept the same parameters as `newSuspendedTransaction()` abo
 which you could call `await` on to achieve your result.
 
 <note>
-`newSuspendedTransaction()` and `suspendedTransactionAsync()` are always executed in a new transaction to prevent concurrency issues when query 
-execution order could be changed by `CoroutineDispatcher`. 
-This means that nesting these suspend transactions may not result in the same behavior as nested `transaction`s (when `useNestedTransactions = false`).
+<code>newSuspendedTransaction()</code> and <code>suspendedTransactionAsync()</code> are always executed in a new transaction to prevent concurrency issues when query 
+execution order could be changed by <code>CoroutineDispatcher</code>. 
+This means that nesting these suspend transactions may not result in the same behavior as nested <code>transaction</code>s (when <code>useNestedTransactions = false</code>).
 </note>

--- a/documentation-website/Writerside/topics/Data-Types.md
+++ b/documentation-website/Writerside/topics/Data-Types.md
@@ -86,13 +86,12 @@ class PGEnum<T : Enum<T>>(enumTypeName: String, enumValue: T?) : PGobject() {
 }
 
 object EnumTable : Table() {
-    val enumColumn = customEnumeration("enumColumn", "FooEnum", {value -> Foo.valueOf(value as String)}, { PGEnum("FooEnum", it) }
+    val enumColumn = customEnumeration("enumColumn", "FooEnum", {value -> Foo.valueOf(value as String)}, { PGEnum("FooEnum", it) })
 }
-...
+
 transaction {
    exec("CREATE TYPE FooEnum AS ENUM ('Bar', 'Baz');")
    SchemaUtils.create(EnumTable)
-   ...
 }
 ```
 

--- a/documentation-website/Writerside/topics/Data-Types.md
+++ b/documentation-website/Writerside/topics/Data-Types.md
@@ -17,6 +17,7 @@ Exposed supports the following data types in the table definition:
 * `binary` - `VARBINARY` with length
 * `uuid` - `BINARY(16)`
 * `reference` - a foreign key
+* `array` - `ARRAY`
 
 The `exposed-java-time` extension (`org.jetbrains.exposed:exposed-java-time:$exposed_version`) provides additional types:
 
@@ -115,22 +116,22 @@ data class Project(val name: String, val language: String, val active: Boolean)
 
 val format = Json { prettyPrint = true }
 
-object Team : Table("team") {
+object Teams : Table("team") {
     val groupId = varchar("group_id", 32)
     val project = json<Project>("project", format) // equivalent to json("project", format, Project.serializer())
 }
 
 transaction {
     val mainProject = Project("Main", "Java", true)
-    Team.insert {
+    Teams.insert {
         it[groupId] = "A"
         it[project] = mainProject
     }
-    Team.update({ Team.groupId eq "A" }) {
+    Teams.update({ Teams.groupId eq "A" }) {
         it[project] = mainProject.copy(language = "Kotlin")
     }
 
-    Team.selectAll().map { "Team ${it[Team.groupId]} -> ${it[Team.project]}" }.forEach { println(it) }
+    Teams.selectAll().map { "Team ${it[Teams.groupId]} -> ${it[Teams.project]}" }.forEach { println(it) }
     // Team A -> Project(name=Main, language=Kotlin, active=true)
 }
 ```
@@ -144,35 +145,35 @@ fun <T : Any> json(name: String, serialize: (T) -> String, deserialize: (String)
 
 JSON path strings can be used to extract values (either as JSON or as a scalar value) at a specific field/key:
 ```kotlin
-val projectName = Team.project.extract<String>("name")
-val languageIsKotlin = Team.project.extract<String>("language").lowerCase() eq "kotlin"
-Team.select(projectName).where { languageIsKotlin }.map { it[projectName] }
+val projectName = Teams.project.extract<String>("name")
+val languageIsKotlin = Teams.project.extract<String>("language").lowerCase() eq "kotlin"
+Teams.select(projectName).where { languageIsKotlin }.map { it[projectName] }
 ```
 
 <note>
-Databases that support a path context root `$` will have this value appended to the generated SQL path expression 
+Databases that support a path context root <code>$</code> will have this value appended to the generated SQL path expression 
 by default, so it is not necessary to include it in the provided argument String. In the above example, if MySQL is being 
-used, the provided path arguments should be `.name` and `.language` respectively.
+used, the provided path arguments should be <code>.name</code> and <code>.language</code> respectively.
 </note>
 
 The JSON functions `exists()` and `contains()` are currently supported as well:
 ```kotlin
-val hasActiveStatus = Team.project.exists(".active")
-val activeProjects = Team.selectAll().where { hasActiveStatus }.count()
+val hasActiveStatus = Teams.project.exists(".active")
+val activeProjects = Teams.selectAll().where { hasActiveStatus }.count()
 
 // Depending on the database, filter paths can be provided instead, as well as optional arguments
 // PostgreSQL example
 val mainId = "Main"
-val hasMainProject = Team.project.exists(".name ? (@ == \$main)", optional = "{\"main\":\"$mainId\"}")
-val mainProjects = Team.selectAll().where { hasMainProject }.map { it[Team.groupId] }
+val hasMainProject = Teams.project.exists(".name ? (@ == \$main)", optional = "{\"main\":\"$mainId\"}")
+val mainProjects = Teams.selectAll().where { hasMainProject }.map { it[Teams.groupId] }
 
-val usesKotlin = Team.project.contains("{\"language\":\"Kotlin\"}")
-val kotlinTeams = Team.selectAll().where { usesKotlin }.count()
+val usesKotlin = Teams.project.contains("{\"language\":\"Kotlin\"}")
+val kotlinTeams = Teams.selectAll().where { usesKotlin }.count()
 
 // Depending on the database, an optional path can be provided too
 // MySQL example
-val usesKotlin = Team.project.contains("\"Kotlin\"", ".language")
-val kotlinTeams = Team.selectAll().where { usesKotlin }.count()
+val usesKotlin = Teams.project.contains("\"Kotlin\"", ".language")
+val kotlinTeams = Teams.selectAll().where { usesKotlin }.count()
 ```
 
 ### Json Arrays
@@ -199,4 +200,70 @@ transaction {
     // generates SQL
     // INSERT INTO team_projects (member_ids, projects) VALUES ([1,2,3], [{"name":"A","language":"Kotlin","active":true},{"name":"B","language":"Java","active":true}])
 }
+```
+
+## How to use Array types
+
+PostgreSQL and H2 databases support the explicit ARRAY data type.
+
+Exposed currently only supports columns defined as one-dimensional arrays, with the stored contents being any out-of-the-box or custom data type.
+If the contents are of a type with a supported `ColumnType` in the `exposed-core` module, the column can be simply defined with that type:
+```kotlin
+object Teams : Table("teams") {
+    val memberIds = array<UUID>("member_ids")
+    val memberNames = array<String>("member_names")
+    val budgets = array<Double>("budgets")
+}
+```
+
+If more control is needed over the base content type, or if the latter is user-defined or from a non-core module, the explicit type should be provided to the function:
+```kotlin
+object Teams : Table("teams") {
+    val memberIds = array<UUID>("member_ids")
+    val memberNames = array<String>("member_names", VarCharColumnType(colLength = 32))
+    val deadlines = array<LocalDate>("deadlines", KotlinLocalDateColumnType()).nullable()
+    val budgets = array<Double>("budgets")
+    val expenses = array<Double?>("expenses", DoubleColumnType()).default(emptyList())
+}
+```
+This will prevent an exception being thrown if Exposed cannot find an associated column mapping for the defined type.
+Null array contents are allowed, and the explicit column type should be provided for these columns as well.
+
+An array column accepts inserts and retrieves stored array contents as a Kotlin `List`:
+```kotlin
+Teams.insert {
+    it[memberIds] = List(5) { UUID.randomUUID() }
+    it[memberNames] = List(5) { i -> "Member ${'A' + i}" }
+    it[budgets] = listOf(9999.0)
+}
+```
+
+### Array Functions
+
+A single element in a stored array can be accessed using the index reference `get()` operator:
+```kotlin
+val firstMember = Teams.memberIds[1]
+Teams
+    .select(firstMember)
+    .where { Teams.expenses[1] greater Teams.budgets[1] }
+```
+<note>
+Both PostgreSQL and H2 use a one-based indexing convention, so the first element is retrieved by using index 1.
+</note>
+
+A new subarray can also be accessed by using `slice()`, which takes a lower and upper bound (inclusive):
+```kotlin
+Teams.select(Teams.deadlines.slice(1, 3))
+```
+Both arguments for these bounds are optional if using PostgreSQL.
+
+An array column can also be used as an argument for the `ANY` and `ALL` SQL operators, either by providing the entire column or a new array expression via `slice()`:
+```kotlin
+Teams
+    .selectAll()
+    .where { Teams.budgets[1] lessEq allFrom(Teams.expenses) }
+
+Teams
+    .selectAll()
+    .where { stringParam("Member A") eq anyFrom(Teams.memberNames.slice(1, 4)) }
 ```

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -302,6 +302,13 @@ StarWarsFilms.selectAll().where {
 
 `notInList` is available to check for expressions that are not equal to any elements in the provided collection.
 
+In addition to the `IN` operator, the `ANY` and `ALL` operators are available with any preceding comparison operator:
+```kotlin
+StarWarsFilms.selectAll().where { StarWarsFilms.sequelId eq anyFrom(arrayOf(6, 4)) }
+```
+
+`anyFrom()` and `allFrom()` also accept subqueries, tables, and array expressions as arguments.
+
 ## Count
 
 `count()` is a method of `Query` that is used like in the example below:
@@ -661,9 +668,9 @@ is no defined primary key, the first unique index is used. If there are no uniqu
 differently, so it is strongly advised that keys are defined to avoid unexpected results.
 
 <note>
-Databases that do not support a specific Insert or Update command implement the standard `MERGE INTO ... USING` statement with aliases and a derived table column list. 
+Databases that do not support a specific Insert or Update command implement the standard <code>MERGE INTO ... USING</code> statement with aliases and a derived table column list. 
 These include Oracle, SQL Server, and H2 compatibility modes (except for MySQL mode). 
-Any columns defined as key constraints (to be used in the `ON` clause) must be included in the statement block to avoid throwing an error.
+Any columns defined as key constraints (to be used in the <code>ON</code> clause) must be included in the statement block to avoid throwing an error.
 </note>
 
 ## Replace
@@ -709,6 +716,6 @@ Also, the constraints used to assess a violation are limited to the primary key 
 The values specified in the statement block will be used for the insert statement and any omitted columns are set to their default values, if applicable.
 
 <note>
-In the example above, if the original row was inserted with a user-defined `rating`, then `replace()` was executed with a block that omitted the `rating` column, 
+In the example above, if the original row was inserted with a user-defined <code>rating</code>, then <code>replace()</code> was executed with a block that omitted the <code>rating</code> column, 
 the newly inserted row would store the default rating value. This is because the old row was completely deleted first.
 </note>

--- a/documentation-website/Writerside/topics/Table-Definition.md
+++ b/documentation-website/Writerside/topics/Table-Definition.md
@@ -127,10 +127,10 @@ Table.indices.map { it.indexName to it.createStatement().first() }
 ```
 
 <note>
-An instance of the `Index` data class can be created directly using its public constructor, for the purpose of 
+An instance of the <code>Index</code> data class can be created directly using its public constructor, for the purpose of 
 evaluating or using  create/modify/drop statements, for example. Doing so will not add the instance to an existing table's 
-list of indices in the way that using `index()` would. Also, if an instance is created with arguments provided to the 
-`functions` parameter, a `functionsTable` argument must also be provided.
+list of indices in the way that using <code>index()</code> would. Also, if an instance is created with arguments provided to the 
+<code>functions</code> parameter, a <code>functionsTable</code> argument must also be provided.
 </note>
 
 ### Unique

--- a/documentation-website/Writerside/topics/Working-with-Transaction.md
+++ b/documentation-website/Writerside/topics/Working-with-Transaction.md
@@ -27,8 +27,8 @@ val jamesList = transaction {
 ```
 
 <note>
-`Blob` and `text` fields won't be available outside of a transaction if you don't load them directly. For `text` fields you can also use
-the `eagerLoading` param when defining the Table to make the text fields available outside of the transaction.
+<code>Blob</code> and <code>text</code> fields won't be available outside of a transaction if you don't load them directly. For <code>text</code> fields you can also use
+the <code>eagerLoading</code> param when defining the Table to make the text fields available outside of the transaction.
 </note>
 
 ```kotlin
@@ -208,7 +208,7 @@ transaction {
 ```
 
 <note>
-As is the case for `transactionIsolation` and `readOnly` properties, this value is not directly managed by Exposed, but is simply relayed to the JDBC driver. 
+As is the case for <code>transactionIsolation</code> and <code>readOnly</code> properties, this value is not directly managed by Exposed, but is simply relayed to the JDBC driver. 
 Some drivers may not support implementing this limit.
 </note>
 


### PR DESCRIPTION
- Add section about using `anyFrom` and `allFrom` to check collections
- Add array type and a how-to-use section
- Pluralize existing table object name to match
- Replace inline markdown with `<code>` tags when nested in `<note>` tag.
    - On Preview, elements wrapped with backticks were not being properly formatted if they were nested in a note block.