### PR TITLE
fix: EXPOSED-393 H2 upsert with JSON column creates invalid data

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -202,6 +202,7 @@ public final class org/jetbrains/exposed/sql/AutoIncColumnType : org/jetbrains/e
 	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun setNullable (Z)V
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
@@ -467,6 +468,7 @@ public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/expos
 	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun setNullable (Z)V
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
@@ -977,6 +979,7 @@ public abstract interface class org/jetbrains/exposed/sql/IColumnType {
 	public abstract fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public abstract fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public abstract fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
 	public abstract fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public abstract fun setNullable (Z)V
 	public abstract fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
@@ -992,6 +995,7 @@ public final class org/jetbrains/exposed/sql/IColumnType$DefaultImpls {
 	public static fun nonNullValueAsDefaultString (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/String;
 	public static fun nonNullValueToString (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/String;
 	public static fun notNullValueToDB (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun parameterMarker (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)Ljava/lang/String;
 	public static fun readObject (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public static fun setParameter (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public static fun validateValueBeforeUpdate (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/lang/Object;)V

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -22,6 +22,7 @@ import kotlin.reflect.full.isSubclassOf
 /**
  * Interface common to all column types.
  */
+@Suppress("TooManyFunctions")
 interface IColumnType<T> {
     /** Returns `true` if the column type is nullable, `false` otherwise. */
     var nullable: Boolean
@@ -95,6 +96,16 @@ interface IColumnType<T> {
      * */
     @Throws(IllegalArgumentException::class)
     fun validateValueBeforeUpdate(value: T?) {}
+
+    /**
+     * Defines the appearance of parameter markers in prepared SQL statements.
+     *
+     * The default parameter marker is `?`, but it can be overridden in specific cases.
+     *
+     * For example, H2 uses `? FORMAT JSON` for JSON columns,
+     * in Postgres a parameter marker can be explicitly cast to a specific type, etc.
+     */
+    fun parameterMarker(value: T?) = "?"
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
@@ -80,9 +80,10 @@ class QueryBuilder(
 
     /** Adds the specified sequence of [arguments] as values of the specified [sqlType]. */
     fun <T> registerArguments(sqlType: IColumnType<*>, arguments: Iterable<T>) {
+        val sqlTypeT = (sqlType as IColumnType<T>)
+
+        // avoid potentially expensive valueToString call unless we need to sort values
         if (arguments is Collection && arguments.size <= 1) {
-            // avoid potentially expensive valueToString call unless we need to sort values
-            val sqlTypeT = (sqlType as IColumnType<T>)
             arguments.forEach {
                 if (prepared) {
                     _args.add(sqlType to it)
@@ -94,7 +95,7 @@ class QueryBuilder(
         } else {
             fun toString(value: T) = when {
                 prepared && value is String -> value
-                else -> (sqlType as IColumnType<T>).valueToString(value)
+                else -> sqlTypeT.valueToString(value)
             }
 
             arguments.map { it to toString(it) }
@@ -102,7 +103,7 @@ class QueryBuilder(
                 .appendTo {
                     if (prepared) {
                         _args.add(sqlType to it.first)
-                        append("?")
+                        append(sqlTypeT.parameterMarker(it.first))
                     } else {
                         append(it.second)
                     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
@@ -82,12 +82,13 @@ class QueryBuilder(
     fun <T> registerArguments(sqlType: IColumnType<*>, arguments: Iterable<T>) {
         if (arguments is Collection && arguments.size <= 1) {
             // avoid potentially expensive valueToString call unless we need to sort values
+            val sqlTypeT = (sqlType as IColumnType<T>)
             arguments.forEach {
                 if (prepared) {
                     _args.add(sqlType to it)
-                    append("?")
+                    append(sqlTypeT.parameterMarker(it))
                 } else {
-                    append((sqlType as IColumnType<T>).valueToString(it))
+                    append(sqlTypeT.valueToString(it))
                 }
             }
         } else {

--- a/exposed-json/api/exposed-json.api
+++ b/exposed-json/api/exposed-json.api
@@ -42,6 +42,7 @@ public class org/jetbrains/exposed/sql/json/JsonColumnType : org/jetbrains/expos
 	public fun getUsesBinaryFormat ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/sql/json/JsonColumnType.kt
@@ -38,6 +38,12 @@ open class JsonColumnType<T : Any>(
         }
     }
 
+    override fun parameterMarker(value: T?): String = if (currentDialect is H2Dialect && value != null) {
+        "? FORMAT JSON"
+    } else {
+        super.parameterMarker(value)
+    }
+
     override fun notNullValueToDB(value: T): Any = serialize(value)
 
     override fun valueToString(value: T?): String = when (value) {

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
@@ -322,20 +322,22 @@ class JsonBColumnTests : DatabaseTestsBase() {
     @Test
     fun testJsonBWithUpsert() {
         // MySQL and related databases are excluded due to their lack of support for upsert operations.
-        withJsonBTable(exclude = TestDB.mySqlRelatedDB + binaryJsonNotSupportedDB) { tester, _, _, _ ->
-            val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
-            val newId = tester.insertAndGetId {
-                it[jsonBColumn] = newData
-            }
+        withJsonBTable(exclude = TestDB.mySqlRelatedDB + binaryJsonNotSupportedDB) { tester, _, _, db ->
+            excludingH2Version1(db) {
+                val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
+                val newId = tester.insertAndGetId {
+                    it[jsonBColumn] = newData
+                }
 
-            val newData2 = newData.copy(active = false)
-            tester.upsert(tester.id) {
-                it[tester.id] = newId
-                it[tester.jsonBColumn] = newData2
-            }
+                val newData2 = newData.copy(active = false)
+                tester.upsert(tester.id) {
+                    it[tester.id] = newId
+                    it[tester.jsonBColumn] = newData2
+                }
 
-            val newResult = tester.selectAll().where { tester.id eq newId }.singleOrNull()
-            assertEquals(newData2, newResult?.get(tester.jsonBColumn))
+                val newResult = tester.selectAll().where { tester.id eq newId }.singleOrNull()
+                assertEquals(newData2, newResult?.get(tester.jsonBColumn))
+            }
         }
     }
 }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -390,20 +390,22 @@ class JsonColumnTests : DatabaseTestsBase() {
     @Test
     fun testJsonWithUpsert() {
         // MySQL and related databases are excluded due to their lack of support for upsert operations.
-        withJsonTable(exclude = TestDB.mySqlRelatedDB) { tester, _, _, _ ->
-            val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
-            val newId = tester.insertAndGetId {
-                it[jsonColumn] = newData
-            }
+        withJsonTable(exclude = TestDB.mySqlRelatedDB) { tester, _, _, db ->
+            excludingH2Version1(db) {
+                val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
+                val newId = tester.insertAndGetId {
+                    it[jsonColumn] = newData
+                }
 
-            val newData2 = newData.copy(active = false)
-            tester.upsert(tester.id) {
-                it[tester.id] = newId
-                it[tester.jsonColumn] = newData2
-            }
+                val newData2 = newData.copy(active = false)
+                tester.upsert(tester.id) {
+                    it[tester.id] = newId
+                    it[tester.jsonColumn] = newData2
+                }
 
-            val newResult = tester.selectAll().where { tester.id eq newId }.singleOrNull()
-            assertEquals(newData2, newResult?.get(tester.jsonColumn))
+                val newResult = tester.selectAll().where { tester.id eq newId }.singleOrNull()
+                assertEquals(newData2, newResult?.get(tester.jsonColumn))
+            }
         }
     }
 }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -389,23 +389,20 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonWithUpsert() {
-        // MySQL and related databases are excluded due to their lack of support for upsert operations.
-        withJsonTable(exclude = TestDB.mySqlRelatedDB) { tester, _, _, db ->
-            excludingH2Version1(db) {
-                val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
-                val newId = tester.insertAndGetId {
-                    it[jsonColumn] = newData
-                }
-
-                val newData2 = newData.copy(active = false)
-                tester.upsert(tester.id) {
-                    it[tester.id] = newId
-                    it[tester.jsonColumn] = newData2
-                }
-
-                val newResult = tester.selectAll().where { tester.id eq newId }.singleOrNull()
-                assertEquals(newData2, newResult?.get(tester.jsonColumn))
+        withJsonTable { tester, _, _, db ->
+            val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
+            val newId = tester.insertAndGetId {
+                it[jsonColumn] = newData
             }
+
+            val newData2 = newData.copy(active = false)
+            tester.upsert {
+                it[tester.id] = newId
+                it[tester.jsonColumn] = newData2
+            }
+
+            val newResult = tester.selectAll().where { tester.id eq newId }.singleOrNull()
+            assertEquals(newData2, newResult?.get(tester.jsonColumn))
         }
     }
 }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonTestsData.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonTestsData.kt
@@ -51,19 +51,13 @@ fun DatabaseTestsBase.withJsonTable(
 ) {
     val tester = JsonTestsData.JsonTable
 
-    withDb(excludeSettings = exclude) { testDb ->
-        excludingH2Version1(testDb) {
-            SchemaUtils.create(tester)
+    withTables(excludeSettings = exclude, tester) { testDb ->
+        val user1 = User("Admin", null)
+        val data1 = DataHolder(user1, 10, true, null)
 
-            val user1 = User("Admin", null)
-            val data1 = DataHolder(user1, 10, true, null)
+        tester.insert { it[jsonColumn] = data1 }
 
-            tester.insert { it[jsonColumn] = data1 }
-
-            statement(tester, user1, data1, testDb)
-
-            SchemaUtils.drop(tester)
-        }
+        statement(tester, user1, data1, testDb)
     }
 }
 
@@ -73,19 +67,13 @@ fun DatabaseTestsBase.withJsonBTable(
 ) {
     val tester = JsonTestsData.JsonBTable
 
-    withDb(excludeSettings = exclude) { testDb ->
-        excludingH2Version1(testDb) {
-            SchemaUtils.create(tester)
+    withTables(excludeSettings = exclude, tester) { testDb ->
+        val user1 = User("Admin", null)
+        val data1 = DataHolder(user1, 10, true, null)
 
-            val user1 = User("Admin", null)
-            val data1 = DataHolder(user1, 10, true, null)
+        tester.insert { it[jsonBColumn] = data1 }
 
-            tester.insert { it[jsonBColumn] = data1 }
-
-            statement(tester, user1, data1, testDb)
-
-            SchemaUtils.drop(tester)
-        }
+        statement(tester, user1, data1, testDb)
     }
 }
 


### PR DESCRIPTION
The original issue is that `upsert()` creates incorrect value in the database for Json column and H2 database.

As I understood the root of the problem is that jdbc driver works differently for `insert` and `merge` prepared statements. In the case of `insert` the json string is saved in the db as it is, in the `merge` case it is stored with escaping characters...

Some more details on [YouTrack/EXPOSED-393](https://youtrack.jetbrains.com/issue/EXPOSED-393/H2-upsert-with-JSON-column-creates-invalid-data)

With this PR the new method in `IColumnType` is introduced: `fun parameterMarker(value: T?) = "?"`

It allows for the `JsonColumnType` to specify modifier for the parameter marker inside a prepared statement (so it looks like `? FORMAT JSON`).

It's done on the column type, because another db-specific check is made on this level also (like in `valueFromDB`/`valueToDB`), and it would also allow to make similar customizations for other columns (`CAST` in MySql, cast via `::<type>` in Postgres, probably named/ordered parameters, but it's more complicated because more information is needed) if it's necessary.