### PR TITLE
EXPOSED-315: Use the slimmer `spring-boot-starter-jdbc` instead of `spring-boot-starter-data-jdbc`

### DIFF
--- a/exposed-spring-boot-starter/README.md
+++ b/exposed-spring-boot-starter/README.md
@@ -3,7 +3,7 @@
 This is a starter for [Spring Boot](https://spring.io/projects/spring-boot) to utilize [Exposed](https://github.com/JetBrains/Exposed) as the ORM instead of [Hibernate](https://hibernate.org/).
 
 ## Getting Started
-This starter will give you the latest version of [Exposed](https://github.com/JetBrains/Exposed) and its `spring-transaction` library along with the [Spring Boot Starter Data JDBC](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jdbc).
+This starter will give you the latest version of [Exposed](https://github.com/JetBrains/Exposed) and its `spring-transaction` library along with the [Spring Boot Starter JDBC](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-jdbc).
 ### Maven
 ```mxml
 <dependencies>
@@ -40,7 +40,7 @@ exposedVersion=0.49.0
 ```
 
 ## Setting up a database connection
-This starter utilizes `spring-boot-starter-data-jdbc` so that all properties usually used for setting up a database in Spring are applicable here.
+This starter utilizes `spring-boot-starter-jdbc` so that all properties usually used for setting up a database in Spring are applicable here.
 
 ### application.properties (h2 example)
 ```properties

--- a/exposed-spring-boot-starter/build.gradle.kts
+++ b/exposed-spring-boot-starter/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     api(project(":exposed-core"))
     api(project(":exposed-dao"))
     api(project(":spring-transaction"))
-    api(libs.spring.boot.starter.data.jdbc)
+    api(libs.spring.boot.starter.jdbc)
     api(libs.spring.boot.autoconfigure)
     compileOnly(libs.spring.boot.configuration.processor)
     testImplementation(libs.spring.boot.starter.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 javax-money = { group = "javax.money", name = "money-api", version.ref = "javax-money" }
 moneta = { group = "org.javamoney", name = "moneta", version.ref = "moneta" }
 
-spring-boot-starter-data-jdbc = { group = "org.springframework.boot", name = "spring-boot-starter-data-jdbc", version.ref = "springBoot" }
+spring-boot-starter-jdbc = { group = "org.springframework.boot", name = "spring-boot-starter-jdbc", version.ref = "springBoot" }
 spring-boot-autoconfigure = { group = "org.springframework.boot", name = "spring-boot-autoconfigure", version.ref = "springBoot" }
 spring-boot-configuration-processor = { group = "org.springframework.boot", name = "spring-boot-configuration-processor", version.ref = "springBoot" }
 spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test", version.ref = "springBoot" }


### PR DESCRIPTION
Youtrack: [EXPOSED-315](https://youtrack.jetbrains.com/issue/EXPOSED-315/Spring-Boot-Starter-Depend-only-on-spring-boot-starter-jdbc-without-the-data)

- Exposed needs the underlying dependency to set up the JDBC, which it gets from simply the `-jdbc` dependency.
- The `-data-jdbc`  also comes with an entire Repository-based programming model that is an ALTERNATIVE to Exposed, and Exposed does not actually need it
- Therefore it makes sense to omit to have fewer constructs pulled in.


Unsure if this should be marked with fix/feat or similar, or whether this should be considered a breaking change or not. it's a breaking change in the sense that you lose some transitive dependencies, but it does not break the behaviour of API of Exposed itself.