### PR TITLE
fix: EXPOSED-349 "defaultValueFun" is lost from Column in Alias

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -400,6 +400,7 @@ public final class org/jetbrains/exposed/sql/Column : org/jetbrains/exposed/sql/
 	public final fun getReferee ()Lorg/jetbrains/exposed/sql/Column;
 	public final fun getTable ()Lorg/jetbrains/exposed/sql/Table;
 	public fun hashCode ()I
+	public final fun isDatabaseGenerated ()Z
 	public fun modifyStatement ()Ljava/util/List;
 	public final fun modifyStatements (Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
 	public final fun nameInDatabaseCase ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -8,7 +8,12 @@ class Alias<out T : Table>(val delegate: T, val alias: String) : Table() {
     /** The table name along with its [alias]. */
     val tableNameWithAlias: String = "${delegate.tableName} $alias"
 
-    private fun <T> Column<T>.clone() = Column<T>(this@Alias, name, columnType)
+    private fun <T> Column<T>.clone() = Column<T>(this@Alias, name, columnType).also {
+        it.defaultValueFun = defaultValueFun
+        it.dbDefaultValue = dbDefaultValue
+        it.isDatabaseGenerated = isDatabaseGenerated
+        it.foreignKey = foreignKey
+    }
 
     /**
      * Returns the original column from the [delegate] table, or `null` if the [column] is not associated

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -43,6 +43,9 @@ class Column<T>(
 
     internal var isDatabaseGenerated: Boolean = false
 
+    /** Returns whether this column's value will be generated in the database. */
+    fun isDatabaseGenerated() = isDatabaseGenerated
+
     /** Appends the SQL representation of this column to the specified [queryBuilder]. */
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = TransactionManager.current().fullIdentity(this@Column, queryBuilder)
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
@@ -2,12 +2,14 @@ package org.jetbrains.exposed.sql.tests.shared
 
 import org.jetbrains.exposed.dao.entityCache
 import org.jetbrains.exposed.dao.flushCache
+import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.dml.withCitiesAndUsers
 import org.jetbrains.exposed.sql.tests.shared.entities.EntityTestsData
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -139,7 +141,8 @@ class AliasesTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun `test alias for same table with join`() {
+    @Test
+    fun `test alias for same table with join`() {
         withTables(EntityTestsData.XTable, EntityTestsData.YTable) {
             val table1Count = EntityTestsData.XTable.id.max().alias("t1max")
             val table2Count = EntityTestsData.XTable.id.max().alias("t2max")
@@ -148,6 +151,66 @@ class AliasesTests : DatabaseTestsBase() {
             t1Alias.join(t2Alias, JoinType.INNER) {
                 t1Alias[table1Count] eq t2Alias[table2Count]
             }.select(t1Alias[table1Count]).toList()
+        }
+    }
+
+    @Test
+    fun testClientDefaultIsSameInAlias() {
+        val tester = object : IntIdTable("tester") {
+            val text = text("text").clientDefault { "DEFAULT_TEXT" }
+        }
+
+        val aliasTester = tester.alias("alias_tester")
+
+        val default = tester.columns.find { it.name == "text" }?.defaultValueFun
+        val aliasDefault = aliasTester.columns.find { it.name == "text" }?.defaultValueFun
+
+        assertEquals(default, aliasDefault)
+    }
+
+    @Test
+    fun testDefaultExpressionIsSameInAlias() {
+        val defaultExpression = stringLiteral("DEFAULT_TEXT")
+
+        val tester = object : IntIdTable("tester") {
+            val text = text("text").defaultExpression(defaultExpression)
+        }
+
+        val testerAlias = tester.alias("alias_tester")
+
+        val default = tester.columns.find { it.name == "text" }?.defaultValueInDb()
+        val aliasDefault = testerAlias.columns.find { it.name == "text" }?.defaultValueInDb()
+
+        assertEquals(default, aliasDefault)
+    }
+
+    @Test
+    fun testDatabaseGeneratedIsSameInAlias() {
+        val tester = object : IntIdTable("tester") {
+            val text = text("text").databaseGenerated()
+        }
+
+        val testerAlias = tester.alias("alias_tester")
+
+        val default = tester.columns.find { it.name == "text" }?.isDatabaseGenerated()
+        val aliasDefault = testerAlias.columns.find { it.name == "text" }?.isDatabaseGenerated()
+
+        assertEquals(default, aliasDefault)
+    }
+
+    @Test
+    fun testReferenceIsSameInAlias() {
+        val stables = object : UUIDTable("Stables") {}
+
+        val facilities = object : UUIDTable("Facilities") {
+            val stableId = reference("stable_id", stables)
+        }
+
+        withTables(facilities, stables) {
+            val facilitiesAlias = facilities.alias("FacilitiesAlias")
+            val foreignKey = facilities.columns.find { it.name == "stable_id" }?.foreignKey
+            val aliasForeignKey = facilitiesAlias.columns.find { it.name == "stable_id" }?.foreignKey
+            assertEquals(foreignKey, aliasForeignKey)
         }
     }
 }


### PR DESCRIPTION
The values set for `clientDefault`, `defaultExpression`, `databaseGenerated`, and `reference` were not being copied when cloning columns for a table alias, so I fixed it in one go for all of them.