### PR TITLE
EXPOSED-365 Unable to insert values into `Array` column

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -1048,11 +1048,16 @@ class ArrayColumnType<E>(
 
     override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
         when {
+            value is Array<*> && isArrayOfByteArrays(value) ->
+                stmt.setArray(index, delegateType, Array(value.size) { value[it] as ByteArray })
             value is Array<*> -> stmt.setArray(index, delegateType, value)
             else -> super.setParameter(stmt, index, value)
         }
     }
 }
+
+private fun isArrayOfByteArrays(value: Array<*>) =
+    value.all { it is ByteArray }
 
 // Date/Time columns
 


### PR DESCRIPTION
Fix for the column with type `bytea[]`(`array<ByteArray>()`). FIxed by passing `byte[][]` instead of `Object[]` to the driver.