### PR TITLE
build!: EXPOSED-234 Set exposed-crypt to jdk 17 & bump spring-security-crypto to 6.+

### DIFF
--- a/exposed-crypt/build.gradle.kts
+++ b/exposed-crypt/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("jvm") apply true
 }
@@ -7,10 +9,20 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 dependencies {
     api(project(":exposed-core"))
     api(libs.spring.security.crypto)
+    testImplementation(project(":exposed-dao"))
+    testImplementation(project(":exposed-tests"))
+    testImplementation(libs.junit)
+    testImplementation(kotlin("test-junit"))
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }

--- a/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnTests.kt
+++ b/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnTests.kt
@@ -1,0 +1,92 @@
+package org.jetbrains.exposed.crypt
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.update
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class EncryptedColumnTests : DatabaseTestsBase() {
+    @Test
+    fun testOutputLengthOfEncryption() {
+        fun testSize(algorithm: String, encryptor: Encryptor, str: String) =
+            assertEquals(
+                encryptor.maxColLength(str.toByteArray().size),
+                encryptor.encrypt(str).toByteArray().size,
+                "Failed to calculate length of $algorithm's output."
+            )
+
+        val encryptors = arrayOf(
+            "AES_256_PBE_GCM" to Algorithms.AES_256_PBE_GCM("passwd", "12345678"),
+            "AES_256_PBE_CBC" to Algorithms.AES_256_PBE_CBC("passwd", "12345678"),
+            "BLOW_FISH" to Algorithms.BLOW_FISH("sadsad"),
+            "TRIPLE_DES" to Algorithms.TRIPLE_DES("1".repeat(24))
+        )
+        val testStrings = arrayOf("1", "2".repeat(10), "3".repeat(31), "4".repeat(1001), "5".repeat(5391))
+
+        for ((algorithm, encryptor) in encryptors) {
+            for (testStr in testStrings) {
+                testSize(algorithm, encryptor, testStr)
+            }
+        }
+    }
+
+    @Test
+    fun testEncryptedColumnTypeWithAString() {
+        val stringTable = object : IntIdTable("StringTable") {
+            val name = encryptedVarchar("name", 80, Algorithms.AES_256_PBE_CBC("passwd", "5c0744940b5c369b"))
+            val city = encryptedBinary("city", 80, Algorithms.AES_256_PBE_GCM("passwd", "5c0744940b5c369b"))
+            val address = encryptedVarchar("address", 100, Algorithms.BLOW_FISH("key"))
+            val age = encryptedVarchar("age", 100, Algorithms.TRIPLE_DES("1".repeat(24)))
+        }
+
+        withTables(stringTable) {
+            val id1 = stringTable.insertAndGetId {
+                it[name] = "testName"
+                it[city] = "testCity".toByteArray()
+                it[address] = "testAddress"
+                it[age] = "testAge"
+            }
+
+            assertEquals(1L, stringTable.selectAll().count())
+
+            assertEquals("testName", stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.name])
+            assertEquals("testCity", String(stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.city]))
+            assertEquals("testAddress", stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.address])
+            assertEquals("testAge", stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.age])
+        }
+    }
+
+    @Test
+    fun testUpdateEncryptedColumnType() {
+        val stringTable = object : IntIdTable("StringTable") {
+            val name = encryptedVarchar("name", 100, Algorithms.AES_256_PBE_GCM("passwd", "12345678"))
+            val city = encryptedBinary("city", 100, Algorithms.AES_256_PBE_CBC("passwd", "12345678"))
+            val address = encryptedVarchar("address", 100, Algorithms.BLOW_FISH("key"))
+        }
+
+        withTables(stringTable) {
+            val id = stringTable.insertAndGetId {
+                it[name] = "TestName"
+                it[city] = "TestCity".toByteArray()
+                it[address] = "TestAddress"
+            }
+
+            val updatedName = "TestName2"
+            val updatedCity = "TestCity2"
+            val updatedAddress = "TestAddress2"
+            stringTable.update({ stringTable.id eq id }) {
+                it[name] = updatedName
+                it[city] = updatedCity.toByteArray()
+                it[address] = updatedAddress
+            }
+
+            assertEquals(updatedName, stringTable.selectAll().where { stringTable.id eq id }.single()[stringTable.name])
+            assertEquals(updatedCity, String(stringTable.selectAll().where { stringTable.id eq id }.single()[stringTable.city]))
+            assertEquals(updatedAddress, stringTable.selectAll().where { stringTable.id eq id }.single()[stringTable.address])
+        }
+    }
+}

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -22,7 +22,6 @@ dependencies {
     implementation(project(":exposed-core"))
     implementation(project(":exposed-jdbc"))
     implementation(project(":exposed-dao"))
-    implementation(project(":exposed-crypt"))
 
     implementation(libs.slf4j)
     implementation(libs.log4j.slf4j.impl)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
 import nl.altindag.log.LogCaptor
-import org.jetbrains.exposed.crypt.Algorithms
-import org.jetbrains.exposed.crypt.encryptedBinary
-import org.jetbrains.exposed.crypt.encryptedVarchar
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
@@ -491,32 +488,6 @@ class SelectTests : DatabaseTestsBase() {
 
             val veryLongString = "1".repeat(255)
             assertEquals(0, stringTable.selectAll().where { stringTable.name eq veryLongString }.count())
-        }
-    }
-
-    @Test
-    fun testEncryptedColumnTypeWithAString() {
-        val stringTable = object : IntIdTable("StringTable") {
-            val name = encryptedVarchar("name", 80, Algorithms.AES_256_PBE_CBC("passwd", "5c0744940b5c369b"))
-            val city = encryptedBinary("city", 80, Algorithms.AES_256_PBE_GCM("passwd", "5c0744940b5c369b"))
-            val address = encryptedVarchar("address", 100, Algorithms.BLOW_FISH("key"))
-            val age = encryptedVarchar("age", 100, Algorithms.TRIPLE_DES("1".repeat(24)))
-        }
-
-        withTables(stringTable) {
-            val id1 = stringTable.insertAndGetId {
-                it[name] = "testName"
-                it[city] = "testCity".toByteArray()
-                it[address] = "testAddress"
-                it[age] = "testAge"
-            }
-
-            assertEquals(1L, stringTable.selectAll().count())
-
-            assertEquals("testName", stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.name])
-            assertEquals("testCity", String(stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.city]))
-            assertEquals("testAddress", stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.address])
-            assertEquals("testAge", stringTable.selectAll().where { stringTable.id eq id1 }.first()[stringTable.age])
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
@@ -1,8 +1,5 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
-import org.jetbrains.exposed.crypt.Algorithms
-import org.jetbrains.exposed.crypt.encryptedBinary
-import org.jetbrains.exposed.crypt.encryptedVarchar
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
@@ -168,36 +165,6 @@ class UpdateTests : DatabaseTestsBase() {
                     // empty
                 }
             }
