### PR TITLE
fix: EXPOSED-382 ClassCastException when uuid().references() is used with EntityID column

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -30,7 +30,7 @@ class Column<T>(
     val referee: Column<*>?
         get() = foreignKey?.targetOf(this)
 
-    /** Returns the column that this column references, casted as a column of type [S], or `null` if the cast fails. */
+    /** Returns the column that this column references, cast as a column of type [S], or `null` if the cast fails. */
     @Suppress("UNCHECKED_CAST")
     fun <S : T> referee(): Column<S>? = referee as? Column<S>
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -125,15 +125,15 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
                     }
                 }
                 else -> {
-                    // @formatter:off
+                    val castReferee = reference.referee<REF>()!!
+                    val baseReferee = (castReferee.columnType as? EntityIDColumnType<REF>)?.idColumn ?: castReferee
                     factory.findWithCacheCondition({
                         reference.referee!!.getValue(this, desc) == refValue
                     }) {
-                        reference.referee<REF>()!! eq refValue
+                        baseReferee eq refValue
                     }.singleOrNull()?.also {
                         storeReferenceInCache(reference, it)
                     }
-                    // @formatter:on
                 }
             } ?: error("Cannot find ${factory.table.tableName} WHERE id=$refValue")
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
@@ -4,7 +4,10 @@ import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.exists
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.junit.Test
@@ -13,30 +16,43 @@ object LongIdTables {
     object Cities : LongIdTable() {
         val name = varchar("name", 50)
     }
+
     class City(id: EntityID<Long>) : LongEntity(id) {
         companion object : LongEntityClass<City>(Cities)
         var name by Cities.name
     }
+
     object People : LongIdTable() {
         val name = varchar("name", 80)
         val cityId = reference("city_id", Cities)
     }
+
     class Person(id: EntityID<Long>) : LongEntity(id) {
         companion object : LongEntityClass<Person>(People)
         var name by People.name
         var city by City referencedOn People.cityId
     }
+
+    object Towns : LongIdTable("towns") {
+        val cityId: Column<Long> = long("city_id").references(Cities.id)
+    }
+
+    class Town(id: EntityID<Long>) : LongEntity(id) {
+        companion object : LongEntityClass<Town>(Towns)
+        var city by City referencedOn Towns.cityId
+    }
 }
 class LongIdTableEntityTest : DatabaseTestsBase() {
-
-    @Test fun `create tables`() {
+    @Test
+    fun `create tables`() {
         withTables(LongIdTables.Cities, LongIdTables.People) {
             assertEquals(true, LongIdTables.Cities.exists())
             assertEquals(true, LongIdTables.People.exists())
         }
     }
 
-    @Test fun `create records`() {
+    @Test
+    fun `create records`() {
         withTables(LongIdTables.Cities, LongIdTables.People) {
             val mumbai = LongIdTables.City.new { name = "Mumbai" }
             val pune = LongIdTables.City.new { name = "Pune" }
@@ -64,7 +80,8 @@ class LongIdTableEntityTest : DatabaseTestsBase() {
         }
     }
 
-    @Test fun `update and delete records`() {
+    @Test
+    fun `update and delete records`() {
         withTables(LongIdTables.Cities, LongIdTables.People) {
             val mumbai = LongIdTables.City.new { name = "Mumbai" }
             val pune = LongIdTables.City.new { name = "Pune" }
@@ -91,6 +108,21 @@ class LongIdTableEntityTest : DatabaseTestsBase() {
             val allPeople = LongIdTables.Person.all().map { Pair(it.name, it.city.name) }
             assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
             assertEquals(false, allPeople.contains(Pair("Tanu Arora", "Pune")))
+        }
+    }
+
+    @Test
+    fun testForeignKeyBetweenLongAndEntityIDColumns() {
+        withTables(LongIdTables.Cities, LongIdTables.Towns) {
+            val cId = LongIdTables.Cities.insertAndGetId {
+                it[name] = "City A"
+            }
+            LongIdTables.Towns.insert {
+                it[cityId] = cId.value
+            }
+
+            val town1 = LongIdTables.Town.all().single()
+            assertEquals(cId, town1.city.id)
         }
     }
 }


### PR DESCRIPTION
Since version 0.50.0, using `Column.references()` invoked on a `UUIDColumnType` that targets an `EntityIDColumnType<UUID>` causes a `ClassCastException`.
This occurs because `PreparedStatementApi.fillParameters()` tries to get the `valueToDB()` from `EntityIDColumnType` rather than the underlying `UUIDColumnType`.
```
uuid("col_name").references(UUIDTable.id)

// throws when trying to access the DAO entity's delegated field
java.util.UUID cannot be cast to org.jetbrains.exposed.dao.id.EntityID
java.lang.ClassCastException: java.util.UUID cannot be cast to org.jetbrains.exposed.dao.id.EntityID
	at org.jetbrains.exposed.sql.EntityIDColumnType.notNullValueToDB(ColumnType.kt:199)
	at org.jetbrains.exposed.sql.IColumnType$DefaultImpls.valueToDB(ColumnType.kt:39)
	at org.jetbrains.exposed.sql.ColumnType.valueToDB(ColumnType.kt:103)
	at org.jetbrains.exposed.sql.statements.api.PreparedStatementApi$DefaultImpls.fillParameters(PreparedStatementApi.kt:24)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcPreparedStatementImpl.fillParameters(JdbcPreparedStatementImpl.kt:22)
```

This exception does not happen with Int- or LongColumnType because their EntityID variants are wrapped as `AutoIncColumnType` that delegates to the correct underlying type.
And this also doesn't happen if `reference()` is used instead because it creates an `EntityIDColumnType` under-the-hood which avoids any type mismatch.

This was likely quietly happening before but only causes an issue now that a stricter column type-safety has been introduced.

**Note:** I considered adding similar logic to `OptionalReference.getValue()`, but there is no optional variant for `Column.references()`, so this point should not be reached.