### PR TITLE
fix!: EXPOSED-360 Storing ULong.MAX_VALUE in ulong column not working

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2558,7 +2558,6 @@ public final class org/jetbrains/exposed/sql/ULongColumnType : org/jetbrains/exp
 	public fun <init> ()V
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun notNullValueToDB-VKZWuLQ (J)Ljava/lang/Object;
-	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB-I7RO_PI (Ljava/lang/Object;)J

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -8,6 +8,7 @@ import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.*
 import java.io.InputStream
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.math.MathContext
 import java.math.RoundingMode
 import java.nio.ByteBuffer
@@ -389,32 +390,33 @@ class ULongColumnType : ColumnType<ULong>() {
         return when (value) {
             is ULong -> value
             is Long -> value.takeIf { it >= 0 }?.toULong()
+            is Double -> value.takeIf { it >= 0 }?.toULong() // For SQLite
             is Number -> {
-                if (currentDialect is MysqlDialect) {
-                    value.toString().toBigInteger().takeIf {
-                        it >= "0".toBigInteger() && it <= ULong.MAX_VALUE.toString().toBigInteger()
-                    }?.toString()?.toULong()
-                } else {
-                    value.toLong().takeIf { it >= 0 }?.toULong()
-                }
+                valueFromDB(value.toString())
             }
-            is String -> value.toULong()
+            is String -> {
+                value.toBigInteger().takeIf {
+                    it >= "0".toBigInteger() && it <= ULong.MAX_VALUE.toString().toBigInteger()
+                }?.toString()?.toULong()
+            }
             else -> error("Unexpected value of type Long: $value of ${value::class.qualifiedName}")
         } ?: error("Negative value but type is ULong: $value")
     }
 
-    override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
-        val v = when {
-            value is ULong && currentDialect is MysqlDialect -> value.toString()
-            value is ULong -> value.toLong()
-            else -> value
+    override fun notNullValueToDB(value: ULong): Any {
+        val dialect = currentDialect
+        return when {
+            // PostgreSQLNG does not throw `out of range` error, so it's handled here to prevent storing invalid values
+            dialect is PostgreSQLNGDialect -> {
+                value.takeIf { it >= 0uL && it <= Long.MAX_VALUE.toULong() }?.toLong()
+                    ?: error("Value out of range: $value")
+            }
+            dialect is PostgreSQLDialect ||
+                (dialect is H2Dialect && dialect.h2Mode == H2Dialect.H2CompatibilityMode.PostgreSQL) -> {
+                BigInteger(value.toString())
+            }
+            else -> value.toString()
         }
-        super.setParameter(stmt, index, v)
-    }
-
-    override fun notNullValueToDB(value: ULong) = when {
-        currentDialect is MysqlDialect -> value.toString()
-        else -> value.toLong()
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -235,9 +235,10 @@ class Join(
     val table: ColumnSet
 ) : ColumnSet() {
 
-    override val columns: List<Column<*>> get() = joinParts.flatMapTo(
-        table.columns.toMutableList()
-    ) { it.joinPart.columns }
+    override val columns: List<Column<*>>
+        get() = joinParts.flatMapTo(
+            table.columns.toMutableList()
+        ) { it.joinPart.columns }
 
     internal val joinParts: MutableList<JoinPart> = mutableListOf()
 
@@ -656,7 +657,10 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /** Creates a numeric column, with the specified [name], for storing 8-byte integers. */
     fun long(name: String): Column<Long> = registerColumn(name, LongColumnType())
 
-    /** Creates a numeric column, with the specified [name], for storing 8-byte unsigned integers. */
+    /** Creates a numeric column, with the specified [name], for storing 8-byte unsigned integers.
+     *
+     * **Note:** For PostgreSQL, the maximum value this column will store is [Long.MAX_VALUE].
+     */
     fun ulong(name: String): Column<ULong> = registerColumn(name, ULongColumnType())
 
     /** Creates a numeric column, with the specified [name], for storing 4-byte (single precision) floating-point numbers. */
@@ -1162,7 +1166,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param isUnique Whether the index is unique or not.
      * @param columns Columns that compose the index.
      */
-    fun index(isUnique: Boolean = false, vararg columns: Column<*>) { index(null, isUnique, *columns) }
+    fun index(isUnique: Boolean = false, vararg columns: Column<*>) {
+        index(null, isUnique, *columns)
+    }
 
     /**
      * Creates an index.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
@@ -55,13 +55,13 @@ abstract class DataTypeProvider {
     open fun longType(): String = "BIGINT"
 
     /** Numeric type for storing 8-byte unsigned integers. */
-    open fun ulongType(): String = "BIGINT"
+    open fun ulongType(): String = "NUMERIC(20)"
 
     /** Numeric type for storing 8-byte integers, and marked as auto-increment. */
     open fun longAutoincType(): String = "BIGINT AUTO_INCREMENT"
 
     /** Numeric type for storing 8-byte unsigned integers, marked as auto-increment. */
-    open fun ulongAutoincType(): String = "BIGINT AUTO_INCREMENT"
+    open fun ulongAutoincType(): String = "NUMERIC(20) AUTO_INCREMENT"
 
     /** Numeric type for storing 4-byte (single precision) floating-point numbers. */
     open fun floatType(): String = "FLOAT"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -8,8 +8,10 @@ import java.util.*
 internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
     override fun byteType(): String = "SMALLINT"
     override fun floatType(): String = "REAL"
+    override fun ulongType(): String = "BIGINT"
     override fun integerAutoincType(): String = "SERIAL"
     override fun longAutoincType(): String = "BIGSERIAL"
+    override fun ulongAutoincType(): String = "BIGSERIAL"
     override fun uuidType(): String = "uuid"
     override fun binaryType(): String = "bytea"
     override fun binaryType(length: Int): String {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -13,8 +13,10 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
             "TINYINT"
         }
     }
+
     override fun integerAutoincType(): String = "INT IDENTITY(1,1)"
     override fun longAutoincType(): String = "BIGINT IDENTITY(1,1)"
+    override fun ulongAutoincType(): String = "NUMERIC(20) IDENTITY(1,1)"
     override fun binaryType(): String {
         exposedLogger.error("The length of the Binary column is missing.")
         error("The length of the Binary column is missing.")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -12,6 +12,7 @@ import java.sql.Statement
 internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun integerAutoincType(): String = "INTEGER PRIMARY KEY AUTOINCREMENT"
     override fun longAutoincType(): String = "INTEGER PRIMARY KEY AUTOINCREMENT"
+    override fun ulongAutoincType(): String = "INTEGER PRIMARY KEY AUTOINCREMENT"
     override fun floatType(): String = "SINGLE"
     override fun binaryType(): String = "BLOB"
     override fun dateTimeType(): String = "TEXT"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.exposed.sql.tests.shared.types
 
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -272,6 +275,23 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             val result = ULongTable.selectAll().toList()
             assertEquals(1, result.size)
             assertEquals(123uL, result.single()[ULongTable.unsignedLong])
+        }
+    }
+
+    @Test
+    fun testMaxULongColumnType() {
+        val ulongMaxValueUnsupportedDatabases = listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.H2_PSQL)
+
+        withTables(ULongTable) { testDb ->
+            val maxValue = if (testDb in ulongMaxValueUnsupportedDatabases) Long.MAX_VALUE.toULong() else ULong.MAX_VALUE
+
+            ULongTable.insert {
+                it[unsignedLong] = maxValue
+            }
+
+            val result = ULongTable.selectAll().toList()
+            assertEquals(1, result.size)
+            assertEquals(maxValue, result.single()[ULongTable.unsignedLong])
         }
     }
 


