### PR TITLE
fix: EXPOSED-366 inList with EntityID column causes type mismatch error

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -833,7 +833,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this expression is equals to any element from [list]. */
     @Suppress("UNCHECKED_CAST")
     @JvmName("inListIds")
-    infix fun <T : Comparable<T>> Column<EntityID<T>?>.inList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
+    infix fun <T : Comparable<T>, ID : EntityID<T>?> Column<ID>.inList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return SingleValueInListOp(this, list.map { EntityIDFunctionProvider.createEntityID(it, idTable) }, isInList = true)
     }
@@ -863,7 +863,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this expression is not equals to any element from [list]. */
     @Suppress("UNCHECKED_CAST")
     @JvmName("notInListIds")
-    infix fun <T : Comparable<T>> Column<EntityID<T>?>.notInList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
+    infix fun <T : Comparable<T>, ID : EntityID<T>?> Column<ID>.notInList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return SingleValueInListOp(this, list.map { EntityIDFunctionProvider.createEntityID(it, idTable) }, isInList = false)
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -220,10 +220,20 @@ class SelectTests : DatabaseTestsBase() {
                 category = EntityTests.Category.new { title = "Category1" }
             }
 
-            val result = EntityTests.Posts.selectAll().where {
+            val result1 = EntityTests.Posts.selectAll().where {
                 EntityTests.Posts.board inList listOf(board1.id)
             }.singleOrNull()?.get(EntityTests.Posts.id)
-            assertEquals(post1.id, result)
+            assertEquals(post1.id, result1)
+
+            val result2 = EntityTests.Board.find {
+                EntityTests.Boards.id inList listOf(1, 2, 3, 4, 5)
+            }.singleOrNull()
+            assertEquals(board1, result2)
+
+            val result3 = EntityTests.Board.find {
+                EntityTests.Boards.id notInList listOf(1, 2, 3, 4, 5)
+            }.singleOrNull()
+            assertNull(result3)
         }
     }
 


### PR DESCRIPTION
Since 0.50.0, attempting to use a valid iterable of comparables with `inList()` invoked by an `EntityID` column leads to a type mismatch.
This happens because the following incorrect overload is being resolved:
```kt
infix fun <T> ExpressionWithColumnType<T>.inList(list: Iterable<T>): InListOrNotInListBaseOp<T> = SingleValueInListOp(this, list, isInList = true)
```
instead of the previous expected overload that wraps values as `EntityID`s:
```kt
infix fun <T : Comparable<T>> Column<EntityID<T>?>.inList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
    val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
    return SingleValueInListOp(this, list.map { EntityIDFunctionProvider.createEntityID(it, idTable) }, isInList = true)
}
```

This reverts the change, and also for `notInList()`.