### PR TITLE
fix!: EXPOSED-317 repetitionAttempts property is misleading

### DIFF
--- a/documentation-website/Writerside/topics/Working-with-Transaction.md
+++ b/documentation-website/Writerside/topics/Working-with-Transaction.md
@@ -169,7 +169,7 @@ Much like with `transactionIsolation`, this value is not directly used by Expose
 
 **Transaction Maximum Attempts**
 
-Transactions also provide a property, `maxAttempts`, which sets the number of attempts that should be made to perform a transaction block.
+Transactions also provide a property, `maxAttempts`, which sets the maximum number of attempts that should be made to perform a transaction block.
 If this value is set to 1 and an SQLException occurs inside the transaction block, the exception will throw without performing a retry.
 If this property is not set, any default value provided in `DatabaseConfig` will be used instead:
 

--- a/documentation-website/Writerside/topics/Working-with-Transaction.md
+++ b/documentation-website/Writerside/topics/Working-with-Transaction.md
@@ -167,27 +167,28 @@ Much like with `transactionIsolation`, this value is not directly used by Expose
 **db**: This parameter is optional and is used to select the database where the transaction should be settled 
 ([see the section above](Transactions.md#working-with-multiple-databases)).
 
-**Transaction Repetition Attempts**
+**Transaction Maximum Attempts**
 
-Transactions also provide a property, `repetitionAttempts`, which sets the number of retries that should be made if an SQLException occurs inside the transaction block. 
+Transactions also provide a property, `maxAttempts`, which sets the number of attempts that should be made to perform a transaction block.
+If this value is set to 1 and an SQLException occurs inside the transaction block, the exception will throw without performing a retry.
 If this property is not set, any default value provided in `DatabaseConfig` will be used instead:
 
 ```kotlin
 val db = Database.connect(
     datasource = datasource,
     databaseConfig = DatabaseConfig {
-        defaultRepetitionAttempts = 3
+        defaultMaxAttempts = 3
     }
 )
 
 // property set in transaction block overrides default DatabaseConfig
 transaction(db = db) {
-    repetitionAttempts = 25
+    maxAttempts = 25
     // operation that may need multiple attempts
 }
 ```
 
-If this property is set to a value greater than 0, `minRepetitionDelay` and `maxRepetitionDelay` can also be set in the transaction block to indicate the minimum 
+If this property is set to a value greater than 1, `minRetryDelay` and `maxRetryDelay` can also be set in the transaction block to indicate the minimum 
 and maximum number of milliseconds to wait before retrying.
 
 **Transaction Query Timeout**

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -633,8 +633,8 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig {
 
 public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public fun <init> ()V
-	public fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZ)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZ)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDefaultIsolationLevel ()I
 	public final fun getDefaultMaxAttempts ()I

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -610,11 +610,14 @@ public final class org/jetbrains/exposed/sql/Database$Companion {
 
 public final class org/jetbrains/exposed/sql/DatabaseConfig {
 	public static final field Companion Lorg/jetbrains/exposed/sql/DatabaseConfig$Companion;
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDefaultIsolationLevel ()I
+	public final fun getDefaultMaxAttempts ()I
 	public final fun getDefaultMaxRepetitionDelay ()J
+	public final fun getDefaultMaxRetryDelay ()J
 	public final fun getDefaultMinRepetitionDelay ()J
+	public final fun getDefaultMinRetryDelay ()J
 	public final fun getDefaultReadOnly ()Z
 	public final fun getDefaultRepetitionAttempts ()I
 	public final fun getDefaultSchema ()Lorg/jetbrains/exposed/sql/Schema;
@@ -630,12 +633,15 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig {
 
 public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public fun <init> ()V
-	public fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZ)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZ)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/SqlLogger;ZLjava/lang/Integer;IIJJIJJZLjava/lang/Long;IZLorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDefaultIsolationLevel ()I
+	public final fun getDefaultMaxAttempts ()I
 	public final fun getDefaultMaxRepetitionDelay ()J
+	public final fun getDefaultMaxRetryDelay ()J
 	public final fun getDefaultMinRepetitionDelay ()J
+	public final fun getDefaultMinRetryDelay ()J
 	public final fun getDefaultReadOnly ()Z
 	public final fun getDefaultRepetitionAttempts ()I
 	public final fun getDefaultSchema ()Lorg/jetbrains/exposed/sql/Schema;
@@ -649,8 +655,11 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public final fun getWarnLongQueriesDuration ()Ljava/lang/Long;
 	public final fun setDefaultFetchSize (Ljava/lang/Integer;)V
 	public final fun setDefaultIsolationLevel (I)V
+	public final fun setDefaultMaxAttempts (I)V
 	public final fun setDefaultMaxRepetitionDelay (J)V
+	public final fun setDefaultMaxRetryDelay (J)V
 	public final fun setDefaultMinRepetitionDelay (J)V
+	public final fun setDefaultMinRetryDelay (J)V
 	public final fun setDefaultReadOnly (Z)V
 	public final fun setDefaultRepetitionAttempts (I)V
 	public final fun setDefaultSchema (Lorg/jetbrains/exposed/sql/Schema;)V
@@ -2429,8 +2438,11 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 	public final fun getDebug ()Z
 	public final fun getDuration ()J
 	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxAttempts ()I
 	public final fun getMaxRepetitionDelay ()J
+	public final fun getMaxRetryDelay ()J
 	public final fun getMinRepetitionDelay ()J
+	public final fun getMinRetryDelay ()J
 	public fun getOuterTransaction ()Lorg/jetbrains/exposed/sql/Transaction;
 	public final fun getQueryTimeout ()Ljava/lang/Integer;
 	public fun getReadOnly ()Z
@@ -2447,8 +2459,11 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 	public final fun setCurrentStatement (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;)V
 	public final fun setDebug (Z)V
 	public final fun setDuration (J)V
+	public final fun setMaxAttempts (I)V
 	public final fun setMaxRepetitionDelay (J)V
+	public final fun setMaxRetryDelay (J)V
 	public final fun setMinRepetitionDelay (J)V
+	public final fun setMinRetryDelay (J)V
 	public final fun setQueryTimeout (Ljava/lang/Integer;)V
 	public final fun setRepetitionAttempts (I)V
 	public final fun setStatementCount (I)V
@@ -3222,15 +3237,21 @@ public final class org/jetbrains/exposed/sql/transactions/ThreadLocalTransaction
 	public fun bindTransactionToThread (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public fun currentOrNull ()Lorg/jetbrains/exposed/sql/Transaction;
 	public fun getDefaultIsolationLevel ()I
+	public fun getDefaultMaxAttempts ()I
 	public fun getDefaultMaxRepetitionDelay ()J
+	public fun getDefaultMaxRetryDelay ()J
 	public fun getDefaultMinRepetitionDelay ()J
+	public fun getDefaultMinRetryDelay ()J
 	public fun getDefaultReadOnly ()Z
 	public fun getDefaultRepetitionAttempts ()I
 	public final fun getThreadLocal ()Ljava/lang/ThreadLocal;
 	public fun newTransaction (IZLorg/jetbrains/exposed/sql/Transaction;)Lorg/jetbrains/exposed/sql/Transaction;
 	public fun setDefaultIsolationLevel (I)V
+	public fun setDefaultMaxAttempts (I)V
 	public fun setDefaultMaxRepetitionDelay (J)V
+	public fun setDefaultMaxRetryDelay (J)V
 	public fun setDefaultMinRepetitionDelay (J)V
+	public fun setDefaultMinRetryDelay (J)V
 	public fun setDefaultReadOnly (Z)V
 	public fun setDefaultRepetitionAttempts (I)V
 	public fun toString ()Ljava/lang/String;
@@ -3265,14 +3286,20 @@ public abstract interface class org/jetbrains/exposed/sql/transactions/Transacti
 	public abstract fun bindTransactionToThread (Lorg/jetbrains/exposed/sql/Transaction;)V
 	public abstract fun currentOrNull ()Lorg/jetbrains/exposed/sql/Transaction;
 	public abstract fun getDefaultIsolationLevel ()I
+	public abstract fun getDefaultMaxAttempts ()I
 	public abstract fun getDefaultMaxRepetitionDelay ()J
+	public abstract fun getDefaultMaxRetryDelay ()J
 	public abstract fun getDefaultMinRepetitionDelay ()J
+	public abstract fun getDefaultMinRetryDelay ()J
 	public abstract fun getDefaultReadOnly ()Z
 	public abstract fun getDefaultRepetitionAttempts ()I
 	public abstract fun newTransaction (IZLorg/jetbrains/exposed/sql/Transaction;)Lorg/jetbrains/exposed/sql/Transaction;
 	public abstract fun setDefaultIsolationLevel (I)V
+	public abstract fun setDefaultMaxAttempts (I)V
 	public abstract fun setDefaultMaxRepetitionDelay (J)V
+	public abstract fun setDefaultMaxRetryDelay (J)V
 	public abstract fun setDefaultMinRepetitionDelay (J)V
+	public abstract fun setDefaultMinRetryDelay (J)V
 	public abstract fun setDefaultReadOnly (Z)V
 	public abstract fun setDefaultRepetitionAttempts (I)V
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -14,8 +14,26 @@ class DatabaseConfig private constructor(
     val useNestedTransactions: Boolean,
     val defaultFetchSize: Int?,
     val defaultIsolationLevel: Int,
+    val defaultMaxAttempts: Int,
+    val defaultMinRetryDelay: Long,
+    val defaultMaxRetryDelay: Long,
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMaxAttempts"),
+        level = DeprecationLevel.WARNING
+    )
     val defaultRepetitionAttempts: Int,
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMinRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
     val defaultMinRepetitionDelay: Long,
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMaxRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
     val defaultMaxRepetitionDelay: Long,
     val defaultReadOnly: Boolean,
     val warnLongQueriesDuration: Long?,
@@ -48,25 +66,44 @@ class DatabaseConfig private constructor(
          */
         var defaultIsolationLevel: Int = -1,
         /**
-         * How many retries will be made inside any `transaction` block if SQLException happens.
-         * This can be overridden on a per-transaction level by specifying the `repetitionAttempts` property in a
+         * The maximum amount of attempts that will be made to perform any transaction block.
+         * If this value is set to 1 and an SQLException happens, the exception will be thrown without performing a retry.
+         * This can be overridden on a per-transaction level by specifying the `maxAttempts` property in a
          * `transaction` block.
-         * Default attempts are 3.
+         * Default amount of attempts is 3.
          */
-        var defaultRepetitionAttempts: Int = 3,
+        var defaultMaxAttempts: Int = 3,
         /**
-         * The minimum number of milliseconds to wait before retrying a transaction if SQLException happens.
-         * This can be overridden on a per-transaction level by specifying the `minRepetitionDelay` property in a
+         * The minimum number of milliseconds to wait before retrying a transaction if an SQLException happens.
+         * This can be overridden on a per-transaction level by specifying the `minRetryDelay` property in a
          * `transaction` block.
          * Default minimum delay is 0.
          */
-        var defaultMinRepetitionDelay: Long = 0,
+        var defaultMinRetryDelay: Long = 0,
         /**
-         * The maximum number of milliseconds to wait before retrying a transaction if SQLException happens.
-         * This can be overridden on a per-transaction level by specifying the `maxRepetitionDelay` property in a
+         * The maximum number of milliseconds to wait before retrying a transaction if an SQLException happens.
+         * This can be overridden on a per-transaction level by specifying the `maxRetryDelay` property in a
          * `transaction` block.
          * Default maximum delay is 0.
          */
+        var defaultMaxRetryDelay: Long = 0,
+        @Deprecated(
+            message = "This property will be removed in future releases",
+            replaceWith = ReplaceWith("defaultMaxAttempts"),
+            level = DeprecationLevel.WARNING
+        )
+        var defaultRepetitionAttempts: Int = 3,
+        @Deprecated(
+            message = "This property will be removed in future releases",
+            replaceWith = ReplaceWith("defaultMinRetryDelay"),
+            level = DeprecationLevel.WARNING
+        )
+        var defaultMinRepetitionDelay: Long = 0,
+        @Deprecated(
+            message = "This property will be removed in future releases",
+            replaceWith = ReplaceWith("defaultMaxRetryDelay"),
+            level = DeprecationLevel.WARNING
+        )
         var defaultMaxRepetitionDelay: Long = 0,
         /**
          * Should all connections/transactions be executed in read-only mode by default or not.
@@ -126,6 +163,9 @@ class DatabaseConfig private constructor(
                 useNestedTransactions = builder.useNestedTransactions,
                 defaultFetchSize = builder.defaultFetchSize,
                 defaultIsolationLevel = builder.defaultIsolationLevel,
+                defaultMaxAttempts = builder.defaultMaxAttempts.coerceAtLeast(1),
+                defaultMinRetryDelay = builder.defaultMinRetryDelay,
+                defaultMaxRetryDelay = builder.defaultMaxRetryDelay,
                 defaultRepetitionAttempts = builder.defaultRepetitionAttempts,
                 defaultMinRepetitionDelay = builder.defaultMinRepetitionDelay,
                 defaultMaxRepetitionDelay = builder.defaultMaxRepetitionDelay,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -65,14 +65,39 @@ open class Transaction(
     /** Whether tracked values like [statementCount] and [duration] should be stored in [statementStats] for debugging. */
     var debug = false
 
-    /** The number of retries that will be made inside this `transaction` block if SQLException happens */
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("maxAttempts"),
+        level = DeprecationLevel.WARNING
+    )
     var repetitionAttempts: Int = db.transactionManager.defaultRepetitionAttempts
 
-    /** The minimum number of milliseconds to wait before retrying this `transaction` if SQLException happens */
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("minRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
     var minRepetitionDelay: Long = db.transactionManager.defaultMinRepetitionDelay
 
-    /** The maximum number of milliseconds to wait before retrying this `transaction` if SQLException happens */
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("maxRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
     var maxRepetitionDelay: Long = db.transactionManager.defaultMaxRepetitionDelay
+
+    /**
+     * The maximum amount of attempts that will be made to perform this `transaction` block.
+     *
+     * If this value is set to 1 and an SQLException happens, the exception will be thrown without performing a retry.
+     */
+    var maxAttempts: Int = maxOf(db.transactionManager.defaultMaxAttempts, repetitionAttempts)
+
+    /** The minimum number of milliseconds to wait before retrying this `transaction` if an SQLException happens. */
+    var minRetryDelay: Long = minOf(db.transactionManager.defaultMinRetryDelay, minRepetitionDelay)
+
+    /** The maximum number of milliseconds to wait before retrying this `transaction` if an SQLException happens. */
+    var maxRetryDelay: Long = maxOf(db.transactionManager.defaultMaxRetryDelay, maxRepetitionDelay)
 
     /**
      * The number of seconds the JDBC driver should wait for a statement to execute in [Transaction] transaction before timing out.
@@ -307,8 +332,8 @@ open class Transaction(
         executedStatements.clear()
     }
 
-    internal fun getRetryInterval(): Long = if (repetitionAttempts > 0) {
-        maxOf((maxRepetitionDelay - minRepetitionDelay) / (repetitionAttempts + 1), 1)
+    internal fun getRetryInterval(): Long = if (maxAttempts > 0) {
+        maxOf((maxRetryDelay - minRetryDelay) / (maxAttempts + 1), 1)
     } else {
         0
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -65,39 +65,51 @@ open class Transaction(
     /** Whether tracked values like [statementCount] and [duration] should be stored in [statementStats] for debugging. */
     var debug = false
 
+    /**
+     * The maximum amount of attempts that will be made to perform this `transaction` block.
+     *
+     * If this value is set to 1 and an SQLException happens, the exception will be thrown without performing a retry.
+     *
+     * @throws IllegalArgumentException If the amount of attempts is set to a value less than 1.
+     */
+    var maxAttempts: Int = db.transactionManager.defaultMaxAttempts
+        set(value) {
+            require(value > 0) { "maxAttempts must be set to perform at least 1 attempt." }
+            field = value
+        }
+
+    /** The minimum number of milliseconds to wait before retrying this `transaction` if an SQLException happens. */
+    var minRetryDelay: Long = db.transactionManager.defaultMinRetryDelay
+
+    /** The maximum number of milliseconds to wait before retrying this `transaction` if an SQLException happens. */
+    var maxRetryDelay: Long = db.transactionManager.defaultMaxRetryDelay
+
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("maxAttempts"),
         level = DeprecationLevel.WARNING
     )
-    var repetitionAttempts: Int = db.transactionManager.defaultRepetitionAttempts
+    var repetitionAttempts: Int
+        get() = maxAttempts
+        set(value) { maxAttempts = value }
 
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("minRetryDelay"),
         level = DeprecationLevel.WARNING
     )
-    var minRepetitionDelay: Long = db.transactionManager.defaultMinRepetitionDelay
+    var minRepetitionDelay: Long
+        get() = minRetryDelay
+        set(value) { minRetryDelay = value }
 
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("maxRetryDelay"),
         level = DeprecationLevel.WARNING
     )
-    var maxRepetitionDelay: Long = db.transactionManager.defaultMaxRepetitionDelay
-
-    /**
-     * The maximum amount of attempts that will be made to perform this `transaction` block.
-     *
-     * If this value is set to 1 and an SQLException happens, the exception will be thrown without performing a retry.
-     */
-    var maxAttempts: Int = maxOf(db.transactionManager.defaultMaxAttempts, repetitionAttempts)
-
-    /** The minimum number of milliseconds to wait before retrying this `transaction` if an SQLException happens. */
-    var minRetryDelay: Long = minOf(db.transactionManager.defaultMinRetryDelay, minRepetitionDelay)
-
-    /** The maximum number of milliseconds to wait before retrying this `transaction` if an SQLException happens. */
-    var maxRetryDelay: Long = maxOf(db.transactionManager.defaultMaxRetryDelay, maxRepetitionDelay)
+    var maxRepetitionDelay: Long
+        get() = maxRetryDelay
+        set(value) { maxRetryDelay = value }
 
     /**
      * The number of seconds the JDBC driver should wait for a statement to execute in [Transaction] transaction before timing out.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -22,47 +22,41 @@ class ThreadLocalTransactionManager(
     private val db: Database,
     private val setupTxConnection: ((ExposedConnection<*>, TransactionInterface) -> Unit)? = null
 ) : TransactionManager {
+    @Volatile
+    override var defaultMaxAttempts: Int = db.config.defaultMaxAttempts
+
+    @Volatile
+    override var defaultMinRetryDelay: Long = db.config.defaultMinRetryDelay
+
+    @Volatile
+    override var defaultMaxRetryDelay: Long = db.config.defaultMaxRetryDelay
+
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxAttempts"),
         level = DeprecationLevel.WARNING
     )
-    @Volatile
-    override var defaultRepetitionAttempts: Int = db.config.defaultRepetitionAttempts
-        @Deprecated("Use DatabaseConfig to define the defaultMaxAttempts", level = DeprecationLevel.WARNING)
-        @TestOnly
-        set
+    override var defaultRepetitionAttempts: Int
+        get() = defaultMaxAttempts
+        set(value) { defaultMaxAttempts = value }
 
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMinRetryDelay"),
         level = DeprecationLevel.WARNING
     )
-    @Volatile
-    override var defaultMinRepetitionDelay: Long = db.config.defaultMinRepetitionDelay
-        @Deprecated("Use DatabaseConfig to define the defaultMinRetryDelay", level = DeprecationLevel.WARNING)
-        @TestOnly
-        set
+    override var defaultMinRepetitionDelay: Long
+        get() = defaultMinRetryDelay
+        set(value) { defaultMinRetryDelay = value }
 
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxRetryDelay"),
         level = DeprecationLevel.WARNING
     )
-    @Volatile
-    override var defaultMaxRepetitionDelay: Long = db.config.defaultMaxRepetitionDelay
-        @Deprecated("Use DatabaseConfig to define the defaultMaxRetryDelay", level = DeprecationLevel.WARNING)
-        @TestOnly
-        set
-
-    @Volatile
-    override var defaultMaxAttempts: Int = maxOf(db.config.defaultMaxAttempts, defaultRepetitionAttempts)
-
-    @Volatile
-    override var defaultMinRetryDelay: Long = minOf(db.config.defaultMinRetryDelay, defaultMinRepetitionDelay)
-
-    @Volatile
-    override var defaultMaxRetryDelay: Long = maxOf(db.config.defaultMaxRetryDelay, defaultMaxRepetitionDelay)
+    override var defaultMaxRepetitionDelay: Long
+        get() = defaultMaxRetryDelay
+        set(value) { defaultMaxRetryDelay = value }
 
     @Volatile
     override var defaultIsolationLevel: Int = db.config.defaultIsolationLevel

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -39,10 +39,31 @@ private object NotInitializedManager : TransactionManager {
 
     override var defaultReadOnly: Boolean = false
 
+    override var defaultMaxAttempts: Int = -1
+
+    override var defaultMinRetryDelay: Long = 0
+
+    override var defaultMaxRetryDelay: Long = 0
+
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMaxAttempts"),
+        level = DeprecationLevel.WARNING
+    )
     override var defaultRepetitionAttempts: Int = -1
 
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMinRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
     override var defaultMinRepetitionDelay: Long = 0
 
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMaxRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
     override var defaultMaxRepetitionDelay: Long = 0
 
     override fun newTransaction(isolation: Int, readOnly: Boolean, outerTransaction: Transaction?): Transaction =
@@ -66,13 +87,34 @@ interface TransactionManager {
     /** Whether transactions should be performed in read-only mode. Unless specified, the database default will be used. */
     var defaultReadOnly: Boolean
 
-    /** The default number of retries that will be performed in a transaction if an exception is thrown. */
-    var defaultRepetitionAttempts: Int
+    /** The default maximum amount of attempts that will be made to perform a transaction. */
+    var defaultMaxAttempts: Int
 
     /** The default minimum number of milliseconds to wait before retrying a transaction if an exception is thrown. */
-    var defaultMinRepetitionDelay: Long
+    var defaultMinRetryDelay: Long
 
     /** The default maximum number of milliseconds to wait before retrying a transaction if an exception is thrown. */
+    var defaultMaxRetryDelay: Long
+
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMaxAttempts"),
+        level = DeprecationLevel.WARNING
+    )
+    var defaultRepetitionAttempts: Int
+
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMinRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
+    var defaultMinRepetitionDelay: Long
+
+    @Deprecated(
+        message = "This property will be removed in future releases",
+        replaceWith = ReplaceWith("defaultMaxRetryDelay"),
+        level = DeprecationLevel.WARNING
+    )
     var defaultMaxRepetitionDelay: Long
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -45,25 +45,13 @@ private object NotInitializedManager : TransactionManager {
 
     override var defaultMaxRetryDelay: Long = 0
 
-    @Deprecated(
-        message = "This property will be removed in future releases",
-        replaceWith = ReplaceWith("defaultMaxAttempts"),
-        level = DeprecationLevel.WARNING
-    )
+    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.WARNING)
     override var defaultRepetitionAttempts: Int = -1
 
-    @Deprecated(
-        message = "This property will be removed in future releases",
-        replaceWith = ReplaceWith("defaultMinRetryDelay"),
-        level = DeprecationLevel.WARNING
-    )
+    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.WARNING)
     override var defaultMinRepetitionDelay: Long = 0
 
