### PR TITLE
deprecate: Raise deprecation levels of API elements

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.exposed.gradle
 
-@Deprecated("Use gradle version catalog")
+@Deprecated("Use gradle version catalog", level = DeprecationLevel.ERROR)
 object Versions {
     const val kotlinCoroutines = "1.7.3"
     const val kotlinxSerialization = "1.5.1"

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1401,10 +1401,6 @@ public final class org/jetbrains/exposed/sql/LikeEscapeOp : org/jetbrains/expose
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/LikeOp : org/jetbrains/exposed/sql/ComparisonOp {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)V
-}
-
 public final class org/jetbrains/exposed/sql/LikePattern {
 	public static final field Companion Lorg/jetbrains/exposed/sql/LikePattern$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/Character;)V
@@ -1528,10 +1524,6 @@ public final class org/jetbrains/exposed/sql/NotExists : org/jetbrains/exposed/s
 
 public final class org/jetbrains/exposed/sql/NotInSubQueryOp : org/jetbrains/exposed/sql/SubQueryOp {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)V
-}
-
-public final class org/jetbrains/exposed/sql/NotLikeOp : org/jetbrains/exposed/sql/ComparisonOp {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)V
 }
 
 public final class org/jetbrains/exposed/sql/NotOp : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/Op$OpBoolean {
@@ -3144,7 +3136,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun columns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
-	public abstract fun getCurrentScheme ()Ljava/lang/String;
+	public abstract synthetic fun getCurrentScheme ()Ljava/lang/String;
 	public final fun getDatabase ()Ljava/lang/String;
 	public abstract fun getDatabaseDialectName ()Ljava/lang/String;
 	public abstract fun getDatabaseProductVersion ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -538,12 +538,6 @@ class LikeEscapeOp(expr1: Expression<*>, expr2: Expression<*>, like: Boolean, va
     }
 }
 
-@Deprecated("Use LikeEscapeOp", replaceWith = ReplaceWith("LikeEscapeOp(expr1, expr2, true, null)"), DeprecationLevel.HIDDEN)
-class LikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "LIKE")
-
-@Deprecated("Use LikeEscapeOp", replaceWith = ReplaceWith("LikeEscapeOp(expr1, expr2, false, null)"), DeprecationLevel.HIDDEN)
-class NotLikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "NOT LIKE")
-
 /**
  * Represents an SQL operator that checks if [expr1] matches the regular expression [expr2].
  */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -38,7 +38,7 @@ abstract class ExposedDatabaseMetadata(val database: String) {
 
     @Deprecated(
         message = "it's temporary solution which will be replaced in a future releases. Do not use it in your code",
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     abstract val currentScheme: String
 

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -38,7 +38,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun columns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
-	public fun getCurrentScheme ()Ljava/lang/String;
+	public synthetic fun getCurrentScheme ()Ljava/lang/String;
 	public fun getDatabaseDialectName ()Ljava/lang/String;
 	public fun getDatabaseProductVersion ()Ljava/lang/String;
 	public fun getDefaultIsolationLevel ()I

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -77,7 +77,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
 
     @Deprecated(
         message = "This will be removed when the interface property is fully deprecated",
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     override val currentScheme: String get() = currentSchema!!
 


### PR DESCRIPTION
**Note:** The following elements had most recent level change in release 0.44.1 (October 2023).

**Raise from ERROR to HIDDEN:**
* `ExposedDatabaseMetadata` interface property `currentScheme`

**Currently HIDDEN, now removed:**
* Op.kt classes: `LikeOp` and `NotLikeOp`

**Additional:**
The original `buildSrc/Versions` object was deprecated in release 0.46.0 (January 2024) in PR #1887 .
Its level is now raised to ERROR. 