### PR TITLE
fix: EXPOSED-299 [H2 modes] SchemaUtils drops and adds identical composite foreign key

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3588,6 +3588,7 @@ public class org/jetbrains/exposed/sql/vendors/H2Dialect : org/jetbrains/exposed
 	public final fun isSecondVersion ()Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
+	public fun resolveRefOptionFromJdbc (I)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -641,6 +641,8 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         withTables(CompositePrimaryKeyTable, CompositeForeignKeyTable) {
             SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
             SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            val statements = SchemaUtils.statementsRequiredToActualizeScheme(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            assertTrue(statements.isEmpty())
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
@@ -184,23 +184,15 @@ class ForeignKeyConstraintTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(id)
         }
 
-        withTables(category, item) { testDb ->
+        withTables(category, item) {
             if (currentDialectTest.supportsOnUpdate) {
                 val constraints = connection.metadata {
                     tableConstraints(listOf(item))
                 }
                 constraints.values.forEach { list ->
                     list.forEach {
-                        when (testDb) {
-                            TestDB.H2_ORACLE, TestDB.H2_SQLSERVER -> {
-                                assertEquals(ReferenceOption.RESTRICT, it.updateRule)
-                                assertEquals(ReferenceOption.RESTRICT, it.deleteRule)
-                            }
-                            else -> {
-                                assertEquals(currentDialectTest.defaultReferenceOption, it.updateRule)
-                                assertEquals(currentDialectTest.defaultReferenceOption, it.deleteRule)
-                            }
-                        }
+                        assertEquals(currentDialectTest.defaultReferenceOption, it.updateRule)
+                        assertEquals(currentDialectTest.defaultReferenceOption, it.deleteRule)
                     }
                 }
             }


### PR DESCRIPTION
Calling `SchemaUtils.createMissingTablesAndColumns()` on a table with a composite foreign key incorrectly produces 2 `ALTER` statements (to drop and add the same constraint) when testing on some H2 compatibility modes (Oracle and SQL Server).

This occurs because these H2 modes delegate to the respective dialects which have `NO_ACTION` stored as their default.
But a foreign key sent to the H2 database with `NO_ACTION` is returned by the driver metadata as the equivalent `RESTRICT`, leading to a false constraint equality check.