### PR TITLE
docs: Add missing KDocs for exposed-dao Entity API

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -18,7 +18,7 @@ open class ColumnWithTransform<TColumn, TReal>(
     /** The function used to convert a transformed value to a value that can be stored in the original column type. */
     val toColumn: (TReal) -> TColumn,
     toReal: (TColumn) -> TReal,
-    /** Whether the original and transformed value should be cached to avoid multiple conversion calls. */
+    /** Whether the original and transformed values should be cached to avoid multiple conversion calls. */
     protected val cacheResult: Boolean = false
 ) {
     private var cache: Pair<TColumn, TReal>? = null
@@ -282,8 +282,6 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
      * for use in many-to-many relations.
      *
      * The reference should have been defined by the creation of a column using `reference()` on an intermediate table.
-     * This should be used as the [targetColumn], while the id column of the table associated with
-     * this [EntityClass] should be used as the [sourceColumn].
      *
      * @param sourceColumn The intermediate table's reference column for the child entity class.
      * @param targetColumn The intermediate table's reference column for the parent entity class.

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -461,14 +461,29 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     ) =
         registerRefRule(column) { OptionalReferrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, cache) }
 
+    /**
+     * Returns a [ColumnWithTransform] delegate that transforms this stored [TColumn] value on every read.
+     *
+     * @param toColumn A pure function that converts a transformed value to a value that can be stored
+     * in this original column type.
+     * @param toReal A pure function that transforms a value stored in this original column type.
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
+     */
     fun <TColumn : Any?, TReal : Any?> Column<TColumn>.transform(
         toColumn: (TReal) -> TColumn,
         toReal: (TColumn) -> TReal
     ): ColumnWithTransform<TColumn, TReal> = ColumnWithTransform(this, toColumn, toReal, false)
 
     /**
-     * Function will return [ColumnWithTransform] delegate that will cache value on read for the same [TColumn] value.
-     * @param toReal should be pure function
+     * Returns a [ColumnWithTransform] delegate that will cache the transformed value on first read of
+     * this same stored [TColumn] value.
+     *
+     * @param toColumn A pure function that converts a transformed value to a value that can be stored
+     * in this original column type.
+     * @param toReal A pure function that transforms a value stored in this original column type.
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
     fun <TColumn : Any?, TReal : Any?> Column<TColumn>.memoizedTransform(
         toColumn: (TReal) -> TColumn,

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
@@ -8,21 +8,40 @@ import java.util.Deque
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.ConcurrentLinkedQueue
 
+/** Represents the possible states of an [Entity] throughout its lifecycle. */
 enum class EntityChangeType {
+    /** The entity has been created. */
     Created,
+
+    /** The entity has been updated. */
     Updated,
+
+    /** The entity has been removed. */
     Removed
 }
 
+/** Stores details about a changed-state event for an [Entity] instance. */
 data class EntityChange(
+    /** The [EntityClass] of the changed entity instance. */
     val entityClass: EntityClass<*, Entity<*>>,
+    /** The unique [EntityID] associated with the entity instance. */
     val entityId: EntityID<*>,
+    /** The exact change state of the event. */
     val changeType: EntityChangeType,
+    /** The unique id for the [Transaction] in which the event took place. */
     val transactionId: String
 )
 
+/**
+ * Returns the actual [Entity] instance associated with [this][EntityChange] event,
+ * or `null` if the entity was not found.
+ */
 fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(): T? = (entityClass as EntityClass<ID, T>).findById(entityId as EntityID<ID>)
 
