### PR TITLE
Feat: EXPOSED-396 Supports fetchBatchedResults with sorting order 

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -245,8 +245,9 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * This query's [FieldSet] will be ordered by the first auto-increment column.
      *
      * @param batchSize Size of each sub-collection to return.
+     * @param sortOrder Order in which the results should be retrieved.
      * @return Retrieved results as a collection of batched [ResultRow] sub-collections.
-     * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectBatchedTests.testFetchBatchedResultsWithWhereAndSetBatchSize
+     * @sample org.jetbrains.exposed.sql.tests.shared.dml.FetchBatchedResultsTests.testFetchBatchedResultsWithWhereAndSetBatchSize
      */
     fun fetchBatchedResults(batchSize: Int = 1000, sortOrder: SortOrder = SortOrder.ASC): Iterable<Iterable<ResultRow>> {
         require(batchSize > 0) { "Batch size should be greater than 0." }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/FetchBatchedResultsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/FetchBatchedResultsTests.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.junit.Test
 import java.util.*
 
-class SelectBatchedTests : DatabaseTestsBase() {
+class FetchBatchedResultsTests : DatabaseTestsBase() {
     @Test
     fun testFetchBatchedResultsWithWhereAndSetBatchSize() {
         val cities = DMLTestsData.Cities


### PR DESCRIPTION
This PR includes `fetchBatchedResults` method which supports the `sortOrder` parameter.

Previously, the `fetchBatchedResults` method only supported the `batchSize` parameter, making it impossible to handle sorting order as it defaulted to ascending.
Adding support for the `sortOrder` parameter will be helpful.

```kotlin
val cities = DMLTestsData.Cities

cities.selectAll()
      .fetchBatchedResults(batchSize = 25, sortOrder = SortOrder.DESC)
```
