### PR TITLE
feat: EXPOSED-355 Support INSERT...RETURNING statement

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1717,6 +1717,8 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static final fun insertIgnore (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;)Ljava/lang/Integer;
 	public static synthetic fun insertIgnore$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;ILjava/lang/Object;)Ljava/lang/Integer;
 	public static final fun insertIgnoreAndGetId (Lorg/jetbrains/exposed/dao/id/IdTable;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/dao/id/EntityID;
+	public static final fun insertReturning (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static synthetic fun insertReturning$default (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun replace (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/ReplaceStatement;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
@@ -1737,6 +1739,8 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static synthetic fun update$default (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)I
 	public static final fun upsert (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/UpsertStatement;
 	public static synthetic fun upsert$default (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/statements/UpsertStatement;
+	public static final fun upsertReturning (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static synthetic fun upsertReturning$default (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/AbstractQuery {
@@ -2999,6 +3003,17 @@ public class org/jetbrains/exposed/sql/statements/ReplaceStatement : org/jetbrai
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 }
 
+public class org/jetbrains/exposed/sql/statements/ReturningStatement : org/jetbrains/exposed/sql/statements/Statement {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lorg/jetbrains/exposed/sql/statements/Statement;)V
+	public fun arguments ()Ljava/lang/Iterable;
+	public synthetic fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/Object;
+	public fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/util/List;
+	public final fun getMainStatement ()Lorg/jetbrains/exposed/sql/statements/Statement;
+	public final fun getReturningExpressions ()Ljava/util/List;
+	public final fun getTable ()Lorg/jetbrains/exposed/sql/Table;
+	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
+}
+
 public class org/jetbrains/exposed/sql/statements/SQLServerBatchInsertStatement : org/jetbrains/exposed/sql/statements/BatchInsertStatement {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Table;ZZ)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Table;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -3666,6 +3681,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	public fun regexp (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;ZLorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun replace (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 	public static synthetic fun replace$default (Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Transaction;ZILjava/lang/Object;)Ljava/lang/String;
+	public fun returning (Ljava/lang/String;Ljava/util/List;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun second (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun stdDevPop (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun stdDevSamp (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1717,8 +1717,8 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static final fun insertIgnore (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;)Ljava/lang/Integer;
 	public static synthetic fun insertIgnore$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;ILjava/lang/Object;)Ljava/lang/Integer;
 	public static final fun insertIgnoreAndGetId (Lorg/jetbrains/exposed/dao/id/IdTable;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/dao/id/EntityID;
-	public static final fun insertReturning (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
-	public static synthetic fun insertReturning$default (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun insertReturning (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/ReturningStatement;
+	public static synthetic fun insertReturning$default (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/statements/ReturningStatement;
 	public static final fun replace (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/ReplaceStatement;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
@@ -1739,8 +1739,8 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static synthetic fun update$default (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)I
 	public static final fun upsert (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/UpsertStatement;
 	public static synthetic fun upsert$default (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/statements/UpsertStatement;
-	public static final fun upsertReturning (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
-	public static synthetic fun upsertReturning$default (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun upsertReturning (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/ReturningStatement;
+	public static synthetic fun upsertReturning$default (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/statements/ReturningStatement;
 }
 
 public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/AbstractQuery {
@@ -3003,14 +3003,16 @@ public class org/jetbrains/exposed/sql/statements/ReplaceStatement : org/jetbrai
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 }
 
-public class org/jetbrains/exposed/sql/statements/ReturningStatement : org/jetbrains/exposed/sql/statements/Statement {
+public class org/jetbrains/exposed/sql/statements/ReturningStatement : org/jetbrains/exposed/sql/statements/Statement, java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Lorg/jetbrains/exposed/sql/statements/Statement;)V
 	public fun arguments ()Ljava/lang/Iterable;
 	public synthetic fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/Object;
-	public fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/util/List;
+	public fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/sql/ResultSet;
 	public final fun getMainStatement ()Lorg/jetbrains/exposed/sql/statements/Statement;
 	public final fun getReturningExpressions ()Ljava/util/List;
 	public final fun getTable ()Lorg/jetbrains/exposed/sql/Table;
+	protected final fun getTransaction ()Lorg/jetbrains/exposed/sql/Transaction;
+	public fun iterator ()Ljava/util/Iterator;
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -385,15 +385,17 @@ fun <T : Table> T.insertIgnore(
  * Represents the SQL statement that inserts new rows into a table and returns specified data from the inserted rows.
  *
  * @param returning Columns and expressions to include in the returned data. This defaults to all columns in the table.
- * @return A list of [ResultRow]s containing the specified [returning] expressions mapped to their resulting data.
+ * @return A [ReturningStatement] that will be executed once iterated over, providing [ResultRow]s containing the specified
+ * expressions mapped to their resulting data.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReturningTests.testInsertReturning
  */
 fun <T : Table> T.insertReturning(
     returning: List<Expression<*>> = columns,
     body: T.(InsertStatement<Number>) -> Unit
-): List<ResultRow> {
+): ReturningStatement {
     val insert = InsertStatement<Number>(this)
     body(insert)
-    return ReturningStatement(this, returning, insert).execute(TransactionManager.current()) ?: emptyList()
+    return ReturningStatement(this, returning, insert)
 }
 
 /**
@@ -461,7 +463,9 @@ fun <T : Table> T.upsert(
  * @param onUpdateExclude List of specific columns to exclude from updating.
  * If left null, all columns will be updated with the values provided for the insert.
  * @param where Condition that determines which rows to update, if a unique violation is found.
- * @return A list of [ResultRow]s containing the specified [returning] expressions mapped to their resulting data.
+ * @return A [ReturningStatement] that will be executed once iterated over, providing [ResultRow]s containing the specified
+ * expressions mapped to their resulting data.
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.ReturningTests.testUpsertReturning
  */
 fun <T : Table> T.upsertReturning(
     vararg keys: Column<*>,
@@ -470,10 +474,10 @@ fun <T : Table> T.upsertReturning(
     onUpdateExclude: List<Column<*>>? = null,
     where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
     body: T.(UpsertStatement<Long>) -> Unit
-): List<ResultRow> {
+): ReturningStatement {
     val update = UpsertStatement<Long>(this, *keys, onUpdate = onUpdate, onUpdateExclude = onUpdateExclude, where = where?.let { SqlExpressionBuilder.it() })
     body(update)
-    return ReturningStatement(this, returning, update).execute(TransactionManager.current()) ?: emptyList()
+    return ReturningStatement(this, returning, update)
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReturningStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReturningStatement.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.exposed.sql.statements
+
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.IColumnType
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import java.sql.ResultSet
+
+/**
+ * Represents the underlying SQL [mainStatement] that also returns a result set with data from any modified rows.
+ *
+ * @param table Table to perform the main statement on and return results from.
+ * @param returningColumns Columns or expressions to include in the returned result set.
+ * @param mainStatement The statement to append the RETURNING clause to. This may be an insert, update, or delete statement.
+ */
+open class ReturningStatement(
+    val table: Table,
+    val returningExpressions: List<Expression<*>>,
+    val mainStatement: Statement<*>
+) : Statement<List<ResultRow>>(mainStatement.type, listOf(table)) {
+    override fun prepareSQL(transaction: Transaction, prepared: Boolean): String {
+        val mainSql = mainStatement.prepareSQL(transaction, prepared)
+        return transaction.db.dialect.functionProvider.returning(mainSql, returningExpressions, transaction)
+    }
+
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = mainStatement.arguments()
+
+    override fun PreparedStatementApi.executeInternal(transaction: Transaction): List<ResultRow> {
+        val resultSet = executeQuery()
+        return processResults(resultSet, transaction)
+    }
+
+    private fun processResults(rs: ResultSet, transaction: Transaction): List<ResultRow> {
+        val fieldIndex = returningExpressions.withIndex().associateBy({ it.value }, { it.index })
+
+        val results = mutableListOf<ResultRow>()
+        while (rs.next()) {
+            results.add(ResultRow.create(rs, fieldIndex))
+        }
+
+        rs.statement?.close()
+        transaction.openResultSetsCount.dec().coerceAtLeast(0)
+        return results
+    }
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReturningStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReturningStatement.kt
@@ -6,42 +6,61 @@ import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.sql.ResultSet
 
 /**
  * Represents the underlying SQL [mainStatement] that also returns a result set with data from any modified rows.
  *
  * @param table Table to perform the main statement on and return results from.
- * @param returningColumns Columns or expressions to include in the returned result set.
+ * @param returningExpressions Columns or expressions to include in the returned result set.
  * @param mainStatement The statement to append the RETURNING clause to. This may be an insert, update, or delete statement.
  */
 open class ReturningStatement(
     val table: Table,
     val returningExpressions: List<Expression<*>>,
     val mainStatement: Statement<*>
-) : Statement<List<ResultRow>>(mainStatement.type, listOf(table)) {
+) : Iterable<ResultRow>, Statement<ResultSet>(mainStatement.type, listOf(table)) {
+    protected val transaction
+        get() = TransactionManager.current()
+
+    override fun PreparedStatementApi.executeInternal(transaction: Transaction): ResultSet = executeQuery()
+
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = mainStatement.arguments()
+
     override fun prepareSQL(transaction: Transaction, prepared: Boolean): String {
         val mainSql = mainStatement.prepareSQL(transaction, prepared)
         return transaction.db.dialect.functionProvider.returning(mainSql, returningExpressions, transaction)
     }
 
-    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = mainStatement.arguments()
-
-    override fun PreparedStatementApi.executeInternal(transaction: Transaction): List<ResultRow> {
-        val resultSet = executeQuery()
-        return processResults(resultSet, transaction)
+    override fun iterator(): Iterator<ResultRow> {
+        val resultIterator = ResultIterator(transaction.exec(this)!!)
+        return Iterable { resultIterator }.iterator()
     }
 
-    private fun processResults(rs: ResultSet, transaction: Transaction): List<ResultRow> {
+    private inner class ResultIterator(val rs: ResultSet) : Iterator<ResultRow> {
         val fieldIndex = returningExpressions.withIndex().associateBy({ it.value }, { it.index })
 
-        val results = mutableListOf<ResultRow>()
-        while (rs.next()) {
-            results.add(ResultRow.create(rs, fieldIndex))
+        private var hasNext = false
+            set(value) {
+                field = value
+                if (!field) {
+                    rs.statement?.close()
+                    transaction.openResultSetsCount--
+                }
+            }
+
+        init {
+            hasNext = rs.next()
         }
 
-        rs.statement?.close()
-        transaction.openResultSetsCount.dec().coerceAtLeast(0)
-        return results
+        override fun hasNext(): Boolean = hasNext
+
+        override operator fun next(): ResultRow {
+            if (!hasNext) throw NoSuchElementException()
+            val result = ResultRow.create(rs, fieldIndex)
+            hasNext = rs.next()
+            return result
+        }
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -743,4 +743,23 @@ abstract class FunctionProvider {
 
     /** Appends optional parameters to an EXPLAIN query. */
     protected open fun StringBuilder.appendOptionsToExplain(options: String) { append("$options ") }
+
+    /**
+     * Returns the SQL command that performs an insert, update, or delete, and also returns data from any modified rows.
+     *
+     * **Note:** This operation is not supported by all vendors, please check the documentation.
+     *
+     * @param mainSql SQL string representing the underlying statement before appending a RETURNING clause.
+     * @param returning Columns and expressions to include in the returned result set.
+     * @param transaction Transaction where the operation is executed.
+     */
+    open fun returning(
+        mainSql: String,
+        returning: List<Expression<*>>,
+        transaction: Transaction
+    ): String {
+        transaction.throwUnsupportedException(
+            "There's no generic SQL for a command with a RETURNING clause. There must be a vendor specific implementation."
+        )
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -320,6 +320,18 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
     }
 
     override fun StringBuilder.appendOptionsToExplain(options: String) { append("($options) ") }
+
+    override fun returning(
+        mainSql: String,
+        returning: List<Expression<*>>,
+        transaction: Transaction
+    ): String {
+        return with(QueryBuilder(true)) {
+            +"$mainSql RETURNING "
+            returning.appendTo { +it }
+            toString()
+        }
+    }
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -252,6 +252,18 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         val sql = super.explain(false, null, internalStatement, transaction)
         return sql.replaceFirst("EXPLAIN ", "EXPLAIN QUERY PLAN ")
     }
+
+    override fun returning(
+        mainSql: String,
+        returning: List<Expression<*>>,
+        transaction: Transaction
+    ): String {
+        return with(QueryBuilder(true)) {
+            +"$mainSql RETURNING "
+            returning.appendTo { +it }
+            toString()
+        }
+    }
 }
 
 /**

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
@@ -1,0 +1,84 @@
+package org.jetbrains.exposed.sql.tests.shared.dml
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.times
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ReturningTests : DatabaseTestsBase() {
+    private val returningSupportedDb = TestDB.postgreSQLRelatedDB.toSet() + TestDB.SQLITE
+
+    object Items : IntIdTable("items") {
+        val name = varchar("name", 32)
+        val price = double("price")
+    }
+
+    @Test
+    fun testInsertReturning() {
+        withTables(TestDB.enabledDialects() - returningSupportedDb, Items) {
+            // return all columns by default
+            val result1 = Items.insertReturning {
+                it[name] = "A"
+                it[price] = 99.0
+            }.single()
+            assertEquals(1, result1[Items.id].value)
+            assertEquals("A", result1[Items.name])
+            assertEquals(99.0, result1[Items.price])
+
+            val result2 = Items.insertReturning(listOf(Items.id, Items.name)) {
+                it[name] = "B"
+                it[price] = 200.0
+            }.single()
+            assertEquals(2, result2[Items.id].value)
+            assertEquals("B", result2[Items.name])
+
+            assertFailsWith<IllegalStateException> { // Items.price not in record set
+                result2[Items.price]
+            }
+
+            assertEquals(2, Items.selectAll().count())
+        }
+    }
+
+    @Test
+    fun testUpsertReturning() {
+        withTables(TestDB.enabledDialects() - returningSupportedDb, Items) {
+            // return all columns by default
+            val result1 = Items.upsertReturning {
+                it[name] = "A"
+                it[price] = 99.0
+            }.single()
+            assertEquals(1, result1[Items.id].value)
+            assertEquals("A", result1[Items.name])
+            assertEquals(99.0, result1[Items.price])
+
+            val result2 = Items.upsertReturning(
+                returning = listOf(Items.name, Items.price),
+                onUpdate = listOf(Items.price to Items.price.times(10.0))
+            ) {
+                it[id] = 1
+                it[name] = "B"
+                it[price] = 200.0
+            }.single()
+            assertEquals("A", result2[Items.name])
+            assertEquals(990.0, result2[Items.price])
+
+            val result3 = Items.upsertReturning(
+                returning = listOf(Items.name),
+                onUpdateExclude = listOf(Items.price),
+                where = { Items.price greater 500.0 }
+            ) {
+                it[id] = 1
+                it[name] = "B"
+                it[price] = 200.0
+            }.single()
+            assertEquals("B", result3[Items.name])
+
+            assertEquals(1, Items.selectAll().count())
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
@@ -3,11 +3,13 @@ package org.jetbrains.exposed.sql.tests.shared.dml
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.times
+import org.jetbrains.exposed.sql.statements.ReturningStatement
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 
 class ReturningTests : DatabaseTestsBase() {
     private val returningSupportedDb = TestDB.postgreSQLRelatedDB.toSet() + TestDB.SQLITE
@@ -79,6 +81,19 @@ class ReturningTests : DatabaseTestsBase() {
             assertEquals("B", result3[Items.name])
 
             assertEquals(1, Items.selectAll().count())
+        }
+    }
+
+    @Test
+    fun testReturningWithNoResults() {
+        withTables(TestDB.enabledDialects() - returningSupportedDb, Items) {
+            // statement not executed if not iterated over
+            val stmt = Items.insertReturning {
+                it[name] = "A"
+                it[price] = 99.0
+            }
+            assertIs<ReturningStatement>(stmt)
+            assertEquals(0, Items.selectAll().count())
         }
     }
 }


### PR DESCRIPTION
Add support for `RETURNING` clause with **insert** and **upsert** statements, in PostgreSQL and SQLite.

This PR sets the base for supporting the same clause with update and delete statements. So more tests will follow with those implementations.

**Usage:**
By default, the returned data is set to all columns from the invoking table.
```kt
val result1: List<ResultRow> = Items.insertReturning {
    it[name] = "A"
    it[price] = 99.0
}

Items.insertReturning(listOf(Items.id, Items.name)) {
    it[name] = "B"
    it[price] = 200.0
}.map {
    it[Items.id].value to it[Items.name]
}
```
**Note:** The statement **auto-executes**, just like other insert/update/delete, and immediately iterates over (and closes) the ResultSet to populate a `List<ResultRow>` that is returned. I thought this was the best behavior to follow the pattern of statements.

**But** this may be undesired if users are returning result sets with large amounts of records. If so, it would be no issue to have the statement extend Iterable, like Query or ExplainQuery, but this would mean it does not get executed until iterated over.

**To-do:**

- [ ] Add support for update statements -> attempt to rebase PR #1695 
- [ ] Add support for delete statements
- [ ] Try to add support for SQL Server `OUTPUT` clause, which should behave similarly
- [ ] Add docs

**Note:**
**Oracle** support is not included because it requires a `RETURNING ... INTO local_variable` clause.
All examples show the _local_variable_ and command being run using PL/SQL in a `DECLARE ... BEGIN ... END;` block.
