### PR TITLE
fix(jdbc): existingIndices() misses indexes from tables with a schema

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -222,8 +222,13 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                     names
                 }
 
-                val tableNameWithoutSchemaPrefix = table.nameInDatabaseCaseUnquoted()
-                val rs = metadata.getIndexInfo(catalog, tableSchema, tableNameWithoutSchemaPrefix, false, false)
+                val storedIndexTable = if
+                    (tableSchema == currentSchema!! && currentDialect is OracleDialect) {
+                    table.nameInDatabaseCase()
+                } else {
+                    table.nameInDatabaseCaseUnquoted()
+                }
+                val rs = metadata.getIndexInfo(catalog, tableSchema, storedIndexTable, false, false)
 
                 val tmpIndices = hashMapOf<Triple<String, Boolean, Op.TRUE?>, MutableList<String>>()
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -221,7 +221,12 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                     rs.close()
                     names
                 }
-                val storedIndexTable = if (tableSchema == currentSchema!!) table.nameInDatabaseCase() else table.nameInDatabaseCaseUnquoted()
+
+                val inCurrentSchema = (tableSchema == currentSchema!!)
+                val tableNameWithoutSchemaPrefix = table.nameInDatabaseCaseUnquoted()
+                val tableNameWithSchemaPrefix = table.nameInDatabaseCase()
+                val storedIndexTable = if (inCurrentSchema) tableNameWithoutSchemaPrefix else tableNameWithSchemaPrefix
+
                 val rs = metadata.getIndexInfo(catalog, tableSchema, storedIndexTable, false, false)
 
                 val tmpIndices = hashMapOf<Triple<String, Boolean, Op.TRUE?>, MutableList<String>>()

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -222,12 +222,8 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                     names
                 }
 
-                val inCurrentSchema = (tableSchema == currentSchema!!)
                 val tableNameWithoutSchemaPrefix = table.nameInDatabaseCaseUnquoted()
-                val tableNameWithSchemaPrefix = table.nameInDatabaseCase()
-                val storedIndexTable = if (inCurrentSchema) tableNameWithoutSchemaPrefix else tableNameWithSchemaPrefix
-
-                val rs = metadata.getIndexInfo(catalog, tableSchema, storedIndexTable, false, false)
+                val rs = metadata.getIndexInfo(catalog, tableSchema, tableNameWithoutSchemaPrefix, false, false)
 
                 val tmpIndices = hashMapOf<Triple<String, Boolean, Op.TRUE?>, MutableList<String>>()
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -685,7 +685,6 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     @Test
     fun testCreateTableWithSchemaPrefix() {
         val schemaName = "my_schema"
-        val schema = Schema(schemaName)
         // index and foreign key both use table name to auto-generate their own names & to compare metadata
         // default columns in SQL Server requires a named constraint that uses table name
         val parentTable = object : IntIdTable("$schemaName.parent_table") {
@@ -698,6 +697,12 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
         // SQLite does not recognize creation of schema other than the attached database
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            val schema = if (testDb == TestDB.SQLSERVER) {
+                Schema(schemaName, "guest")
+            } else {
+                Schema(schemaName)
+            }
+
             // Should not require to be in the same schema
             SchemaUtils.createSchema(schema)
             SchemaUtils.create(parentTable, childTable)
@@ -709,10 +714,12 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                 assertTrue(childTable.exists())
 
                 // Try in the same schema
-                SchemaUtils.setSchema(schema)
-                SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
-                assertTrue(parentTable.exists())
-                assertTrue(childTable.exists())
+                if (testDb != TestDB.ORACLE) {
+                    SchemaUtils.setSchema(schema)
+                    SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
+                    assertTrue(parentTable.exists())
+                    assertTrue(childTable.exists())
+                }
             } finally {
                 if (testDb == TestDB.SQLSERVER) {
                     SchemaUtils.drop(childTable, parentTable)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -698,10 +698,18 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
         // SQLite does not recognize creation of schema other than the attached database
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            // Should not require to be in the same schema
             SchemaUtils.createSchema(schema)
             SchemaUtils.create(parentTable, childTable)
 
             try {
+                // Try in different schema
+                SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
+                assertTrue(parentTable.exists())
+                assertTrue(childTable.exists())
+
+                // Try in the same schema
+                SchemaUtils.setSchema(schema)
                 SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
                 assertTrue(parentTable.exists())
                 assertTrue(childTable.exists())


### PR DESCRIPTION
we noticed a bug when using tables that have a schema where indexes were not being attached to the instance.

we were calling `metadata.getIndexInfo(catalog, tableSchema, storedIndexTable, false, false)` and getting no indexes returned. we were calling it with params like this:

```kotlin
metadata.getIndexInfo(catalog,"test", "test.test_table", false, false)
```