### PR TITLE
feat: EXPOSED-368 Ordering on References

### DIFF
--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -173,6 +173,32 @@ class User(id: EntityID<Int>): IntEntity(id) {
 }
 ```
 
+### Ordered reference
+
+You can also define the order in which referenced entities appear:
+
+```kotlin
+class User(id: EntityID<Int>) : IntEntity(id) {
+    companion object : IntEntityClass<User>(Users)
+
+    ...
+    val ratings by UserRating referrersOn UserRatings.user orderBy UserRatings.value
+    ...
+}
+```
+
+In a more complex scenario, you can specify multiple columns along with the corresponding sort order for each:
+
+```kotlin
+class User(id: EntityID<Int>) : IntEntity(id) {
+    companion object : IntEntityClass<User>(Users)
+
+    ...
+    val ratings by UserRating referrersOn UserRatings.user orderBy listOf(UserRatings.value to DESC, UserRatings.id to ASC)
+    ...
+}
+```
+
 ### many-to-many reference
 In some cases, a many-to-many reference may be required.
 Let's assume you want to add a reference to the following Actors table to the StarWarsFilm class:

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -199,6 +199,18 @@ class User(id: EntityID<Int>) : IntEntity(id) {
 }
 ```
 
+Without using the `infix` call, the `orderBy` method is chained after `referrersOn`:
+
+```kotlin
+class User(id: EntityID<Int>) : IntEntity(id) {
+    companion object : IntEntityClass<User>(Users)
+    
+    ...
+    val ratings by UserRating.referrersOn(UserRatings.user)
+        .orderBy(listOf(UserRatings.value to SortOrder.DESC, UserRatings.id to SortOrder.ASC))
+    ...
+```
+
 ### many-to-many reference
 In some cases, a many-to-many reference may be required.
 Let's assume you want to add a reference to the following Actors table to the StarWarsFilm class:

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -207,7 +207,7 @@ class User(id: EntityID<Int>) : IntEntity(id) {
     
     ...
     val ratings by UserRating.referrersOn(UserRatings.user)
-        .orderBy(listOf(UserRatings.value to SortOrder.DESC, UserRatings.id to SortOrder.ASC))
+        .orderBy(UserRatings.value to SortOrder.DESC, UserRatings.id to SortOrder.ASC)
     ...
 ```
 

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -194,7 +194,7 @@ class User(id: EntityID<Int>) : IntEntity(id) {
     companion object : IntEntityClass<User>(Users)
 
     ...
-    val ratings by UserRating referrersOn UserRatings.user orderBy listOf(UserRatings.value to DESC, UserRatings.id to ASC)
+    val ratings by UserRating referrersOn UserRatings.user orderBy listOf(UserRatings.value to SortOrder.DESC, UserRatings.id to SortOrder.ASC)
     ...
 }
 ```

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -284,6 +284,7 @@ public class org/jetbrains/exposed/dao/Referrers : kotlin/properties/ReadOnlyPro
 	public final fun orderBy (Ljava/util/List;)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun orderBy (Lkotlin/Pair;)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun orderBy (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/dao/Referrers;
+	public final fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/dao/Referrers;
 }
 
 public abstract class org/jetbrains/exposed/dao/UIntEntity : org/jetbrains/exposed/dao/Entity {

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -1,3 +1,15 @@
+public abstract class org/jetbrains/exposed/dao/BaseReferrers : kotlin/properties/ReadOnlyProperty {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
+	public final fun getCache ()Z
+	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
+	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
+	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public final fun orderBy (Ljava/util/List;)Lorg/jetbrains/exposed/dao/BaseReferrers;
+	public final fun orderBy (Lkotlin/Pair;)Lorg/jetbrains/exposed/dao/BaseReferrers;
+	public final fun orderBy (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/dao/BaseReferrers;
+}
+
 public class org/jetbrains/exposed/dao/ColumnWithTransform {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -256,13 +268,8 @@ public final class org/jetbrains/exposed/dao/OptionalReference {
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
 }
 
-public final class org/jetbrains/exposed/dao/OptionalReferrers : kotlin/properties/ReadOnlyProperty {
+public final class org/jetbrains/exposed/dao/OptionalReferrers : org/jetbrains/exposed/dao/BaseReferrers {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
-	public final fun getCache ()Z
-	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
-	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
-	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
-	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
 public final class org/jetbrains/exposed/dao/Reference {
@@ -276,13 +283,8 @@ public final class org/jetbrains/exposed/dao/ReferencesKt {
 	public static final fun with (Ljava/lang/Iterable;[Lkotlin/reflect/KProperty1;)Ljava/lang/Iterable;
 }
 
-public final class org/jetbrains/exposed/dao/Referrers : kotlin/properties/ReadOnlyProperty {
+public final class org/jetbrains/exposed/dao/Referrers : org/jetbrains/exposed/dao/BaseReferrers {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
-	public final fun getCache ()Z
-	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
-	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
-	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
-	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
 public abstract class org/jetbrains/exposed/dao/UIntEntity : org/jetbrains/exposed/dao/Entity {

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -1,15 +1,3 @@
-public abstract class org/jetbrains/exposed/dao/BaseReferrers : kotlin/properties/ReadOnlyProperty {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
-	public final fun getCache ()Z
-	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
-	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
-	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
-	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public final fun orderBy (Ljava/util/List;)Lorg/jetbrains/exposed/dao/BaseReferrers;
-	public final fun orderBy (Lkotlin/Pair;)Lorg/jetbrains/exposed/dao/BaseReferrers;
-	public final fun orderBy (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/dao/BaseReferrers;
-}
-
 public class org/jetbrains/exposed/dao/ColumnWithTransform {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -234,6 +222,9 @@ public final class org/jetbrains/exposed/dao/InnerTableLink : kotlin/properties/
 	public final fun getTargetColumn ()Lorg/jetbrains/exposed/sql/Column;
 	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public final fun orderBy (Ljava/util/List;)Lorg/jetbrains/exposed/dao/InnerTableLink;
+	public final fun orderBy (Lkotlin/Pair;)Lorg/jetbrains/exposed/dao/InnerTableLink;
+	public final fun orderBy (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/dao/InnerTableLink;
 	public synthetic fun setValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
 	public fun setValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;Lorg/jetbrains/exposed/sql/SizedIterable;)V
 }
@@ -268,7 +259,7 @@ public final class org/jetbrains/exposed/dao/OptionalReference {
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
 }
 
-public final class org/jetbrains/exposed/dao/OptionalReferrers : org/jetbrains/exposed/dao/BaseReferrers {
+public final class org/jetbrains/exposed/dao/OptionalReferrers : org/jetbrains/exposed/dao/Referrers {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
 }
 
@@ -283,8 +274,16 @@ public final class org/jetbrains/exposed/dao/ReferencesKt {
 	public static final fun with (Ljava/lang/Iterable;[Lkotlin/reflect/KProperty1;)Ljava/lang/Iterable;
 }
 
-public final class org/jetbrains/exposed/dao/Referrers : org/jetbrains/exposed/dao/BaseReferrers {
+public class org/jetbrains/exposed/dao/Referrers : kotlin/properties/ReadOnlyProperty {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
+	public final fun getCache ()Z
+	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
+	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
+	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public final fun orderBy (Ljava/util/List;)Lorg/jetbrains/exposed/dao/Referrers;
+	public final fun orderBy (Lkotlin/Pair;)Lorg/jetbrains/exposed/dao/Referrers;
+	public final fun orderBy (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/dao/Referrers;
 }
 
 public abstract class org/jetbrains/exposed/dao/UIntEntity : org/jetbrains/exposed/dao/Entity {

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
@@ -101,7 +101,7 @@ open class Referrers<ParentID : Comparable<ParentID>, in Parent : Entity<ParentI
     val factory: EntityClass<ChildID, Child>,
     val cache: Boolean
 ) : ReadOnlyProperty<Parent, SizedIterable<Child>> {
-    /** The list of columns and their [SortOrder] for ordering referred entities in on-to-many relationship. */
+    /** The list of columns and their [SortOrder] for ordering referred entities in one-to-many relationship. */
     private val orderByExpressions: MutableList<Pair<Expression<*>, SortOrder>> = mutableListOf()
 
     init {
@@ -144,6 +144,9 @@ open class Referrers<ParentID : Comparable<ParentID>, in Parent : Entity<ParentI
 
     /** Modifies this reference to sort entities by a column specified in [expression] using ascending order. **/
     infix fun orderBy(expression: Expression<*>) = orderBy(listOf(expression to SortOrder.ASC))
+
+    /** Modifies this reference to sort entities based on multiple columns as specified in [order]. **/
+    fun orderBy(vararg order: Pair<Expression<*>, SortOrder>) = orderBy(order.toList())
 }
 
 /**

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/OrderedReferenceTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/OrderedReferenceTest.kt
@@ -1,0 +1,139 @@
+package org.jetbrains.exposed.sql.tests.shared.entities
+
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.SortOrder.DESC
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.junit.Test
+
+class OrderedReferenceTest : DatabaseTestsBase() {
+    object Users : IntIdTable()
+
+    object UserRatings : IntIdTable() {
+        val value = integer("value")
+        val user = reference("user", Users)
+    }
+
+    object UserNullableRatings : IntIdTable() {
+        val value = integer("value")
+        val user = reference("user", Users).nullable()
+    }
+
+    class UserRatingDefaultOrder(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<UserRatingDefaultOrder>(UserRatings)
+
+        var value by UserRatings.value
+        var user by UserDefaultOrder referencedOn UserRatings.user
+    }
+
+    class UserNullableRatingDefaultOrder(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<UserNullableRatingDefaultOrder>(UserNullableRatings)
+
+        var value by UserNullableRatings.value
+        var user by UserDefaultOrder optionalReferencedOn UserNullableRatings.user
+    }
+
+    class UserDefaultOrder(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<UserDefaultOrder>(Users)
+
+        val ratings by UserRatingDefaultOrder referrersOn UserRatings.user orderBy UserRatings.value
+        val nullableRatings by UserNullableRatingDefaultOrder optionalReferrersOn UserNullableRatings.user orderBy UserNullableRatings.value
+    }
+
+    @Test
+    fun testDefaultOrder() {
+        withOrderedReferenceTestTables {
+            val user = UserDefaultOrder.all().first()
+
+            unsortedRatingValues.sorted().zip(user.ratings).forEach { (value, rating) ->
+                assertEquals(value, rating.value)
+            }
+            unsortedRatingValues.sorted().zip(user.nullableRatings).forEach { (value, rating) ->
+                assertEquals(value, rating.value)
+            }
+        }
+    }
+
+    class UserRatingMultiColumn(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<UserRatingMultiColumn>(UserRatings)
+
+        var value by UserRatings.value
+        var user by UserMultiColumn referencedOn UserRatings.user
+    }
+
+    class UserNullableRatingMultiColumn(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<UserNullableRatingMultiColumn>(UserNullableRatings)
+
+        var value by UserNullableRatings.value
+        var user by UserMultiColumn optionalReferencedOn UserNullableRatings.user
+    }
+
+    class UserMultiColumn(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<UserMultiColumn>(Users)
+
+        val ratings by UserRatingMultiColumn referrersOn UserRatings.user orderBy listOf(UserRatings.value to DESC, UserRatings.id to DESC)
+        val nullableRatings by UserNullableRatingMultiColumn optionalReferrersOn UserNullableRatings.user orderBy listOf(
+            UserNullableRatings.value to DESC,
+            UserNullableRatings.id to DESC
+        )
+    }
+
+    @Test
+    fun testMultiColumnOrder() {
+        withOrderedReferenceTestTables {
+            val ratings = UserMultiColumn.all().first().ratings.map { it }
+            val nullableRatings = UserMultiColumn.all().first().nullableRatings.map { it }
+
+            // Ensure each value is less than the one before it.
+            // IDs should be sorted within groups of identical values.
+            fun assertRatingsOrdered(current: UserRatingMultiColumn, prev: UserRatingMultiColumn) {
+                assertTrue(current.value <= prev.value)
+                if (current.value == prev.value) {
+                    assertTrue(current.id <= prev.id)
+                }
+            }
+
+            fun assertNullableRatingsOrdered(current: UserNullableRatingMultiColumn, prev: UserNullableRatingMultiColumn) {
+                assertTrue(current.value <= prev.value)
+                if (current.value == prev.value) {
+                    assertTrue(current.id <= prev.id)
+                }
+            }
+
+            for (i in 1..<ratings.size) {
+                assertRatingsOrdered(ratings[i], ratings[i - 1])
+                assertNullableRatingsOrdered(nullableRatings[i], nullableRatings[i - 1])
+            }
+        }
+    }
+
+    private val unsortedRatingValues = listOf(0, 3, 1, 2, 4, 4, 5, 4, 5, 6, 9, 8)
+
+    private fun withOrderedReferenceTestTables(statement: Transaction.(TestDB) -> Unit) {
+        withTables(Users, UserRatings, UserNullableRatings) { db ->
+            val userId = Users.insert { }.resultedValues?.firstOrNull()?.get(Users.id) ?: error("User was not created")
+            unsortedRatingValues.forEach { value ->
+                UserRatings.insert {
+                    it[user] = userId
+                    it[UserRatings.value] = value
+                }
+                UserNullableRatings.insert {
+                    it[user] = userId
+                    it[UserRatings.value] = value
+                }
+                UserNullableRatings.insert {
+                    it[user] = null
+                    it[UserRatings.value] = value
+                }
+            }
+            statement(db)
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/OrderedReferenceTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/OrderedReferenceTest.kt
@@ -79,11 +79,15 @@ class OrderedReferenceTest : DatabaseTestsBase() {
     class UserMultiColumn(id: EntityID<Int>) : IntEntity(id) {
         companion object : IntEntityClass<UserMultiColumn>(Users)
 
-        val ratings by UserRatingMultiColumn referrersOn UserRatings.user orderBy listOf(UserRatings.value to DESC, UserRatings.id to DESC)
-        val nullableRatings by UserNullableRatingMultiColumn optionalReferrersOn UserNullableRatings.user orderBy listOf(
-            UserNullableRatings.value to DESC,
-            UserNullableRatings.id to DESC
-        )
+        val ratings by UserRatingMultiColumn
+            .referrersOn(UserRatings.user)
+            .orderBy(UserRatings.value to DESC, UserRatings.id to DESC)
+        val nullableRatings by UserNullableRatingMultiColumn
+            .optionalReferrersOn(UserNullableRatings.user)
+            .orderBy(
+                UserNullableRatings.value to DESC,
+                UserNullableRatings.id to DESC
+            )
     }
 
     @Test


### PR DESCRIPTION
PR add the possibility to add sorting for one-to-many references. Usage looks like:

```kotlin
class User(id: EntityID<Int>) : IntEntity(id) {
    companion object : IntEntityClass<User>(Users)
    ...
    val ratings by UserRating referrersOn UserRatings.user orderBy UserRatings.value
    ...
}
```

Open questions that I haven't yet resolved:

1) It's not possible to create several references with different orders. For example, something like this would not work:
 ```kotlin
class User(id: EntityID<Int>) : IntEntity(id) {
    companion object : IntEntityClass<User>(Users)
    ...
    val ratingsByValue by UserRating referrersOn UserRatings.user orderBy UserRatings.value
    val ratingsById by UserRating referrersOn UserRatings.user orderBy UserRatings.id
    ...
}
```

The reason is the caching of referencing rules inside `EntityClass::refDefinitions`. Every time we try to add a reference to the same column, the cached one is returned.
Solution options:
- let it be as it is. We may assume that user should not create references with different orders. But at the current moment there is no error handling, and if a user actually tries to add several references in different order, they will get unexpected behaviour (actually, the first created reference would be used every time)
- extend cache with order and save inside cache not only per column, but also per sorting configuration. For me, it looks like a better solution if we need that caching.
- do we need that caching? I mean, what is the purpose of this caching? Can a user now intentionally create two references to another entity and expect that it would be the same reference?

2) There are 2 classes `Referrers` and `OptionalReferrers`, but to me one of them (for instance `OptionalReference`) looks redundant. They do the same thing and have only a small difference in field `reference` (in one case it has type `Column<REF>` in another `Column<REF?>`, but since REF is generic, it can be specified one level above. It will look like:

```kotlin    
// Before
infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.optionalReferrersOn(
    column: Column<REF?>
) =
    registerRefRule(column) { OptionalReferrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, true) }

// After
infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.optionalReferrersOn(
column: Column<REF?>
) =
registerRefRule(column) { Referrers<ID, Entity<ID>, TargetID, Target, REF?>(column, this, true) }
```
After that `OptionalReferrers` can be removed. The only reason to keep it I see is the semantic (previous variant is better readable from user perspective).

For now I created `BaseReferrers` to place common logic inside one class, but I can join all of these 3 classes (`Referrers`, `OptionalReferrers`, `BaseReferrers`) into one `Referrers`.