### PR TITLE
fix: EXPOSED-384 CurrentTimestamp cannot be used with OffsetDateTimeColumnType

### DIFF
--- a/exposed-java-time/api/exposed-java-time.api
+++ b/exposed-java-time/api/exposed-java-time.api
@@ -3,14 +3,21 @@ public final class org/jetbrains/exposed/sql/javatime/CurrentDate : org/jetbrain
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/javatime/CurrentDateTime : org/jetbrains/exposed/sql/Function {
+public final class org/jetbrains/exposed/sql/javatime/CurrentDateTime : org/jetbrains/exposed/sql/javatime/CurrentTimestampBase {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/javatime/CurrentDateTime;
+}
+
+public final class org/jetbrains/exposed/sql/javatime/CurrentTimestamp : org/jetbrains/exposed/sql/javatime/CurrentTimestampBase {
+	public static final field INSTANCE Lorg/jetbrains/exposed/sql/javatime/CurrentTimestamp;
+}
+
+public abstract class org/jetbrains/exposed/sql/javatime/CurrentTimestampBase : org/jetbrains/exposed/sql/Function {
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/javatime/CurrentTimestamp : org/jetbrains/exposed/sql/Function {
-	public static final field INSTANCE Lorg/jetbrains/exposed/sql/javatime/CurrentTimestamp;
-	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+public final class org/jetbrains/exposed/sql/javatime/CurrentTimestampWithTimeZone : org/jetbrains/exposed/sql/javatime/CurrentTimestampBase {
+	public static final field INSTANCE Lorg/jetbrains/exposed/sql/javatime/CurrentTimestampWithTimeZone;
 }
 
 public final class org/jetbrains/exposed/sql/javatime/Date : org/jetbrains/exposed/sql/Function {

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -26,11 +26,9 @@ class Time<T : Temporal?>(val expr: Expression<T>) : Function<LocalTime>(JavaLoc
 }
 
 /**
- * Represents an SQL function that returns the current date and time, as [LocalDateTime].
- *
- * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
+ * Represents the base SQL function that returns the current date and time, as determined by the specified [columnType].
  */
-object CurrentDateTime : Function<LocalDateTime>(JavaLocalDateTimeColumnType.INSTANCE) {
+sealed class CurrentTimestampBase<T>(columnType: IColumnType<T & Any>) : Function<T>(columnType) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when {
             (currentDialect as? MysqlDialect)?.isFractionDateTimeSupported() == true -> "CURRENT_TIMESTAMP(6)"
@@ -38,6 +36,27 @@ object CurrentDateTime : Function<LocalDateTime>(JavaLocalDateTimeColumnType.INS
         }
     }
 }
+
+/**
+ * Represents an SQL function that returns the current date and time, as [LocalDateTime].
+ *
+ * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
+ */
+object CurrentDateTime : CurrentTimestampBase<LocalDateTime>(JavaLocalDateTimeColumnType.INSTANCE)
+
+/**
+ * Represents an SQL function that returns the current date and time, as [Instant].
+ *
+ * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
+ */
+object CurrentTimestamp : CurrentTimestampBase<Instant>(JavaInstantColumnType.INSTANCE)
+
+/**
+ * Represents an SQL function that returns the current date and time with time zone, as [OffsetDateTime].
+ *
+ * @sample org.jetbrains.exposed.DefaultsTest.testTimestampWithTimeZoneDefaults
+ */
+object CurrentTimestampWithTimeZone : CurrentTimestampBase<OffsetDateTime>(JavaOffsetDateTimeColumnType.INSTANCE)
 
 /**
  * Represents an SQL function that returns the current date, as [LocalDate].
@@ -50,20 +69,6 @@ object CurrentDate : Function<LocalDate>(JavaLocalDateColumnType.INSTANCE) {
             is MysqlDialect -> "CURRENT_DATE()"
             is SQLServerDialect -> "GETDATE()"
             else -> "CURRENT_DATE"
-        }
-    }
-}
-
-/**
- * Represents an SQL function that returns the current date and time, as [Instant].
- *
- * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
- */
-object CurrentTimestamp : Function<Instant>(JavaInstantColumnType.INSTANCE) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        +when {
-            (currentDialect as? MysqlDialect)?.isFractionDateTimeSupported() == true -> "CURRENT_TIMESTAMP(6)"
-            else -> "CURRENT_TIMESTAMP"
         }
     }
 }

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -38,6 +38,21 @@ sealed class CurrentTimestampBase<T>(columnType: IColumnType<T & Any>) : Functio
 }
 
 /**
+ * Represents an SQL function that returns the current date, as [LocalDate].
+ *
+ * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
+ */
+object CurrentDate : Function<LocalDate>(JavaLocalDateColumnType.INSTANCE) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        +when (currentDialect) {
+            is MysqlDialect -> "CURRENT_DATE()"
+            is SQLServerDialect -> "GETDATE()"
+            else -> "CURRENT_DATE"
+        }
+    }
+}
+
+/**
  * Represents an SQL function that returns the current date and time, as [LocalDateTime].
  *
  * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
@@ -57,21 +72,6 @@ object CurrentTimestamp : CurrentTimestampBase<Instant>(JavaInstantColumnType.IN
  * @sample org.jetbrains.exposed.DefaultsTest.testTimestampWithTimeZoneDefaults
  */
 object CurrentTimestampWithTimeZone : CurrentTimestampBase<OffsetDateTime>(JavaOffsetDateTimeColumnType.INSTANCE)
