### PR TITLE
fix: Tests `testAdjustQueryHaving`, `testQueryAndHaving`, and `testQueryOrHaving` resolve wrong `eq` function, and `testGroupBy03` shows compiler warning

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -343,7 +343,7 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.eq(
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.eq(
         other: ExpressionWithColumnType<E>
     ): Op<Boolean> = other eq this
 
@@ -377,7 +377,7 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is not equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.neq(
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.neq(
         other: ExpressionWithColumnType<E>
     ): Op<Boolean> = other neq this
 
@@ -400,7 +400,7 @@ interface ISqlExpressionBuilder {
     ): LessOp = LessOp(this, other)
 
     /** Checks if this expression is less than some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.less(
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.less(
         other: ExpressionWithColumnType<E>
     ): LessOp = LessOp(this, other)
 
@@ -423,7 +423,7 @@ interface ISqlExpressionBuilder {
     ): LessEqOp = LessEqOp(this, other)
 
     /** Checks if this expression is less than or equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.lessEq(
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.lessEq(
         other: ExpressionWithColumnType<E>
     ): LessEqOp = LessEqOp(this, other)
 
@@ -446,7 +446,7 @@ interface ISqlExpressionBuilder {
     ): GreaterOp = GreaterOp(this, other)
 
     /** Checks if this expression is greater than some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.greater(
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.greater(
         other: ExpressionWithColumnType<E>
     ): GreaterOp = GreaterOp(this, other)
 
@@ -469,7 +469,7 @@ interface ISqlExpressionBuilder {
     ): GreaterEqOp = GreaterEqOp(this, other)
 
     /** Checks if this expression is greater than or equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.greaterEq(
+    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.greaterEq(
         other: ExpressionWithColumnType<E>
     ): GreaterEqOp = GreaterEqOp(this, other)
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/AdjustQueryTests.kt
@@ -122,7 +122,7 @@ class AdjustQueryTests : DatabaseTestsBase() {
     fun testAdjustQueryHaving() {
         withCitiesAndUsers { cities, users, _ ->
             val predicateHaving = Op.build {
-                DMLTestsData.Users.id.count() eq DMLTestsData.Cities.id.max()
+                DMLTestsData.Users.id.count().eq<Number, Long, Int>(DMLTestsData.Cities.id.max())
             }
 
             val queryAdjusted = (cities innerJoin users)
@@ -146,7 +146,7 @@ class AdjustQueryTests : DatabaseTestsBase() {
     fun testQueryAndHaving() {
         withCitiesAndUsers { cities, users, _ ->
             val predicateHaving = Op.build {
-                DMLTestsData.Users.id.count() eq DMLTestsData.Cities.id.max()
+                DMLTestsData.Users.id.count().eq<Number, Long, Int>(DMLTestsData.Cities.id.max())
             }
 
             val queryAdjusted = (cities innerJoin users)
@@ -172,7 +172,7 @@ class AdjustQueryTests : DatabaseTestsBase() {
     fun testQueryOrHaving() {
         withCitiesAndUsers { cities, users, _ ->
             val predicateHaving = Op.build {
-                DMLTestsData.Users.id.count() eq DMLTestsData.Cities.id.max()
+                DMLTestsData.Users.id.count().eq<Number, Long, Int>(DMLTestsData.Cities.id.max())
             }
 
             val queryAdjusted = (cities innerJoin users)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/GroupByTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/GroupByTests.kt
@@ -53,7 +53,7 @@ class GroupByTests : DatabaseTestsBase() {
             val maxExpr = cities.id.max()
             val r = (cities innerJoin users).select(cities.name, users.id.count(), maxExpr)
                 .groupBy(cities.name)
-                .having { users.id.count().eq(maxExpr) }
+                .having { users.id.count().eq<Number, Long, Int>(maxExpr) }
                 .orderBy(cities.name)
                 .toList()
 


### PR DESCRIPTION
The tests `testAdjustQueryHaving`, `testQueryAndHaving`, and `testQueryOrHaving` falsely resolve this `eq` function

infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.eq(
        other: ExpressionWithColumnType<E>
    ): Op<Boolean> = other eq this

instead of this

infix fun <T, S1 : T?, S2 : T?> Expression<in S1>.eq(other: Expression<in S2>): Op<Boolean> = when (other as Expression<*>) {
        is Op.NULL -> isNull()
        else -> EqOp(this, other)
    }

The same happens when using `neq`, `less`, `lessEq`, `greater`, and `greaterEq`, so those are fixed in this commit too.

Even when the correct function is resolved, a compiler warning still shows up because the compiler cannot infer the type of the argument when `Long` and `Int` are being compared. To remove the warning, the types are explicitly passed to the `eq` function like this `.eq<Number, Long, Int>`.

This was tested with Kotlin 2.0.0-Beta4.