### PR TITLE
EXPOSED-387 Exposed Join.lastQueryAlias not working correctly

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -178,7 +178,7 @@ fun Table.joinQuery(on: (SqlExpressionBuilder.(QueryAlias) -> Op<Boolean>), join
  * @sample org.jetbrains.exposed.sql.tests.shared.AliasesTests.testJoinSubQuery02
  */
 val Join.lastQueryAlias: QueryAlias?
-    get() = joinParts.map { it.joinPart as? QueryAlias }.firstOrNull()
+    get() = joinParts.mapNotNull { it.joinPart as? QueryAlias }.lastOrNull()
 
 /**
  * Wraps a [query] as an [Expression] so that it can be used as part of an SQL statement or in another query clause.

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
@@ -77,6 +77,25 @@ class AliasesTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testJoinSubQuery03() {
+        withCitiesAndUsers { cities, users, userData ->
+            val firstJoinQuery = cities
+                .leftJoin(users)
+                .joinQuery(
+                    on = { it[userData.user_id] eq users.id },
+                    joinPart = { userData.selectAll() }
+                )
+            assertEquals("q0", firstJoinQuery.lastQueryAlias?.alias)
+
+            val secondJoinQuery = firstJoinQuery.joinQuery(
+                on = { it[userData.user_id] eq users.id },
+                joinPart = { userData.selectAll() }
+            )
+            assertEquals("q1", secondJoinQuery.lastQueryAlias?.alias)
+        }
+    }
+
+    @Test
     fun testWrapRowWithAliasedTable() {
         withTables(EntityTestsData.XTable, EntityTestsData.YTable) {
             val entity1 = EntityTestsData.XEntity.new {


### PR DESCRIPTION
The fix of `Join.lastQueryAlias` function. It was returning the first query instead of the last one (and `null` when the first join was not a join of SubQuery). Simple test reproduced it.