### PR TITLE
docs: EXPOSED-319 H2 customEnumeration example throws

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -25,7 +25,6 @@ import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Assume
 import org.junit.Test
-import org.postgresql.util.PGobject
 import java.util.*
 import kotlin.random.Random
 import kotlin.test.assertContentEquals
@@ -1121,19 +1120,6 @@ class DDLTests : DatabaseTestsBase() {
                     testColumn.isNotNull() neq Op.TRUE
                 }
             }
-        }
-    }
-
-    internal enum class Foo {
-        Bar, Baz;
-
-        override fun toString(): String = "Foo Enum ToString: $name"
-    }
-
-    class PGEnum<T : Enum<T>>(enumTypeName: String, enumValue: T?) : PGobject() {
-        init {
-            value = enumValue?.name
-            type = enumTypeName
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/EnumerationTests.kt
@@ -8,32 +8,40 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
-import org.jetbrains.exposed.sql.tests.shared.DDLTests
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
 import org.junit.Test
+import org.postgresql.util.PGobject
 
 class EnumerationTests : DatabaseTestsBase() {
     private val supportsCustomEnumerationDB = TestDB.mySqlRelatedDB + listOf(TestDB.H2, TestDB.H2_PSQL, TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)
 
+    internal enum class Foo {
+        Bar, Baz;
+
+        override fun toString(): String = "Foo Enum ToString: $name"
+    }
+
+    class PGEnum<T : Enum<T>>(enumTypeName: String, enumValue: T?) : PGobject() {
+        init {
+            value = enumValue?.name
+            type = enumTypeName
+        }
+    }
+
     object EnumTable : IntIdTable("EnumTable") {
-        internal var enumColumn: Column<DDLTests.Foo> = enumeration("enumColumn")
+        internal var enumColumn: Column<Foo> = enumeration("enumColumn")
 
         internal fun initEnumColumn(sql: String) {
             (columns as MutableList<Column<*>>).remove(enumColumn)
             enumColumn = customEnumeration(
                 "enumColumn", sql,
-                { value ->
-                    when {
-                        currentDialectTest is H2Dialect && value is Int -> DDLTests.Foo.entries[value]
-                        else -> DDLTests.Foo.valueOf(value as String)
-                    }
-                },
+                { value -> Foo.valueOf(value as String) },
                 { value ->
                     when (currentDialectTest) {
-                        is PostgreSQLDialect -> DDLTests.PGEnum(sql, value)
+                        is PostgreSQLDialect -> PGEnum(sql, value)
                         else -> value.name
                     }
                 }
@@ -68,24 +76,23 @@ class EnumerationTests : DatabaseTestsBase() {
                     exec(EnumTable.indices.first().dropStatement().single())
                 }
                 EnumTable.insert {
-                    it[enumColumn] = DDLTests.Foo.Bar
+                    it[enumColumn] = Foo.Bar
                 }
-                assertEquals(DDLTests.Foo.Bar, EnumTable.selectAll().single()[EnumTable.enumColumn])
+                assertEquals(Foo.Bar, EnumTable.selectAll().single()[EnumTable.enumColumn])
 
                 EnumTable.update {
-                    it[enumColumn] = DDLTests.Foo.Baz
+                    it[enumColumn] = Foo.Baz
                 }
 
                 val entity = enumClass.new {
-                    enum = DDLTests.Foo.Baz
+                    enum = Foo.Baz
                 }
-                assertEquals(DDLTests.Foo.Baz, entity.enum)
+                assertEquals(Foo.Baz, entity.enum)
                 entity.id.value // flush entity
-                assertEquals(DDLTests.Foo.Baz, entity.enum)
-                assertEquals(DDLTests.Foo.Baz, enumClass.reload(entity)!!.enum)
-                entity.enum = DDLTests.Foo.Bar
-//                flushCache()
-                assertEquals(DDLTests.Foo.Bar, enumClass.reload(entity, true)!!.enum)
+                assertEquals(Foo.Baz, entity.enum)
+                assertEquals(Foo.Baz, enumClass.reload(entity)!!.enum)
+                entity.enum = Foo.Bar
+                assertEquals(Foo.Bar, enumClass.reload(entity, true)!!.enum)
             } finally {
                 try {
                     SchemaUtils.drop(EnumTable)
@@ -109,7 +116,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 }
                 EnumTable.initEnumColumn(sqlType)
                 with(EnumTable) {
-                    enumColumn.default(DDLTests.Foo.Bar)
+                    enumColumn.default(Foo.Bar)
                 }
                 SchemaUtils.create(EnumTable)
                 // drop shared table object's unique index if created in other test
@@ -119,7 +126,7 @@ class EnumerationTests : DatabaseTestsBase() {
 
                 EnumTable.insert { }
                 val default = EnumTable.selectAll().single()[EnumTable.enumColumn]
-                assertEquals(DDLTests.Foo.Bar, default)
+                assertEquals(Foo.Bar, default)
             } finally {
                 try {
                     SchemaUtils.drop(EnumTable)
@@ -131,7 +138,7 @@ class EnumerationTests : DatabaseTestsBase() {
     @Test
     fun testCustomEnumerationWithReference() {
         val referenceTable = object : Table("ref_table") {
-            var referenceColumn: Column<DDLTests.Foo> = enumeration("ref_column")
+            var referenceColumn: Column<Foo> = enumeration("ref_column")
 
             fun initRefColumn() {
                 (columns as MutableList<Column<*>>).remove(referenceColumn)
@@ -159,7 +166,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 referenceTable.initRefColumn()
                 SchemaUtils.create(referenceTable)
 
-                val fooBar = DDLTests.Foo.Bar
+                val fooBar = Foo.Bar
                 val id1 = EnumTable.insert {
                     it[enumColumn] = fooBar
                 } get EnumTable.enumColumn
@@ -180,8 +187,8 @@ class EnumerationTests : DatabaseTestsBase() {
     @Test
     fun testEnumerationColumnsWithReference() {
         val tester = object : Table("tester") {
-            val enumColumn = enumeration<DDLTests.Foo>("enum_column").uniqueIndex()
-            val enumNameColumn = enumerationByName<DDLTests.Foo>("enum_name_column", 32).uniqueIndex()
+            val enumColumn = enumeration<Foo>("enum_column").uniqueIndex()
+            val enumNameColumn = enumerationByName<Foo>("enum_name_column", 32).uniqueIndex()
         }
         val referenceTable = object : Table("ref_table") {
             val referenceColumn = reference("ref_column", tester.enumColumn)
@@ -189,8 +196,8 @@ class EnumerationTests : DatabaseTestsBase() {
         }
 
         withTables(tester, referenceTable) {
-            val fooBar = DDLTests.Foo.Bar
-            val fooBaz = DDLTests.Foo.Baz
+            val fooBar = Foo.Bar
+            val fooBaz = Foo.Baz
             val entry = tester.insert {
                 it[enumColumn] = fooBar
                 it[enumNameColumn] = fooBaz


### PR DESCRIPTION
The example code for using `customEnumeration()` with H2 throws a cast exception.
If the type sent to the database is a string, it is not expected that the value returned by the database will be an integer.

Both transformation functions use or return a string now.

Confirmed that examples for MySQL and PostgreSQL do work.