### PR TITLE
Write two tests that catch a possible bug with SQLite + batchInsert

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -1534,6 +1534,17 @@ class EntityTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testIdValueIsTheSameAsCustomPrimaryKeyColumn() {
+        withTables(RequestsTable) {
+            val request = Request.new {
+                requestId = "123"
+            }
+
+            assertEquals("123", request.id.value)
+        }
+    }
+
     object CreditCards : IntIdTable("CreditCards") {
         val number = varchar("number", 16)
         val spendingLimit = ulong("spendingLimit").databaseGenerated()


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/EXPOSED-405/SQLite-bugs-Table-with-custom-ID-behaves-weirdly-in-DAO-and-batchInsert

Two errors show up:
    1. A customly declared ID column is not set to the `id` property on DAO `new {}`
    2. The ResultRow from a `batchInsert` fails to unwrap data on 2 ways:
      - if you check the `id` first, it fails because it becomes 1 instead of "batman" as the test expected
      - if you check `username` first, it fails later on `id` because the ResultRow caches the internal lookup, but the cache doesn't make a distinction
        between the return value String and EntityID<String> - creating a ClassCastException