### PR TITLE
fix: EXPOSED-405 SQLite bugs: Table with custom ID behaves weirdly in DAO and batchInsert

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2960,6 +2960,7 @@ public class org/jetbrains/exposed/sql/statements/BatchUpsertStatement : org/jet
 	public final fun getWhere ()Lorg/jetbrains/exposed/sql/Op;
 	protected fun isColumnValuePreferredFromResultSet (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Z
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
+	public fun prepared (Lorg/jetbrains/exposed/sql/Transaction;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;
 }
 
 public class org/jetbrains/exposed/sql/statements/DeleteStatement : org/jetbrains/exposed/sql/statements/Statement {
@@ -3259,6 +3260,7 @@ public class org/jetbrains/exposed/sql/statements/UpsertStatement : org/jetbrain
 	public final fun getWhere ()Lorg/jetbrains/exposed/sql/Op;
 	protected fun isColumnValuePreferredFromResultSet (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Z
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
+	public fun prepared (Lorg/jetbrains/exposed/sql/Transaction;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;
 }
 
 public final class org/jetbrains/exposed/sql/statements/api/ExposedBlob {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.statements
 
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
 import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -56,7 +56,7 @@ open class BatchUpsertStatement(
     override fun prepared(transaction: Transaction, sql: String): PreparedStatementApi {
         // We must return values from upsert because returned id could be different depending on insert or upsert happened
         if (!currentDialect.supportsOnlyIdentifiersInGeneratedKeys) {
-            return transaction.connection.prepareStatement(sql, true)
+            return transaction.connection.prepareStatement(sql, shouldReturnGeneratedValues)
         }
 
         return super.prepared(transaction, sql)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -181,7 +181,9 @@ open class InsertStatement<Key : Any>(
 
     protected open fun PreparedStatementApi.execInsertFunction(): Pair<Int, ResultSet?> {
         val inserted = if (arguments().count() > 1 || isAlwaysBatch) executeBatch().sum() else executeUpdate()
-        val rs = if (autoIncColumns.isNotEmpty()) {
+        // According to the `processResults()` method when supportsOnlyIdentifiersInGeneratedKeys is false
+        // all the columns could be taken from result set
+        val rs = if (autoIncColumns.isNotEmpty() || !currentDialect.supportsOnlyIdentifiersInGeneratedKeys) {
             resultSet
         } else {
             null
@@ -205,7 +207,6 @@ open class InsertStatement<Key : Any>(
                     column.autoIncColumnType?.nextValExpression != null -> currentDialect.supportsSequenceAsGeneratedKeys
                     column.columnType.isAutoInc -> true
                     column in nextValExpressionColumns -> currentDialect.supportsSequenceAsGeneratedKeys
-                    column.columnType is EntityIDColumnType<*> -> !currentDialect.supportsOnlyIdentifiersInGeneratedKeys
                     else -> false
                 }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -703,4 +703,21 @@ class InsertTests : DatabaseTestsBase() {
             }
         }
     }
+
+    @Test
+    fun testNoAutoIncrementAppliedToCustomStringPrimaryKey() {
+        val tester = object : IdTable<String>("test_no_auto_increment_table") {
+            val customId = varchar("custom_id", 128)
+            override val primaryKey: PrimaryKey = PrimaryKey(customId)
+            override val id: Column<EntityID<String>> = customId.entityId()
+        }
+
+        withTables(tester) {
+            val result1 = tester.batchInsert(listOf("custom-id-value")) { username ->
+                this[tester.customId] = username
+            }.single()
+            assertEquals("custom-id-value", result1[tester.id].value)
+            assertEquals("custom-id-value", result1[tester.customId])
+        }
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
@@ -562,6 +562,9 @@ class UpsertTests : DatabaseTestsBase() {
             Words.batchUpsert(
                 lettersWithDuplicates,
                 onUpdate = incrementCount,
+                // PostgresNG throws IndexOutOfBound if shouldReturnGeneratedValues == true
+                // Related issue in pgjdbc-ng repository: https://github.com/impossibl/pgjdbc-ng/issues/545
+                shouldReturnGeneratedValues = false,
                 where = { Words.word inList firstThreeVowels }
             ) { letter ->
                 this[Words.word] = letter


### PR DESCRIPTION
Inside `InsertStatement` there is a field `autoIncColumns` with the getter that should return the list of auto increment columns.  One of the checks it does is `column.columnType is EntityIDColumnType<*> -> !currentDialect.supportsOnlyIdentifiersInGeneratedKeys`, but looks like it's a wrong assumption since not every `EntityIDColumnType` must be autoincrementable (test with custom `String` primary key demonstrates it)

If I'm right, the main way to create `EntityIDColumnType` for the user is to use `entityId()` methods on column, but to make it autoincrement the method `cloneWithAutoInc()` (`autoIncrement()`) should be used, what will make column `AutoIncColumnType` what is also checked inside `InsertStatement`.

The only test that was affected by removing this check is `testFlushNonAutoincEntityWithoutDefaultValue`, that test was removed. The name of the test states `...NonAutoincEntity...`, but if I'm right the whole test works only because a table `AutoIncSharedTable` created, and the same name `"SharedTable"` for both (auto/non-auto increment) tables is chosen.
Inside the test two entries are created without specifying `id` explicitly, what (here I'm not sure) should not work, because it's not autoincrement column... if you know what this test checks, I'd be happy to know about it)
