### PR TITLE
fix: EXPOSED-293 Logger prints plaintext value of encryptedVarchar

### DIFF
--- a/exposed-crypt/api/exposed-crypt.api
+++ b/exposed-crypt/api/exposed-crypt.api
@@ -10,6 +10,7 @@ public final class org/jetbrains/exposed/crypt/EncryptedBinaryColumnType : org/j
 	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;I)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -19,6 +20,7 @@ public final class org/jetbrains/exposed/crypt/EncryptedVarCharColumnType : org/
 	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;I)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-crypt/build.gradle.kts
+++ b/exposed-crypt/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     testImplementation(project(":exposed-tests"))
     testImplementation(libs.junit)
     testImplementation(kotlin("test-junit"))
+    testImplementation(libs.logcaptor)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedBinaryColumnType.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedBinaryColumnType.kt
@@ -11,6 +11,10 @@ class EncryptedBinaryColumnType(
     private val encryptor: Encryptor,
     length: Int
 ) : BinaryColumnType(length) {
+    override fun nonNullValueToString(value: Any): String {
+        return super.nonNullValueToString(notNullValueToDB(value))
+    }
+
     override fun notNullValueToDB(value: Any): Any {
         if (value !is ByteArray) {
             error("Unexpected value of type Byte: $value of ${value::class.qualifiedName}")

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedVarCharColumnType.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedVarCharColumnType.kt
@@ -12,6 +12,10 @@ class EncryptedVarCharColumnType(
     private val encryptor: Encryptor,
     colLength: Int,
 ) : VarCharColumnType(colLength) {
+    override fun nonNullValueToString(value: Any): String {
+        return super.nonNullValueToString(notNullValueToDB(value))
+    }
+
     override fun notNullValueToDB(value: Any): Any {
         return encryptor.encrypt(value.toString())
     }

--- a/exposed-crypt/src/test/resources/logback-test.xml
+++ b/exposed-crypt/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS} %level %thread %logger{0}:%method:%line - %message %n</pattern>
+        </encoder>
+    </appender>
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="CONSOLE"/>
+        <includeCallerData>true</includeCallerData>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC" />
+    </root>
+    <logger name="Exposed" level="INFO" additivity="false">
+        <appender-ref ref="ASYNC"/>
+    </logger>
+</configuration>


### PR DESCRIPTION
When using either `encryptedVarchar()` or `encryptedBinary()` columns with an enabled logger, the logger output reveals the actual unencrypted string values for the statement parameters, rather than what is encrypted and sent to the database.

This occurs because both columns delegate to the default `super.nonNullValueToString()` which just processes the provided input values without encryption.

```
// before
INSERT INTO stringtable (address, city, "name") VALUES ('TestAddress', TestCity, 'TestName')

// after
INSERT INTO stringtable (address, city, "name") VALUES ('NCoXob9KL2ffCyERcyae5w==', wVGt2pST+xCE8IvkWF4pjxJt1/t13mNJpgJ+VZU9fOc=, 'JIYzcRaeV0rjc7/9BteruZ+LWykJJQ+Nn9Kz18SWuvg0Opi8ZfD0Cw==')
```