### PR DESCRIPTION
### **The issue**:
When attempting to store `ULong.MAX_VALUE` in a `ulong` column, retrieving it results in -1 and not `ULong.MAX_VALUE` for all database dialects (except for MySQL and MariaDB). The reason is that we invoke `.toLong()` on the `ULong` value before we store it in the database (in `notNullValueToDB` in `ULongColumnType`) and that gets the -1 from [here](https://github.com/JetBrains/kotlin/blob/0938b46726b9c6938df309098316ce741815bb55/libraries/stdlib/unsigned/src/kotlin/ULong.kt#L27) because of the [implementation](https://github.com/JetBrains/kotlin/blob/0938b46726b9c6938df309098316ce741815bb55/libraries/stdlib/unsigned/src/kotlin/ULong.kt#L323) of `ULong.toLong()`.

### **The fix**:
Before this fix, the maximum value that could be stored with `ULongColumnType` for all database dialects (except for MySQL and MariaDB) was `Long.MAX_VALUE`. This is because the `ULong` value was being converted to `Long` in the `notNullValueToDB` function, restricting the range to that of `Long`. Instead, it is now converted to a `BigInteger` for PostgreSQL, a `Long` for PostgreSQLNG (with a range check), and a `String` for the rest of the database dialects. The `ulong` column can now store `ULong.MAX_VALUE` for H2 (excluding H2_PSQL), Oracle, SQLite and SQL Server.

### **Breaking change**:
`ulongType()` is now NUMERIC(20) instead of BIGINT for H2 (excluding H2_PSQL), SQLite, and SQL Server to allow storing the full range of `ULong`, including `ULong.MAX_VALUE`.

### **Limitations**:
- For PostgreSQL, it is not possible to change `ulongType()` to NUMERIC(20) because that would cause a mismatch when it references an auto-incrementing ulong column of type BIGSERIAL. It's also not possible to change the `autoIncType` to NUMERIC(20) either, because PostgreSQL does [not](https://www.postgresql.org/docs/current/datatype-numeric.html#:~:text=The%20data%20types%20smallserial%2C%20serial%20and%20bigserial%20are%20not%20true%20types%2C%20but%20merely%20a%20notational%20convenience%20for%20creating%20unique%20identifier%20columns%20(similar%20to%20the%20AUTO_INCREMENT%20property%20supported%20by%20some%20other%20databases).) support the AUTO_INCREMENT property. So the maximum value that can be stored is `Long.MAX_VALUE`.
- For SQLite, it is [not possible](https://www.sqlite.org/autoinc.html#:~:text=Because%20AUTOINCREMENT%20keyword%20changes%20the%20behavior%20of%20the%20ROWID%20selection%20algorithm%2C%20AUTOINCREMENT%20is%20not%20allowed%20on%20WITHOUT%20ROWID%20tables%20or%20on%20any%20table%20column%20other%20than%20INTEGER%20PRIMARY%20KEY.) to have auto-increment on a column of type other than INTEGER PRIMARY KEY, so the maximum value that can be stored using a `ulong` auto-increment column is the same as that of a `long` column.