### PR TITLE
fix: EXPOSED-302 Count with alias fails if table name includes schema

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -301,7 +301,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     override fun count(): Long {
         return if (distinct || groupedByColumns.isNotEmpty() || limit != null) {
             fun Column<*>.makeAlias() =
-                alias(transaction.db.identifierManager.quoteIfNecessary("${table.tableName}_$name"))
+                alias(transaction.db.identifierManager.quoteIfNecessary("${table.tableNameWithoutSchemeSanitized}_$name"))
 
             val originalSet = set
             try {


### PR DESCRIPTION
Attempting to use `count()` in a query that requires an alias (for example, with DISTINCT, GROUP BY, or LIMIT clauses) throws a syntax exception if the table name includes the schema name.

This occurs because the alias name created in `count()` concatenates the full table name with a dot character.

The alias now uses the table name without a schema prefix and sanitized of quotations, if present.