-    @Deprecated(
-        message = "This property will be removed in future releases",
-        replaceWith = ReplaceWith("defaultMaxRetryDelay"),
-        level = DeprecationLevel.WARNING
-    )
+    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.WARNING)
     override var defaultMaxRepetitionDelay: Long = 0
 
     override fun newTransaction(isolation: Int, readOnly: Boolean, outerTransaction: Transaction?): Transaction =

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -77,7 +77,7 @@ abstract class DatabaseTestsBase {
 
         val database = dbSettings.db!!
         transaction(database.transactionManager.defaultIsolationLevel, db = database) {
-            repetitionAttempts = 1
+            maxAttempts = 1
             registerInterceptor(CurrentTestDBInterceptor)
             currentTestDB = dbSettings
             statement(dbSettings)
@@ -123,7 +123,7 @@ abstract class DatabaseTestsBase {
                 } catch (_: Exception) {
                     val database = dialect.db!!
                     inTopLevelTransaction(database.transactionManager.defaultIsolationLevel, db = database) {
-                        repetitionAttempts = 1
+                        maxAttempts = 1
                         SchemaUtils.drop(*tables)
                     }
                 }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
@@ -71,7 +71,7 @@ enum class TestDB(
             driver = ORACLE.driver
         )
         transaction(Connection.TRANSACTION_READ_COMMITTED, db = tmp) {
-            repetitionAttempts = 1
+            maxAttempts = 1
 
             @Suppress("SwallowedException", "TooGenericExceptionCaught")
             try {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseEntityTest.kt
@@ -197,7 +197,7 @@ class MultiDatabaseEntityTest {
             }
         }
         inTopLevelTransaction(Connection.TRANSACTION_READ_COMMITTED, db = db1) {
-            repetitionAttempts = 1
+            maxAttempts = 1
             assertNull(EntityTestsData.BEntity.testCache(db1b1.id))
             val b1Reread = EntityTestsData.BEntity[db1b1.id]
             assertEquals(db1b1.id, b1Reread.id)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionExceptions.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionExceptions.kt
@@ -70,7 +70,7 @@ class ConnectionExceptions {
         val db = Database.connect(datasource = wrappingDataSource)
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, db = db) {
-                repetitionAttempts = 5
+                maxAttempts = 5
                 this.exec("BROKEN_SQL_THAT_CAUSES_EXCEPTION()")
             }
             fail("Should have thrown an exception")
@@ -106,7 +106,7 @@ class ConnectionExceptions {
         val db = Database.connect(datasource = wrappingDataSource)
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, db = db) {
-                repetitionAttempts = 5
+                maxAttempts = 5
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")
@@ -132,7 +132,7 @@ class ConnectionExceptions {
         val db = Database.connect(datasource = wrappingDataSource)
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, db = db) {
-                repetitionAttempts = 5
+                maxAttempts = 5
                 this.exec("SELECT 1;")
             }
             fail("Should have thrown an exception")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTimeoutTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTimeoutTest.kt
@@ -32,7 +32,7 @@ class ConnectionTimeoutTest : DatabaseTestsBase() {
 
         try {
             transaction(Connection.TRANSACTION_SERIALIZABLE, db = db) {
-                repetitionAttempts = 42
+                maxAttempts = 42
                 exec("SELECT 1;")
                 // NO OP
             }
@@ -50,7 +50,7 @@ class ConnectionTimeoutTest : DatabaseTestsBase() {
         val db = Database.connect(
             datasource = datasource,
             databaseConfig = DatabaseConfig {
-                defaultRepetitionAttempts = 10
+                defaultMaxAttempts = 10
             }
         )
 
@@ -69,7 +69,7 @@ class ConnectionTimeoutTest : DatabaseTestsBase() {
         try {
             // property set in transaction block should override default DatabaseConfig
             transaction(Connection.TRANSACTION_SERIALIZABLE, db = db) {
-                repetitionAttempts = 25
+                maxAttempts = 25
                 exec("SELECT 1;")
             }
             fail("Should have thrown ${GetConnectException::class.simpleName}")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/CoroutineTests.kt
@@ -81,7 +81,7 @@ class CoroutineTests : DatabaseTestsBase() {
 
                 val insertJob = launch {
                     newSuspendedTransaction(Dispatchers.Default, db = db) {
-                        repetitionAttempts = 20
+                        maxAttempts = 20
 
                         // throws JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation
                         // until original row is updated with a new id
@@ -92,7 +92,7 @@ class CoroutineTests : DatabaseTestsBase() {
                 }
                 val updateJob = launch {
                     newSuspendedTransaction(Dispatchers.Default, db = db) {
-                        repetitionAttempts = 20
+                        maxAttempts = 20
 
                         TestingUnique.update({ TestingUnique.id eq originalId }) { it[id] = updatedId }
 
@@ -162,7 +162,7 @@ class CoroutineTests : DatabaseTestsBase() {
 
                 val (insertResult, updateResult) = listOf(
                     suspendedTransactionAsync(db = db) {
-                        repetitionAttempts = 20
+                        maxAttempts = 20
 
                         // throws JdbcSQLIntegrityConstraintViolationException: Unique index or primary key violation
                         // until original row is updated with a new id
@@ -171,7 +171,7 @@ class CoroutineTests : DatabaseTestsBase() {
                         TestingUnique.selectAll().count()
                     },
                     suspendedTransactionAsync(db = db) {
-                        repetitionAttempts = 20
+                        maxAttempts = 20
 
                         TestingUnique.update({ TestingUnique.id eq originalId }) { it[id] = updatedId }
                         TestingUnique.selectAll().count()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
@@ -60,7 +60,7 @@ class NestedTransactionsTest : DatabaseTestsBase() {
 
             try {
                 inTopLevelTransaction(this.transactionIsolation) {
-                    repetitionAttempts = 1
+                    maxAttempts = 1
                     throw IllegalStateException("Should be rethrow")
                 }
             } catch (e: Exception) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
@@ -14,7 +14,7 @@ class RollbackTransactionTest : DatabaseTestsBase() {
     fun testRollbackWithoutSavepoints() {
         withTables(RollbackTable) {
             inTopLevelTransaction(db.transactionManager.defaultIsolationLevel) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 RollbackTable.insert { it[RollbackTable.value] = "before-dummy" }
                 transaction {
                     assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "before-dummy" }.count())
@@ -38,7 +38,7 @@ class RollbackTransactionTest : DatabaseTestsBase() {
             try {
                 db.useNestedTransactions = true
                 inTopLevelTransaction(db.transactionManager.defaultIsolationLevel) {
-                    repetitionAttempts = 1
+                    maxAttempts = 1
                     RollbackTable.insert { it[RollbackTable.value] = "before-dummy" }
                     transaction {
                         assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "before-dummy" }.count())

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -57,7 +57,7 @@ class ThreadLocalManagerTest : DatabaseTestsBase() {
         withTables(excludeSettings = excludeSettings, RollbackTable) {
             assertFails {
                 inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, true) {
-                    repetitionAttempts = 1
+                    maxAttempts = 1
                     RollbackTable.insert { it[value] = "random-something" }
                 }
             }.message?.run { assertTrue(contains("read-only")) } ?: fail("message should not be null")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionIsolationTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionIsolationTest.kt
@@ -20,7 +20,7 @@ class TransactionIsolationTest : DatabaseTestsBase() {
     fun `test what transaction isolation was applied`() {
         withDb {
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 assertEquals(Connection.TRANSACTION_SERIALIZABLE, this.connection.transactionIsolation)
             }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -712,13 +712,13 @@ class EntityTests : DatabaseTestsBase() {
     fun sharingEntityBetweenTransactions() {
         withTables(Humans) {
             val human1 = newTransaction {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 Human.new {
                     this.h = "foo"
                 }
             }
             newTransaction {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 assertEquals(null, Human.testCache(human1.id))
                 assertEquals("foo", Humans.selectAll().single()[Humans.h])
                 human1.h = "bar"
@@ -727,7 +727,7 @@ class EntityTests : DatabaseTestsBase() {
             }
 
             newTransaction {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 assertEquals("bar", Humans.selectAll().single()[Humans.h])
             }
         }
@@ -966,7 +966,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 School.find {
                     Schools.id eq school1.id
                 }.first().load(School::region)
@@ -1011,7 +1011,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 School.all().with(School::region, School::secondaryRegion)
                 assertNotNull(School.testCache(school1.id))
                 assertNotNull(School.testCache(school2.id))
@@ -1042,7 +1042,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 val school2 = School.find {
                     Schools.id eq school1.id
                 }.first().load(School::secondaryRegion)
@@ -1102,7 +1102,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 val cache = TransactionManager.current().entityCache
 
                 School.all().with(School::students)
@@ -1144,7 +1144,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 val cache = TransactionManager.current().entityCache
 
                 School.find { Schools.id eq school1.id }.first().load(School::students)
@@ -1189,7 +1189,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 School.all().with(School::students, Student::detentions)
                 val cache = TransactionManager.current().entityCache
 
@@ -1252,7 +1252,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 School.all().with(School::holidays)
                 val cache = TransactionManager.current().entityCache
 
@@ -1400,7 +1400,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 Student.all().with(Student::bio)
                 val cache = TransactionManager.current().entityCache
 
@@ -1445,7 +1445,7 @@ class EntityTests : DatabaseTestsBase() {
             commit()
 
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
-                repetitionAttempts = 1
+                maxAttempts = 1
                 Student.all().first().load(Student::bio)
                 val cache = TransactionManager.current().entityCache
 


### PR DESCRIPTION
The KDocs and the name for the property `Transaction.repetitionAttempts` makes it seem like setting the value to 1 means that any failed transaction would undergo 1 automatic retry or repeated attempt.
Instead, setting the value to 1 means that the transaction is only run once, without any repetition or retry, and any failure is thrown. [Example logic in source code](https://github.com/JetBrains/Exposed/blob/main/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt#L284)

The property, and its related delay and default variants, are being deprecated in favor of properties that are more aligned with their underlying purpose and the common naming conventions of other standard retry tools/plugins/frameworks:
- `repetitionAttempts` -> `maxAttempts`
- `minRepetitionDelay` -> `minRetryDelay`
- `maxRepetitionDelay` -> `maxRetryDelay`

These properties are being replaced in 3 places:
1. `DatabaseConfig` and its helper builder class
2. `Transaction` class
3. `TransactionManager` interface and its implementations

---

**Breaking Changes:**
- If `maxAttempts` is meant to be the amount of attempts to run a transaction, then it may seem like setting the property to 0 should disable a transaction from being performed. This is not the case, as the transaction is always run at minimum once. Now, setting the property (or the deprecated version) to a value less than 1 throws an exception.
- The deprecated properties were moved out from the constructor of `DatabaseConfig.Builder` to allow getters and setters to be added. They were replaced by the new properties that accept the same type of argument. This should be a minor change as the `Builder` class constructor is not meant to be used directly.