### PR TITLE
fix: EXPOSED-307 [SQLite] Delete ignore not supported and throws

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -237,8 +237,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         if (!ENABLE_UPDATE_DELETE_LIMIT && limit != null) {
             transaction.throwUnsupportedException("SQLite doesn't support LIMIT in DELETE clause.")
         }
-        val def = super.delete(false, table, where, limit, transaction)
-        return if (ignore) def.replaceFirst("DELETE", "DELETE OR IGNORE") else def
+        return super.delete(ignore, table, where, limit, transaction)
     }
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
 import junit.framework.TestCase.assertNull
+import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
@@ -11,8 +12,10 @@ import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Test
+import kotlin.test.expect
 
 class DeleteTests : DatabaseTestsBase() {
     private val notSupportLimit by lazy {
@@ -42,6 +45,20 @@ class DeleteTests : DatabaseTestsBase() {
             users.deleteWhere { users.name like "%thing" }
             val hasSmth = users.select(users.id).where { users.name.like("%thing") }.any()
             assertEquals(false, hasSmth)
+
+            if (currentDialectTest is MysqlDialect) {
+                assertEquals(1, cities.selectAll().where { cities.id eq 1 }.count())
+                expectException<ExposedSQLException> {
+                    // a regular delete throws SQLIntegrityConstraintViolationException because Users reference Cities
+                    // Cannot delete or update a parent row: a foreign key constraint fails
+                    cities.deleteWhere { cities.id eq 1 }
+                }
+                expect(0) {
+                    // the error is now ignored and the record is skipped
+                    cities.deleteIgnoreWhere { cities.id eq 1 }
+                }
+                assertEquals(1, cities.selectAll().where { cities.id eq 1 }.count())
+            }
         }
     }
 


### PR DESCRIPTION
Attempting to use `deleteIgnoreWhere()` with SQLite results in:
> SQLiteException: [SQLITE_ERROR] SQL error or missing database (near "OR": syntax error)

SQLiteDialect is currently setup to generate this SQL even though DELETE IGNORE is [not supported](https://www.sqlite.org/lang_delete.html):
```
DELETE OR IGNORE FROM Cities WHERE Cities.cityId = 1
```

DELETE IGNORE is only supported by MySQL and MariaDB and no test exists for it, so it's been added to the base delete tests.
SQLite now fails early, like all other DB, with `UnsupportedByDialectException` if ignore is set to true.