### PR TITLE
docs: Specify a URL for clicks on the header logo

### DIFF
--- a/documentation-website/Writerside/cfg/buildprofiles.xml
+++ b/documentation-website/Writerside/cfg/buildprofiles.xml
@@ -2,7 +2,9 @@
 <buildprofiles xsi:noNamespaceSchemaLocation="https://helpserver.labs.jb.gg/help/schemas/mvp/build-profiles.xsd"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-    <variables></variables>
+    <variables>
+        <product-web-url>https://jetbrains.github.io/Exposed/home.html</product-web-url>
+    </variables>
     <build-profile instance="hi">
         <variables>
             <noindex-content>true</noindex-content>


### PR DESCRIPTION
**Problem**
Currently, when you click on the Exposed logo in the header, it navigates to the URL [https://jetbrains.github.io/Exposed/](https://jetbrains.github.io/Exposed/) which doesn't contain a topic.

**Solution**
Specified a [product-web-url](https://www.jetbrains.com/help/writerside/buildprofiles-xml.html#product-web-url) in the WS build config to point to the home page.