### PR TITLE
fix(DoubleColumnType): correctly handle precision when casting Float to DoubleColumnType for a `real` column

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -440,6 +440,8 @@ class DoubleColumnType : ColumnType<Double>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.doubleType()
     override fun valueFromDB(value: Any): Double = when (value) {
         is Double -> value
+        // Cast as string to prevent precision loss
+        is Float -> value.toString().toDouble()
         is Number -> value.toDouble()
         is String -> value.toDouble()
         else -> error("Unexpected value of type Double: $value of ${value::class.qualifiedName}")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/DoubleColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/DoubleColumnTypeTests.kt
@@ -46,5 +46,4 @@ class DoubleColumnTypeTests : DatabaseTestsBase() {
             SchemaUtils.drop(TestTable)
         }
     }
-
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/DoubleColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/DoubleColumnTypeTests.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class DoubleColumnTypeTests : DatabaseTestsBase() {
+    object TestTable : IntIdTable("double_table") {
+        val amount = double("amount")
+    }
+
+    @Test
+    fun `test correctly gets data from the DB`() {
+        withTables(TestTable) {
+            val id = TestTable.insertAndGetId {
+                it[amount] = 9.23
+            }
+
+            TestTable.selectAll().where { TestTable.id eq id }.singleOrNull()?.let {
+                assertEquals(9.23, it[TestTable.amount])
+            }
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/DoubleColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/DoubleColumnTypeTests.kt
@@ -3,8 +3,6 @@ package org.jetbrains.exposed.sql.tests.shared.types
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
-import org.jetbrains.exposed.sql.tests.TestDB
-import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.junit.Test
 


### PR DESCRIPTION
we found an issue when casting values from the DB to a DoubleColumnType when the underlying column was a `real`

## isolated example

### Problem
<img width="259" alt="image" src="https://github.com/JetBrains/Exposed/assets/87341573/7624fa66-effa-47ae-85c2-ea8607149221">

### Solution
<img width="279" alt="image" src="https://github.com/JetBrains/Exposed/assets/87341573/8deaa84f-fdea-4419-9466-fa84c41b0ed3">

## bug found in prod

db had this:
<img width="366" alt="image" src="https://github.com/JetBrains/Exposed/assets/87341573/4ec2a68e-cf6a-4c0a-925a-f32cef15115f">

when debugging through the value was represented as a `Float`, shown here:
<img width="914" alt="image" src="https://github.com/JetBrains/Exposed/assets/87341573/7151dbaa-2155-4758-bc1c-635f7ca7fd0c">
<img width="766" alt="image" src="https://github.com/JetBrains/Exposed/assets/87341573/480ab0b9-7ce9-4797-a5da-ea65aa514fd2">

the data is coming back as `Float` because the Postgres column is a `real` and not a `double precision` 


