### PR TITLE
feat: Add support for variable-length binary columns in H2

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -741,7 +741,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /**
      * Creates a binary column, with the specified [name], for storing byte arrays of arbitrary size.
      *
-     * **Note:** This function is only supported by Oracle, PostgeSQL, and H2 dialects, for the rest please specify a length.
+     * **Note:** This function is only supported by Oracle, PostgeSQL, and H2 dialects. For the rest, please specify a length.
      * For H2 dialects, the maximum size is 1,000,000,000 bytes.
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.testBinaryWithoutLength

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -741,7 +741,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /**
      * Creates a binary column, with the specified [name], for storing byte arrays of arbitrary size.
      *
-     * **Note:** This function is only supported by Oracle and PostgeSQL dialects, for the rest please specify a length.
+     * **Note:** This function is only supported by Oracle, PostgeSQL, and H2 dialects, for the rest please specify a length.
+     * For H2 dialects, the maximum size is 1,000,000,000 bytes.
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.testBinaryWithoutLength
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -8,10 +8,7 @@ import java.sql.DatabaseMetaData
 import java.util.*
 
 internal object H2DataTypeProvider : DataTypeProvider() {
-    override fun binaryType(): String {
-        exposedLogger.error("The length of the Binary column is missing.")
-        error("The length of the Binary column is missing.")
-    }
+    override fun binaryType(): String = "VARBINARY"
 
     override fun uuidType(): String = "UUID"
     override fun uuidToDB(value: UUID): Any = value.toString()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -604,7 +604,7 @@ class DDLTests : DatabaseTestsBase() {
 
         fun SizedIterable<ResultRow>.readAsString() = map { String(it[tableWithBinary.binaryColumn]) }
 
-        withDb(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.SQLITE, TestDB.H2_PSQL)) {
+        withDb(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG, TestDB.SQLITE, TestDB.H2_PSQL, TestDB.H2)) {
             val exposedBytes = "Exposed".toByteArray()
             val kotlinBytes = "Kotlin".toByteArray()
 


### PR DESCRIPTION
H2 supports VARBINARY columns without a specified length: https://www.h2database.com/html/datatypes.html#binary_varying_type

Currently, the H2 column types throw an error if the length is not specified.  We can use VARBINARY without a specified length instead.

While these columns are limited to 1,000,000,000 bytes, in practice I do not think users will run into this limitation. I added a note to the `binary` column docs anyways.