### PR TITLE
fix: EXPOSED-259 supportsSubqueryUnions is too strict for PostgreSQL 12+

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3756,6 +3756,7 @@ public class org/jetbrains/exposed/sql/vendors/PostgreSQLDialect : org/jetbrains
 	public fun getName ()Ljava/lang/String;
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsSubqueryUnions ()Z
 	public fun getSupportsWindowFrameGroupsMode ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -48,7 +48,7 @@ interface DatabaseDialect {
     /** Returns`true` if the dialect supports schema creation. */
     val supportsCreateSchema: Boolean get() = true
 
-    /** Returns `true` if the dialect supports subqueries within a UNION/EXCEPT/INTERSECT statement */
+    /** Returns `true` if the dialect supports subqueries within a UNION/EXCEPT/INTERSECT statement. */
     val supportsSubqueryUnions: Boolean get() = false
 
     /** Returns `true` if the dialect provides a special dummy DUAL table, accessible by all users. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -326,6 +326,8 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
  * PostgreSQL dialect implementation.
  */
 open class PostgreSQLDialect(override val name: String = dialectName) : VendorDialect(dialectName, PostgreSQLDataTypeProvider, PostgreSQLFunctionProvider) {
+    override val supportsSubqueryUnions: Boolean = true
+
     override val supportsOrderByNullsFirstLast: Boolean = true
 
     override val requiresAutoCommitOnCreateDrop: Boolean = true

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UnionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UnionTests.kt
@@ -155,7 +155,7 @@ class UnionTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test union of sorted queries`() {
+    fun testUnionOfSortedQueries() {
         withCitiesAndUsers { _, users, _ ->
             val andreyOrSergeyQuery: Query =
                 users.selectAll().where { users.id inList setOf("andrey", "sergey") }.orderBy(users.id to SortOrder.DESC)
@@ -174,7 +174,7 @@ class UnionTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test union of limited queries`() {
+    fun testUnionOfLimitedQueries() {
         withCitiesAndUsers { _, users, _ ->
             val andreyOrSergeyQuery = users.selectAll().where { users.id inList setOf("andrey", "sergey") }.limit(1)
 
@@ -192,7 +192,7 @@ class UnionTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test union of sorted and limited queries`() {
+    fun testUnionOfSortedAndLimitedQueries() {
         withCitiesAndUsers { _, users, _ ->
             val andreyOrSergeyQuery =
                 users.selectAll().where { users.id inList setOf("andrey", "sergey") }.orderBy(users.id to SortOrder.DESC).limit(1)


### PR DESCRIPTION
PostgreSQLDialect currently sets `supportsSubqueryUnions` property to `false` by default even though the use of subqueries (SELECT query including ORDER BY and/or LIMIT clause) has been supported alongside set operations since as early as [PostgreSQL version 12](https://www.postgresql.org/docs/12/queries-union.html).

The PostgreSQL GDG currently supports [only versions 12 through 16](https://www.postgresql.org/support/versioning/).
The 3 existing subquery union tests pass on all latest version [Docker images](https://hub.docker.com/_/postgres): 12.18-alpine, 13.14-alpine, 14.11-alpine, 15.6-alpine, 16.2 (latest).