### PR TITLE
feat: EXPOSED-296 Add ability to check if a Sequence exists in a database

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2012,6 +2012,7 @@ public final class org/jetbrains/exposed/sql/Sequence {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun createStatement ()Ljava/util/List;
 	public final fun dropStatement ()Ljava/util/List;
+	public final fun exists ()Z
 	public final fun getCache ()Ljava/lang/Long;
 	public final fun getCycle ()Ljava/lang/Boolean;
 	public final fun getDdl ()Ljava/util/List;
@@ -3204,6 +3205,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun getUrl ()Ljava/lang/String;
 	public abstract fun getVersion ()Ljava/math/BigDecimal;
 	public abstract fun resetCurrentScheme ()V
+	public abstract fun sequences ()Ljava/util/List;
 	public abstract fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
 	public abstract fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
 }
@@ -3489,6 +3491,8 @@ public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialec
 	public abstract fun resetSchemaCaches ()V
 	public abstract fun resolveRefOptionFromJdbc (I)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public abstract fun schemaExists (Lorg/jetbrains/exposed/sql/Schema;)Z
+	public abstract fun sequenceExists (Lorg/jetbrains/exposed/sql/Sequence;)Z
+	public abstract fun sequences ()Ljava/util/List;
 	public abstract fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public abstract fun supportsSelectForUpdate ()Z
 	public abstract fun tableColumns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
@@ -3711,6 +3715,7 @@ public class org/jetbrains/exposed/sql/vendors/H2Dialect : org/jetbrains/exposed
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
 	public fun resolveRefOptionFromJdbc (I)Lorg/jetbrains/exposed/sql/ReferenceOption;
+	public fun sequences ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -3796,6 +3801,7 @@ public class org/jetbrains/exposed/sql/vendors/OracleDialect : org/jetbrains/exp
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
 	public fun resolveRefOptionFromJdbc (I)Lorg/jetbrains/exposed/sql/ReferenceOption;
+	public fun sequences ()Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 }
 
@@ -3867,6 +3873,7 @@ public class org/jetbrains/exposed/sql/vendors/SQLServerDialect : org/jetbrains/
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
+	public fun sequences ()Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 }
 
@@ -3959,6 +3966,8 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun resetSchemaCaches ()V
 	public fun resolveRefOptionFromJdbc (I)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public fun schemaExists (Lorg/jetbrains/exposed/sql/Schema;)Z
+	public fun sequenceExists (Lorg/jetbrains/exposed/sql/Sequence;)Z
+	public fun sequences ()Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 	public fun supportsSelectForUpdate ()Z
 	public fun tableColumns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
@@ -76,4 +76,9 @@ class Sequence(
 
         return listOf(dropSequenceDDL)
     }
+
+    /**
+     * Returns whether this sequence exists in the database.
+     */
+    fun exists(): Boolean = currentDialect.sequenceExists(this)
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -67,6 +67,9 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     /** Returns a map with the [PrimaryKeyMetadata] in each of the specified [tables]. */
     abstract fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?>
 
+    /** Returns a list of the names of all sequences in the database. */
+    abstract fun sequences(): List<String>
+
     /**
      * Returns a map with the [ForeignKeyConstraint] of all the defined columns in each of the specified [tables],
      * with the table name used as the key.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -87,6 +87,9 @@ interface DatabaseDialect {
     /** Checks if the specified schema exists. */
     fun schemaExists(schema: Schema): Boolean
 
+    /** Returns whether the specified sequence exists. */
+    fun sequenceExists(sequence: Sequence): Boolean
+
     fun checkTableMapping(table: Table): Boolean = true
 
     /** Returns a map with the column metadata of all the defined columns in each of the specified [tables]. */
@@ -102,6 +105,9 @@ interface DatabaseDialect {
 
     /** Returns a map with the primary key metadata in each of the specified [tables]. */
     fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> = emptyMap()
+
+    /** Returns a list of the names of all sequences in the database. */
+    fun sequences(): List<String>
 
     /** Returns `true` if the dialect supports `SELECT FOR UPDATE` statements, `false` otherwise. */
     fun supportsSelectForUpdate(): Boolean

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -303,6 +303,16 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         }
     }
 
