### PR TITLE
fix: EXPOSED-371 Fix incorrect table reference passed to EntityID instance when using value-based utility functions

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -36,7 +36,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
     @Suppress("UNCHECKED_CAST")
     @JvmName("setWithEntityIdValue")
     operator fun <S : Comparable<S>> set(column: Column<EntityID<S>>, value: S) {
-        val entityId: EntityID<S> = EntityID(value, column.table as IdTable<S>)
+        val entityId: EntityID<S> = EntityID(value, (column.foreignKey?.targetTable ?: column.table) as IdTable<S>)
         column.columnType.validateValueBeforeUpdate(entityId)
         values[column] = entityId
     }
@@ -47,7 +47,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
         require(column.columnType.nullable || value != null) {
             "Trying to set null to not nullable column $column"
         }
-        val entityId: EntityID<S>? = value?.let { EntityID(it, column.table as IdTable<S>) }
+        val entityId: EntityID<S>? = value?.let { EntityID(it, (column.foreignKey?.targetTable ?: column.table) as IdTable<S>) }
         column.columnType.validateValueBeforeUpdate(entityId)
         values[column] = entityId
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -280,6 +280,23 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
+    @Test fun testInsertWithForeignId() {
+        val idTable = object : IntIdTable("idTable") {}
+        val standardTable = object : Table("standardTable") {
+            val externalId = reference("externalId", idTable.id)
+        }
+        withTables(idTable, standardTable) {
+            val id1 = idTable.insertAndGetId {}
+
+            standardTable.insert {
+                it[externalId] = id1.value
+            }
+
+            val allRecords = standardTable.selectAll().map { it[standardTable.externalId] }
+            assertTrue(allRecords == listOf(id1))
+        }
+    }
+
     @Test fun testInsertWithExpression() {
         val tbl = object : IntIdTable("testInsert") {
             val nullableInt = integer("nullableIntCol").nullable()


### PR DESCRIPTION
Fix https://youtrack.jetbrains.com/issue/EXPOSED-371/Unsafe-cast-of-columns-table-to-IdTable-when-using-EntityID-value