### PR TITLE
refactor!: Column type safety

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -176,14 +176,19 @@ public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exp
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
 	public final fun getDelegateType ()Ljava/lang/String;
 	public final fun getMaximumCardinality ()Ljava/lang/Integer;
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/util/List;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/util/List;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/util/List;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun valueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/util/List;
+	public synthetic fun valueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun valueToString (Ljava/util/List;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/AutoIncColumnType : org/jetbrains/exposed/sql/IColumnType {
@@ -217,10 +222,12 @@ public final class org/jetbrains/exposed/sql/Avg : org/jetbrains/exposed/sql/Fun
 
 public class org/jetbrains/exposed/sql/BasicBinaryColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString ([B)Ljava/lang/String;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)[B
 }
 
 public final class org/jetbrains/exposed/sql/Between : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {
@@ -248,7 +255,8 @@ public class org/jetbrains/exposed/sql/BinaryColumnType : org/jetbrains/exposed/
 	public final fun getLength ()I
 	public fun hashCode ()I
 	public fun sqlType ()Ljava/lang/String;
-	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public fun validateValueBeforeUpdate ([B)V
 }
 
 public final class org/jetbrains/exposed/sql/BlobColumnType : org/jetbrains/exposed/sql/ColumnType {
@@ -256,8 +264,8 @@ public final class org/jetbrains/exposed/sql/BlobColumnType : org/jetbrains/expo
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getUseObjectIdentifier ()Z
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;)Ljava/lang/String;
 	public synthetic fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Lorg/jetbrains/exposed/sql/statements/api/ExposedBlob;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
@@ -269,8 +277,10 @@ public final class org/jetbrains/exposed/sql/BlobColumnType : org/jetbrains/expo
 public final class org/jetbrains/exposed/sql/BooleanColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public static final field Companion Lorg/jetbrains/exposed/sql/BooleanColumnType$Companion;
 	public fun <init> ()V
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Z)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Z)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -324,7 +334,8 @@ public class org/jetbrains/exposed/sql/CharColumnType : org/jetbrains/exposed/sq
 	public final fun getColLength ()I
 	public fun hashCode ()I
 	public fun sqlType ()Ljava/lang/String;
-	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public fun validateValueBeforeUpdate (Ljava/lang/String;)V
 }
 
 public final class org/jetbrains/exposed/sql/CharLength : org/jetbrains/exposed/sql/Function {
@@ -335,8 +346,10 @@ public final class org/jetbrains/exposed/sql/CharLength : org/jetbrains/exposed/
 
 public final class org/jetbrains/exposed/sql/CharacterColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun nonNullValueToString (C)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (C)Ljava/lang/Object;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Character;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -459,7 +472,6 @@ public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/expos
 	public fun toString ()Ljava/lang/String;
 	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
 	public fun valueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueToString (Ljava/lang/Object;)Ljava/lang/String;
 }
