### PR TITLE
chore: Fix TC Docker `version` is obsolete

### DIFF
--- a/buildScripts/docker/docker-compose-mariadb.yml
+++ b/buildScripts/docker/docker-compose-mariadb.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.8'
 
 services:
     mariadb:

--- a/buildScripts/docker/docker-compose-mysql.yml
+++ b/buildScripts/docker/docker-compose-mysql.yml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "3.8"
 
 services:
     mysql:

--- a/buildScripts/docker/docker-compose-mysql8.yml
+++ b/buildScripts/docker/docker-compose-mysql8.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.8'
 
 services:
     mysql8:

--- a/buildScripts/docker/docker-compose-oracle.yml
+++ b/buildScripts/docker/docker-compose-oracle.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.8'
 
 services:
     oracle:

--- a/buildScripts/docker/docker-compose-postgres.yml
+++ b/buildScripts/docker/docker-compose-postgres.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.8'
 
 services:
     postgres:

--- a/buildScripts/docker/docker-compose-sqlserver.yml
+++ b/buildScripts/docker/docker-compose-sqlserver.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.8'
 
 services:
     sqlserver:


### PR DESCRIPTION
TC builds (both `main` & team branches) started failing on task `sqlserverComposeUp` with the message: `java.lang.RuntimeException: Exit-code 18 when calling docker-compose` eventhough no changes have been made to the compose files.

Assuming a docker build configuration change on the TC agent, the version property has been bumped to the max in all compose files.

If there's no backwards compatibility issue, the next step would be to consider removing the property entirely ([docker reference](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional)), as all docker-compose tasks show the warning message: `'version' is obsolete`.