### PR TITLE
fix: EXPOSED-402 ClassCastException when eager loading with uuid().references()

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.dao.with
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.exists
 import org.jetbrains.exposed.sql.insert
@@ -121,8 +122,13 @@ class LongIdTableEntityTest : DatabaseTestsBase() {
                 it[cityId] = cId.value
             }
 
+            // lazy loaded reference
             val town1 = LongIdTables.Town.all().single()
             assertEquals(cId, town1.city.id)
+
+            // eager loaded reference
+            val town1WithCity = LongIdTables.Town.all().with(LongIdTables.Town::city).single()
+            assertEquals(cId, town1WithCity.city.id)
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/UuidTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/UuidTableEntityTest.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.dao.UUIDEntity
 import org.jetbrains.exposed.dao.UUIDEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.dao.with
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.exists
 import org.jetbrains.exposed.sql.insert
@@ -171,8 +172,13 @@ class UUIDTableEntityTest : DatabaseTestsBase() {
                 it[cityId] = cId.value
             }
 
+            // lazy loaded reference
             val town1 = UUIDTables.Town.all().single()
             assertEquals(cId, town1.city.id)
+
+            // eager loaded reference
+            val town1WithCity = UUIDTables.Town.all().with(UUIDTables.Town::city).single()
+            assertEquals(cId, town1WithCity.city.id)
         }
     }
 }


### PR DESCRIPTION
Since version 0.50.0, using `Column.references()` invoked on a `UUIDColumnType` that targets an `EntityIDColumnType<UUID>` causes a `ClassCastException` when references are eager loaded, for the same type mismatch as detailed in PR #2079 

This extends the previous fix to include Reference objects in `preloadRelations()`, by forcing the query clause to use the underlying/wrapped type of `EntityIDColumnType` if there is a type mismatch between `refColumn` and `refIds`.

If more issues arise from this use case, we may need to consider something in `Column.referree()`, though the possible implications of that would need to be properly assessed.