### PR TITLE
fix: EXPOSED-340 Syntax error using upsert with MySQL8 below 8.0.19

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -243,7 +243,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         }
 
         val isAliasSupported = when (val dialect = transaction.db.dialect) {
-            is MysqlDialect -> dialect !is MariaDBDialect && transaction.db.isFullVersionCovered("8.0.19")
+            is MysqlDialect -> dialect !is MariaDBDialect && dialect.fullVersion >= "8.0.19"
             else -> false // H2_MySQL mode also uses this function provider & requires older version
         }
 
@@ -270,13 +270,6 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
             toString()
         }
     }
-
-    /** Whether the major, minor, & patch version of the database is equal to or greater than the provided [version]. */
-    private fun Database.isFullVersionCovered(version: String): Boolean {
-        val fullVersion = metadata { databaseProductVersion }.split('.').map(String::toInt)
-        val otherVersion = version.split('.').map(String::toInt)
-        return fullVersion.zip(otherVersion).all { (full, other) -> full >= other }
-    }
 }
 
 /**
@@ -286,6 +279,10 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
 
     internal val isMysql8: Boolean by lazy {
         TransactionManager.current().db.isVersionCovers(BigDecimal("8.0"))
+    }
+
+    internal val fullVersion: String by lazy {
+        TransactionManager.current().db.metadata { databaseProductVersion }
     }
 
     override val supportsCreateSequence: Boolean = false

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -243,7 +243,7 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         }
 
         val isAliasSupported = when (val dialect = transaction.db.dialect) {
-            is MysqlDialect -> dialect !is MariaDBDialect && dialect.isMysql8
+            is MysqlDialect -> dialect !is MariaDBDialect && transaction.db.isFullVersionCovered("8.0.19")
             else -> false // H2_MySQL mode also uses this function provider & requires older version
         }
 
@@ -269,6 +269,13 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
             }
             toString()
         }
+    }
+
+    /** Whether the major, minor, & patch version of the database is equal to or greater than the provided [version]. */
+    private fun Database.isFullVersionCovered(version: String): Boolean {
+        val fullVersion = metadata { databaseProductVersion }.split('.').map(String::toInt)
+        val otherVersion = version.split('.').map(String::toInt)
+        return fullVersion.zip(otherVersion).all { (full, other) -> full >= other }
     }
 }
 


### PR DESCRIPTION
MySQL `upsert()` uses an alias for the insert row values when the database version is 8+.
But this is actually only possible starting with version 8.0.19.

Existing property `MysqlDialect.isMysql8` calls `isVersionCovers()`, which only fetches the database's major and minor version, so it is not sufficient for this comparison.
To get the patch version as well requires fetching metadata using the full `databaseProductVersion` property.

Tested locally with MySQL docker images 8.0.35, 8.0.19, 8.0.18, and 8.0.13.