### PR TITLE
fix: EXPOSED-301 Update with join throws if additionalConstraint provided

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
@@ -6,6 +6,8 @@ import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.H2Dialect.H2CompatibilityMode
 import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
 import org.jetbrains.exposed.sql.vendors.OracleDialect
+import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
 import org.jetbrains.exposed.sql.vendors.h2Mode
 
@@ -45,20 +47,38 @@ open class UpdateStatement(val targetsSet: ColumnSet, val limit: Int?, val where
     }
 
     override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = QueryBuilder(true).run {
+        val dialect = currentDialect
         when {
-            targetsSet is Join && currentDialect is OracleDialect -> {
-                where?.toQueryBuilder(this)
-                values.forEach {
-                    registerArgument(it.key, it.value)
-                }
+            targetsSet is Join && dialect is OracleDialect -> {
+                registerAdditionalArgs(targetsSet)
+                registerWhereArg()
+                registerUpdateArgs()
+            }
+            targetsSet is Join && (dialect is SQLServerDialect || dialect is PostgreSQLDialect) -> {
+                registerUpdateArgs()
+                registerAdditionalArgs(targetsSet)
+                registerWhereArg()
+            }
+            targetsSet is Join -> {
+                registerAdditionalArgs(targetsSet)
+                registerUpdateArgs()
+                registerWhereArg()
             }
             else -> {
-                values.forEach {
-                    registerArgument(it.key, it.value)
-                }
-                where?.toQueryBuilder(this)
+                registerUpdateArgs()
+                registerWhereArg()
             }
         }
         if (args.isNotEmpty()) listOf(args) else emptyList()
+    }
+
+    private fun QueryBuilder.registerWhereArg() { where?.toQueryBuilder(this) }
+
+    private fun QueryBuilder.registerUpdateArgs() { values.forEach { registerArgument(it.key, it.value) } }
+
+    private fun QueryBuilder.registerAdditionalArgs(join: Join) {
+        join.joinParts.forEach {
+            it.additionalConstraint?.invoke(SqlExpressionBuilder)?.toQueryBuilder(this)
+        }
     }
 }


### PR DESCRIPTION
Attempting to use any `join` function in its full overload form, with an `additionalConstraint` argument, results in an exception if an `update()` is called after instead of a `select()`, for example:
> org.jetbrains.exposed.exceptions.ExposedSQLException: No value specified for parameter 2.

This occurs because the `additionalConstraint` conditions are being correctly appended to generated SQL, but their arguments are not being first registered with the prepared update statement.

The arguments in the update statement now correctly register any `additionalConstraint` and take into account their order if an update with a WHERE clause is called.

No unit tests existed for the full overload form with `update()`, so they have been added to existing tests.