### PR TITLE
Improve instructions for Maven users

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,6 @@ Similar to our mascot, Exposed can be used to mimic a variety of database engine
 
 Releases of Exposed are available in the Maven Central repository. You can declare this repository in your build script as follows:
 
-#### Maven
-
-```xml
-<!-- Versions after 0.30.1 -->
-<!-- Versions before 0.30.1 is unavailable for now-->
-<repositories>
-    <repository>
-        <id>mavenCentral</id>
-        <name>mavenCentral</name>
-        <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-</repositories>
-```
-
 #### Gradle Groovy and Kotlin DSL
 
 **Warning:** You might need to set your Kotlin JVM target to 8, and when using Spring to 17, in order for this to work properly:
@@ -58,6 +44,10 @@ repositories {
     mavenCentral()
 }
 ```
+
+#### Maven
+
+The Maven Central repository is enabled by default for Maven users.
 
 ### Exposed modules
 

--- a/documentation-website/Writerside/topics/Getting-Started.md
+++ b/documentation-website/Writerside/topics/Getting-Started.md
@@ -6,29 +6,30 @@
     <tab title="Maven">
         <code-block lang="xml">
 <![CDATA[
-<repositories>
-    <repository>
-        <id>mavenCentral</id>
-        <name>mavenCentral</name>
-        <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-</repositories>
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.exposed</groupId>
+      <artifactId>exposed-bom</artifactId>
+      <version>0.48.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
 
 <dependencies>
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-core</artifactId>
-      <version>0.48.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-dao</artifactId>
-      <version>0.48.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.exposed</groupId>
       <artifactId>exposed-jdbc</artifactId>
-      <version>0.48.0</version>
     </dependency>
 </dependencies>
 ]]>

--- a/documentation-website/Writerside/topics/Modules-Documentation.md
+++ b/documentation-website/Writerside/topics/Modules-Documentation.md
@@ -14,15 +14,7 @@ To use them you have to add appropriate dependency into your repositories mappin
     </code-block>
   </tab>
   <tab title="Maven">
-        <code-block lang="xml">
-          &lt;repositories&gt;
-              &lt;repository&gt;
-                  &lt;id&gt;mavenCentral&lt;/id&gt;
-                  &lt;name&gt;mavenCentral&lt;/name&gt;
-                  &lt;url&gt;https://repo1.maven.org/maven2/&lt;/url&gt;
-              &lt;/repository&gt;
-          &lt;/repositories&gt;
-          </code-block>
+    The Maven Central repository is enabled by default for Maven users.
   </tab>
   <tab title="Groovy Gradle">
     <code-block lang="groovy">

--- a/exposed-bom/README.md
+++ b/exposed-bom/README.md
@@ -3,15 +3,6 @@ Bill of Materials for all Exposed modules
 
 # Maven
 ```xml
-<!-- Versions after 0.33.1 -->
-<repositories>
-    <repository>
-        <id>mavenCentral</id>
-        <name>mavenCentral</name>
-        <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-</repositories>
-
 <dependencyManagement>
     <dependencies>
         <dependency>
@@ -28,17 +19,14 @@ Bill of Materials for all Exposed modules
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-core</artifactId>
-        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-dao</artifactId>
-        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.jetbrains.exposed</groupId>
         <artifactId>exposed-jdbc</artifactId>
-        <scope>provided</scope>
     </dependency>
 </dependencies>
 ```

--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -6,14 +6,6 @@ This is a starter for [Spring Boot](https://spring.io/projects/spring-boot) to u
 This starter will give you the latest version of [Exposed](https://github.com/JetBrains/Exposed) and its `spring-transaction` library along with the [Spring Boot Starter Data JDBC](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jdbc).
 ### Maven
 ```mxml
-<repositories>
-  <repository>
-    <id>mavenCentral</id>
-    <name>mavenCentral</name>
-    <url>https://repo1.maven.org/maven2/</url>
-  </repository>
-</repositories>
-
 <dependencies>
   <dependency>
     <groupId>org.jetbrains.exposed</groupId>


### PR DESCRIPTION
Maven Central is available as a repository by default when using Maven, so it's not necessary to add it explicitly and I wouldn't recommend doing this. This advice might even mess up corporate users which can only access Maven Central via their company's artifact manager.

This PR also recommends using `exposed-bom` for dependency management.