### PR TITLE
fix: EXPOSED-217 Unnecessary query after calling with() and iteration

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1324,6 +1324,16 @@ public final class org/jetbrains/exposed/sql/LazySizedCollection : org/jetbrains
 	public fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
+public abstract interface class org/jetbrains/exposed/sql/LazySizedIterable : org/jetbrains/exposed/sql/SizedIterable {
+	public abstract fun getLoadedResult ()Ljava/util/List;
+	public abstract fun setLoadedResult (Ljava/util/List;)V
+}
+
+public final class org/jetbrains/exposed/sql/LazySizedIterable$DefaultImpls {
+	public static fun forUpdate (Lorg/jetbrains/exposed/sql/LazySizedIterable;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public static fun notForUpdate (Lorg/jetbrains/exposed/sql/LazySizedIterable;)Lorg/jetbrains/exposed/sql/SizedIterable;
+}
+
 public final class org/jetbrains/exposed/sql/Lead : org/jetbrains/exposed/sql/WindowFunction {
 	public fun <init> (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.dao
 
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.LazySizedIterable
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.emptySized
 import org.jetbrains.exposed.sql.transactions.TransactionManager
@@ -240,6 +241,7 @@ private fun <ID : Comparable<ID>> List<Entity<ID>>.preloadRelations(
 
 fun <SRCID : Comparable<SRCID>, SRC : Entity<SRCID>, REF : Entity<*>, L : Iterable<SRC>> L.with(vararg relations: KProperty1<out REF, Any?>): L {
     toList().apply {
+        (this@with as? LazySizedIterable<SRC>)?.loadedResult = this
         if (any { it.isNewEntity() }) {
             TransactionManager.current().flushCache()
         }


### PR DESCRIPTION
Using `all()` to get a collection of entities returns an instance of an anonymous `SizedIterable` object.
When eager loading references from this object, `with()` first iterates over the object then preloads relations for each retrieved entity, which correctly generates 2 SQL statements:
```kt
val x: SizedIterable<School> = School.all().with(School::region)

// SELECT SCHOOL.ID, SCHOOL."name", SCHOOL.REGION_ID, SCHOOL.SECONDARY_REGION_ID FROM SCHOOL
// SELECT REGION.ID, REGION."name" FROM REGION WHERE REGION.ID = 1
```

If this eager loading is followed by iteration (using `toList()` or `forEach()` e.g.), the first SQL statement is executed again because the anonymous object delegates to the source iterator, `AbstractQuery.iterator` and its results (from the first execution) are discarded after being used to load references.
The retrieved references, however, are cached in each `Entity.referenceCache`, so the second SQL is not executed again:
```kt
val x: List<School> = School.all().with(School::region).toList()

// SELECT SCHOOL.ID, SCHOOL."name", SCHOOL.REGION_ID, SCHOOL.SECONDARY_REGION_ID FROM SCHOOL
// SELECT REGION.ID, REGION."name" FROM REGION WHERE REGION.ID = 1
// SELECT SCHOOL.ID, SCHOOL."name", SCHOOL.REGION_ID, SCHOOL.SECONDARY_REGION_ID FROM SCHOOL
```

This occurs because `with()` was refactored in PR #1585  to return the same invoking type, rather than a List. So the source iterator of the returned `SizedIterable` executes a query when called.

This fix stores the result of the first query in the `SizedIterable` instance and ensures the right iterator is invoked if a result has been cached.