### PR TITLE
fix: EXPOSED-353 dateLiteral does not work on OracleDB 12c or 19c

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -66,12 +66,6 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
 
     override fun jsonType(): String = "VARCHAR2(4000)"
 
-    override fun processForDefaultValue(e: Expression<*>): String = when {
-        e is LiteralOp<*> && (e.columnType as? IDateColumnType)?.hasTimePart == false -> "DATE ${super.processForDefaultValue(e)}"
-        e is LiteralOp<*> && e.columnType is IDateColumnType -> "TIMESTAMP ${super.processForDefaultValue(e)}"
-        else -> super.processForDefaultValue(e)
-    }
-
     override fun hexToDb(hexString: String): String = "HEXTORAW('$hexString')"
 }
 

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -249,13 +249,10 @@ class JavaLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
     override fun sqlType(): String = currentDialect.dataTypeProvider.timeType()
 
     override fun nonNullValueToString(value: LocalTime): String {
-        if (currentDialect is OracleDialect) {
-            return "TO_TIMESTAMP('${ORACLE_TIME_STRING_FORMATTER.format(value)}', 'YYYY-MM-DD HH24:MI:SS')"
+        val dialect = currentDialect
+        if (dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+            return "TIMESTAMP '${ORACLE_TIME_STRING_FORMATTER.format(value)}'"
         }
-        if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
-            return "'${ORACLE_TIME_STRING_FORMATTER.format(value)}'"
-        }
-
         return "'${DEFAULT_TIME_STRING_FORMATTER.format(value)}'"
     }
 

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DateTimeLiteralTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DateTimeLiteralTest.kt
@@ -1,0 +1,208 @@
+package org.jetbrains.exposed
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.*
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.update
+import org.junit.Ignore
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import kotlin.test.assertNotNull
+
+class DateTimeLiteralTest : DatabaseTestsBase() {
+    private val defaultDate = LocalDate.of(2000, 1, 1)
+    private val futureDate = LocalDate.of(3000, 1, 1)
+
+    object TableWithDate : IntIdTable() {
+        val date = date("date")
+    }
+
+    private val defaultDatetime = LocalDateTime.of(2000, 1, 1, 8, 0, 0, 100000000)
+    private val futureDatetime = LocalDateTime.of(3000, 1, 1, 8, 0, 0, 100000000)
+
+    object TableWithDatetime : IntIdTable() {
+        val datetime = datetime("datetime")
+    }
+
+    private val defaultTimestamp = Instant.parse("2000-01-01T01:00:00.00Z")
+    private val futureTimestamp = Instant.parse("3000-01-01T01:00:00.00Z")
+
+    object TableWithTimestamp : IntIdTable() {
+        val timestamp = timestamp("timestamp")
+    }
+
+    private val defaultLocalTime = LocalTime.of(1, 0, 0)
+    private val futureLocalTime = LocalTime.of(18, 0, 0)
+
+    object TableWithTime : IntIdTable() {
+        val time = time("time")
+    }
+
+    @Test
+    fun testInsertWithDateLiteral() {
+        withTables(TableWithDate) {
+            TableWithDate.insert {
+                it[date] = dateLiteral(defaultDate)
+            }
+            assertEquals(defaultDate, TableWithDate.selectAll().first()[TableWithDate.date])
+        }
+    }
+
+    @Test
+    fun testUpdateWithDateLiteral() {
+        withTables(TableWithDate) {
+            TableWithDate.insert {
+                it[date] = defaultDate
+            }
+
+            TableWithDate.update { it[date] = dateLiteral(futureDate) }
+            assertEquals(futureDate, TableWithDate.selectAll().first()[TableWithDate.date])
+        }
+    }
+
+    @Test
+    fun testSelectByDateLiteralEquality() {
+        withTables(TableWithDate) {
+            TableWithDate.insert {
+                it[date] = defaultDate
+            }
+
+            val query = TableWithDate.select(TableWithDate.date).where { TableWithDate.date eq dateLiteral(defaultDate) }
+            assertEquals(defaultDate, query.single()[TableWithDate.date])
+        }
+    }
+
+    @Test
+    fun testSelectByDateLiteralComparison() {
+        withTables(TableWithDate) {
+            TableWithDate.insert {
+                it[date] = defaultDate
+            }
+            val query = TableWithDate.selectAll().where { TableWithDate.date less dateLiteral(futureDate) }
+            assertNotNull(query.firstOrNull())
+        }
+    }
+
+    @Test
+    fun testInsertDatetimeLiteral() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = dateTimeLiteral(defaultDatetime)
+            }
+            assertEquals(defaultDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
+        }
+    }
+
+    @Test
+    fun testUpdateWithDatetimeLiteral() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+
+            TableWithDatetime.update { it[datetime] = dateTimeLiteral(futureDatetime) }
+            assertEquals(futureDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
+        }
+    }
+
+    @Test
+    fun testSelectByDatetimeLiteralEquality() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+
+            val query = TableWithDatetime.select(TableWithDatetime.datetime).where { TableWithDatetime.datetime eq dateTimeLiteral(defaultDatetime) }
+            assertEquals(defaultDatetime, query.single()[TableWithDatetime.datetime])
+        }
+    }
+
+    @Test
+    fun testSelectByDatetimeLiteralComparison() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+            val query = TableWithDatetime.selectAll().where { TableWithDatetime.datetime less dateTimeLiteral(futureDatetime) }
+            assertNotNull(query.firstOrNull())
+        }
+    }
+
+    @Test
+    fun testInsertWithTimestampLiteral() {
+        withTables(TableWithTimestamp) {
+            TableWithTimestamp.insert {
+                it[timestamp] = timestampLiteral(defaultTimestamp)
+            }
+            assertEquals(defaultTimestamp, TableWithTimestamp.selectAll().first()[TableWithTimestamp.timestamp])
+        }
+    }
+
+    @Test
+    fun testUpdateWithTimestampLiteral() {
+        withTables(TableWithTimestamp) {
+            TableWithTimestamp.insert {
+                it[timestamp] = defaultTimestamp
+            }
+
+            TableWithTimestamp.update { it[timestamp] = timestampLiteral(futureTimestamp) }
+            assertEquals(futureTimestamp, TableWithTimestamp.selectAll().first()[TableWithTimestamp.timestamp])
+        }
+    }
+
+    @Test
+    fun testSelectByTimestampLiteralEquality() {
+        withTables(TableWithTimestamp) {
+            TableWithTimestamp.insert {
+                it[timestamp] = defaultTimestamp
+            }
+
+            val query = TableWithTimestamp.select(TableWithTimestamp.timestamp).where { TableWithTimestamp.timestamp eq timestampLiteral(defaultTimestamp) }
+            assertEquals(defaultTimestamp, query.single()[TableWithTimestamp.timestamp])
+        }
+    }
+
+    @Test
+    fun testInsertTimeLiteral() {
+        withTables(TableWithTime) {
+            TableWithTime.insert {
+                it[time] = timeLiteral(defaultLocalTime)
+            }
+            assertEquals(defaultLocalTime, TableWithTime.selectAll().first()[TableWithTime.time])
+        }
+    }
+
+    @Test
+    fun testUpdateWithTimeLiteral() {
+        withTables(TableWithTime) {
+            TableWithTime.insert {
+                it[time] = defaultLocalTime
+            }
+
+            TableWithTime.update { it[time] = timeLiteral(futureLocalTime) }
+            assertEquals(futureLocalTime, TableWithTime.selectAll().first()[TableWithTime.time])
+        }
+    }
+
+    @Test
+    @Ignore(
+        "Test fails with 'Collection is empty.' message. It can not find anything in db after insert. " +
+            "But SQL requests looks correct, and work well manually applied."
+    )
+    fun testSelectByTimeLiteralEquality() {
+        withTables(TableWithTime) {
+            TableWithTime.insert {
+                it[time] = defaultLocalTime
+            }
+
+            val query = TableWithTime.select(TableWithTime.id, TableWithTime.time).where { TableWithTime.time eq timeLiteral(defaultLocalTime) }
+            assertEquals(defaultLocalTime, query.single()[TableWithTime.time])
+        }
+    }
+}

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DateTimeLiteralTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DateTimeLiteralTest.kt
@@ -6,13 +6,10 @@ import org.jetbrains.exposed.sql.javatime.*
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
-import org.jetbrains.exposed.sql.update
-import org.junit.Ignore
 import org.junit.Test
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 import kotlin.test.assertNotNull
 
 class DateTimeLiteralTest : DatabaseTestsBase() {
@@ -31,39 +28,9 @@ class DateTimeLiteralTest : DatabaseTestsBase() {
     }
 
     private val defaultTimestamp = Instant.parse("2000-01-01T01:00:00.00Z")
-    private val futureTimestamp = Instant.parse("3000-01-01T01:00:00.00Z")
 
     object TableWithTimestamp : IntIdTable() {
         val timestamp = timestamp("timestamp")
-    }
-
-    private val defaultLocalTime = LocalTime.of(1, 0, 0)
-    private val futureLocalTime = LocalTime.of(18, 0, 0)
-
-    object TableWithTime : IntIdTable() {
-        val time = time("time")
-    }
-
-    @Test
-    fun testInsertWithDateLiteral() {
-        withTables(TableWithDate) {
-            TableWithDate.insert {
-                it[date] = dateLiteral(defaultDate)
-            }
-            assertEquals(defaultDate, TableWithDate.selectAll().first()[TableWithDate.date])
-        }
-    }
-
-    @Test
-    fun testUpdateWithDateLiteral() {
-        withTables(TableWithDate) {
-            TableWithDate.insert {
-                it[date] = defaultDate
-            }
-
-            TableWithDate.update { it[date] = dateLiteral(futureDate) }
-            assertEquals(futureDate, TableWithDate.selectAll().first()[TableWithDate.date])
-        }
     }
 
     @Test
@@ -86,28 +53,6 @@ class DateTimeLiteralTest : DatabaseTestsBase() {
             }
             val query = TableWithDate.selectAll().where { TableWithDate.date less dateLiteral(futureDate) }
             assertNotNull(query.firstOrNull())
-        }
-    }
-
-    @Test
-    fun testInsertDatetimeLiteral() {
-        withTables(TableWithDatetime) {
-            TableWithDatetime.insert {
-                it[datetime] = dateTimeLiteral(defaultDatetime)
-            }
-            assertEquals(defaultDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
-        }
-    }
-
-    @Test
-    fun testUpdateWithDatetimeLiteral() {
-        withTables(TableWithDatetime) {
-            TableWithDatetime.insert {
-                it[datetime] = defaultDatetime
-            }
-
-            TableWithDatetime.update { it[datetime] = dateTimeLiteral(futureDatetime) }
-            assertEquals(futureDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
         }
     }
 
@@ -135,28 +80,6 @@ class DateTimeLiteralTest : DatabaseTestsBase() {
     }
 
     @Test
-    fun testInsertWithTimestampLiteral() {
-        withTables(TableWithTimestamp) {
-            TableWithTimestamp.insert {
-                it[timestamp] = timestampLiteral(defaultTimestamp)
-            }
-            assertEquals(defaultTimestamp, TableWithTimestamp.selectAll().first()[TableWithTimestamp.timestamp])
-        }
-    }
-
-    @Test
-    fun testUpdateWithTimestampLiteral() {
-        withTables(TableWithTimestamp) {
-            TableWithTimestamp.insert {
-                it[timestamp] = defaultTimestamp
-            }
-
-            TableWithTimestamp.update { it[timestamp] = timestampLiteral(futureTimestamp) }
-            assertEquals(futureTimestamp, TableWithTimestamp.selectAll().first()[TableWithTimestamp.timestamp])
-        }
-    }
-
-    @Test
     fun testSelectByTimestampLiteralEquality() {
         withTables(TableWithTimestamp) {
             TableWithTimestamp.insert {
@@ -165,44 +88,6 @@ class DateTimeLiteralTest : DatabaseTestsBase() {
 
             val query = TableWithTimestamp.select(TableWithTimestamp.timestamp).where { TableWithTimestamp.timestamp eq timestampLiteral(defaultTimestamp) }
             assertEquals(defaultTimestamp, query.single()[TableWithTimestamp.timestamp])
-        }
-    }
-
-    @Test
-    fun testInsertTimeLiteral() {
-        withTables(TableWithTime) {
-            TableWithTime.insert {
-                it[time] = timeLiteral(defaultLocalTime)
-            }
-            assertEquals(defaultLocalTime, TableWithTime.selectAll().first()[TableWithTime.time])
-        }
-    }
-
-    @Test
-    fun testUpdateWithTimeLiteral() {
-        withTables(TableWithTime) {
-            TableWithTime.insert {
-                it[time] = defaultLocalTime
-            }
-
-            TableWithTime.update { it[time] = timeLiteral(futureLocalTime) }
-            assertEquals(futureLocalTime, TableWithTime.selectAll().first()[TableWithTime.time])
-        }
-    }
-
-    @Test
-    @Ignore(
-        "Test fails with 'Collection is empty.' message. It can not find anything in db after insert. " +
-            "But SQL requests looks correct, and work well manually applied."
-    )
-    fun testSelectByTimeLiteralEquality() {
-        withTables(TableWithTime) {
-            TableWithTime.insert {
-                it[time] = defaultLocalTime
-            }
-
-            val query = TableWithTime.select(TableWithTime.id, TableWithTime.time).where { TableWithTime.time eq timeLiteral(defaultLocalTime) }
-            assertEquals(defaultLocalTime, query.single()[TableWithTime.time])
         }
     }
 }

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
@@ -174,7 +174,8 @@ class DateTimeWithTimeZoneColumnType : ColumnType<DateTime>(), IDateColumnType {
     override fun nonNullValueToString(value: DateTime): String = when (currentDialect) {
         is SQLiteDialect -> "'${SQLITE_AND_MYSQL_DATE_TIME_WITH_TIME_ZONE_FORMATTER.print(value)}'"
         is MysqlDialect -> "'${SQLITE_AND_MYSQL_DATE_TIME_WITH_TIME_ZONE_FORMATTER.print(value)}'"
-        is OracleDialect -> "'${ORACLE_DATE_TIME_WITH_TIME_ZONE_FORMATTER.print(value)}'"
+        is OracleDialect ->
+            "TO_TIMESTAMP_TZ('${ORACLE_DATE_TIME_WITH_TIME_ZONE_FORMATTER.print(value.toDateTime(DateTimeZone.getDefault()))}', 'YYYY-MM-DD HH24:MI:SS.FF3 TZH:TZM')"
         else -> "'${DEFAULT_DATE_TIME_WITH_TIME_ZONE_FORMATTER.print(value)}'"
     }
 

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaDateTimeLiteralTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaDateTimeLiteralTest.kt
@@ -1,0 +1,70 @@
+package org.jetbrains.exposed
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.jodatime.dateTimeLiteral
+import org.jetbrains.exposed.sql.jodatime.datetime
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.update
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+class JodaDateTimeLiteralTest : DatabaseTestsBase() {
+    private val pattern = "dd-mm-yyyy hh.mm.ss"
+
+    private val defaultDatetime: DateTime = DateTime.parse("01-01-2000 01.00.00", DateTimeFormat.forPattern(pattern))
+    private val futureDatetime: DateTime = DateTime.parse("01-01-3000 01.00.00", DateTimeFormat.forPattern(pattern))
+
+    object TableWithDatetime : IntIdTable() {
+        val datetime = datetime("datetime")
+    }
+
+    @Test
+    fun testInsertWithDateLiteral() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = dateTimeLiteral(defaultDatetime)
+            }
+            assertEquals(defaultDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
+        }
+    }
+
+    @Test
+    fun testUpdateWithDatetimeLiteral() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+
+            TableWithDatetime.update { it[datetime] = dateTimeLiteral(futureDatetime) }
+            assertEquals(futureDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
+        }
+    }
+
+    @Test
+    fun testSelectByDatetimeLiteralEquality() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+
+            val query = TableWithDatetime.select(TableWithDatetime.datetime).where { TableWithDatetime.datetime eq dateTimeLiteral(defaultDatetime) }
+            assertEquals(defaultDatetime, query.single()[TableWithDatetime.datetime])
+        }
+    }
+
+    @Test
+    fun testSelectByDatetimeLiteralComparison() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+            val query = TableWithDatetime.selectAll().where { TableWithDatetime.datetime less dateTimeLiteral(futureDatetime) }
+            assertNotNull(query.firstOrNull())
+        }
+    }
+}

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaDateTimeLiteralTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaDateTimeLiteralTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.sql.jodatime.datetime
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
-import org.jetbrains.exposed.sql.update
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.junit.Test
@@ -21,28 +20,6 @@ class JodaDateTimeLiteralTest : DatabaseTestsBase() {
 
     object TableWithDatetime : IntIdTable() {
         val datetime = datetime("datetime")
-    }
-
-    @Test
-    fun testInsertWithDateLiteral() {
-        withTables(TableWithDatetime) {
-            TableWithDatetime.insert {
-                it[datetime] = dateTimeLiteral(defaultDatetime)
-            }
-            assertEquals(defaultDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
-        }
-    }
-
-    @Test
-    fun testUpdateWithDatetimeLiteral() {
-        withTables(TableWithDatetime) {
-            TableWithDatetime.insert {
-                it[datetime] = defaultDatetime
-            }
-
-            TableWithDatetime.update { it[datetime] = dateTimeLiteral(futureDatetime) }
-            assertEquals(futureDatetime, TableWithDatetime.selectAll().first()[TableWithDatetime.datetime])
-        }
     }
 
     @Test

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -324,6 +324,9 @@ class KotlinInstantColumnType : ColumnType<Instant>(), IDateColumnType {
                 "'${formatter.format(instant)}'"
             }
 
+            dialect is SQLiteDialect ->
+                "'${SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(instant)}'"
+
             dialect is OracleDialect -> oracleDateTimeLiteral(value)
 
             else -> "'${DEFAULT_DATE_TIME_STRING_FORMATTER.format(instant)}'"

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -265,12 +265,11 @@ class KotlinLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
     override fun nonNullValueToString(value: LocalTime): String {
         val dialect = currentDialect
 
-        if (dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
-            return oracleLocalTimeLiteral(value)
+        return when {
+            dialect is OracleDialect -> oracleLocalTimeLiteral(value)
+            dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle -> "TIMESTAMP '${ORACLE_TIME_STRING_FORMATTER.format(value.toJavaLocalTime())}'"
+            else -> "'${DEFAULT_TIME_STRING_FORMATTER.format(value.toJavaLocalTime())}'"
         }
-
-        val instant = value.toJavaLocalTime()
-        return "'${DEFAULT_TIME_STRING_FORMATTER.format(instant)}'"
     }
 
     override fun valueFromDB(value: Any): LocalTime = when (value) {

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -118,6 +118,18 @@ private fun dateTimeWithFractionFormat(fraction: Int): DateTimeFormatter {
     return DateTimeFormatter.ofPattern(newFormat).withLocale(Locale.ROOT).withZone(ZoneId.systemDefault())
 }
 
+private fun oracleDateTimeLiteral(instant: Instant) =
+    "TO_TIMESTAMP('${SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(instant.toJavaInstant())}', 'YYYY-MM-DD HH24:MI:SS.FF3')"
+
+private fun oracleLocalTimeLiteral(time: LocalTime) =
+    "TO_TIMESTAMP('${ORACLE_TIME_STRING_FORMATTER.format(time.toJavaLocalTime())}', 'YYYY-MM-DD HH24:MI:SS')"
+
+private fun oracleDateTimeWithTimezoneLiteral(dateTime: OffsetDateTime) =
+    "TO_TIMESTAMP_TZ('${dateTime.format(ORACLE_OFFSET_DATE_TIME_FORMATTER)}', 'YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM')"
+
+private fun oracleDateLiteral(instant: Instant) =
+    "TO_DATE('${DEFAULT_DATE_STRING_FORMATTER.format(instant.toJavaInstant())}', 'YYYY-MM-DD')"
+
 private val LocalDate.millis get() = this.atStartOfDayIn(TimeZone.currentSystemDefault()).epochSeconds * MILLIS_IN_SECOND
 
 /**
@@ -132,6 +144,9 @@ class KotlinLocalDateColumnType : ColumnType<LocalDate>(), IDateColumnType {
 
     override fun nonNullValueToString(value: LocalDate): String {
         val instant = Instant.fromEpochMilliseconds(value.atStartOfDayIn(DEFAULT_TIME_ZONE).toEpochMilliseconds())
+        if (currentDialect is OracleDialect) {
+            return oracleDateLiteral(instant)
+        }
         return "'${DEFAULT_DATE_STRING_FORMATTER.format(instant.toJavaInstant())}'"
     }
 
@@ -178,8 +193,8 @@ class KotlinLocalDateTimeColumnType : ColumnType<LocalDateTime>(), IDateColumnTy
         val dialect = currentDialect
         return when {
             dialect is SQLiteDialect -> "'${SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(instant.toJavaInstant())}'"
-            dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle ->
-                "'${SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(instant.toJavaInstant())}'"
+            dialect is OracleDialect -> oracleDateTimeLiteral(instant)
+
             dialect is MysqlDialect -> {
                 val formatter = if (dialect.isFractionDateTimeSupported()) MYSQL_FRACTION_DATE_TIME_STRING_FORMATTER else MYSQL_DATE_TIME_STRING_FORMATTER
                 "'${formatter.format(instant.toJavaInstant())}'"
@@ -249,14 +264,13 @@ class KotlinLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
 
     override fun nonNullValueToString(value: LocalTime): String {
         val dialect = currentDialect
-        val formatter = if (dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
-            ORACLE_TIME_STRING_FORMATTER
-        } else {
-            DEFAULT_TIME_STRING_FORMATTER
+
+        if (dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+            return oracleLocalTimeLiteral(value)
         }
 
         val instant = value.toJavaLocalTime()
-        return "'${formatter.format(instant)}'"
+        return "'${DEFAULT_TIME_STRING_FORMATTER.format(instant)}'"
     }
 
     override fun valueFromDB(value: Any): LocalTime = when (value) {
@@ -274,6 +288,7 @@ class KotlinLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
             }
             java.time.LocalTime.parse(value, formatter).toKotlinLocalTime()
         }
+
         else -> valueFromDB(value.toString())
     }
 
@@ -307,12 +322,13 @@ class KotlinInstantColumnType : ColumnType<Instant>(), IDateColumnType {
 
         val dialect = currentDialect
         return when {
-            dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle ->
-                "'${SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(instant)}'"
             dialect is MysqlDialect -> {
                 val formatter = if (dialect.isFractionDateTimeSupported()) MYSQL_FRACTION_DATE_TIME_STRING_FORMATTER else MYSQL_DATE_TIME_STRING_FORMATTER
                 "'${formatter.format(instant)}'"
             }
+
+            dialect is OracleDialect -> oracleDateTimeLiteral(value)
+
             else -> "'${DEFAULT_DATE_TIME_STRING_FORMATTER.format(instant)}'"
         }
     }
@@ -330,6 +346,7 @@ class KotlinInstantColumnType : ColumnType<Instant>(), IDateColumnType {
     override fun notNullValueToDB(value: Instant): Any = when {
         currentDialect is SQLiteDialect ->
             SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(value.toJavaInstant())
+
         else -> java.sql.Timestamp.from(value.toJavaInstant())
     }
 
@@ -338,8 +355,10 @@ class KotlinInstantColumnType : ColumnType<Instant>(), IDateColumnType {
         return when {
             dialect is PostgreSQLDialect ->
                 "'${SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(value.toJavaInstant()).trimEnd('0').trimEnd('.')}'::timestamp without time zone"
+
             dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle ->
                 "'${SQLITE_AND_ORACLE_DATE_TIME_STRING_FORMATTER.format(value.toJavaInstant()).trimEnd('0').trimEnd('.')}'"
+
             else -> super.nonNullValueAsDefaultString(value)
         }
     }
@@ -362,7 +381,7 @@ class KotlinOffsetDateTimeColumnType : ColumnType<OffsetDateTime>(), IDateColumn
     override fun nonNullValueToString(value: OffsetDateTime): String = when (currentDialect) {
         is SQLiteDialect -> "'${value.format(SQLITE_OFFSET_DATE_TIME_FORMATTER)}'"
         is MysqlDialect -> "'${value.format(MYSQL_OFFSET_DATE_TIME_FORMATTER)}'"
-        is OracleDialect -> "'${value.format(ORACLE_OFFSET_DATE_TIME_FORMATTER)}'"
+        is OracleDialect -> oracleDateTimeWithTimezoneLiteral(value)
         else -> "'${value.format(DEFAULT_OFFSET_DATE_TIME_FORMATTER)}'"
     }
 
@@ -375,6 +394,7 @@ class KotlinOffsetDateTimeColumnType : ColumnType<OffsetDateTime>(), IDateColumn
                 OffsetDateTime.parse(value)
             }
         }
+
         else -> error("Unexpected value: $value of ${value::class.qualifiedName}")
     }
 
@@ -394,9 +414,13 @@ class KotlinOffsetDateTimeColumnType : ColumnType<OffsetDateTime>(), IDateColumn
         return when {
             dialect is PostgreSQLDialect -> // +00 appended because PostgreSQL stores it in UTC time zone
                 "'${value.format(POSTGRESQL_OFFSET_DATE_TIME_AS_DEFAULT_FORMATTER).trimEnd('0').trimEnd('.')}+00'::timestamp with time zone"
+
             dialect is H2Dialect && dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle ->
                 "'${value.format(POSTGRESQL_OFFSET_DATE_TIME_AS_DEFAULT_FORMATTER).trimEnd('0').trimEnd('.')}'"
+
             dialect is MysqlDialect -> "'${value.format(MYSQL_OFFSET_DATE_TIME_AS_DEFAULT_FORMATTER)}'"
+
+            dialect is OracleDialect -> oracleDateTimeWithTimezoneLiteral(value)
             else -> super.nonNullValueAsDefaultString(value)
         }
     }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DateTimeLiteralTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DateTimeLiteralTest.kt
@@ -1,0 +1,95 @@
+package org.jetbrains.exposed.sql.kotlin.datetime
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+import kotlin.test.assertNotNull
+
+class DateTimeLiteralTest : DatabaseTestsBase() {
+    private val defaultDate = LocalDate(2000, 1, 1)
+    private val futureDate = LocalDate(3000, 1, 1)
+
+    object TableWithDate : IntIdTable() {
+        val date = date("date")
+    }
+
+    private val defaultDatetime = LocalDateTime(2000, 1, 1, 8, 0, 0, 100000000)
+    private val futureDatetime = LocalDateTime(3000, 1, 1, 8, 0, 0, 100000000)
+
+    object TableWithDatetime : IntIdTable() {
+        val datetime = datetime("datetime")
+    }
+
+    private val defaultTimestamp = Instant.parse("2000-01-01T01:00:00.00Z")
+
+    object TableWithTimestamp : IntIdTable() {
+        val timestamp = timestamp("timestamp")
+    }
+
+    @Test
+    fun testSelectByDateLiteralEquality() {
+        withTables(TableWithDate) {
+            TableWithDate.insert {
+                it[date] = defaultDate
+            }
+
+            val query = TableWithDate.select(TableWithDate.date).where { TableWithDate.date eq dateLiteral(defaultDate) }
+            assertEquals(defaultDate, query.single()[TableWithDate.date])
+        }
+    }
+
+    @Test
+    fun testSelectByDateLiteralComparison() {
+        withTables(TableWithDate) {
+            TableWithDate.insert {
+                it[date] = defaultDate
+            }
+            val query = TableWithDate.selectAll().where { TableWithDate.date less dateLiteral(futureDate) }
+            assertNotNull(query.firstOrNull())
+        }
+    }
+
+    @Test
+    fun testSelectByDatetimeLiteralEquality() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+
+            val query = TableWithDatetime.select(TableWithDatetime.datetime).where { TableWithDatetime.datetime eq dateTimeLiteral(defaultDatetime) }
+            assertEquals(defaultDatetime, query.single()[TableWithDatetime.datetime])
+        }
+    }
+
+    @Test
+    fun testSelectByDatetimeLiteralComparison() {
+        withTables(TableWithDatetime) {
+            TableWithDatetime.insert {
+                it[datetime] = defaultDatetime
+            }
+            val query = TableWithDatetime.selectAll().where { TableWithDatetime.datetime less dateTimeLiteral(futureDatetime) }
+            assertNotNull(query.firstOrNull())
+        }
+    }
+
+    @Test
+    fun testSelectByTimestampLiteralEquality() {
+        withTables(TableWithTimestamp) {
+            addLogger(StdOutSqlLogger)
+            TableWithTimestamp.insert {
+                it[timestamp] = defaultTimestamp
+            }
+
+            val query = TableWithTimestamp.select(TableWithTimestamp.timestamp).where { TableWithTimestamp.timestamp eq timestampLiteral(defaultTimestamp) }
+            assertEquals(defaultTimestamp, query.single()[TableWithTimestamp.timestamp])
+        }
+    }
+}


### PR DESCRIPTION
Here is the fix for usage date literals with Oracle DB. PR adds an explicit date format for date literals, because the default format is parametrized in DB, and can be different from the one we use.