### PR TITLE
EXPOSED-376 batchUpsert does not return database values on conflict

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2927,6 +2927,7 @@ public class org/jetbrains/exposed/sql/statements/BatchUpsertStatement : org/jet
 	public final fun getKeys ()[Lorg/jetbrains/exposed/sql/Column;
 	public final fun getOnUpdate ()Ljava/util/List;
 	public final fun getOnUpdateExclude ()Ljava/util/List;
+	protected fun isColumnValuePreferredFromResultSet (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Z
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 }
 
@@ -2994,6 +2995,7 @@ public class org/jetbrains/exposed/sql/statements/InsertStatement : org/jetbrain
 	public final fun getResultedValues ()Ljava/util/List;
 	public final fun getTable ()Lorg/jetbrains/exposed/sql/Table;
 	protected fun isColumnValuePreferredFromResultSet (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Z
+	protected final fun isEntityIdClientSideGeneratedUUID (Lorg/jetbrains/exposed/sql/Column;)Z
 	public final fun isIgnore ()Z
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 	public fun prepared (Lorg/jetbrains/exposed/sql/Transaction;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -42,4 +42,9 @@ open class BatchUpsertStatement(
         }
         return functionProvider.upsert(table, arguments!!.first(), onUpdate, onUpdateExclude, null, transaction, keys = keys)
     }
+
+    override fun isColumnValuePreferredFromResultSet(column: Column<*>, value: Any?): Boolean {
+        return isEntityIdClientSideGeneratedUUID(column) ||
+            super.isColumnValuePreferredFromResultSet(column, value)
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -219,4 +219,10 @@ open class InsertStatement<Key : Any>(
             builder.args
         } ?: emptyList()
     }
+
+    protected fun isEntityIdClientSideGeneratedUUID(column: Column<*>) =
+        (column.columnType as? EntityIDColumnType<*>)
+            ?.idColumn
+            ?.takeIf { it.columnType is UUIDColumnType }
+            ?.defaultValueFun != null
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -53,10 +53,4 @@ open class UpsertStatement<Key : Any>(
         return isEntityIdClientSideGeneratedUUID(column) ||
             super.isColumnValuePreferredFromResultSet(column, value)
     }
-
-    private fun isEntityIdClientSideGeneratedUUID(column: Column<*>) =
-        (column.columnType as? EntityIDColumnType<*>)
-            ?.idColumn
-            ?.takeIf { it.columnType is UUIDColumnType }
-            ?.defaultValueFun != null
 }


### PR DESCRIPTION
The problem of the wrong auto-generated uuid primary key returned from `batchUpsert()`. The fix is the same like with `upsert()` command in the recent [PR/2075](https://github.com/JetBrains/Exposed/pull/2075)