### PR TITLE
fix: EXPOSED-350 keepLoadedReferencesOutOfTransaction causes duplicate query when true

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -642,8 +642,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
                 distinctRefIds.forEach { id ->
                     cache.getOrPutReferrers(id, refColumn) { result[id]?.let { SizedCollection(it) } ?: emptySized() }.also {
                         if (keepLoadedReferenceOutOfTransaction) {
-                            val childEntity = find { refColumn eq id }.firstOrNull()
-                            childEntity?.storeReferenceInCache(refColumn, it)
+                            cache.find(this, id)?.storeReferenceInCache(refColumn, it)
                         }
                     }
                 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -1679,7 +1679,18 @@ class EntityTests : DatabaseTestsBase() {
                         country = lebanon
                     }
 
+                    debug = true
+
                     Country.all().with(Country::dishes)
+
+                    statementStats
+                        .filterKeys { it.startsWith("SELECT ") }
+                        .forEach { (_, stats) ->
+                            val (count, _) = stats
+                            assertEquals(1, count)
+                        }
+
+                    debug = false
                 } finally {
                     SchemaUtils.drop(Dishes, Countries)
                 }


### PR DESCRIPTION
Bug fix in version 0.45.0 introduced a side effect. The query for loading child references would be executed twice if `keepLoadedReferencesOutOfTransaction = true`:
```kotlin
Parent.findById(1)?.load(Parent::children)
// OR Parent.all().with(Parent::children)

// SQL: SELECT parents.id, parents."name" FROM parents WHERE parents.id = 1
// SQL: SELECT childs.id, childs."name", childs.parent_id FROM childs WHERE childs.parent_id = 1
// SQL: SELECT childs.id, childs."name", childs.parent_id FROM childs WHERE childs.parent_id = 1
```

This happens because the new select query was being sent to the database without checking the cache first for loaded references.

Switched to a search method that goes through the cache first and made sure the test also covers that each query is only run once.