### PR TITLE
docs: Add missing KDocs for exposed-dao EntityCache API

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
@@ -8,21 +8,36 @@ import java.util.*
 import kotlin.collections.HashMap
 import kotlin.collections.HashSet
 
+/** The current [EntityCache] for [this][Transaction] scope, or a new instance if none exists. */
 val Transaction.entityCache: EntityCache by transactionScope { EntityCache(this) }
 
+/**
+ * Class responsible for the storage of [Entity] instances in a specific [transaction].
+ */
 @Suppress("UNCHECKED_CAST")
 class EntityCache(private val transaction: Transaction) {
     private var flushingEntities = false
     private var initializingEntities: LinkedIdentityHashSet<Entity<*>> = LinkedIdentityHashSet()
     internal val pendingInitializationLambdas = IdentityHashMap<Entity<*>, MutableList<(Entity<*>) -> Unit>>()
+
+    /** The mapping of [IdTable]s to associated [Entity] instances (as a mapping of entity id values to entities). */
     val data = LinkedHashMap<IdTable<*>, MutableMap<Any, Entity<*>>>()
     internal val inserts = LinkedHashMap<IdTable<*>, MutableSet<Entity<*>>>()
     private val updates = LinkedHashMap<IdTable<*>, MutableSet<Entity<*>>>()
     internal val referrers = HashMap<Column<*>, MutableMap<EntityID<*>, SizedIterable<*>>>()
 
     /**
-     * Amount of entities to keep in a cache per an Entity class.
-     * On setting a new value all data stored in cache will be adjusted to a new size
+     * The amount of entities to store in this [EntityCache] per [Entity] class.
+     *
+     * By default, this value is configured by `DatabaseConfig.maxEntitiesToStoreInCachePerEntity`,
+     * which defaults to storing all entities.
+     *
+     * On setting a new value, all data stored in the cache will be adjusted to the new size. If the new value
+     * is less than the current cache size by N, the first N entities stored will be removed. If the new value
+     * is greater than the current cache size, the adjusted cache will only be filled with more entities after
+     * they are retrieved, for example by calling [EntityClass.all].
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityCacheTests.changeEntityCacheMaxEntitiesToStoreInMiddleOfTransaction
      */
     var maxEntitiesToStore = transaction.db.config.maxEntitiesToStoreInCachePerEntity
         set(value) {
@@ -48,29 +63,59 @@ class EntityCache(private val transaction: Transaction) {
         LimitedHashMap()
     }
 
+    /**
+     * Returns a [SizedIterable] containing all child [Entity] instances that reference the parent entity with
+     * the provided [sourceId] using the specified [key] column.
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.preloadReferrersOnAnEntity
+     */
     fun <R : Entity<*>> getReferrers(sourceId: EntityID<*>, key: Column<*>): SizedIterable<R>? {
         return referrers[key]?.get(sourceId) as? SizedIterable<R>
     }
 
+    /**
+     * Returns a [SizedIterable] containing all child [Entity] instances that reference the parent entity with
+     * the provided [sourceId] using the specified [key] column.
+     *
+     * If either the [key] column is not present or a value does not exist for the parent entity, the default [refs]
+     * will be called and its result will be put into the map under the given keys and the call result returned.
+     */
     fun <ID : Any, R : Entity<ID>> getOrPutReferrers(sourceId: EntityID<*>, key: Column<*>, refs: () -> SizedIterable<R>): SizedIterable<R> {
         return referrers.getOrPut(key) { HashMap() }.getOrPut(sourceId) { LazySizedCollection(refs()) } as SizedIterable<R>
     }
 
+    /**
+     * Searches this [EntityCache] for an [Entity] by its [EntityID] value using its associated [EntityClass] as the key.
+     *
+     * @return The entity that has this wrapped id value, or `null` if no entity was found.
+     */
     fun <ID : Comparable<ID>, T : Entity<ID>> find(f: EntityClass<ID, T>, id: EntityID<ID>): T? =
         getMap(f)[id.value] as T?
             ?: inserts[f.table]?.firstOrNull { it.id == id } as? T
             ?: initializingEntities.firstOrNull { it.klass == f && it.id == id } as? T
 
+    /**
+     * Gets all [Entity] instances in this [EntityCache] that match the associated [EntityClass].
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityCacheTests.testPerTransactionEntityCacheLimit
+     */
     fun <ID : Comparable<ID>, T : Entity<ID>> findAll(f: EntityClass<ID, T>): Collection<T> = getMap(f).values as Collection<T>
 
+    /** Stores the specified [Entity] in this [EntityCache] using its associated [EntityClass] as the key. */
     fun <ID : Comparable<ID>, T : Entity<ID>> store(f: EntityClass<ID, T>, o: T) {
         getMap(f)[o.id.value] = o
     }
 
+    /**
+     * Stores the specified [Entity] in this [EntityCache].
+     *
+     * The [EntityClass] associated with this entity will be inferred based on its [Entity.klass] property.
+     */
     fun store(o: Entity<*>) {
         getMap(o.klass.table)[o.id.value] = o
     }
 
+    /** Removes the specified [Entity] from this [EntityCache] using its associated [table] as the key. */
     fun <ID : Comparable<ID>, T : Entity<ID>> remove(table: IdTable<ID>, o: T) {
         getMap(table).remove(o.id.value)
     }
@@ -88,14 +133,17 @@ class EntityCache(private val transaction: Transaction) {
 
     internal fun isEntityInInitializationState(entity: Entity<*>) = entity in initializingEntities
 
+    /** Stores the specified [Entity] in this [EntityCache] as scheduled to be inserted into the database. */
     fun <ID : Comparable<ID>, T : Entity<ID>> scheduleInsert(f: EntityClass<ID, T>, o: T) {
         inserts.getOrPut(f.table) { LinkedIdentityHashSet() }.add(o as Entity<*>)
     }
 
+    /** Stores the specified [Entity] in this [EntityCache] as scheduled to be updated in the database. */
     fun <ID : Comparable<ID>, T : Entity<ID>> scheduleUpdate(f: EntityClass<ID, T>, o: T) {
         updates.getOrPut(f.table) { LinkedIdentityHashSet() }.add(o as Entity<*>)
     }
 
+    /** Sends all pending inserts and updates for all [Entity] instances in this [EntityCache] to the database. */
     fun flush() {
         val toFlush = when {
             inserts.isEmpty() && updates.isEmpty() -> emptyList()
@@ -129,6 +177,11 @@ class EntityCache(private val transaction: Transaction) {
         }
     }
 
+    /**
+     * Sends all pending inserts and updates for [Entity] instances in this [EntityCache] to the database.
+     *
+     * The only entities that will be flushed are those that can be associated with any of the specified [tables].
+     */
     fun flush(tables: Iterable<IdTable<*>>) {
         if (flushingEntities) return
         try {
@@ -212,6 +265,13 @@ class EntityCache(private val transaction: Transaction) {
         transaction.alertSubscribers()
     }
 
+    /**
+     * Clears this [EntityCache] of all stored data, including any reference mappings.
+     *
+     * @param flush By default, pending inserts and updates for all cached entities will first be sent to the
+     * database. If this is set to `false`, any pending operations will not be flushed and will be removed as well.
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityCacheTests.changeEntityCacheMaxEntitiesToStoreInMiddleOfTransaction
+     */
     fun clear(flush: Boolean = true) {
         if (flush) flush()
         data.clear()
@@ -220,6 +280,7 @@ class EntityCache(private val transaction: Transaction) {
         clearReferrersCache()
     }
 
+    /** Clears this [EntityCache] of stored data that maps cached parent entities to their referencing child entities. */
     fun clearReferrersCache() {
         referrers.clear()
     }
@@ -231,7 +292,10 @@ class EntityCache(private val transaction: Transaction) {
     }
 
     companion object {
-
+        /**
+         * Clears the internal cache of any [created] entity that can be associated
+         * with an [ImmutableCachedEntityClass].
+         */
         fun invalidateGlobalCaches(created: List<Entity<*>>) {
             created.asSequence().mapNotNull { it.klass as? ImmutableCachedEntityClass<*, *> }.distinct().forEach {
                 it.expireCache()
@@ -240,6 +304,12 @@ class EntityCache(private val transaction: Transaction) {
     }
 }
 
+/**
+ * Sends all pending [Entity] inserts and updates stored in this transaction's [EntityCache] to the database.
+ *
+ * @return A list of all new entities that were stored as scheduled for insert.
+ * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.testInsertChildWithFlush
+ */
 fun Transaction.flushCache(): List<Entity<*>> {
     with(entityCache) {
         val newEntities = inserts.flatMap { it.value }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityCacheTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityCacheTests.kt
@@ -129,7 +129,7 @@ class EntityCacheTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `change EntityCache maxEntitiesToStore in the middle of transaction`() {
+    fun changeEntityCacheMaxEntitiesToStoreInMiddleOfTransaction() {
         withTables(TestTable) {
             repeat(20) {
                 TestEntity.new {


### PR DESCRIPTION
Add KDocs in `exposed-dao/EntityCache.kt`.

All related public API elements now show a KDoc when hovered over by a mouse in IDE or when _Quick Documentation_ shortcut is used (`F1 | Ctrl+Q`).