@@ -545,17 +557,23 @@ public final class org/jetbrains/exposed/sql/CurrentRowWindowFrameBound : org/je
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/CustomEnumerationColumnType : org/jetbrains/exposed/sql/StringColumnType {
+public final class org/jetbrains/exposed/sql/CustomEnumerationColumnType : org/jetbrains/exposed/sql/ColumnType {
+	public static final field Companion Lorg/jetbrains/exposed/sql/CustomEnumerationColumnType$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public final fun getFromDb ()Lkotlin/jvm/functions/Function1;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getSql ()Ljava/lang/String;
 	public final fun getToDb ()Lkotlin/jvm/functions/Function1;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun nonNullValueToString (Ljava/lang/Enum;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Enum;)Ljava/lang/Object;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Enum;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/sql/CustomEnumerationColumnType$Companion {
 }
 
 public class org/jetbrains/exposed/sql/CustomFunction : org/jetbrains/exposed/sql/Function {
@@ -740,8 +758,10 @@ public final class org/jetbrains/exposed/sql/EntityIDColumnType : org/jetbrains/
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getIdColumn ()Lorg/jetbrains/exposed/sql/Column;
 	public fun hashCode ()I
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lorg/jetbrains/exposed/dao/id/EntityID;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lorg/jetbrains/exposed/dao/id/EntityID;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -753,21 +773,32 @@ public final class org/jetbrains/exposed/sql/EnumerationColumnType : org/jetbrai
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getKlass ()Lkotlin/reflect/KClass;
 	public fun hashCode ()I
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Integer;
+	public fun notNullValueToDB (Ljava/lang/Enum;)Ljava/lang/Integer;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Enum;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class org/jetbrains/exposed/sql/EnumerationNameColumnType : org/jetbrains/exposed/sql/VarCharColumnType {
+public final class org/jetbrains/exposed/sql/EnumerationNameColumnType : org/jetbrains/exposed/sql/ColumnType {
+	public static final field Companion Lorg/jetbrains/exposed/sql/EnumerationNameColumnType$Companion;
 	public fun <init> (Lkotlin/reflect/KClass;I)V
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColLength ()I
 	public final fun getKlass ()Lkotlin/reflect/KClass;
 	public fun hashCode ()I
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun nonNullValueToString (Ljava/lang/Enum;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Enum;)Ljava/lang/Object;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public fun validateValueBeforeUpdate (Ljava/lang/Enum;)V
+	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Enum;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/sql/EnumerationNameColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/sql/EqOp : org/jetbrains/exposed/sql/ComparisonOp {
@@ -955,7 +986,6 @@ public final class org/jetbrains/exposed/sql/IColumnType$DefaultImpls {
 	public static fun setParameter (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public static fun validateValueBeforeUpdate (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)V
 	public static fun valueAsDefaultString (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/String;
-	public static fun valueFromDB (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun valueToDB (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun valueToString (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/String;
 }
@@ -2231,8 +2261,10 @@ public abstract class org/jetbrains/exposed/sql/StringColumnType : org/jetbrains
 	protected final fun escapeAndQuote (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getCollate ()Ljava/lang/String;
 	public fun hashCode ()I
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/StringColumnType$Companion {
@@ -2475,7 +2507,8 @@ public final class org/jetbrains/exposed/sql/Trim : org/jetbrains/exposed/sql/Fu
 
 public final class org/jetbrains/exposed/sql/UByteColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB-7apg3OU (B)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -2484,7 +2517,8 @@ public final class org/jetbrains/exposed/sql/UByteColumnType : org/jetbrains/exp
 
 public final class org/jetbrains/exposed/sql/UIntegerColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB-WZ4Q5Ns (I)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -2493,7 +2527,8 @@ public final class org/jetbrains/exposed/sql/UIntegerColumnType : org/jetbrains/
 
 public final class org/jetbrains/exposed/sql/ULongColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB-VKZWuLQ (J)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -2502,7 +2537,8 @@ public final class org/jetbrains/exposed/sql/ULongColumnType : org/jetbrains/exp
 
 public final class org/jetbrains/exposed/sql/UShortColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB-xj2QHRw (S)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -2512,8 +2548,10 @@ public final class org/jetbrains/exposed/sql/UShortColumnType : org/jetbrains/ex
 public final class org/jetbrains/exposed/sql/UUIDColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public static final field Companion Lorg/jetbrains/exposed/sql/UUIDColumnType$Companion;
 	public fun <init> ()V
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/util/UUID;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/util/UUID;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -2576,7 +2614,8 @@ public class org/jetbrains/exposed/sql/VarCharColumnType : org/jetbrains/exposed
 	public fun hashCode ()I
 	public fun preciseType ()Ljava/lang/String;
 	public fun sqlType ()Ljava/lang/String;
-	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public fun validateValueBeforeUpdate (Ljava/lang/String;)V
 }
 
 public final class org/jetbrains/exposed/sql/VarPop : org/jetbrains/exposed/sql/Function, org/jetbrains/exposed/sql/WindowFunction {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
@@ -18,15 +18,16 @@ open class EntityID<T : Comparable<T>> protected constructor(val table: IdTable<
     var _value: Any? = id
 
     /** The identity value of type [T] wrapped by this [EntityID] instance. */
-    val value: T get() {
-        if (_value == null) {
-            invokeOnNoValue()
-            check(_value != null) { "Entity must be inserted" }
-        }
+    val value: T
+        get() {
+            if (_value == null) {
+                invokeOnNoValue()
+                check(_value != null) { "Entity must be inserted" }
+            }
 
-        @Suppress("UNCHECKED_CAST")
-        return _value!! as T
-    }
+            @Suppress("UNCHECKED_CAST")
+            return _value!! as T
+        }
 
     /** Performs steps when the internal [_value] is accessed without first being initialized. */
     protected open fun invokeOnNoValue() {}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -8,7 +8,7 @@ class Alias<out T : Table>(val delegate: T, val alias: String) : Table() {
     /** The table name along with its [alias]. */
     val tableNameWithAlias: String = "${delegate.tableName} $alias"
 
-    private fun <T : Any?> Column<T>.clone() = Column<T>(this@Alias, name, columnType)
+    private fun <T> Column<T>.clone() = Column<T>(this@Alias, name, columnType)
 
     /**
      * Returns the original column from the [delegate] table, or `null` if the [column] is not associated
@@ -111,7 +111,7 @@ class QueryAlias(val query: AbstractQuery<*>, val alias: String) : ColumnSet() {
 
     override infix fun crossJoin(otherTable: ColumnSet): Join = Join(this, otherTable, JoinType.CROSS)
 
-    private fun <T : Any?> Column<T>.clone() = Column<T>(table.alias(alias), name, columnType)
+    private fun <T> Column<T>.clone() = Column<T>(table.alias(alias), name, columnType)
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -21,7 +21,7 @@ class Column<T>(
     /** Name of the column. */
     val name: String,
     /** Data type of the column. */
-    override val columnType: IColumnType
+    override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>(), DdlAware, Comparable<Column<*>> {
     /** The foreign key constraint on this column, or `null` if the column is not referencing. */
     var foreignKey: ForeignKeyConstraint? = null
@@ -63,12 +63,13 @@ class Column<T>(
     private val isLastColumnInPK: Boolean
         get() = this == table.primaryKey?.columns?.last()
 
-    internal val isPrimaryConstraintWillBeDefined: Boolean get() = when {
-        currentDialect is SQLiteDialect && columnType.isAutoInc -> false
-        table.isCustomPKNameDefined() -> isLastColumnInPK
-        isOneColumnPK() -> false
-        else -> isLastColumnInPK
-    }
+    internal val isPrimaryConstraintWillBeDefined: Boolean
+        get() = when {
+            currentDialect is SQLiteDialect && columnType.isAutoInc -> false
+            table.isCustomPKNameDefined() -> isLastColumnInPK
+            isOneColumnPK() -> false
+            else -> isLastColumnInPK
+        }
 
     override fun createStatement(): List<String> {
         val alterTablePrefix = "ALTER TABLE ${TransactionManager.current().identity(table)} ADD"
@@ -154,7 +155,7 @@ class Column<T>(
     /**
      * Returns a copy of this column, but with the given column type.
      */
-    fun withColumnType(columnType: IColumnType) = Column<T>(
+    fun withColumnType(columnType: IColumnType<T & Any>) = Column<T>(
         table = this.table,
         name = this.name,
         columnType = columnType

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -3,7 +3,6 @@ package org.jetbrains.exposed.sql
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
-import org.jetbrains.exposed.sql.statements.DefaultValueMarker
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.*
@@ -23,7 +22,7 @@ import kotlin.reflect.full.isSubclassOf
 /**
  * Interface common to all column types.
  */
-interface IColumnType {
+interface IColumnType<T> {
     /** Returns `true` if the column type is nullable, `false` otherwise. */
     var nullable: Boolean
 
@@ -34,31 +33,29 @@ interface IColumnType {
      * Converts the specified [value] (from the database) to an object of the appropriated type, for this column type.
      * Default implementation returns the same instance.
      */
-    fun valueFromDB(value: Any): Any = value
+    fun valueFromDB(value: Any): T?
 
     /** Returns an object compatible with the database, from the specified [value], for this column type. */
-    fun valueToDB(value: Any?): Any? = value?.let(::notNullValueToDB)
+    fun valueToDB(value: T?): Any? = value?.let(::notNullValueToDB)
 
     /** Returns an object compatible with the database, from the specified **non-null** [value], for this column type. */
-    fun notNullValueToDB(value: Any): Any = value
+    fun notNullValueToDB(value: T & Any): Any = value
 
     /**
      * Returns the SQL representation of the specified [value], for this column type.
      * If the value is `null` and the column is not nullable, an exception will be thrown.
      * Used when generating an SQL statement and when logging that statement.
      */
-    fun valueToString(value: Any?): String = when (value) {
+    fun valueToString(value: T?): String = when (value) {
         null -> {
             check(nullable) { "NULL in non-nullable column" }
             "NULL"
         }
-        DefaultValueMarker -> "DEFAULT"
-        is Iterable<*> -> value.joinToString(",", transform = ::valueToString)
         else -> nonNullValueToString(value)
     }
 
     /** Returns the SQL representation of the specified **non-null** [value], for this column type. */
-    fun nonNullValueToString(value: Any): String = notNullValueToDB(value).toString()
+    fun nonNullValueToString(value: T & Any): String = notNullValueToDB(value).toString()
 
     /**
      * Returns the String representation of the specified [value] when [value] is set as the default for
@@ -66,7 +63,7 @@ interface IColumnType {
      * If the value is `null` and the column is not nullable, an exception will be thrown.
      * Used for metadata default value comparison.
      */
-    fun valueAsDefaultString(value: Any?): String = when (value) {
+    fun valueAsDefaultString(value: T?): String = when (value) {
         null -> {
             check(nullable) { "NULL in non-nullable column" }
             "NULL"
@@ -78,7 +75,7 @@ interface IColumnType {
      * Returns the String representation of the specified **non-null** [value] when [value] is set as the default for
      * the column.
      */
-    fun nonNullValueAsDefaultString(value: Any): String = nonNullValueToString(value)
+    fun nonNullValueAsDefaultString(value: T & Any): String = nonNullValueToString(value)
 
     /** Returns the object at the specified [index] in the [rs]. */
     fun readObject(rs: ResultSet, index: Int): Any? = rs.getObject(index)
@@ -97,22 +94,21 @@ interface IColumnType {
      * [value] can be of any type (including [Expression])
      * */
     @Throws(IllegalArgumentException::class)
-    fun validateValueBeforeUpdate(value: Any?) {}
+    fun validateValueBeforeUpdate(value: T?) {}
 }
 
 /**
  * Standard column type.
  */
-abstract class ColumnType(override var nullable: Boolean = false) : IColumnType {
+abstract class ColumnType<T>(override var nullable: Boolean = false) : IColumnType<T> {
     override fun toString(): String = sqlType()
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as ColumnType
+        other as ColumnType<*>
 
-        if (nullable != other.nullable) return false
-        return true
+        return nullable == other.nullable
     }
 
     override fun hashCode(): Int = 31 * javaClass.hashCode() + nullable.hashCode()
@@ -121,12 +117,12 @@ abstract class ColumnType(override var nullable: Boolean = false) : IColumnType 
 /**
  * Auto-increment column type.
  */
-class AutoIncColumnType(
+class AutoIncColumnType<T>(
     /** Returns the base column type of this auto-increment column. */
-    val delegate: ColumnType,
+    val delegate: ColumnType<T>,
     private val _autoincSeq: String?,
     private val fallbackSeqName: String
-) : IColumnType by delegate {
+) : IColumnType<T> by delegate {
 
     private val nextValValue = run {
         val sequence = Sequence(_autoincSeq ?: fallbackSeqName)
@@ -142,7 +138,7 @@ class AutoIncColumnType(
     val nextValExpression: NextVal<*>?
         get() = nextValValue.takeIf { autoincSeq != null }
 
-    private fun resolveAutoIncType(columnType: IColumnType): String = when {
+    private fun resolveAutoIncType(columnType: IColumnType<*>): String = when {
         columnType is EntityIDColumnType<*> -> resolveAutoIncType(columnType.idColumn.columnType)
         columnType is IntegerColumnType && autoincSeq != null -> currentDialect.dataTypeProvider.integerType()
         columnType is IntegerColumnType -> currentDialect.dataTypeProvider.integerAutoincType()
@@ -166,7 +162,7 @@ class AutoIncColumnType(
             other == null -> false
             this === other -> true
             this::class != other::class -> false
-            other !is AutoIncColumnType -> false
+            other !is AutoIncColumnType<*> -> false
             delegate != other.delegate -> false
             _autoincSeq != other._autoincSeq -> false
             fallbackSeqName != other.fallbackSeqName -> false
@@ -183,15 +179,15 @@ class AutoIncColumnType(
 }
 
 /** Returns `true` if this is an auto-increment column, `false` otherwise. */
-val IColumnType.isAutoInc: Boolean
+val IColumnType<*>.isAutoInc: Boolean
     get() = this is AutoIncColumnType || (this is EntityIDColumnType<*> && idColumn.columnType.isAutoInc)
 
 /** Returns the name of the auto-increment sequence of this column. */
-val Column<*>.autoIncColumnType: AutoIncColumnType?
+val Column<*>.autoIncColumnType: AutoIncColumnType<*>?
     get() = (columnType as? AutoIncColumnType)
         ?: (columnType as? EntityIDColumnType<*>)?.idColumn?.columnType as? AutoIncColumnType
 
-internal fun IColumnType.rawSqlType(): IColumnType = when {
+internal fun IColumnType<*>.rawSqlType(): IColumnType<*> = when {
     this is AutoIncColumnType -> delegate
     this is EntityIDColumnType<*> && idColumn.columnType is AutoIncColumnType -> idColumn.columnType.delegate
     else -> this
@@ -203,7 +199,7 @@ internal fun IColumnType.rawSqlType(): IColumnType = when {
 class EntityIDColumnType<T : Comparable<T>>(
     /** The underlying wrapped column storing the identity values. */
     val idColumn: Column<T>
-) : ColumnType() {
+) : ColumnType<EntityID<T>>() {
 
     init {
         require(idColumn.table is IdTable<*>) { "EntityId supported only for IdTables" }
@@ -211,19 +207,9 @@ class EntityIDColumnType<T : Comparable<T>>(
 
     override fun sqlType(): String = idColumn.columnType.sqlType()
 
-    override fun notNullValueToDB(value: Any): Any = idColumn.columnType.notNullValueToDB(
-        when (value) {
-            is EntityID<*> -> value.value
-            else -> value
-        }
-    )
+    override fun notNullValueToDB(value: EntityID<T>): Any = idColumn.columnType.notNullValueToDB(value.value)
 
-    override fun nonNullValueToString(value: Any): String = idColumn.columnType.nonNullValueToString(
-        when (value) {
-            is EntityID<*> -> value.value
-            else -> value
-        }
-    )
+    override fun nonNullValueToString(value: EntityID<T>): String = idColumn.columnType.nonNullValueToString(value.value)
 
     @Suppress("UNCHECKED_CAST")
     override fun valueFromDB(value: Any): EntityID<T> = EntityIDFunctionProvider.createEntityID(
@@ -241,7 +227,7 @@ class EntityIDColumnType<T : Comparable<T>>(
 
         return when (other) {
             is EntityIDColumnType<*> -> idColumn == other.idColumn
-            is IColumnType -> idColumn.columnType == other
+            is IColumnType<*> -> idColumn.columnType == other
             else -> false
         }
     }
@@ -254,7 +240,7 @@ class EntityIDColumnType<T : Comparable<T>>(
 /**
  * Numeric column for storing 1-byte integers.
  */
-class ByteColumnType : ColumnType() {
+class ByteColumnType : ColumnType<Byte>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.byteType()
 
     override fun valueFromDB(value: Any): Byte = when (value) {
@@ -272,7 +258,7 @@ class ByteColumnType : ColumnType() {
  * database's 2-byte integer type with a check constraint that ensures storage of only values
  * between 0 and [UByte.MAX_VALUE] inclusive.
  */
-class UByteColumnType : ColumnType() {
+class UByteColumnType : ColumnType<UByte>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.ubyteType()
 
     override fun valueFromDB(value: Any): UByte {
@@ -293,19 +279,13 @@ class UByteColumnType : ColumnType() {
         super.setParameter(stmt, index, v)
     }
 
-    override fun notNullValueToDB(value: Any): Any {
-        val v = when (value) {
-            is UByte -> value.toShort()
-            else -> value
-        }
-        return super.notNullValueToDB(v)
-    }
+    override fun notNullValueToDB(value: UByte): Any = value.toShort()
 }
 
 /**
  * Numeric column for storing 2-byte integers.
  */
-class ShortColumnType : ColumnType() {
+class ShortColumnType : ColumnType<Short>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.shortType()
     override fun valueFromDB(value: Any): Short = when (value) {
         is Short -> value
@@ -321,7 +301,7 @@ class ShortColumnType : ColumnType() {
  * **Note:** If the database being used is not MySQL or MariaDB, this column will represent the database's 4-byte
  * integer type with a check constraint that ensures storage of only values between 0 and [UShort.MAX_VALUE] inclusive.
  */
-class UShortColumnType : ColumnType() {
+class UShortColumnType : ColumnType<UShort>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.ushortType()
     override fun valueFromDB(value: Any): UShort {
         return when (value) {
@@ -341,19 +321,13 @@ class UShortColumnType : ColumnType() {
         super.setParameter(stmt, index, v)
     }
 
-    override fun notNullValueToDB(value: Any): Any {
-        val v = when (value) {
-            is UShort -> value.toInt()
-            else -> value
-        }
-        return super.notNullValueToDB(v)
-    }
+    override fun notNullValueToDB(value: UShort): Any = value.toInt()
 }
 
 /**
  * Numeric column for storing 4-byte integers.
  */
-class IntegerColumnType : ColumnType() {
+class IntegerColumnType : ColumnType<Int>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.integerType()
     override fun valueFromDB(value: Any): Int = when (value) {
         is Int -> value
@@ -370,7 +344,7 @@ class IntegerColumnType : ColumnType() {
  * 8-byte integer type with a check constraint that ensures storage of only values
  * between 0 and [UInt.MAX_VALUE] inclusive.
  */
-class UIntegerColumnType : ColumnType() {
+class UIntegerColumnType : ColumnType<UInt>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.uintegerType()
     override fun valueFromDB(value: Any): UInt {
         return when (value) {
@@ -390,19 +364,13 @@ class UIntegerColumnType : ColumnType() {
         super.setParameter(stmt, index, v)
     }
 
-    override fun notNullValueToDB(value: Any): Any {
-        val v = when (value) {
-            is UInt -> value.toLong()
-            else -> value
-        }
-        return super.notNullValueToDB(v)
-    }
+    override fun notNullValueToDB(value: UInt): Any = value.toLong()
 }
 
 /**
  * Numeric column for storing 8-byte integers.
  */
-class LongColumnType : ColumnType() {
+class LongColumnType : ColumnType<Long>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.longType()
     override fun valueFromDB(value: Any): Long = when (value) {
         is Long -> value
@@ -415,7 +383,7 @@ class LongColumnType : ColumnType() {
 /**
  * Numeric column for storing unsigned 8-byte integers.
  */
-class ULongColumnType : ColumnType() {
+class ULongColumnType : ColumnType<ULong>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.ulongType()
     override fun valueFromDB(value: Any): ULong {
         return when (value) {
@@ -444,20 +412,16 @@ class ULongColumnType : ColumnType() {
         super.setParameter(stmt, index, v)
     }
 
-    override fun notNullValueToDB(value: Any): Any {
-        val v = when {
-            value is ULong && currentDialect is MysqlDialect -> value.toString()
-            value is ULong -> value.toLong()
-            else -> value
-        }
-        return super.notNullValueToDB(v)
+    override fun notNullValueToDB(value: ULong) = when {
+        currentDialect is MysqlDialect -> value.toString()
+        else -> value.toLong()
     }
 }
 
 /**
  * Numeric column for storing 4-byte (single precision) floating-point numbers.
  */
-class FloatColumnType : ColumnType() {
+class FloatColumnType : ColumnType<Float>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.floatType()
     override fun valueFromDB(value: Any): Float = when (value) {
         is Float -> value
@@ -470,7 +434,7 @@ class FloatColumnType : ColumnType() {
 /**
  * Numeric column for storing 8-byte (double precision) floating-point numbers.
  */
-class DoubleColumnType : ColumnType() {
+class DoubleColumnType : ColumnType<Double>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.doubleType()
     override fun valueFromDB(value: Any): Double = when (value) {
         is Double -> value
@@ -488,7 +452,7 @@ class DecimalColumnType(
     val precision: Int,
     /** Count of decimal digits in the fractional part. */
     val scale: Int
-) : ColumnType() {
+) : ColumnType<BigDecimal>() {
     override fun sqlType(): String = "DECIMAL($precision, $scale)"
 
     override fun readObject(rs: ResultSet, index: Int): Any? {
@@ -547,7 +511,7 @@ class DecimalColumnType(
 /**
  * Character column for storing single characters.
  */
-class CharacterColumnType : ColumnType() {
+class CharacterColumnType : ColumnType<Char>() {
     override fun sqlType(): String = "CHAR"
     override fun valueFromDB(value: Any): Char = when (value) {
         is Char -> value
@@ -556,8 +520,9 @@ class CharacterColumnType : ColumnType() {
         else -> error("Unexpected value of type Char: $value of ${value::class.qualifiedName}")
     }
 
-    override fun notNullValueToDB(value: Any): Any = value.toString()
-    override fun nonNullValueToString(value: Any): String = "'$value'"
+    override fun notNullValueToDB(value: Char): Any = value.toString()
+
+    override fun nonNullValueToString(value: Char): String = "'$value'"
 }
 
 /**
@@ -566,7 +531,7 @@ class CharacterColumnType : ColumnType() {
 abstract class StringColumnType(
     /** Returns the collate type used in by this column. */
     val collate: String? = null
-) : ColumnType() {
+) : ColumnType<String>() {
     /** Returns the specified [value] with special characters escaped. */
     protected fun escape(value: String): String = value.map { charactersToEscape[it] ?: it }.joinToString("")
 
@@ -576,15 +541,15 @@ abstract class StringColumnType(
         else -> escape(value)
     }
 
-    override fun valueFromDB(value: Any): Any = when (value) {
+    override fun valueFromDB(value: Any): String = when (value) {
         is Clob -> value.characterStream.readText()
         is ByteArray -> String(value)
-        else -> value
+        else -> value.toString()
     }
 
-    override fun nonNullValueToString(value: Any): String = buildString {
+    override fun nonNullValueToString(value: String): String = buildString {
         append('\'')
-        append(escape(value.toString()))
+        append(escape(value))
         append('\'')
     }
 
@@ -595,9 +560,7 @@ abstract class StringColumnType(
 
         other as StringColumnType
 
-        if (collate != other.collate) return false
-
-        return true
+        return collate == other.collate
     }
 
     override fun hashCode(): Int {
@@ -609,7 +572,6 @@ abstract class StringColumnType(
     companion object {
         private val charactersToEscape = mapOf(
             '\'' to "\'\'",
-//            '\"' to "\"\"", // no need to escape double quote as we put string in single quotes
             '\r' to "\\r",
             '\n' to "\\n"
         )
@@ -631,7 +593,7 @@ open class CharColumnType(
         }
     }
 
-    override fun validateValueBeforeUpdate(value: Any?) {
+    override fun validateValueBeforeUpdate(value: String?) {
         if (value is String) {
             val valueLength = value.codePointCount(0, value.length)
             require(valueLength <= colLength) {
@@ -677,7 +639,7 @@ open class VarCharColumnType(
         }
     }
 
-    override fun validateValueBeforeUpdate(value: Any?) {
+    override fun validateValueBeforeUpdate(value: String?) {
         if (value is String) {
             val valueLength = value.codePointCount(0, value.length)
             require(valueLength <= colLength) {
@@ -693,9 +655,7 @@ open class VarCharColumnType(
 
         other as VarCharColumnType
 
-        if (colLength != other.colLength) return false
-
-        return true
+        return colLength == other.colLength
     }
 
     override fun hashCode(): Int {
@@ -752,21 +712,19 @@ open class LargeTextColumnType(
 /**
  * Binary column for storing binary strings of variable and _unlimited_ length.
  */
-open class BasicBinaryColumnType : ColumnType() {
+open class BasicBinaryColumnType : ColumnType<ByteArray>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.binaryType()
 
     override fun readObject(rs: ResultSet, index: Int): Any? = rs.getBytes(index)
 
-    override fun valueFromDB(value: Any): Any = when (value) {
+    override fun valueFromDB(value: Any): ByteArray = when (value) {
         is Blob -> value.binaryStream.use { it.readBytes() }
         is InputStream -> value.use { it.readBytes() }
-        else -> value
+        is ByteArray -> value
+        else -> error("Unexpected value $value of type ${value::class.qualifiedName}")
     }
 
-    override fun nonNullValueToString(value: Any): String = when (value) {
-        is ByteArray -> value.toString(Charsets.UTF_8)
-        else -> value.toString()
-    }
+    override fun nonNullValueToString(value: ByteArray): String = value.toString(Charsets.UTF_8)
 }
 
 /**
@@ -778,7 +736,7 @@ open class BinaryColumnType(
 ) : BasicBinaryColumnType() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.binaryType(length)
 
-    override fun validateValueBeforeUpdate(value: Any?) {
+    override fun validateValueBeforeUpdate(value: ByteArray?) {
         if (value is ByteArray) {
             val valueLength = value.size
             require(valueLength <= length) {
@@ -794,9 +752,7 @@ open class BinaryColumnType(
 
         other as BinaryColumnType
 
-        if (length != other.length) return false
-
-        return true
+        return length == other.length
     }
 
     override fun hashCode(): Int {
@@ -812,12 +768,13 @@ open class BinaryColumnType(
 class BlobColumnType(
     /** Returns whether an OID column should be used instead of BYTEA. This value only applies to PostgreSQL databases. */
     val useObjectIdentifier: Boolean = false
-) : ColumnType() {
+) : ColumnType<ExposedBlob>() {
     override fun sqlType(): String = when {
         useObjectIdentifier && currentDialect is PostgreSQLDialect -> "oid"
         useObjectIdentifier -> error("Storing BLOBs using OID columns is only supported by PostgreSQL")
         else -> currentDialect.dataTypeProvider.blobType()
     }
+
     override fun valueFromDB(value: Any): ExposedBlob = when (value) {
         is ExposedBlob -> value
         is InputStream -> ExposedBlob(value)
@@ -825,21 +782,7 @@ class BlobColumnType(
         else -> error("Unexpected value of type Blob: $value of ${value::class.qualifiedName}")
     }
 
-    override fun notNullValueToDB(value: Any): Any {
-        return if (value is Blob) {
-            value.binaryStream
-        } else {
-            value
-        }
-    }
-
-    override fun nonNullValueToString(value: Any): String {
-        if (value !is ExposedBlob) {
-            error("Unexpected value of type Blob: $value of ${value::class.qualifiedName}")
-        }
-
-        return currentDialect.dataTypeProvider.hexToDb(value.hexString())
-    }
+    override fun nonNullValueToString(value: ExposedBlob): String = currentDialect.dataTypeProvider.hexToDb(value.hexString())
 
     override fun readObject(rs: ResultSet, index: Int) = when {
         currentDialect is SQLServerDialect -> rs.getBytes(index)?.let(::ExposedBlob)
@@ -859,7 +802,7 @@ class BlobColumnType(
 /**
  * Binary column for storing [UUID].
  */
-class UUIDColumnType : ColumnType() {
+class UUIDColumnType : ColumnType<UUID>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.uuidType()
 
     override fun valueFromDB(value: Any): UUID = when {
@@ -870,16 +813,9 @@ class UUIDColumnType : ColumnType() {
         else -> error("Unexpected value of type UUID: $value of ${value::class.qualifiedName}")
     }
 
-    override fun notNullValueToDB(value: Any): Any = currentDialect.dataTypeProvider.uuidToDB(valueToUUID(value))
+    override fun notNullValueToDB(value: UUID): Any = currentDialect.dataTypeProvider.uuidToDB(value)
 
-    override fun nonNullValueToString(value: Any): String = "'${valueToUUID(value)}'"
-
-    private fun valueToUUID(value: Any): UUID = when (value) {
-        is UUID -> value
-        is String -> UUID.fromString(value)
-        is ByteArray -> ByteBuffer.wrap(value).let { UUID(it.long, it.long) }
-        else -> error("Unexpected value of type UUID: ${value.javaClass.canonicalName}")
-    }
+    override fun nonNullValueToString(value: UUID): String = "'$value'"
 
     override fun readObject(rs: ResultSet, index: Int): Any? = when (currentDialect) {
         is MariaDBDialect -> rs.getBytes(index)
@@ -897,7 +833,7 @@ class UUIDColumnType : ColumnType() {
 /**
  * Boolean column for storing boolean values.
  */
-class BooleanColumnType : ColumnType() {
+class BooleanColumnType : ColumnType<Boolean>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.booleanType()
 
     override fun valueFromDB(value: Any): Boolean = when (value) {
@@ -906,12 +842,11 @@ class BooleanColumnType : ColumnType() {
         else -> value.toString().toBoolean()
     }
 
-    override fun nonNullValueToString(value: Any): String =
-        currentDialect.dataTypeProvider.booleanToStatementString(value as Boolean)
+    override fun nonNullValueToString(value: Boolean): String =
+        currentDialect.dataTypeProvider.booleanToStatementString(value)
 
-    override fun notNullValueToDB(value: Any): Any = when {
-        value is Boolean &&
-            (currentDialect is OracleDialect || currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) ->
+    override fun notNullValueToDB(value: Boolean): Any = when {
+        (currentDialect is OracleDialect || currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) ->
             nonNullValueToString(value)
         else -> value
     }
@@ -929,7 +864,7 @@ class BooleanColumnType : ColumnType() {
 class EnumerationColumnType<T : Enum<T>>(
     /** Returns the enum class used in this column type. */
     val klass: KClass<T>
-) : ColumnType() {
+) : ColumnType<T>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.integerType()
     private val enumConstants by lazy { klass.java.enumConstants!! }
 
@@ -940,11 +875,7 @@ class EnumerationColumnType<T : Enum<T>>(
         else -> error("$value of ${value::class.qualifiedName} is not valid for enum ${klass.simpleName}")
     }
 
-    override fun notNullValueToDB(value: Any): Int = when (value) {
-        is Int -> value
-        is Enum<*> -> value.ordinal
-        else -> error("$value of ${value::class.qualifiedName} is not valid for enum ${klass.simpleName}")
-    }
+    override fun notNullValueToDB(value: T): Int = value.ordinal
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -971,9 +902,11 @@ class EnumerationColumnType<T : Enum<T>>(
 class EnumerationNameColumnType<T : Enum<T>>(
     /** Returns the enum class used in this column type. */
     val klass: KClass<T>,
-    colLength: Int
-) : VarCharColumnType(colLength) {
+    val colLength: Int
+) : ColumnType<T>() {
     private val enumConstants by lazy { klass.java.enumConstants!!.associateBy { it.name } }
+
+    override fun sqlType(): String = currentDialect.dataTypeProvider.varcharType(colLength)
 
     @Suppress("UNCHECKED_CAST")
     override fun valueFromDB(value: Any): T = when (value) {
@@ -984,10 +917,21 @@ class EnumerationNameColumnType<T : Enum<T>>(
         else -> error("$value of ${value::class.qualifiedName} is not valid for enum ${klass.qualifiedName}")
     }
 
-    override fun notNullValueToDB(value: Any): Any = when (value) {
-        is String -> super.notNullValueToDB(value)
-        is Enum<*> -> super.notNullValueToDB(value.name)
-        else -> error("$value of ${value::class.qualifiedName} is not valid for enum ${klass.qualifiedName}")
+    override fun notNullValueToDB(value: T): Any = value.name
+
+    override fun nonNullValueToString(value: T): String = buildString {
+        append('\'')
+        append(escape(value.name))
+        append('\'')
+    }
+
+    override fun validateValueBeforeUpdate(value: T?) {
+        if (value != null) {
+            val valueLength = value.name.codePointCount(0, value.name.length)
+            require(valueLength <= colLength) {
+                "Value can't be stored to database column because exceeds length ($valueLength > $colLength)"
+            }
+        }
     }
 
     override fun equals(other: Any?): Boolean {
@@ -1007,6 +951,16 @@ class EnumerationNameColumnType<T : Enum<T>>(
         result = 31 * result + klass.hashCode()
         return result
     }
+
+    private fun escape(value: String): String = value.map { charactersToEscape[it] ?: it }.joinToString("")
+
+    companion object {
+        private val charactersToEscape = mapOf(
+            '\'' to "\'\'",
+            '\r' to "\\r",
+            '\n' to "\\n"
+        )
+    }
 }
 
 /**
@@ -1021,16 +975,29 @@ class CustomEnumerationColumnType<T : Enum<T>>(
     val fromDb: (Any) -> T,
     /** Returns the function that converts an enumeration instance [T] to a value that will be stored to a database. */
     val toDb: (T) -> Any
-) : StringColumnType() {
+) : ColumnType<T>() {
     override fun sqlType(): String = sql ?: error("Column $name should exist in database")
 
     @Suppress("UNCHECKED_CAST")
     override fun valueFromDB(value: Any): T = if (value::class.isSubclassOf(Enum::class)) value as T else fromDb(value)
 
-    @Suppress("UNCHECKED_CAST")
-    override fun notNullValueToDB(value: Any): Any = toDb(value as T)
+    override fun notNullValueToDB(value: T): Any = toDb(value)
 
-    override fun nonNullValueToString(value: Any): String = super.nonNullValueToString(notNullValueToDB(value))
+    override fun nonNullValueToString(value: T): String = buildString {
+        append('\'')
+        append(escape(notNullValueToDB(value).toString()))
+        append('\'')
+    }
+
+    private fun escape(value: String): String = value.map { charactersToEscape[it] ?: it }.joinToString("")
+
+    companion object {
+        private val charactersToEscape = mapOf(
+            '\'' to "\'\'",
+            '\r' to "\\r",
+            '\n' to "\\n"
+        )
+    }
 }
 
 // Array columns
@@ -1038,12 +1005,12 @@ class CustomEnumerationColumnType<T : Enum<T>>(
 /**
  * Array column for storing a collection of elements.
  */
-class ArrayColumnType(
+class ArrayColumnType<E>(
     /** Returns the base column type of this array column's individual elements. */
-    val delegate: ColumnType,
+    val delegate: ColumnType<E & Any>,
     /** Returns the maximum amount of allowed elements in this array column. */
     val maximumCardinality: Int? = null
-) : ColumnType() {
+) : ColumnType<List<E>>() {
     override fun sqlType(): String = buildString {
         append(delegate.sqlType())
         when {
@@ -1056,37 +1023,24 @@ class ArrayColumnType(
     val delegateType: String
         get() = delegate.sqlType().substringBefore('(')
 
-    override fun valueFromDB(value: Any): Any = when {
-        value is java.sql.Array -> (value.array as Array<*>).map { e -> e?.let { delegate.valueFromDB(it) } }
-        else -> value
+    @Suppress("UNCHECKED_CAST")
+    override fun valueFromDB(value: Any): List<E> = when {
+        value is java.sql.Array -> (value.array as Array<*>).map { e -> e?.let { delegate.valueFromDB(it) } as E }
+        else -> value as? List<E> ?: error("Unexpected value $value of type ${value::class.qualifiedName}")
     }
 
-    override fun notNullValueToDB(value: Any): Any = when {
-        value is List<*> -> value.map { e -> e?.let { delegate.notNullValueToDB(it) } }.toTypedArray()
-        else -> value
+    override fun notNullValueToDB(value: List<E>): Any = value.map { e -> e?.let { delegate.notNullValueToDB(it) } }.toTypedArray()
+
+    override fun valueToString(value: List<E>?): String = if (value != null) nonNullValueToString(value) else super.valueToString(value)
+
+    override fun nonNullValueToString(value: List<E>): String {
+        val prefix = if (currentDialect is H2Dialect) "ARRAY [" else "ARRAY["
+        return value.joinToString(",", prefix, "]") { delegate.valueToString(it) }
     }
 
-    override fun valueToString(value: Any?): String = when (value) {
-        is List<*> -> nonNullValueToString(value)
-        is Array<*> -> nonNullValueToString(value.toList())
-        else -> super.valueToString(value)
-    }
-
-    override fun nonNullValueToString(value: Any): String = when {
-        value is List<*> -> {
-            val prefix = if (currentDialect is H2Dialect) "ARRAY [" else "ARRAY["
-            value.joinToString(",", prefix, "]") { delegate.valueToString(it) }
-        }
-        else -> super.nonNullValueToString(value)
-    }
-
-    override fun nonNullValueAsDefaultString(value: Any): String = when (value) {
-        is List<*> -> {
-            val prefix = if (currentDialect is H2Dialect) "ARRAY [" else "ARRAY["
-            value.joinToString(",", prefix, "]") { delegate.valueAsDefaultString(it) }
-        }
-        is Array<*> -> nonNullValueAsDefaultString(value.toList())
-        else -> super.nonNullValueAsDefaultString(value)
+    override fun nonNullValueAsDefaultString(value: List<E>): String {
+        val prefix = if (currentDialect is H2Dialect) "ARRAY [" else "ARRAY["
+        return value.joinToString(",", prefix, "]") { delegate.valueAsDefaultString(it) }
     }
 
     override fun readObject(rs: ResultSet, index: Int): Any? = rs.getArray(index)
@@ -1126,25 +1080,29 @@ interface JsonColumnMarker {
 @InternalApi
 fun <T : Any> resolveColumnType(
     klass: KClass<T>,
-    defaultType: ColumnType? = null
-): ColumnType = when (klass) {
-    Boolean::class -> BooleanColumnType()
-    Byte::class -> ByteColumnType()
-    UByte::class -> UByteColumnType()
-    Short::class -> ShortColumnType()
-    UShort::class -> UShortColumnType()
-    Int::class -> IntegerColumnType()
-    UInt::class -> UIntegerColumnType()
-    Long::class -> LongColumnType()
-    ULong::class -> ULongColumnType()
-    Float::class -> FloatColumnType()
-    Double::class -> DoubleColumnType()
-    String::class -> TextColumnType()
-    Char::class -> CharacterColumnType()
-    ByteArray::class -> BasicBinaryColumnType()
-    BigDecimal::class -> DecimalColumnType.INSTANCE
-    UUID::class -> UUIDColumnType()
-    else -> defaultType ?: error(
+    defaultType: ColumnType<*>? = null
+): ColumnType<T> {
+    val type = when (klass) {
+        Boolean::class -> BooleanColumnType()
+        Byte::class -> ByteColumnType()
+        UByte::class -> UByteColumnType()
+        Short::class -> ShortColumnType()
+        UShort::class -> UShortColumnType()
+        Int::class -> IntegerColumnType()
+        UInt::class -> UIntegerColumnType()
+        Long::class -> LongColumnType()
+        ULong::class -> ULongColumnType()
+        Float::class -> FloatColumnType()
+        Double::class -> DoubleColumnType()
+        String::class -> TextColumnType()
+        Char::class -> CharacterColumnType()
+        ByteArray::class -> BasicBinaryColumnType()
+        BigDecimal::class -> DecimalColumnType.INSTANCE
+        UUID::class -> UUIDColumnType()
+        else -> defaultType
+    } as? ColumnType<T>
+
+    return type ?: error(
         "A column type could not be associated with ${klass.qualifiedName}. Provide an explicit column type argument."
     )
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ExplainQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ExplainQuery.kt
@@ -22,7 +22,7 @@ open class ExplainQuery(
 
     override fun PreparedStatementApi.executeInternal(transaction: Transaction): ResultSet = executeQuery()
 
-    override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = internalStatement.arguments()
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = internalStatement.arguments()
 
     override fun prepareSQL(transaction: Transaction, prepared: Boolean): String {
         val internalSql = internalStatement.prepareSQL(transaction, prepared)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -9,7 +9,7 @@ import java.math.BigDecimal
 /**
  * Represents an SQL function.
  */
-abstract class Function<T>(override val columnType: IColumnType) : ExpressionWithColumnType<T>()
+abstract class Function<T>(override val columnType: IColumnType<T & Any>) : ExpressionWithColumnType<T>()
 
 /**
  * Represents a custom SQL function.
@@ -17,7 +17,7 @@ abstract class Function<T>(override val columnType: IColumnType) : ExpressionWit
 open class CustomFunction<T>(
     /** Returns the name of the function. */
     val functionName: String,
-    columnType: IColumnType,
+    columnType: IColumnType<T & Any>,
     /** Returns the list of arguments of this function. */
     vararg val expr: Expression<*>
 ) : Function<T>(columnType) {
@@ -34,7 +34,7 @@ open class CustomFunction<T>(
 open class CustomOperator<T>(
     /** Returns the name of the operator. */
     val operatorName: String,
-    columnType: IColumnType,
+    columnType: IColumnType<T & Any>,
     /** Returns the left-hand side operand. */
     val expr1: Expression<*>,
     /** Returns the right-hand side operand. */
@@ -84,7 +84,7 @@ class CharLength<T : String?>(
 class LowerCase<T : String?>(
     /** Returns the expression to convert. */
     val expr: Expression<T>
-) : Function<T>(TextColumnType()) {
+) : Function<String>(TextColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("LOWER(", expr, ")") }
 }
 
@@ -94,7 +94,7 @@ class LowerCase<T : String?>(
 class UpperCase<T : String?>(
     /** Returns the expression to convert. */
     val expr: Expression<T>
-) : Function<T>(TextColumnType()) {
+) : Function<String>(TextColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("UPPER(", expr, ")") }
 }
 
@@ -124,7 +124,7 @@ class GroupConcat<T : String?>(
     val distinct: Boolean,
     /** Returns the order in which the elements of each group are sorted. */
     vararg val orderBy: Pair<Expression<*>, SortOrder>
-) : Function<T>(TextColumnType()) {
+) : Function<String>(TextColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.groupConcat(this, queryBuilder)
     }
@@ -138,7 +138,7 @@ class Substring<T : String?>(
     private val start: Expression<Int>,
     /** Returns the length of the substring. */
     val length: Expression<Int>
-) : Function<T>(TextColumnType()) {
+) : Function<String>(TextColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.substring(expr, start, length, queryBuilder)
     }
@@ -150,7 +150,7 @@ class Substring<T : String?>(
 class Trim<T : String?>(
     /** Returns the expression being trimmed. */
     val expr: Expression<T>
-) : Function<T>(TextColumnType()) {
+) : Function<String>(TextColumnType()) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("TRIM(", expr, ")") }
 }
 
@@ -170,7 +170,7 @@ class Locate<T : String?>(val expr: Expression<T>, val substring: String) : Func
 class Min<T : Comparable<T>, in S : T?>(
     /** Returns the expression from which the minimum value is obtained. */
     val expr: Expression<in S>,
-    columnType: IColumnType
+    columnType: IColumnType<T>
 ) : Function<T?>(columnType), WindowFunction<T?> {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("MIN(", expr, ")") }
 
@@ -185,7 +185,7 @@ class Min<T : Comparable<T>, in S : T?>(
 class Max<T : Comparable<T>, in S : T?>(
     /** Returns the expression from which the maximum value is obtained. */
     val expr: Expression<in S>,
-    columnType: IColumnType
+    columnType: IColumnType<T>
 ) : Function<T?>(columnType), WindowFunction<T?> {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("MAX(", expr, ")") }
 
@@ -197,9 +197,9 @@ class Max<T : Comparable<T>, in S : T?>(
 /**
  * Represents an SQL function that returns the average (arithmetic mean) of all non-null input values, or `null` if there are no non-null values.
  */
-class Avg<T : Comparable<T>, in S : T?>(
+class Avg<T : Comparable<T>, S : T?>(
     /** Returns the expression from which the average is calculated. */
-    val expr: Expression<in S>,
+    val expr: Expression<S>,
     scale: Int
 ) : Function<BigDecimal?>(DecimalColumnType(Int.MAX_VALUE, scale)), WindowFunction<BigDecimal?> {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("AVG(", expr, ")") }
@@ -215,7 +215,7 @@ class Avg<T : Comparable<T>, in S : T?>(
 class Sum<T>(
     /** Returns the expression from which the sum is calculated. */
     val expr: Expression<T>,
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : Function<T?>(columnType), WindowFunction<T?> {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { append("SUM(", expr, ")") }
 
@@ -351,7 +351,7 @@ class VarSamp<T>(
 sealed class NextVal<T>(
     /** Returns the sequence from which the next value is obtained. */
     val seq: Sequence,
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : Function<T>(columnType) {
 
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
@@ -393,30 +393,30 @@ class CaseWhen<T>(
 
     /** Adds a conditional expression with a [result] if the expression evaluates to `true`. */
     @Suppress("UNCHECKED_CAST")
-    fun <R : T> When(cond: Expression<Boolean>, result: Expression<R>): CaseWhen<R> {
+    fun When(cond: Expression<Boolean>, result: Expression<T>): CaseWhen<T> {
         cases.add(cond to result)
-        return this as CaseWhen<R>
+        return this
     }
 
     /** Adds an expression that will be used as the function result if all [cases] evaluate to `false`. */
-    fun <R : T> Else(e: Expression<R>): ExpressionWithColumnType<R> = CaseWhenElse(this, e)
+    fun Else(e: Expression<T>): ExpressionWithColumnType<T> = CaseWhenElse(this, e)
 }
 
 /**
  * Represents an SQL function that steps through conditions, and either returns a value when the first condition is met
  * or returns [elseResult] if all conditions are `false`.
  */
-class CaseWhenElse<T, R : T>(
+class CaseWhenElse<T>(
     /** The conditions to check and their results if met. */
     val caseWhen: CaseWhen<T>,
     /** The result if none of the conditions checked are found to be `true`. */
-    val elseResult: Expression<R>
-) : ExpressionWithColumnType<R>(), ComplexExpression {
+    val elseResult: Expression<T>
+) : ExpressionWithColumnType<T>(), ComplexExpression {
 
-    override val columnType: IColumnType =
-        (elseResult as? ExpressionWithColumnType<R>)?.columnType
-            ?: caseWhen.cases.map { it.second }.filterIsInstance<ExpressionWithColumnType<*>>().firstOrNull()?.columnType
-            ?: BooleanColumnType.INSTANCE
+    override val columnType: IColumnType<T & Any> =
+        (elseResult as? ExpressionWithColumnType<T>)?.columnType
+            ?: caseWhen.cases.map { it.second }.filterIsInstance<ExpressionWithColumnType<T>>().firstOrNull()?.columnType
+            ?: error("No column type has been found")
 
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder {
@@ -438,11 +438,11 @@ class CaseWhenElse<T, R : T>(
 /**
  * Represents an SQL function that returns the first of its arguments that is not null.
  */
-class Coalesce<out T, S : T?, R : T>(
+class Coalesce<out T, S : T?>(
     private val expr: ExpressionWithColumnType<S>,
     private val alternate: Expression<out T>,
     private vararg val others: Expression<out T>
-) : Function<R>(expr.columnType) {
+) : Function<S>(expr.columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         (listOf(expr, alternate) + others).appendTo(
             prefix = "COALESCE(",
@@ -460,7 +460,7 @@ class Coalesce<out T, S : T?, R : T>(
 class Cast<T>(
     /** Returns the expression being casted. */
     val expr: Expression<*>,
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : Function<T>(columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         currentDialect.functionProvider.cast(expr, columnType, queryBuilder)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -309,7 +309,7 @@ class PlusOp<T, S : T>(
     /** The right-hand side operand. */
     expr2: Expression<S>,
     /** The column type of this expression. */
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : CustomOperator<T>("+", columnType, expr1, expr2)
 
 /**
@@ -321,7 +321,7 @@ class MinusOp<T, S : T>(
     /** The right-hand side operand. */
     expr2: Expression<S>,
     /** The column type of this expression. */
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : CustomOperator<T>("-", columnType, expr1, expr2)
 
 /**
@@ -333,7 +333,7 @@ class TimesOp<T, S : T>(
     /** The right-hand side operand. */
     expr2: Expression<S>,
     /** The column type of this expression. */
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : CustomOperator<T>("*", columnType, expr1, expr2)
 
 /**
@@ -345,7 +345,7 @@ class DivideOp<T, S : T>(
     /** The right-hand side operand. */
     private val divisor: Expression<S>,
     /** The column type of this expression. */
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : CustomOperator<T>("/", columnType, dividend, divisor) {
     companion object {
         fun <T : BigDecimal?, S : T> DivideOp<T, S>.withScale(scale: Int): DivideOp<T, S> {
@@ -356,7 +356,7 @@ class DivideOp<T, S : T>(
                 decimalLiteral(it.setScale(1)) // it is needed to treat dividend as decimal instead of integer in SQL
             } ?: dividend
 
-            return DivideOp(newExpression as Expression<T>, divisor, decimalColumnType)
+            return DivideOp(newExpression as Expression<T>, divisor, decimalColumnType as IColumnType<T & Any>)
         }
     }
 }
@@ -369,7 +369,7 @@ class ModOp<T : Number?, S : Number?, R : Number?>(
     val expr1: Expression<T>,
     /** Returns the right-hand side operand. */
     val expr2: Expression<S>,
-    override val columnType: IColumnType
+    override val columnType: IColumnType<R & Any>
 ) : ExpressionWithColumnType<R>() {
 
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
@@ -431,7 +431,7 @@ class AndBitOp<T, S : T>(
     /** The right-hand side operand. */
     val expr2: Expression<S>,
     /** The column type of this expression. */
-    override val columnType: IColumnType
+    override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         when (val dialect = currentDialectIfAvailable) {
@@ -462,7 +462,7 @@ class OrBitOp<T, S : T>(
     /** The right-hand side operand. */
     val expr2: Expression<S>,
     /** The column type of this expression. */
-    override val columnType: IColumnType
+    override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         when (val dialect = currentDialectIfAvailable) {
@@ -494,7 +494,7 @@ class XorBitOp<T, S : T>(
     /** The right-hand side operand. */
     val expr2: Expression<S>,
     /** The column type of this expression. */
-    override val columnType: IColumnType
+    override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         when (val dialect = currentDialectIfAvailable) {
@@ -638,7 +638,7 @@ class NotEqSubQueryOp<T>(expr: Expression<T>, query: AbstractQuery<*>) : SubQuer
  * Represents the specified [value] as an SQL literal, using the specified [columnType] to convert the value.
  */
 class LiteralOp<T>(
-    override val columnType: IColumnType,
+    override val columnType: IColumnType<T & Any>,
     /** Returns the value being used as a literal. */
     val value: T
 ) : ExpressionWithColumnType<T>() {
@@ -692,7 +692,7 @@ fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(Decimal
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType? = null): LiteralOp<List<T>> {
+inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType<T>? = null): LiteralOp<List<T>> {
     @OptIn(InternalApi::class)
     return LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class)), value)
 }
@@ -706,14 +706,14 @@ class QueryParameter<T>(
     /** Returns the value being used as a query parameter. */
     val value: T,
     /** Returns the column type of this expression. */
-    val sqlType: IColumnType
+    val sqlType: IColumnType<T & Any>
 ) : Expression<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { registerArgument(sqlType, value) }
 }
 
 /** Returns the specified [value] as a query parameter with the same type as [column]. */
 fun <T : Comparable<T>> idParam(value: EntityID<T>, column: Column<EntityID<T>>): Expression<EntityID<T>> =
-    QueryParameter(value, EntityIDColumnType(column))
+    QueryParameter(value, column.columnType)
 
 /** Returns the specified [value] as a boolean query parameter. */
 fun booleanParam(value: Boolean): Expression<Boolean> = QueryParameter(value, BooleanColumnType.INSTANCE)
@@ -771,7 +771,7 @@ fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Express
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType? = null): Expression<List<T>> {
+inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType<T>? = null): Expression<List<T>> {
     @OptIn(InternalApi::class)
     return QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class)))
 }
@@ -785,7 +785,7 @@ inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType
 class NoOpConversion<T, S>(
     /** Returns the expression whose type is being changed. */
     val expr: Expression<T>,
-    override val columnType: IColumnType
+    override val columnType: IColumnType<S & Any>
 ) : ExpressionWithColumnType<S>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder { +expr }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -204,16 +204,17 @@ object SchemaUtils {
                                     else -> processed.trim('\'')
                                 }
                             }
-                            column.columnType is ArrayColumnType && dialect is PostgreSQLDialect -> {
+                            column.columnType is ArrayColumnType<*> && dialect is PostgreSQLDialect -> {
                                 (value as List<*>)
                                     .takeIf { it.isNotEmpty() }
                                     ?.run {
-                                        val delegate = column.withColumnType(column.columnType.delegate)
+                                        val delegateColumnType = column.columnType.delegate as IColumnType<Any>
+                                        val delegateColumn = (column as Column<Any?>).withColumnType(delegateColumnType)
                                         val processed = map {
-                                            if (delegate.columnType is StringColumnType) {
+                                            if (delegateColumn.columnType is StringColumnType) {
                                                 "'$it'::text"
                                             } else {
-                                                dbDefaultToString(delegate, delegate.asLiteral(it))
+                                                dbDefaultToString(delegateColumn, delegateColumn.asLiteral(it))
                                             }
                                         }
                                         "ARRAY$processed"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -515,7 +515,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     // Column registration
 
     /** Adds a column of the specified [type] and with the specified [name] to the table. */
-    fun <T> registerColumn(name: String, type: IColumnType): Column<T> = Column<T>(
+    fun <T> registerColumn(name: String, type: IColumnType<T & Any>): Column<T> = Column<T>(
         this,
         name,
         type
@@ -826,7 +826,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param maximumCardinality The maximum amount of allowed elements. **Note** Providing an array size limit
      * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      */
-    fun <T> array(name: String, columnType: ColumnType, maximumCardinality: Int? = null): Column<List<T>> =
+    fun <E> array(name: String, columnType: ColumnType<E & Any>, maximumCardinality: Int? = null): Column<List<E>> =
         registerColumn(name, ArrayColumnType(columnType.apply { nullable = true }, maximumCardinality))
 
     /**
@@ -844,9 +844,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      * @throws IllegalStateException If no column type mapping is found.
      */
-    inline fun <reified T : Any> array(name: String, maximumCardinality: Int? = null): Column<List<T>> {
+    inline fun <reified E : Any> array(name: String, maximumCardinality: Int? = null): Column<List<E>> {
         @OptIn(InternalApi::class)
-        return array(name, resolveColumnType(T::class), maximumCardinality)
+        return array(name, resolveColumnType(E::class), maximumCardinality)
     }
 
     // Auto-generated values
@@ -1011,7 +1011,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         onUpdate: ReferenceOption? = null,
         fkName: String? = null
     ): Column<T> {
-        val column = Column<T>(
+        val column = Column(
             this,
             name,
             refColumn.columnType.cloneAsBaseType()
@@ -1334,7 +1334,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         }
     }
 
-    private fun IColumnType.cloneAsBaseType(): IColumnType = ((this as? AutoIncColumnType)?.delegate ?: this).clone()
+    private fun <T> IColumnType<T>.cloneAsBaseType(): IColumnType<T> = ((this as? AutoIncColumnType)?.delegate ?: this).clone()
 
     private fun <T> Column<T>.cloneWithAutoInc(idSeqName: String?): Column<T> = when (columnType) {
         is AutoIncColumnType -> this

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -163,7 +163,7 @@ open class Transaction(
      */
     fun exec(
         @Language("sql") stmt: String,
-        args: Iterable<Pair<IColumnType, Any?>> = emptyList(),
+        args: Iterable<Pair<IColumnType<*>, Any?>> = emptyList(),
         explicitStatementType: StatementType? = null
     ) = exec(stmt, args, explicitStatementType) { }
 
@@ -185,7 +185,7 @@ open class Transaction(
      */
     fun <T : Any> exec(
         @Language("sql") stmt: String,
-        args: Iterable<Pair<IColumnType, Any?>> = emptyList(),
+        args: Iterable<Pair<IColumnType<*>, Any?>> = emptyList(),
         explicitStatementType: StatementType? = null,
         transform: (ResultSet) -> T?
     ): T? {
@@ -213,7 +213,7 @@ open class Transaction(
 
             override fun prepareSQL(transaction: Transaction, prepared: Boolean): String = stmt
 
-            override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = listOf(
+            override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = listOf(
                 args.map { (columnType, value) ->
                     columnType.apply { nullable = true } to value
                 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/WindowFunction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/WindowFunction.kt
@@ -15,7 +15,7 @@ interface WindowFunction<T> {
 /** Represents an SQL window function with window definition. */
 @Suppress("TooManyFunctions")
 class WindowFunctionDefinition<T>(
-    override val columnType: IColumnType,
+    override val columnType: IColumnType<T & Any>,
     /** Returns the function that definition is used for. */
     private val function: WindowFunction<T>
 ) : ExpressionWithColumnType<T>() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/functions/array/ArrayFunctions.kt
@@ -19,7 +19,7 @@ class ArrayGet<E, T : List<E>?>(
     val expression: Expression<T>,
     /** The one-based index position at which the stored array is accessed. */
     val index: Int,
-    columnType: IColumnType
+    columnType: IColumnType<E & Any>
 ) : Function<E?>(columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder {
@@ -39,7 +39,7 @@ class ArraySlice<E, T : List<E>?>(
     val lower: Int?,
     /** The upper bounds (inclusive) of a subarray. If left `null`, the database will use the stored array's upper limit. */
     val upper: Int?,
-    columnType: IColumnType
+    columnType: IColumnType<T & Any>
 ) : Function<T>(columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         val functionProvider = when (currentDialect.h2Mode) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
@@ -45,7 +45,7 @@ class AllAnyFromSubQueryOp<T>(
 class AllAnyFromArrayOp<T : Any>(
     isAny: Boolean,
     array: List<T>,
-    private val delegateType: ColumnType
+    private val delegateType: ColumnType<T>
 ) : AllAnyFromBaseOp<T, List<T>>(isAny, array) {
     override fun QueryBuilder.registerSubSearchArgument(subSearch: List<T>) {
         registerArgument(ArrayColumnType(delegateType), subSearch)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpdateStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpdateStatement.kt
@@ -50,7 +50,7 @@ open class BatchUpdateStatement(val table: IdTable<*>) : UpdateStatement(table, 
 
     override fun PreparedStatementApi.executeInternal(transaction: Transaction): Int = if (data.size == 1) executeUpdate() else executeBatch().sum()
 
-    override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = data.map { (id, row) ->
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = data.map { (id, row) ->
         firstDataSet.map { it.first.columnType to row[it.first] } + (table.id.columnType to id)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
@@ -32,7 +32,7 @@ open class DeleteStatement(
     override fun prepareSQL(transaction: Transaction, prepared: Boolean): String =
         transaction.db.dialect.functionProvider.delete(isIgnore, table, where?.let { QueryBuilder(prepared).append(it).toString() }, limit, transaction)
 
-    override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = QueryBuilder(true).run {
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = QueryBuilder(true).run {
         where?.toQueryBuilder(this)
         listOf(args)
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertSelectStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertSelectStatement.kt
@@ -29,7 +29,7 @@ open class InsertSelectStatement(
 
     override fun PreparedStatementApi.executeInternal(transaction: Transaction): Int? = executeUpdate()
 
-    override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = selectQuery.arguments()
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = selectQuery.arguments()
 
     override fun prepareSQL(transaction: Transaction, prepared: Boolean): String =
         transaction.db.dialect.functionProvider.insert(isIgnore, targets.single(), columns, selectQuery.prepareSQL(transaction, prepared), transaction)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -208,7 +208,7 @@ open class InsertStatement<Key : Any>(
             listOf(result).apply { field = this }
         }
 
-    override fun arguments(): List<Iterable<Pair<IColumnType, Any?>>> {
+    override fun arguments(): List<Iterable<Pair<IColumnType<*>, Any?>>> {
         return arguments?.map { args ->
             val builder = QueryBuilder(true)
             args.filter { (_, value) ->

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/Statement.kt
@@ -36,7 +36,7 @@ abstract class Statement<out T>(val type: StatementType, val targets: List<Table
     abstract fun prepareSQL(transaction: Transaction, prepared: Boolean = true): String
 
     /** Returns all mappings of columns and expression types to their values needed to prepare an SQL statement. */
-    abstract fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>>
+    abstract fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>>
 
     /**
      * Uses a [transaction] connection and an [sql] string representation to return a precompiled SQL statement,
@@ -82,7 +82,7 @@ abstract class Statement<out T>(val type: StatementType, val targets: List<Table
         } catch (e: SQLException) {
             throw ExposedSQLException(e, contexts, transaction)
         }
-        contexts.forEachIndexed { i, context ->
+        contexts.forEachIndexed { _, context ->
             statement.fillParameters(context.args)
             // REVIEW
             if (contexts.size > 1 || isAlwaysBatch) statement.addBatch()
@@ -108,7 +108,7 @@ abstract class Statement<out T>(val type: StatementType, val targets: List<Table
 }
 
 /** Holds information related to a particular [statement] and the [args] needed to prepare it for execution. */
-class StatementContext(val statement: Statement<*>, val args: Iterable<Pair<IColumnType, Any?>>) {
+class StatementContext(val statement: Statement<*>, val args: Iterable<Pair<IColumnType<*>, Any?>>) {
     /** Returns the string representation of the SQL statement associated with this [StatementContext]. */
     fun sql(transaction: Transaction) = statement.prepareSQL(transaction)
 }
@@ -138,7 +138,7 @@ fun StatementContext.expandArgs(transaction: Transaction): String {
                     append(sql.substring(lastPos, i))
                     lastPos = i + 1
                     val (col, value) = iterator.next()
-                    append(col.valueToString(value))
+                    append((col as IColumnType<Any>).valueToString(value))
                 }
                 char == '\'' || char == '\"' -> {
                     when {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt
@@ -46,7 +46,7 @@ open class UpdateStatement(val targetsSet: ColumnSet, val limit: Int?, val where
         }
     }
 
-    override fun arguments(): Iterable<Iterable<Pair<IColumnType, Any?>>> = QueryBuilder(true).run {
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = QueryBuilder(true).run {
         val dialect = currentDialect
         when {
             targetsSet is Join && dialect is OracleDialect -> {
@@ -72,9 +72,13 @@ open class UpdateStatement(val targetsSet: ColumnSet, val limit: Int?, val where
         if (args.isNotEmpty()) listOf(args) else emptyList()
     }
 
-    private fun QueryBuilder.registerWhereArg() { where?.toQueryBuilder(this) }
+    private fun QueryBuilder.registerWhereArg() {
+        where?.toQueryBuilder(this)
+    }
 
-    private fun QueryBuilder.registerUpdateArgs() { values.forEach { registerArgument(it.key, it.value) } }
+    private fun QueryBuilder.registerUpdateArgs() {
+        values.forEach { registerArgument(it.key, it.value) }
+    }
 
     private fun QueryBuilder.registerAdditionalArgs(join: Join) {
         join.joinParts.forEach {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.exposed.sql.statements
 
 import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.vendors.*
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
+import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider
 
 /**
  * Represents the SQL statement that either inserts a new row into a table, or updates the existing row if insertion would violate a unique constraint.
@@ -34,7 +36,7 @@ open class UpsertStatement<Key : Any>(
         return functionProvider.upsert(table, arguments!!.first(), onUpdate, onUpdateExclude, where, transaction, keys = keys)
     }
 
-    override fun arguments(): List<Iterable<Pair<IColumnType, Any?>>> {
+    override fun arguments(): List<Iterable<Pair<IColumnType<*>, Any?>>> {
         return arguments?.map { args ->
             val builder = QueryBuilder(true)
             args.filter { (_, value) ->

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/PreparedStatementApi.kt
@@ -19,9 +19,9 @@ interface PreparedStatementApi {
      * Sets the value for each column or expression in [args] into the appropriate statement parameter and
      * returns the number of parameters filled.
      */
-    fun fillParameters(args: Iterable<Pair<IColumnType, Any?>>): Int {
+    fun fillParameters(args: Iterable<Pair<IColumnType<*>, Any?>>): Int {
         args.forEachIndexed { index, (c, v) ->
-            c.setParameter(this, index + 1, c.valueToDB(v))
+            c.setParameter(this, index + 1, (c as IColumnType<Any>).valueToDB(v))
         }
 
         return args.count() + 1
@@ -59,7 +59,7 @@ interface PreparedStatementApi {
     operator fun set(index: Int, value: Any)
 
     /** Sets the statement parameter at the [index] position to SQL NULL, if allowed wih the specified [columnType]. */
-    fun setNull(index: Int, columnType: IColumnType)
+    fun setNull(index: Int, columnType: IColumnType<*>)
 
     /**
      * Sets the statement parameter at the [index] position to the provided [inputStream],

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
@@ -147,7 +147,7 @@ abstract class DataTypeProvider {
             "'$e'"
         }
 
-        e is LiteralOp<*> -> e.columnType.valueAsDefaultString(e.value)
+        e is LiteralOp<*> -> (e.columnType as IColumnType<Any?>).valueAsDefaultString(e.value)
         e is Function<*> -> "$e"
         currentDialect is MysqlDialect -> "$e"
         currentDialect is SQLServerDialect -> "$e"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -257,7 +257,7 @@ abstract class FunctionProvider {
      */
     open fun cast(
         expr: Expression<*>,
-        type: IColumnType,
+        type: IColumnType<*>,
         builder: QueryBuilder
     ): Unit = builder {
         append("CAST(", expr, " AS ", type.sqlType(), ")")
@@ -343,7 +343,7 @@ abstract class FunctionProvider {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         throw UnsupportedByDialectException(
@@ -365,7 +365,7 @@ abstract class FunctionProvider {
         target: Expression<*>,
         candidate: Expression<*>,
         path: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         throw UnsupportedByDialectException(
@@ -387,7 +387,7 @@ abstract class FunctionProvider {
         expression: Expression<*>,
         vararg path: String,
         optional: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         throw UnsupportedByDialectException(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -129,7 +129,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) = queryBuilder {
         if (toScalar) append("JSON_UNQUOTE(")
@@ -142,7 +142,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         target: Expression<*>,
         candidate: Expression<*>,
         path: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) = queryBuilder {
         append("JSON_CONTAINS(", target, ", ", candidate)
@@ -156,7 +156,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         expression: Expression<*>,
         vararg path: String,
         optional: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         val oneOrAll = optional?.lowercase()
@@ -186,7 +186,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         override fun sqlType(): String = "CHAR"
     }
 
-    override fun cast(expr: Expression<*>, type: IColumnType, builder: QueryBuilder) = when (type) {
+    override fun cast(expr: Expression<*>, type: IColumnType<*>, builder: QueryBuilder) = when (type) {
         is StringColumnType -> super.cast(expr, CharColumnType, builder)
         else -> super.cast(expr, type, builder)
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -173,7 +173,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {
@@ -191,7 +191,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
         expression: Expression<*>,
         vararg path: String,
         optional: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -29,7 +29,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
         e is LiteralOp<*> && e.columnType is BlobColumnType && e.columnType.useObjectIdentifier && (currentDialect as? H2Dialect) == null -> {
             "lo_from_bytea(0, ${super.processForDefaultValue(e)} :: bytea)"
         }
-        e is LiteralOp<*> && e.columnType is ArrayColumnType -> {
+        e is LiteralOp<*> && e.columnType is ArrayColumnType<*> -> {
             val processed = super.processForDefaultValue(e)
             processed
                 .takeUnless { it == "ARRAY[]" }
@@ -145,7 +145,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) = queryBuilder {
         append("${jsonType.sqlType()}_EXTRACT_PATH")
@@ -159,7 +159,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         target: Expression<*>,
         candidate: Expression<*>,
         path: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         path?.let {
@@ -178,7 +178,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         expression: Expression<*>,
         vararg path: String,
         optional: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -152,7 +152,7 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         if (path.size > 1) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -133,7 +133,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         expression: Expression<T>,
         vararg path: String,
         toScalar: Boolean,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) = queryBuilder {
         append("JSON_EXTRACT(", expression, ", ")
@@ -145,7 +145,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         expression: Expression<*>,
         vararg path: String,
         optional: String?,
-        jsonType: IColumnType,
+        jsonType: IColumnType<*>,
         queryBuilder: QueryBuilder
     ) {
         val transaction = TransactionManager.current()

--- a/exposed-crypt/api/exposed-crypt.api
+++ b/exposed-crypt/api/exposed-crypt.api
@@ -10,20 +10,28 @@ public final class org/jetbrains/exposed/crypt/EncryptedBinaryColumnType : org/j
 	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;I)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString ([B)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB ([B)[B
+	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public fun validateValueBeforeUpdate ([B)V
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)[B
 }
 
 public final class org/jetbrains/exposed/crypt/EncryptedVarCharColumnType : org/jetbrains/exposed/sql/VarCharColumnType {
 	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;I)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun validateValueBeforeUpdate (Ljava/lang/Object;)V
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public fun validateValueBeforeUpdate (Ljava/lang/String;)V
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/crypt/Encryptor {

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedBinaryColumnType.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedBinaryColumnType.kt
@@ -11,29 +11,18 @@ class EncryptedBinaryColumnType(
     private val encryptor: Encryptor,
     length: Int
 ) : BinaryColumnType(length) {
-    override fun nonNullValueToString(value: Any): String {
+    override fun nonNullValueToString(value: ByteArray): String {
         return super.nonNullValueToString(notNullValueToDB(value))
     }
 
-    override fun notNullValueToDB(value: Any): Any {
-        if (value !is ByteArray) {
-            error("Unexpected value of type Byte: $value of ${value::class.qualifiedName}")
-        }
+    override fun notNullValueToDB(value: ByteArray): ByteArray = encryptor.encrypt(String(value)).toByteArray()
 
-        return encryptor.encrypt(String(value)).toByteArray()
-    }
-
-    override fun valueFromDB(value: Any): Any {
+    override fun valueFromDB(value: Any): ByteArray {
         val encryptedByte = super.valueFromDB(value)
-
-        if (encryptedByte !is ByteArray) {
-            error("Unexpected value of type Byte: $value of ${value::class.qualifiedName}")
-        }
-
         return encryptor.decrypt(String(encryptedByte)).toByteArray()
     }
 
-    override fun validateValueBeforeUpdate(value: Any?) {
+    override fun validateValueBeforeUpdate(value: ByteArray?) {
         if (value != null) {
             super.validateValueBeforeUpdate(notNullValueToDB(value))
         }

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedVarCharColumnType.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedVarCharColumnType.kt
@@ -12,25 +12,20 @@ class EncryptedVarCharColumnType(
     private val encryptor: Encryptor,
     colLength: Int,
 ) : VarCharColumnType(colLength) {
-    override fun nonNullValueToString(value: Any): String {
+    override fun nonNullValueToString(value: String): String {
         return super.nonNullValueToString(notNullValueToDB(value))
     }
 
-    override fun notNullValueToDB(value: Any): Any {
-        return encryptor.encrypt(value.toString())
+    override fun notNullValueToDB(value: String): String {
+        return encryptor.encrypt(value)
     }
 
-    override fun valueFromDB(value: Any): Any {
+    override fun valueFromDB(value: Any): String {
         val encryptedStr = super.valueFromDB(value)
-
-        if (encryptedStr !is String) {
-            error("Unexpected value of type String: $value of ${value::class.qualifiedName}")
-        }
-
         return encryptor.decrypt(encryptedStr)
     }
 
-    override fun validateValueBeforeUpdate(value: Any?) {
+    override fun validateValueBeforeUpdate(value: String?) {
         if (value != null) {
             super.validateValueBeforeUpdate(notNullValueToDB(value))
         }

--- a/exposed-java-time/api/exposed-java-time.api
+++ b/exposed-java-time/api/exposed-java-time.api
@@ -9,7 +9,7 @@ public final class org/jetbrains/exposed/sql/javatime/CurrentDateTime : org/jetb
 }
 
 public final class org/jetbrains/exposed/sql/javatime/CurrentTimestamp : org/jetbrains/exposed/sql/Function {
-	public fun <init> ()V
+	public static final field INSTANCE Lorg/jetbrains/exposed/sql/javatime/CurrentTimestamp;
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
@@ -71,8 +71,10 @@ public final class org/jetbrains/exposed/sql/javatime/JavaDateFunctionsKt {
 public final class org/jetbrains/exposed/sql/javatime/JavaDurationColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public static final field Companion Lorg/jetbrains/exposed/sql/javatime/JavaDurationColumnType$Companion;
 	public fun <init> ()V
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/time/Duration;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/time/Duration;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -86,9 +88,12 @@ public final class org/jetbrains/exposed/sql/javatime/JavaInstantColumnType : or
 	public static final field Companion Lorg/jetbrains/exposed/sql/javatime/JavaInstantColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/time/Instant;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/time/Instant;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/time/Instant;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -102,11 +107,15 @@ public final class org/jetbrains/exposed/sql/javatime/JavaLocalDateColumnType : 
 	public static final field Companion Lorg/jetbrains/exposed/sql/javatime/JavaLocalDateColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/time/LocalDate;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/time/LocalDate;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/time/LocalDate;)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/time/LocalDate;
 }
 
 public final class org/jetbrains/exposed/sql/javatime/JavaLocalDateColumnType$Companion {
@@ -116,12 +125,16 @@ public final class org/jetbrains/exposed/sql/javatime/JavaLocalDateTimeColumnTyp
 	public static final field Companion Lorg/jetbrains/exposed/sql/javatime/JavaLocalDateTimeColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/time/LocalDateTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/time/LocalDateTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/time/LocalDateTime;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/time/LocalDateTime;
 }
 
 public final class org/jetbrains/exposed/sql/javatime/JavaLocalDateTimeColumnType$Companion {
@@ -131,9 +144,12 @@ public final class org/jetbrains/exposed/sql/javatime/JavaLocalTimeColumnType : 
 	public static final field Companion Lorg/jetbrains/exposed/sql/javatime/JavaLocalTimeColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/time/LocalTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/time/LocalTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/time/LocalTime;)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/time/LocalTime;
@@ -146,9 +162,12 @@ public final class org/jetbrains/exposed/sql/javatime/JavaOffsetDateTimeColumnTy
 	public static final field Companion Lorg/jetbrains/exposed/sql/javatime/JavaOffsetDateTimeColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/time/OffsetDateTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/time/OffsetDateTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/time/OffsetDateTime;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -55,11 +55,11 @@ object CurrentDate : Function<LocalDate>(JavaLocalDateColumnType.INSTANCE) {
 }
 
 /**
- * Represents an SQL function that returns the current date and time.
+ * Represents an SQL function that returns the current date and time, as [Instant].
  *
  * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
  */
-class CurrentTimestamp<T : Temporal> : Function<T>(JavaInstantColumnType.INSTANCE) {
+object CurrentTimestamp : Function<Instant>(JavaInstantColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when {
             (currentDialect as? MysqlDialect)?.isFractionDateTimeSupported() == true -> "CURRENT_TIMESTAMP(6)"

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -295,7 +295,7 @@ class DefaultsTest : DatabaseTestsBase() {
         fun abs(value: Int) = object : ExpressionWithColumnType<Int>() {
             override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("ABS($value)") }
 
-            override val columnType: IColumnType = IntegerColumnType()
+            override val columnType: IColumnType<Int> = IntegerColumnType()
         }
 
         val foo = object : IntIdTable("foo") {
@@ -321,7 +321,7 @@ class DefaultsTest : DatabaseTestsBase() {
     fun testDefaultExpressions02() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
-            val defaultDateTime = datetime("defaultDateTime").defaultExpression(CurrentTimestamp())
+            val defaultDateTime = datetime("defaultDateTime").defaultExpression(CurrentDateTime)
         }
 
         val nonDefaultDate = LocalDate.of(2000, 1, 1).atStartOfDay()
@@ -369,8 +369,8 @@ class DefaultsTest : DatabaseTestsBase() {
             val name = text("name")
             val defaultDate = date("default_date").defaultExpression(CurrentDate)
             val defaultDateTime1 = datetime("default_date_time_1").defaultExpression(CurrentDateTime)
-            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentTimestamp())
-            val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp())
+            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentDateTime)
+            val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp)
         }
 
         withDb {
@@ -502,7 +502,7 @@ class DefaultsTest : DatabaseTestsBase() {
 
         val tester = object : Table("tester") {
             val timestampWithDefault = timestamp("timestampWithDefault").default(instant)
-            val timestampWithDefaultExpression = timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp())
+            val timestampWithDefaultExpression = timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp)
         }
 
         // SQLite does not support ALTER TABLE on a column that has a default value

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/sqlserver/SQLServerDefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/sqlserver/SQLServerDefaultsTest.kt
@@ -16,7 +16,7 @@ class SQLServerDefaultsTest : DatabaseTestsBase() {
     fun testDefaultExpressionsForTemporalTable() {
         fun databaseGeneratedTimestamp() = object : ExpressionWithColumnType<LocalDateTime>() {
             override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { +"DEFAULT" }
-            override val columnType: IColumnType = JavaLocalDateTimeColumnType()
+            override val columnType: IColumnType<LocalDateTime> = JavaLocalDateTimeColumnType()
         }
 
         val temporalTable = object : UUIDTable("TemporalTable") {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcConnectionImpl.kt
@@ -124,7 +124,7 @@ class JdbcConnectionImpl(override val connection: Connection) : ExposedConnectio
 
             override fun prepareSQL(transaction: Transaction, prepared: Boolean): String = sqls.joinToString("\n")
 
-            override fun arguments(): Iterable<Iterable<Pair<ColumnType, Any?>>> = emptyList()
+            override fun arguments(): Iterable<Iterable<Pair<ColumnType<*>, Any?>>> = emptyList()
         }
 
         prepStatement.execute(TransactionManager.current())

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcPreparedStatementImpl.kt
@@ -69,7 +69,7 @@ class JdbcPreparedStatementImpl(
         statement.setObject(index, value)
     }
 
-    override fun setNull(index: Int, columnType: IColumnType) {
+    override fun setNull(index: Int, columnType: IColumnType<*>) {
         if (columnType is BinaryColumnType || (columnType is BlobColumnType && !columnType.useObjectIdentifier)) {
             statement.setNull(index, Types.LONGVARBINARY)
         } else {

--- a/exposed-jodatime/api/exposed-jodatime.api
+++ b/exposed-jodatime/api/exposed-jodatime.api
@@ -20,12 +20,16 @@ public final class org/jetbrains/exposed/sql/jodatime/DateColumnType : org/jetbr
 	public fun getHasTimePart ()Z
 	public final fun getTime ()Z
 	public fun hashCode ()I
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lorg/joda/time/DateTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lorg/joda/time/DateTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lorg/joda/time/DateTime;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Lorg/joda/time/DateTime;
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/DateColumnTypeKt {
@@ -56,9 +60,12 @@ public final class org/jetbrains/exposed/sql/jodatime/DateFunctionsKt {
 public final class org/jetbrains/exposed/sql/jodatime/DateTimeWithTimeZoneColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IDateColumnType {
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lorg/joda/time/DateTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lorg/joda/time/DateTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lorg/joda/time/DateTime;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -225,7 +225,7 @@ class JodaTimeDefaultsTest : JodaTimeBaseTest() {
         fun abs(value: Int) = object : ExpressionWithColumnType<Int>() {
             override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("ABS($value)") }
 
-            override val columnType: IColumnType = IntegerColumnType()
+            override val columnType: IColumnType<Int> = IntegerColumnType()
         }
 
         val foo = object : IntIdTable("foo") {

--- a/exposed-json/api/exposed-json.api
+++ b/exposed-json/api/exposed-json.api
@@ -41,8 +41,7 @@ public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/expos
 	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;
 	public fun getUsesBinaryFormat ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonConditions.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonConditions.kt
@@ -23,7 +23,7 @@ class Contains(
     /** An optional String representing JSON path/keys that match specific fields to search for [candidate]. */
     val path: String?,
     /** The column type of [target] to check, if casting to JSONB is required. */
-    val jsonType: IColumnType
+    val jsonType: IColumnType<*>
 ) : Op<Boolean>(), ComplexExpression {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) =
         currentDialect.functionProvider.jsonContains(target, candidate, path, jsonType, queryBuilder)
@@ -40,7 +40,7 @@ class Exists(
     /** An optional String representing any vendor-specific clause or argument. */
     val optional: String?,
     /** The column type of [expression] to check, if casting to JSONB is required. */
-    val jsonType: IColumnType
+    val jsonType: IColumnType<*>
 ) : Op<Boolean>(), ComplexExpression {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) =
         currentDialect.functionProvider.jsonExists(expression, path = path, optional, jsonType, queryBuilder)

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonFunctions.kt
@@ -22,8 +22,8 @@ class Extract<T>(
     /** Whether the extracted result should be a scalar or text value; if `false`, result will be a JSON object. */
     val toScalar: Boolean,
     /** The column type of [expression] to check, if casting to JSONB is required. */
-    val jsonType: IColumnType,
-    columnType: IColumnType
+    val jsonType: IColumnType<*>,
+    columnType: IColumnType<T & Any>
 ) : Function<T>(columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) =
         currentDialect.functionProvider.jsonExtract(expression, path = path, toScalar, jsonType, queryBuilder)

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -9,7 +9,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime : o
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp : org/jetbrains/exposed/sql/Function {
-	public fun <init> ()V
+	public static final field INSTANCE Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp;
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
@@ -91,8 +91,10 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions
 public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDurationColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public static final field Companion Lorg/jetbrains/exposed/sql/kotlin/datetime/KotlinDurationColumnType$Companion;
 	public fun <init> ()V
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString-LRDsOJo (J)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB-LRDsOJo (J)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -106,9 +108,12 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinInstantColumn
 	public static final field Companion Lorg/jetbrains/exposed/sql/kotlin/datetime/KotlinInstantColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lkotlinx/datetime/Instant;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lkotlinx/datetime/Instant;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lkotlinx/datetime/Instant;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -122,11 +127,15 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalDateColu
 	public static final field Companion Lorg/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalDateColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lkotlinx/datetime/LocalDate;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lkotlinx/datetime/LocalDate;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lkotlinx/datetime/LocalDate;)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Lkotlinx/datetime/LocalDate;
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalDateColumnType$Companion {
@@ -136,12 +145,16 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalDateTime
 	public static final field Companion Lorg/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalDateTimeColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lkotlinx/datetime/LocalDateTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lkotlinx/datetime/LocalDateTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lkotlinx/datetime/LocalDateTime;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Lkotlinx/datetime/LocalDateTime;
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalDateTimeColumnType$Companion {
@@ -151,9 +164,12 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalTimeColu
 	public static final field Companion Lorg/jetbrains/exposed/sql/kotlin/datetime/KotlinLocalTimeColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lkotlinx/datetime/LocalTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lkotlinx/datetime/LocalTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lkotlinx/datetime/LocalTime;)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Lkotlinx/datetime/LocalTime;
@@ -166,9 +182,12 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinOffsetDateTim
 	public static final field Companion Lorg/jetbrains/exposed/sql/kotlin/datetime/KotlinOffsetDateTimeColumnType$Companion;
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/time/OffsetDateTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/time/OffsetDateTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/time/OffsetDateTime;)Ljava/lang/Object;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
@@ -82,7 +82,7 @@ object CurrentDate : Function<LocalDate>(KotlinLocalDateColumnType.INSTANCE) {
  *
  * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
  */
-class CurrentTimestamp<T> : Function<T>(KotlinInstantColumnType.INSTANCE) {
+object CurrentTimestamp : Function<Instant>(KotlinInstantColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when {
             (currentDialect as? MysqlDialect)?.isFractionDateTimeSupported() == true -> "CURRENT_TIMESTAMP(6)"

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -293,7 +293,7 @@ class DefaultsTest : DatabaseTestsBase() {
         fun abs(value: Int) = object : ExpressionWithColumnType<Int>() {
             override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("ABS($value)") }
 
-            override val columnType: IColumnType = IntegerColumnType()
+            override val columnType: IColumnType<Int> = IntegerColumnType()
         }
 
         val foo = object : IntIdTable("foo") {
@@ -319,7 +319,7 @@ class DefaultsTest : DatabaseTestsBase() {
     fun testDefaultExpressions02() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
-            val defaultDateTime = datetime("defaultDateTime").defaultExpression(CurrentTimestamp())
+            val defaultDateTime = datetime("defaultDateTime").defaultExpression(CurrentDateTime)
         }
 
         val nonDefaultDate = LocalDate(2000, 1, 1)
@@ -373,8 +373,8 @@ class DefaultsTest : DatabaseTestsBase() {
             val name = text("name")
             val defaultDate = date("default_date").defaultExpression(CurrentDate)
             val defaultDateTime1 = datetime("default_date_time_1").defaultExpression(CurrentDateTime)
-            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentTimestamp())
-            val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp())
+            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentDateTime)
+            val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp)
         }
 
         withDb {
@@ -537,7 +537,7 @@ class DefaultsTest : DatabaseTestsBase() {
 
         val tester = object : Table("tester") {
             val timestampWithDefault = timestamp("timestampWithDefault").default(instant)
-            val timestampWithDefaultExpression = timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp())
+            val timestampWithDefaultExpression = timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp)
         }
 
         // SQLite does not support ALTER TABLE on a column that has a default value

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/sqlserver/SQLServerDefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/sqlserver/SQLServerDefaultsTest.kt
@@ -17,7 +17,7 @@ class SQLServerDefaultsTest : DatabaseTestsBase() {
     fun testDefaultExpressionsForTemporalTable() {
         fun databaseGeneratedTimestamp() = object : ExpressionWithColumnType<LocalDateTime>() {
             override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { +"DEFAULT" }
-            override val columnType: IColumnType = KotlinLocalDateTimeColumnType()
+            override val columnType: IColumnType<LocalDateTime> = KotlinLocalDateTimeColumnType()
         }
 
         val temporalTable = object : UUIDTable("TemporalTable") {

--- a/exposed-money/api/exposed-money.api
+++ b/exposed-money/api/exposed-money.api
@@ -15,10 +15,23 @@ public final class org/jetbrains/exposed/sql/money/CompositeMoneyColumnTypeKt {
 	public static final fun compositeMoneyNullable (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/money/CompositeMoneyColumn;
 }
 
-public final class org/jetbrains/exposed/sql/money/CurrencyColumnType : org/jetbrains/exposed/sql/VarCharColumnType {
+public final class org/jetbrains/exposed/sql/money/CurrencyColumnType : org/jetbrains/exposed/sql/ColumnType {
+	public static final field Companion Lorg/jetbrains/exposed/sql/money/CurrencyColumnType$Companion;
 	public fun <init> ()V
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljavax/money/CurrencyUnit;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljavax/money/CurrencyUnit;)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
+	public fun validateValueBeforeUpdate (Ljavax/money/CurrencyUnit;)V
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljavax/money/CurrencyUnit;
+}
+
+public final class org/jetbrains/exposed/sql/money/CurrencyColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/sql/money/CurrencyColumnTypeKt {

--- a/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CurrencyColumnType.kt
+++ b/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CurrencyColumnType.kt
@@ -1,8 +1,10 @@
 package org.jetbrains.exposed.sql.money
 
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ColumnType
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.VarCharColumnType
+import org.jetbrains.exposed.sql.vendors.currentDialect
 import javax.money.CurrencyUnit
 import javax.money.Monetary
 
@@ -12,22 +14,61 @@ import javax.money.Monetary
  * @author Vladislav Kisel
  */
 @Suppress("MagicNumber")
-class CurrencyColumnType : VarCharColumnType(3) {
+class CurrencyColumnType : ColumnType<CurrencyUnit>() {
 
-    override fun notNullValueToDB(value: Any): Any {
-        return when (value) {
-            is String -> value
-            is CurrencyUnit -> value.currencyCode
-            else -> error("Unexpected value: $value of ${value::class.qualifiedName}")
+    override fun sqlType(): String = currentDialect.dataTypeProvider.varcharType(colLength)
+
+    override fun validateValueBeforeUpdate(value: CurrencyUnit?) {
+        if (value is CurrencyUnit) {
+            val valueLength = value.currencyCode.codePointCount(0, value.currencyCode.length)
+            require(valueLength <= colLength) {
+                "Value can't be stored to database column because exceeds length ($valueLength > $colLength)"
+            }
         }
     }
 
-    override fun valueFromDB(value: Any): Any {
+    override fun valueFromDB(value: Any): CurrencyUnit {
         return when (value) {
             is CurrencyUnit -> value
             is String -> Monetary.getCurrency(value)
             else -> valueFromDB(value.toString())
         }
+    }
+
+    override fun notNullValueToDB(value: CurrencyUnit): Any = value.currencyCode
+
+    override fun nonNullValueToString(value: CurrencyUnit): String = buildString {
+        append('\'')
+        append(escape(value.currencyCode))
+        append('\'')
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as VarCharColumnType
+
+        return colLength == other.colLength
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + colLength
+        return result
+    }
+
+    private fun escape(value: String): String = value.map { charactersToEscape[it] ?: it }.joinToString("")
+
+    companion object {
+        private const val colLength = 3
+
+        private val charactersToEscape = mapOf(
+            '\'' to "\'\'",
+            '\r' to "\\r",
+            '\n' to "\\n"
+        )
     }
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ReplaceColumnTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ReplaceColumnTests.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.sql.tests.shared.ddl
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.exceptions.DuplicateColumnException
 import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.EntityIDColumnType
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.junit.Test
@@ -14,7 +15,7 @@ class ReplaceColumnTests : DatabaseTestsBase() {
         withTables(IDTable) {
             expectException<DuplicateColumnException> {
                 // Duplicate the id column by replacing the IDTable.code by a column with the name "id"
-                val id = Column<Int>(IDTable, IDTable.id.name, IDTable.id.columnType)
+                val id = Column<Int>(IDTable, IDTable.id.name, (IDTable.id.columnType as EntityIDColumnType<Int>).idColumn.columnType)
                 IDTable.replaceColumn(IDTable.code, id)
             }
         }


### PR DESCRIPTION
The goal of this PR is to have type safety in the overridden functions of the interface `IColumnType`, which will reduce the number of checks in those functions. This change propagates to other classes and interfaces that extend and use `IColumnType`.

The following are affected:

1. Custom column types
2. Custom functions extending `CustomFunction`
3. Custom operators extending `CustomOperator`
4. Custom expressions extending `ExpressionWithColumnType`
5. Usages of `CurrentTimestamp` function (class to object)