### PR TITLE
docs: Add missing KDocs for exposed-dao EntityClass API

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityBatchUpdate.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityBatchUpdate.kt
@@ -6,10 +6,24 @@ import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.statements.BatchUpdateStatement
 import java.util.*
 
+/**
+ * Class responsible for performing a batch update operation on multiple instances of an [Entity] class.
+ *
+ * @param klass The [EntityClass] associated with the entities to batch update.
+ */
 class EntityBatchUpdate(private val klass: EntityClass<*, Entity<*>>) {
 
     private val data = ArrayList<Pair<EntityID<*>, SortedMap<Column<*>, Any?>>>()
 
+    /**
+     * Adds the specified [entity] to the list of entities to batch update.
+     *
+     * The column-value mapping for this entity will initially be empty.
+     * Columns to update should be assigned by using the `set()` operator on this [EntityBatchUpdate] instance.
+     *
+     * @throws IllegalStateException If the entity being added cannot be associated with the [EntityClass]
+     * provided on instantiation of this [EntityBatchUpdate].
+     */
     fun addBatch(entity: Entity<*>) {
         if (entity.klass != klass) error("Entity class${entity.klass} differs from expected entity class $klass")
         data.add(entity.id to TreeMap())
@@ -25,6 +39,10 @@ class EntityBatchUpdate(private val klass: EntityClass<*, Entity<*>>) {
         values[column] = value
     }
 
+    /**
+     * Executes the batch update SQL statement for each added entity in the provided [transaction]
+     * and returns the number of updated rows.
+     */
     fun execute(transaction: Transaction): Int {
         val updateSets = data.filterNot { it.second.isEmpty() }.groupBy { it.second.keys }
         return updateSets.values.fold(0) { acc, set ->

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -394,6 +394,10 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
         return prototype
     }
 
+    /**
+     * Creates a [View] or subset of [Entity] instances, which are managed by this [EntityClass] and
+     * conform to the specified [op] conditional expression.
+     */
     inline fun view(op: SqlExpressionBuilder.() -> Op<Boolean>) = View(SqlExpressionBuilder.op(), this)
 
     private val refDefinitions = HashMap<Pair<Column<*>, KClass<*>>, Any>()

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
@@ -7,6 +7,13 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.vendors.ForUpdateOption
 import kotlin.reflect.KProperty
 
+/**
+ * A [SizedIterable] of [Entity] instances that represent a subset of all managed entities that conform to the
+ * provided [op] conditional expression.
+ *
+ * @param op The conditional expression to use when querying for matching entities.
+ * @param factory The [EntityClass] to use when searching for matching entities.
+ */
 class View<out Target : Entity<*>> (val op: Op<Boolean>, val factory: EntityClass<*, Target>) : SizedIterable<Target> {
     override fun limit(n: Int, offset: Long): SizedIterable<Target> = factory.find(op).limit(n, offset)
     override fun count(): Long = factory.find(op).count()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
@@ -75,7 +75,7 @@ class AliasesTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test wrap row with Aliased table`() {
+    fun testWrapRowWithAliasedTable() {
         withTables(EntityTestsData.XTable, EntityTestsData.YTable) {
             val entity1 = EntityTestsData.XEntity.new {
                 this.b1 = false
@@ -93,7 +93,7 @@ class AliasesTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test wrap row with Aliased query`() {
+    fun testWrapRowWithAliasedQuery() {
         withTables(EntityTestsData.XTable, EntityTestsData.YTable) {
             val entity1 = EntityTestsData.XEntity.new {
                 this.b1 = false

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityBugsRegressionTest.kt
@@ -113,7 +113,7 @@ class `Text id loosed on insert issue 1379` : DatabaseTestsBase() {
     }
 }
 
-class `Entity Cache not Updated on Commit issue 1380` : DatabaseTestsBase() {
+class EntityCacheNotUpdatedOnCommitIssue1380 : DatabaseTestsBase() {
     object TestTable : IntIdTable() {
         val value = integer("value")
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -620,7 +620,7 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test what update of inserted entities goes before an insert`() {
+    fun testThatUpdateOfInsertedEntitiesGoesBeforeAnInsert() {
         withTables(Categories, Posts, Boards) {
             val category1 = Category.new {
                 title = "category1"
@@ -675,7 +675,7 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test new(id) with get`() {
+    fun testNewIdWithGet() {
         // SQL Server doesn't support an explicit id for auto-increment table
         withTables(listOf(TestDB.SQLSERVER), Parents, Children) {
             val parentId = Parent.new {


### PR DESCRIPTION
Add KDocs in `exposed-dao` files relating to `EntityClass`.

All related public API elements now show a KDoc when hovered over by a mouse in IDE or when _Quick Documentation_ shortcut is used (`F1 | Ctrl+Q`).