+/**
+ * Returns the actual [Entity] instance associated with [this][EntityChange] event,
+ * or `null` if its [EntityClass] type is neither equivalent to nor a subclass of [klass].
+ */
 fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(klass: EntityClass<ID, T>): T? {
     if (!entityClass.isAssignableTo(klass)) return null
     return toEntity<ID, T>()
@@ -32,17 +51,24 @@ private val Transaction.unprocessedEvents: Deque<EntityChange> by transactionSco
 private val Transaction.entityEvents: Deque<EntityChange> by transactionScope { ConcurrentLinkedDeque() }
 private val entitySubscribers = ConcurrentLinkedQueue<(EntityChange) -> Unit>()
 
+/**
+ * Class responsible for providing functions that allow [EntityChange] state logic and lifecycle features to be
+ * made available for alerting triggers or customizing additional functionality.
+ */
 object EntityHook {
+    /** Registers a specific changed-state [action] for alerts and returns the [action]. */
     fun subscribe(action: (EntityChange) -> Unit): (EntityChange) -> Unit {
         entitySubscribers.add(action)
         return action
     }
 
+    /** Unregisters a specific changed-state [action] from alerts. */
     fun unsubscribe(action: (EntityChange) -> Unit) {
         entitySubscribers.remove(action)
     }
 }
 
+/** Creates a new [EntityChange] with [this][Transaction.id] details and registers it as an entity event. */
 fun Transaction.registerChange(entityClass: EntityClass<*, Entity<*>>, entityId: EntityID<*>, changeType: EntityChangeType) {
     EntityChange(entityClass, entityId, changeType, id).let {
         if (unprocessedEvents.peekLast() != it) {
@@ -53,6 +79,11 @@ fun Transaction.registerChange(entityClass: EntityClass<*, Entity<*>>, entityId:
 }
 
 private var isProcessingEventsLaunched by transactionScope { false }
+
+/**
+ * Triggers alerts for all unprocessed entity events using any changed-state actions previously registered
+ * using `EntityHook.subscribe()`.
+ */
 fun Transaction.alertSubscribers() {
     if (isProcessingEventsLaunched) return
     while (true) {
@@ -66,8 +97,14 @@ fun Transaction.alertSubscribers() {
     }
 }
 
+/** Returns a list of all [EntityChange] events that have been registered in [this] [Transaction]. */
 fun Transaction.registeredChanges() = entityEvents.toList()
 
+/**
+ * Calls the specified function [body] with the given changed-state [action] registered and returns its result.
+ *
+ * The [action] will be unregistered at the end of the call to the [body] block.
+ */
 fun <T> withHook(action: (EntityChange) -> Unit, body: () -> T): T {
     EntityHook.subscribe(action)
     try {

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
@@ -10,23 +10,23 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 /** Represents the possible states of an [Entity] throughout its lifecycle. */
 enum class EntityChangeType {
-    /** The entity has been created. */
+    /** The entity has been inserted in the database. */
     Created,
 
-    /** The entity has been updated. */
+    /** The entity has been updated in the database. */
     Updated,
 
-    /** The entity has been removed. */
+    /** The entity has been removed from the database. */
     Removed
 }
 
-/** Stores details about a changed-state event for an [Entity] instance. */
+/** Stores details about a state-change event for an [Entity] instance. */
 data class EntityChange(
     /** The [EntityClass] of the changed entity instance. */
     val entityClass: EntityClass<*, Entity<*>>,
     /** The unique [EntityID] associated with the entity instance. */
     val entityId: EntityID<*>,
-    /** The exact change state of the event. */
+    /** The exact changed state of the event. */
     val changeType: EntityChangeType,
     /** The unique id for the [Transaction] in which the event took place. */
     val transactionId: String
@@ -34,13 +34,15 @@ data class EntityChange(
 
 /**
  * Returns the actual [Entity] instance associated with [this][EntityChange] event,
- * or `null` if the entity was not found.
+ * or `null` if the entity is not found.
  */
-fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(): T? = (entityClass as EntityClass<ID, T>).findById(entityId as EntityID<ID>)
+fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(): T? =
+    (entityClass as EntityClass<ID, T>).findById(entityId as EntityID<ID>)
 
 /**
  * Returns the actual [Entity] instance associated with [this][EntityChange] event,
- * or `null` if its [EntityClass] type is neither equivalent to nor a subclass of [klass].
+ * or `null` if either its [EntityClass] type is neither equivalent to nor a subclass of [klass],
+ * or if the entity is not found.
  */
 fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(klass: EntityClass<ID, T>): T? {
     if (!entityClass.isAssignableTo(klass)) return null
@@ -52,24 +54,32 @@ private val Transaction.entityEvents: Deque<EntityChange> by transactionScope { 
 private val entitySubscribers = ConcurrentLinkedQueue<(EntityChange) -> Unit>()
 
 /**
- * Class responsible for providing functions that allow [EntityChange] state logic and lifecycle features to be
- * made available for alerting triggers or customizing additional functionality.
+ * Class responsible for providing functions that expose [EntityChange] state logic and entity lifecycle features
+ * for alerting triggers or customizing additional functionality.
  */
 object EntityHook {
-    /** Registers a specific changed-state [action] for alerts and returns the [action]. */
+    /**
+     * Registers a specific state-change [action] for alerts and returns the [action].
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityHookTest.testCallingFlushNotifiesEntityHookSubscribers
+     */
     fun subscribe(action: (EntityChange) -> Unit): (EntityChange) -> Unit {
         entitySubscribers.add(action)
         return action
     }
 
-    /** Unregisters a specific changed-state [action] from alerts. */
+    /** Unregisters a specific state-change [action] from alerts. */
     fun unsubscribe(action: (EntityChange) -> Unit) {
         entitySubscribers.remove(action)
     }
 }
 
-/** Creates a new [EntityChange] with [this][Transaction.id] details and registers it as an entity event. */
-fun Transaction.registerChange(entityClass: EntityClass<*, Entity<*>>, entityId: EntityID<*>, changeType: EntityChangeType) {
+/** Creates a new [EntityChange] with [this][Transaction] id and registers it as an entity event. */
+fun Transaction.registerChange(
+    entityClass: EntityClass<*, Entity<*>>,
+    entityId: EntityID<*>,
+    changeType: EntityChangeType
+) {
     EntityChange(entityClass, entityId, changeType, id).let {
         if (unprocessedEvents.peekLast() != it) {
             unprocessedEvents.addLast(it)
@@ -81,8 +91,8 @@ fun Transaction.registerChange(entityClass: EntityClass<*, Entity<*>>, entityId:
 private var isProcessingEventsLaunched by transactionScope { false }
 
 /**
- * Triggers alerts for all unprocessed entity events using any changed-state actions previously registered
- * using `EntityHook.subscribe()`.
+ * Triggers alerts for all unprocessed entity events using any state-change actions previously registered
+ * via [EntityHook.subscribe].
  */
 fun Transaction.alertSubscribers() {
     if (isProcessingEventsLaunched) return
@@ -97,11 +107,11 @@ fun Transaction.alertSubscribers() {
     }
 }
 
-/** Returns a list of all [EntityChange] events that have been registered in [this] [Transaction]. */
+/** Returns a list of all [EntityChange] events that have been registered in this [Transaction]. */
 fun Transaction.registeredChanges() = entityEvents.toList()
 
 /**
- * Calls the specified function [body] with the given changed-state [action] registered and returns its result.
+ * Calls the specified function [body] with the given state-change [action], registers the action, and returns its result.
  *
  * The [action] will be unregistered at the end of the call to the [body] block.
  */

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
@@ -22,7 +22,7 @@ internal fun <T> executeAsPartOfEntityLifecycle(body: () -> T): T {
 }
 
 /**
- * Represents a [StatementInterceptor] specifically for the statement lifecycle of [Entity] instances,
+ * Represents a [StatementInterceptor] specifically responsible for the statement lifecycle of [Entity] instances,
  * which is loaded whenever a [Transaction] instance is initialized.
  */
 class EntityLifecycleInterceptor : GlobalStatementInterceptor {

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
@@ -21,6 +21,10 @@ internal fun <T> executeAsPartOfEntityLifecycle(body: () -> T): T {
     }
 }
 
+/**
+ * Represents a [StatementInterceptor] specifically for the statement lifecycle of [Entity] instances,
+ * which is loaded whenever a [Transaction] instance is initialized.
+ */
 class EntityLifecycleInterceptor : GlobalStatementInterceptor {
 
     override fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> {

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/exceptions/EntityNotFoundException.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/exceptions/EntityNotFoundException.kt
@@ -3,5 +3,9 @@ package org.jetbrains.exposed.dao.exceptions
 import org.jetbrains.exposed.dao.EntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 
+/**
+ * An exception that provides information about an [entity] that could not be accessed
+ * either within the scope of the current entity cache or as a result of a database search error.
+ */
 class EntityNotFoundException(val id: EntityID<*>, val entity: EntityClass<*, *>) :
     Exception("Entity ${entity.klass.simpleName}, id=$id not found in the database")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityHookTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityHookTest.kt
@@ -306,7 +306,7 @@ class EntityHookTest : DatabaseTestsBase() {
     }
 
     @Test
-    fun `calling flush notifies EntityHook subscribers`() {
+    fun testCallingFlushNotifiesEntityHookSubscribers() {
         withTables(EntityHookTestData.User.table) {
             var hookCalls = 0
             val user = EntityHookTestData.User.new {


### PR DESCRIPTION
Add KDocs to `exposed-dao` files relating to the Entity class only.

All related public API elements now show a KDoc when hovered over by a mouse in IDE or when _Quick Documentation_ shortcut is used (`F1 | Ctrl+Q`).