### PR TITLE
feat: EXPOSED-336 Support Where clause with batchUpsert

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1721,10 +1721,10 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static final fun batchReplace (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;ZLkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static synthetic fun batchReplace$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Iterable;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun batchReplace$default (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
-	public static final fun batchUpsert (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Iterable;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;ZLkotlin/jvm/functions/Function2;)Ljava/util/List;
-	public static final fun batchUpsert (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;ZLkotlin/jvm/functions/Function2;)Ljava/util/List;
-	public static synthetic fun batchUpsert$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Iterable;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
-	public static synthetic fun batchUpsert$default (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun batchUpsert (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Iterable;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun batchUpsert (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static synthetic fun batchUpsert$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Iterable;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun batchUpsert$default (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun deleteAll (Lorg/jetbrains/exposed/sql/Table;)I
 	public static final fun deleteIgnoreWhere (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/jvm/functions/Function2;)I
 	public static synthetic fun deleteIgnoreWhere$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)I
@@ -2949,11 +2949,14 @@ public class org/jetbrains/exposed/sql/statements/BatchUpdateStatement : org/jet
 }
 
 public class org/jetbrains/exposed/sql/statements/BatchUpsertStatement : org/jetbrains/exposed/sql/statements/BaseBatchInsertStatement {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Z)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/exposed/sql/Op;Z)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/exposed/sql/Op;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun arguments ()Ljava/lang/Iterable;
+	public fun arguments ()Ljava/util/List;
 	public final fun getKeys ()[Lorg/jetbrains/exposed/sql/Column;
 	public final fun getOnUpdate ()Ljava/util/List;
 	public final fun getOnUpdateExclude ()Ljava/util/List;
+	public final fun getWhere ()Lorg/jetbrains/exposed/sql/Op;
 	protected fun isColumnValuePreferredFromResultSet (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Z
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -43,16 +43,12 @@ open class BatchUpsertStatement(
     }
 
     override fun arguments(): List<Iterable<Pair<IColumnType<*>, Any?>>> {
-        return arguments?.map { args ->
-            val builder = QueryBuilder(true)
-            args.filter { (_, value) ->
-                value != DefaultValueMarker
-            }.forEach { (column, value) ->
-                builder.registerArgument(column, value)
-            }
-            where?.toQueryBuilder(builder)
-            builder.args
-        } ?: emptyList()
+        val whereArgs = QueryBuilder(true).apply {
+            where?.toQueryBuilder(this)
+        }.args
+        return super.arguments().map {
+            it + whereArgs
+        }
     }
 
     override fun isColumnValuePreferredFromResultSet(column: Column<*>, value: Any?): Boolean {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.exposed.sql.statements
 
-import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.Expression
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
 import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider
@@ -21,6 +18,7 @@ import org.jetbrains.exposed.sql.vendors.MysqlFunctionProvider
  * If left null, all columns will be updated with the values provided for the insert.
  * @param onUpdateExclude List of specific columns to exclude from updating.
  * If left null, all columns will be updated with the values provided for the insert.
+ * @param where Condition that determines which rows to update, if a unique violation is found. This clause may not be supported by all vendors.
  * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs) should be returned.
  * See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
  */
@@ -29,6 +27,7 @@ open class BatchUpsertStatement(
     vararg val keys: Column<*>,
     val onUpdate: List<Pair<Column<*>, Expression<*>>>?,
     val onUpdateExclude: List<Column<*>>?,
+    val where: Op<Boolean>?,
     shouldReturnGeneratedValues: Boolean = true
 ) : BaseBatchInsertStatement(table, ignore = false, shouldReturnGeneratedValues) {
 
@@ -40,7 +39,20 @@ open class BatchUpsertStatement(
             }
             else -> dialect.functionProvider
         }
-        return functionProvider.upsert(table, arguments!!.first(), onUpdate, onUpdateExclude, null, transaction, keys = keys)
+        return functionProvider.upsert(table, arguments!!.first(), onUpdate, onUpdateExclude, where, transaction, keys = keys)
+    }
+
+    override fun arguments(): List<Iterable<Pair<IColumnType<*>, Any?>>> {
+        return arguments?.map { args ->
+            val builder = QueryBuilder(true)
+            args.filter { (_, value) ->
+                value != DefaultValueMarker
+            }.forEach { (column, value) ->
+                builder.registerArgument(column, value)
+            }
+            where?.toQueryBuilder(builder)
+            builder.args
+        } ?: emptyList()
     }
 
     override fun isColumnValuePreferredFromResultSet(column: Column<*>, value: Any?): Boolean {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -37,16 +37,12 @@ open class UpsertStatement<Key : Any>(
     }
 
     override fun arguments(): List<Iterable<Pair<IColumnType<*>, Any?>>> {
-        return arguments?.map { args ->
-            val builder = QueryBuilder(true)
-            args.filter { (_, value) ->
-                value != DefaultValueMarker
-            }.forEach { (column, value) ->
-                builder.registerArgument(column, value)
-            }
-            where?.toQueryBuilder(builder)
-            builder.args
-        } ?: emptyList()
+        val whereArgs = QueryBuilder(true).apply {
+            where?.toQueryBuilder(this)
+        }.args
+        return super.arguments().map {
+            it + whereArgs
+        }
     }
 
     override fun isColumnValuePreferredFromResultSet(column: Column<*>, value: Any?): Boolean {

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class JsonBColumnTests : DatabaseTestsBase() {
-    private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE) + TestDB.ALL_H2_V1
+    private val binaryJsonNotSupportedDB = TestDB.ALL_H2_V1 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE
 
     @Test
     fun testInsertAndSelect() {
@@ -55,7 +55,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWithSliceExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, user1, data1, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, user1, data1, _ ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
             val isActive = tester.jsonBColumn.extract<Boolean>("${pathPrefix}active", toScalar = false)
             val result1 = tester.select(isActive).singleOrNull()
@@ -74,7 +74,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWhereWithExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, data1, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, data1, _ ->
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(logins = 1000)
             }
@@ -112,7 +112,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
             assertEquals(updatedUser, dataEntity.all().single().jsonBColumn)
 
-            if (testDb !in TestDB.ALL_H2) {
+            if (testDb !in TestDB.ALL_H2_V2) {
                 dataEntity.new { jsonBColumn = dataA }
                 val loginCount = if (currentDialectTest is PostgreSQLDialect) {
                     dataTable.jsonBColumn.extract<Int>("logins").castTo(IntegerColumnType())
@@ -127,7 +127,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonContains() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, user1, data1, testDb ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, user1, data1, testDb ->
             val alphaTeamUser = user1.copy(team = "Alpha")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(user = alphaTeamUser)
@@ -151,7 +151,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExists() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, data1, testDb ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, data1, testDb ->
             val maximumLogins = 1000
             val teamA = "A"
             val newId = tester.insertAndGetId {
@@ -187,7 +187,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExtractWithArrays() {
-        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, singleId, _, _ ->
+        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, singleId, _, _ ->
             val path1 = if (currentDialectTest is PostgreSQLDialect) {
                 arrayOf("users", "0", "team")
             } else {
@@ -205,7 +205,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonContainsWithArrays() {
-        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, tripleId, testDb ->
+        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, tripleId, testDb ->
             val hasSmallNumbers = tester.numbers.contains("[3, 5]")
             assertEquals(tripleId, tester.selectAll().where { hasSmallNumbers }.single()[tester.id])
 
@@ -218,7 +218,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExistsWithArrays() {
-        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, tripleId, testDb ->
+        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, tripleId, testDb ->
             val optional = if (testDb in TestDB.ALL_MYSQL_LIKE) "one" else null
 
             val hasMultipleUsers = tester.groups.exists(".users[1]", optional = optional)
@@ -237,7 +237,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
             val user2 = jsonb<User>("user_2", Json.Default).clientDefault { defaultUser }
         }
 
-        withDb(excludeSettings = binaryJsonNotSupportedDB) { testDb ->
+        withDb(excludeSettings = binaryJsonNotSupportedDB) {
             if (isOldMySql()) {
                 expectException<UnsupportedByDialectException> {
                     SchemaUtils.createMissingTablesAndColumns(defaultTester)
@@ -274,7 +274,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
             val intArray = jsonb<IntArray>("int_array", Json.Default)
         }
 
-        withTables(excludeSettings = binaryJsonNotSupportedDB, iterables) { testDb ->
+        withTables(excludeSettings = binaryJsonNotSupportedDB, iterables) {
             // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
             addLogger(StdOutSqlLogger)
 
@@ -303,7 +303,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
             val user = jsonb<User>("user", Json.Default).nullable()
         }
 
-        withTables(excludeSettings = binaryJsonNotSupportedDB, tester) { testDb ->
+        withTables(excludeSettings = binaryJsonNotSupportedDB, tester) {
             val nullId = tester.insertAndGetId {
                 it[user] = null
             }
@@ -321,7 +321,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonBWithUpsert() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, _, db ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, _, _ ->
             val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = newData

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -101,7 +101,7 @@ class JsonColumnTests : DatabaseTestsBase() {
     fun testWithNonSerializableClass() {
         data class Fake(val number: Int)
 
-        withDb { testDb ->
+        withDb {
             expectException<SerializationException> {
                 // Throws with message: Serializer for class 'Fake' is not found.
                 // Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
@@ -305,7 +305,7 @@ class JsonColumnTests : DatabaseTestsBase() {
             val user2 = json<User>("user_2", Json.Default).clientDefault { defaultUser }
         }
 
-        withDb { testDb ->
+        withDb {
             if (isOldMySql()) {
                 expectException<UnsupportedByDialectException> {
                     SchemaUtils.createMissingTablesAndColumns(defaultTester)
@@ -342,7 +342,7 @@ class JsonColumnTests : DatabaseTestsBase() {
             val intArray = json<IntArray>("int_array", Json.Default)
         }
 
-        withTables(iterables) { testDb ->
+        withTables(iterables) {
             // the logger is left in to test that it does not throw ClassCastException on insertion of iterables
             addLogger(StdOutSqlLogger)
 
@@ -371,7 +371,7 @@ class JsonColumnTests : DatabaseTestsBase() {
             val user = json<User>("user", Json.Default).nullable()
         }
 
-        withTables(tester) { testDb ->
+        withTables(tester) {
             val nullId = tester.insertAndGetId {
                 it[user] = null
             }
@@ -389,7 +389,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonWithUpsert() {
-        withJsonTable(exclude = TestDB.ALL_H2_V1) { tester, _, _, db ->
+        withJsonTable(exclude = TestDB.ALL_H2_V1) { tester, _, _, _ ->
             val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
             val newId = tester.insertAndGetId {
                 it[jsonColumn] = newData

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ExplainTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ExplainTests.kt
@@ -15,7 +15,7 @@ import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Test
 
 class ExplainTests : DatabaseTestsBase() {
-    private val explainUnsupportedDb = listOf(TestDB.SQLSERVER, TestDB.H2_V2_SQLSERVER, TestDB.ORACLE, TestDB.H2_V2_ORACLE)
+    private val explainUnsupportedDb = TestDB.ALL_SQLSERVER_LIKE + TestDB.ALL_ORACLE_LIKE
 
     private object Countries : IntIdTable("countries") {
         val code = varchar("country_code", 8)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
@@ -23,7 +23,7 @@ class ReturningTests : DatabaseTestsBase() {
 
     @Test
     fun testInsertReturning() {
-        withTables(TestDB.enabledDialects() - returningSupportedDb, Items) {
+        withTables(TestDB.ALL - returningSupportedDb, Items) {
             // return all columns by default
             val result1 = Items.insertReturning {
                 it[name] = "A"
@@ -50,7 +50,7 @@ class ReturningTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertReturning() {
-        withTables(TestDB.enabledDialects() - returningSupportedDb, Items) {
+        withTables(TestDB.ALL - returningSupportedDb, Items) {
             // return all columns by default
             val result1 = Items.upsertReturning {
                 it[name] = "A"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
@@ -22,11 +22,9 @@ import kotlin.properties.Delegates
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
-// Upsert implementation does not support H2 version 1
-// https://youtrack.jetbrains.com/issue/EXPOSED-30/Phase-Out-Support-for-H2-Version-1.x
 class UpsertTests : DatabaseTestsBase() {
     // these DB require key columns from ON clause to be included in the derived source table (USING clause)
-    private val upsertViaMergeDB = listOf(TestDB.SQLSERVER, TestDB.ORACLE) + TestDB.ALL_H2
+    private val upsertViaMergeDB = TestDB.ALL_H2 + TestDB.SQLSERVER + TestDB.ORACLE
 
     @Test
     fun testUpsertWithPKConflict() {
@@ -60,7 +58,7 @@ class UpsertTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(idA, idB)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) { testDb ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
             val insertStmt = tester.insert {
                 it[idA] = 1
                 it[idB] = 1
@@ -129,7 +127,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertWithUniqueIndexConflict() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) { testDb ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
             val wordA = Words.upsert {
                 it[word] = "A"
                 it[count] = 10
@@ -203,7 +201,7 @@ class UpsertTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(id)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) { testDb ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
             val uuid1 = tester.upsert {
                 it[title] = "A"
             } get tester.id
@@ -244,7 +242,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertWithManualUpdateAssignment() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) { testDb ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
             val testWord = "Test"
             val incrementCount = listOf(Words.count to Words.count.plus(1))
 
@@ -267,7 +265,7 @@ class UpsertTests : DatabaseTestsBase() {
             val losses = integer("losses").default(100)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) { testDb ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
             val itemA = tester.upsert {
                 it[item] = "Item A"
             } get tester.item
@@ -554,7 +552,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testBatchUpsertWithWhere() {
-        withTables(excludeSettings = TestDB.mySqlRelatedDB + upsertViaMergeDB, Words) {
+        withTables(excludeSettings = TestDB.ALL_MYSQL_LIKE + upsertViaMergeDB, Words) {
             val vowels = listOf("A", "E", "I", "O", "U")
             val alphabet = ('A'..'Z').map { it.toString() }
             val lettersWithDuplicates = alphabet + vowels
@@ -627,7 +625,7 @@ class UpsertTests : DatabaseTestsBase() {
 
         // At present, only Postgres returns the correct UUID directly from the result set.
         // For other databases incorrect ID is returned from the 'upsert' command.
-        withTables(excludeSettings = TestDB.entries - listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG), tester) { testDb ->
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES.toSet(), tester) {
             val insertId = tester.insertAndGetId {
                 it[key] = 1
                 it[value] = "one"
@@ -653,7 +651,7 @@ class UpsertTests : DatabaseTestsBase() {
             val value = text("test_value")
         }
 
-        withTables(excludeSettings = TestDB.entries - listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG), tester) {
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES.toSet(), tester) {
             val insertId = tester.insertAndGetId {
                 it[key] = 1
                 it[value] = "one"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -555,7 +555,7 @@ class EntityTests : DatabaseTestsBase() {
     @Test
     fun callLimitOnRelationDoesntMutateTheCachedValue() {
         withTables(Posts, Boards, Categories) {
-            addLogger(StdOutSqlLogger)
+            addLogger(StdOutSqlLogger) // this is left in on purpose for flaky tests
             val category1 = Category.new {
                 title = "cat1"
             }


### PR DESCRIPTION
- Add new `where` parameter to existing `batchUpsert()` and relevant overrides in `BatchUpsertStatement` class
- Update KDocs
- Remove duplicate KDocs from private functions