### PR TITLE
fix: Error when updating different entities mapped to the same table

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityBatchUpdate.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityBatchUpdate.kt
@@ -25,7 +25,12 @@ class EntityBatchUpdate(private val klass: EntityClass<*, Entity<*>>) {
      * provided on instantiation of this [EntityBatchUpdate].
      */
     fun addBatch(entity: Entity<*>) {
-        if (entity.klass != klass) error("Entity class${entity.klass} differs from expected entity class $klass")
+        if (entity.klass.table != klass.table) {
+            error(
+                "Table ${entity.klass.table.tableName} for entity class ${entity.klass} differs from expected table " +
+                    "${klass.table.tableName} for entity class $klass"
+            )
+        }
         data.add(entity.id to TreeMap())
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -1754,4 +1754,39 @@ class EntityTests : DatabaseTestsBase() {
             }
         }
     }
+
+    object TestTable : IntIdTable("TestTable") {
+        val value = integer("value")
+    }
+
+    class TestEntityA(id: EntityID<Int>) : IntEntity(id) {
+        var value by TestTable.value
+
+        companion object : IntEntityClass<TestEntityA>(TestTable)
+    }
+
+    class TestEntityB(id: EntityID<Int>) : IntEntity(id) {
+        var value by TestTable.value
+
+        companion object : IntEntityClass<TestEntityB>(TestTable)
+    }
+
+    @Test
+    fun testDifferentEntitiesMappedToTheSameTable() {
+        withTables(TestTable) {
+            val entityA = TestEntityA.new {
+                value = 1
+            }
+            val entityB = TestEntityB.new {
+                value = 2
+            }
+
+            flushCache()
+
+            entityA.value = 3
+            entityB.value = 4
+
+            flushCache()
+        }
+    }
 }


### PR DESCRIPTION
This error was introduced [here](https://github.com/JetBrains/Exposed/pull/1668/files#:~:text=if%20(entity.klass%20!%3D%20klass)%20error(%22Entity%20class%24%7Bentity.klass%7D%20differs%20from%20expected%20entity%20class%20%24klass%22)) and was not detected because there were no tests covering this usage.