-        }
-    }
-
-    @Test
-    fun `update encryptedColumnType`() {
-        val stringTable = object : IntIdTable("StringTable") {
-            val name = encryptedVarchar("name", 100, Algorithms.AES_256_PBE_GCM("passwd", "12345678"))
-            val city = encryptedBinary("city", 100, Algorithms.AES_256_PBE_CBC("passwd", "12345678"))
-            val address = encryptedVarchar("address", 100, Algorithms.BLOW_FISH("key"))
-        }
-
-        withTables(stringTable) {
-            val id = stringTable.insertAndGetId {
-                it[name] = "TestName"
-                it[city] = "TestCity".toByteArray()
-                it[address] = "TestAddress"
-            }
-
-            val updatedName = "TestName2"
-            val updatedCity = "TestCity2"
-            val updatedAddress = "TestAddress2"
-            stringTable.update({ stringTable.id eq id }) {
-                it[name] = updatedName
-                it[city] = updatedCity.toByteArray()
-                it[address] = updatedAddress
-            }
-
-            assertEquals(updatedName, stringTable.selectAll().where { stringTable.id eq id }.single()[stringTable.name])
-            assertEquals(updatedCity, String(stringTable.selectAll().where { stringTable.id eq id }.single()[stringTable.city]))
-            assertEquals(updatedAddress, stringTable.selectAll().where { stringTable.id eq id }.single()[stringTable.address])
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -1,11 +1,8 @@
 package org.jetbrains.exposed.sql.tests.shared.functions
 
-import org.jetbrains.exposed.crypt.Algorithms
-import org.jetbrains.exposed.crypt.Encryptor
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.concat
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -15,7 +12,6 @@ import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.tests.shared.dml.withCitiesAndUsers
 import org.jetbrains.exposed.sql.vendors.*
 import org.junit.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -612,30 +608,6 @@ class FunctionsTests : DatabaseTestsBase() {
             val concatField3 = SqlExpressionBuilder.run { "Hi " plus users.name + "!" }
             val result3 = users.select(concatField3).where { users.id eq "andrey" }.single()
             assertEquals("Hi Andrey!", result3[concatField3])
-        }
-    }
-
-    private val encryptors = arrayOf(
-        "AES_256_PBE_GCM" to Algorithms.AES_256_PBE_GCM("passwd", "12345678"),
-        "AES_256_PBE_CBC" to Algorithms.AES_256_PBE_CBC("passwd", "12345678"),
-        "BLOW_FISH" to Algorithms.BLOW_FISH("sadsad"),
-        "TRIPLE_DES" to Algorithms.TRIPLE_DES("1".repeat(24))
-    )
-    private val testStrings = arrayOf("1", "2".repeat(10), "3".repeat(31), "4".repeat(1001), "5".repeat(5391))
-
-    @Test
-    fun `test output length of encryption`() {
-        fun testSize(algorithm: String, encryptor: Encryptor, str: String) =
-            assertEquals(
-                encryptor.maxColLength(str.toByteArray().size),
-                encryptor.encrypt(str).toByteArray().size,
-                "Failed to calculate length of $algorithm's output."
-            )
-
-        for ((algorithm, encryptor) in encryptors) {
-            for (testStr in testStrings) {
-                testSize(algorithm, encryptor, testStr)
-            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ sqlserver = "9.4.1.jre8"
 springFramework = "6.1.4"
 springBoot = "3.2.0"
 
-spring-security-crypto = "5.8.8"
+spring-security-crypto = "6.2.1"
 joda-time = "2.12.7"
 junit = "4.13.2"
 kotlinx-datetime = "0.5.0"


### PR DESCRIPTION
- Bump `spring-security-crypto` dependency from 5.8.8 to 6.2.1.
    - As for the other spring modules, upgrading to version 6.+ now requires JDK 17.
- Relocate related tests from `exposed-tests` to dedicated test directory in `exposed-crypt`.
    - `exposed-tests` uses JDK 8, so its dependency on the `exposed-crypt` project fails.