+    override fun sequences(): List<String> {
+        val sequences = mutableListOf<String>()
+        TransactionManager.current().exec("SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SEQUENCES") { rs ->
+            while (rs.next()) {
+                sequences.add(rs.getString("SEQUENCE_NAME"))
+            }
+        }
+        return sequences
+    }
+
     companion object : DialectNameProvider("H2")
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -393,5 +393,15 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
         else -> currentDialect.defaultReferenceOption
     }
 
+    override fun sequences(): List<String> {
+        val sequences = mutableListOf<String>()
+        TransactionManager.current().exec("SELECT SEQUENCE_NAME FROM USER_SEQUENCES") { rs ->
+            while (rs.next()) {
+                sequences.add(rs.getString("SEQUENCE_NAME"))
+            }
+        }
+        return sequences
+    }
+
     companion object : DialectNameProvider("Oracle")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -360,6 +360,16 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15#arguments
     override val likePatternSpecialChars = sqlServerLikePatternSpecialChars
 
+    override fun sequences(): List<String> {
+        val sequences = mutableListOf<String>()
+        TransactionManager.current().exec("SELECT name FROM sys.sequences") { rs ->
+            while (rs.next()) {
+                sequences.add(rs.getString("name"))
+            }
+        }
+        return sequences
+    }
+
     companion object : DialectNameProvider("SQLServer") {
         private val sqlServerLikePatternSpecialChars = mapOf('%' to null, '_' to null, '[' to ']')
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
@@ -91,6 +91,10 @@ abstract class VendorDialect(
         return allSchemas.any { it == schema.identifier.inProperCase() }
     }
 
+    override fun sequenceExists(sequence: Sequence): Boolean {
+        return sequences().any { it == sequence.identifier.inProperCase() }
+    }
+
     override fun tableColumns(vararg tables: Table): Map<Table, List<ColumnMetadata>> =
         TransactionManager.current().connection.metadata { columns(*tables) }
 
@@ -115,6 +119,9 @@ abstract class VendorDialect(
 
     override fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> =
         TransactionManager.current().db.metadata { existingPrimaryKeys(*tables) }
+
+    override fun sequences(): List<String> =
+        TransactionManager.current().db.metadata { sequences() }
 
     private val supportsSelectForUpdate: Boolean by lazy {
         TransactionManager.current().db.metadata { supportsSelectForUpdate }

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -52,6 +52,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun getUrl ()Ljava/lang/String;
 	public fun getVersion ()Ljava/math/BigDecimal;
 	public fun resetCurrentScheme ()V
+	public fun sequences ()Ljava/util/List;
 	public fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
 	public fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
 }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -285,6 +285,16 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         }
     }
 
+    @Suppress("MagicNumber")
+    override fun sequences(): List<String> {
+        val sequences = mutableListOf<String>()
+        val rs = metadata.getTables(null, null, null, arrayOf("SEQUENCE"))
+        while (rs.next()) {
+            sequences.add(rs.getString(3))
+        }
+        return sequences
+    }
+
     @Synchronized
     override fun tableConstraints(tables: List<Table>): Map<String, List<ForeignKeyConstraint>> {
         val allTables = SchemaUtils.sortTablesByReferences(tables).associateBy { it.nameInDatabaseCaseUnquoted() }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -1169,7 +1169,7 @@ class DDLTests : DatabaseTestsBase() {
             val adminBy = reference("adminBy", users).nullable()
         }
 
-        withTables(subscriptions) {
+        withTables(users, subscriptions) {
             val query = subscriptions.join(users, JoinType.INNER, additionalConstraint = { subscriptions.user eq users.id }).selectAll()
             assertEquals(0L, query.count())
         }


### PR DESCRIPTION
Added two functions:
- `sequences()` returns all the existing sequences that a user has the right to access in a database
- `exists()` for a `Sequence` that checks if a sequence exists by looking up all the existing sequences that a user has the right to access in a database, and checking if the identifier of the `Sequence` matches that of any of the existing sequences