-
-/**
- * Represents an SQL function that returns the current date, as [LocalDate].
- *
- * @sample org.jetbrains.exposed.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
- */
-object CurrentDate : Function<LocalDate>(JavaLocalDateColumnType.INSTANCE) {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-        +when (currentDialect) {
-            is MysqlDialect -> "CURRENT_DATE()"
-            is SQLServerDialect -> "GETDATE()"
-            else -> "CURRENT_DATE"
-        }
-    }
-}
 
 /** Represents an SQL function that extracts the year field from a given temporal [expr]. */
 class Year<T : Temporal?>(val expr: Expression<T>) : Function<Int>(IntegerColumnType()) {

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -427,7 +427,7 @@ class DefaultsTest : DatabaseTestsBase() {
                     "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
                     "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
                     "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestamp.itOrNull()}" +
+                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
                     ")"
 
                 val expected = if (currentDialectTest is OracleDialect ||

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -407,6 +407,7 @@ class DefaultsTest : DatabaseTestsBase() {
         val testTable = object : IntIdTable("t") {
             val t1 = timestampWithTimeZone("t1").default(nowWithTimeZone)
             val t2 = timestampWithTimeZone("t2").defaultExpression(timestampWithTimeZoneLiteral)
+            val t3 = timestampWithTimeZone("t3").defaultExpression(CurrentTimestampWithTimeZone)
         }
 
         fun Expression<*>.itOrNull() = when {
@@ -425,7 +426,8 @@ class DefaultsTest : DatabaseTestsBase() {
                     "${"t".inProperCase()} (" +
                     "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
                     "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}" +
+                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestamp.itOrNull()}" +
                     ")"
 
                 val expected = if (currentDialectTest is OracleDialect ||
@@ -446,6 +448,9 @@ class DefaultsTest : DatabaseTestsBase() {
                 val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+                val dbDefault = row1[testTable.t3]
+                assertEquals(dbDefault.offset, nowWithTimeZone.offset)
+                assertTrue { dbDefault.toLocalDateTime() >= nowWithTimeZone.toLocalDateTime() }
 
                 SchemaUtils.drop(testTable)
             }

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -30,6 +30,7 @@ import org.joda.time.DateTimeZone
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class JodaTimeDefaultsTest : JodaTimeBaseTest() {
     object TableWithDBDefault : IntIdTable() {
@@ -375,6 +376,7 @@ class JodaTimeDefaultsTest : JodaTimeBaseTest() {
         val testTable = object : IntIdTable("t") {
             val t1 = timestampWithTimeZone("t1").default(nowWithTimeZone)
             val t2 = timestampWithTimeZone("t2").defaultExpression(timestampWithTimeZoneLiteral)
+            val t3 = timestampWithTimeZone("t3").defaultExpression(CurrentDateTime)
         }
 
         fun Expression<*>.itOrNull() = when {
@@ -394,7 +396,8 @@ class JodaTimeDefaultsTest : JodaTimeBaseTest() {
                     "${"t".inProperCase()} (" +
                     "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
                     "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}" +
+                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentDateTime.itOrNull()}" +
                     ")"
 
                 val expected = if (currentDialectTest is OracleDialect ||
@@ -415,6 +418,7 @@ class JodaTimeDefaultsTest : JodaTimeBaseTest() {
                 val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+                assertTrue { row1[testTable.t3].millis >= nowWithTimeZone.millis }
 
                 SchemaUtils.drop(testTable)
             }

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -3,14 +3,21 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentDate : org/j
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime : org/jetbrains/exposed/sql/Function {
+public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime : org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestampBase {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentDateTime;
+}
+
+public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp : org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestampBase {
+	public static final field INSTANCE Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp;
+}
+
+public abstract class org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestampBase : org/jetbrains/exposed/sql/Function {
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
-public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp : org/jetbrains/exposed/sql/Function {
-	public static final field INSTANCE Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestamp;
-	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+public final class org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestampWithTimeZone : org/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestampBase {
+	public static final field INSTANCE Lorg/jetbrains/exposed/sql/kotlin/datetime/CurrentTimestampWithTimeZone;
 }
 
 public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnTypeKt {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -431,7 +431,7 @@ class DefaultsTest : DatabaseTestsBase() {
                     "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
                     "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
                     "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestamp.itOrNull()}" +
+                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
                     ")"
 
                 val expected = if (currentDialectTest is OracleDialect ||

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -411,6 +411,7 @@ class DefaultsTest : DatabaseTestsBase() {
         val testTable = object : IntIdTable("t") {
             val t1 = timestampWithTimeZone("t1").default(nowWithTimeZone)
             val t2 = timestampWithTimeZone("t2").defaultExpression(timestampWithTimeZoneLiteral)
+            val t3 = timestampWithTimeZone("t3").defaultExpression(CurrentTimestampWithTimeZone)
         }
 
         fun Expression<*>.itOrNull() = when {
@@ -429,7 +430,8 @@ class DefaultsTest : DatabaseTestsBase() {
                     "${"t".inProperCase()} (" +
                     "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
                     "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}" +
+                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestamp.itOrNull()}" +
                     ")"
 
                 val expected = if (currentDialectTest is OracleDialect ||
@@ -450,6 +452,9 @@ class DefaultsTest : DatabaseTestsBase() {
                 val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
                 assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+                val dbDefault = row1[testTable.t3]
+                assertEquals(dbDefault.offset, nowWithTimeZone.offset)
+                assertTrue { dbDefault.toLocalDateTime().toKotlinLocalDateTime() >= nowWithTimeZone.toLocalDateTime().toKotlinLocalDateTime() }
 
                 SchemaUtils.drop(testTable)
             }


### PR DESCRIPTION
Version 0.50.0 introduced 2 changes to `CurrentTimestamp`:
- It is now an object instead of a class.
- It no longer returns type `T`, but instead returns an `Instant`.

So its previous use as a default expression with a timezone compatible column is no longer possible, as even changing to a singleton still requirs `OffsetDateTime` as the return type:
```kt
// compile error - invoke() not found
val t3: Column<OffsetDateTime> = timestampWithTimeZone("t3").defaultExpression(CurrentTimestamp())

// compile error - type mismatch
val t3: Column<OffsetDateTime> = timestampWithTimeZone("t3").defaultExpression(CurrentTimestamp)
```
---

This fix introduces a new object `CurrentTimestampWithTimeZone` for this specific use, to both modules `exposed-java-time` and `exposed-kotlin-datetime`.

Rather than repeating the same query builder logic, the 3 `CurrentX` objects now extend from a base sealed class.

**Note:** A new object was not added to `exposed-joda-time` since `timestampWithTimeZone()` use the same `DateTime` column type, so it can be used with `CurrentDateTime`.