### PR TITLE
feat: Add time extension function for temporal expressions in Kotlin and Java

### DIFF
--- a/detekt/detekt-config.yml
+++ b/detekt/detekt-config.yml
@@ -58,7 +58,7 @@ complexity:
     TooManyFunctions:
         thresholdInClasses: 40
         thresholdInFiles: 100
-        thresholdInObjects: 27
+        thresholdInObjects: 28
         thresholdInInterfaces: 12
     CyclomaticComplexMethod:
         threshold: 26

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3786,6 +3786,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	public fun stdDevSamp (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun substring (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/String;)V
 	public static synthetic fun substring$default (Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;Ljava/lang/String;ILjava/lang/Object;)V
+	public fun time (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun update (Lorg/jetbrains/exposed/sql/Join;Ljava/util/List;Ljava/lang/Integer;Lorg/jetbrains/exposed/sql/Op;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun update (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/lang/Integer;Lorg/jetbrains/exposed/sql/Op;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun upsert (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/exposed/sql/Op;Lorg/jetbrains/exposed/sql/Transaction;[Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -183,6 +183,18 @@ abstract class FunctionProvider {
     }
 
     /**
+     * SQL function that extracts the time field from a given temporal expression.
+     *
+     * @param expr Expression to extract the year from.
+     * @param queryBuilder Query builder to append the SQL function to.
+     */
+    open fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) {
+        throw UnsupportedByDialectException(
+            "There's no generic SQL for TIME. There must be a vendor-specific implementation.", currentDialect
+        )
+    }
+
+    /**
      * SQL function that extracts the year field from a given date.
      *
      * @param expr Expression to extract the year from.
@@ -829,7 +841,9 @@ abstract class FunctionProvider {
     }
 
     /** Appends optional parameters to an EXPLAIN query. */
-    protected open fun StringBuilder.appendOptionsToExplain(options: String) { append("$options ") }
+    protected open fun StringBuilder.appendOptionsToExplain(options: String) {
+        append("$options ")
+    }
 
     /**
      * Returns the SQL command that performs an insert, update, or delete, and also returns data from any modified rows.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -136,6 +136,10 @@ internal object H2FunctionProvider : FunctionProvider() {
     override fun <T> date(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("CAST(", expr, " AS DATE)")
     }
+
+    override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("FORMATDATETIME(", expr, ", 'HH:mm:ss.SSSSSSSSS')")
+    }
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -271,6 +271,10 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
             toString()
         }
     }
+
+    override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("SUBSTRING_INDEX(", expr, ", ' ', -1)")
+    }
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -135,6 +135,10 @@ internal object OracleFunctionProvider : FunctionProvider() {
         append("CAST(", expr, " AS DATE)")
     }
 
+    override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("('1970-01-01 ' || TO_CHAR(", expr, ", 'HH24:MI:SS.FF6'))")
+    }
+
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("Extract(YEAR FROM ")
         append(expr)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -101,6 +101,10 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         append("CAST(", expr, " AS DATE)")
     }
 
+    override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("TO_CHAR(", expr, ", 'HH24:MI:SS.US')")
+    }
+
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("Extract(YEAR FROM ")
         append(expr)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -119,6 +119,10 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         append("CAST(", expr, " AS DATE)")
     }
 
+    override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("SUBSTRING(CONVERT(NVARCHAR, ", expr, ", 121), 12, 15)")
+    }
+
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("DATEPART(YEAR, ", expr, ")")
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -72,6 +72,10 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ): Unit = TransactionManager.current().throwUnsupportedException("SQLite doesn't provide built in REGEXP expression, use LIKE instead.")
 
+    override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
+        append("SUBSTR(", expr, ", INSTR(", expr, ", ' ') + 1, LENGTH(", expr, ") - INSTR(", expr, ", ' ') - 1)")
+    }
+
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("STRFTIME('%Y',")
         append(expr)

--- a/exposed-java-time/api/exposed-java-time.api
+++ b/exposed-java-time/api/exposed-java-time.api
@@ -66,6 +66,7 @@ public final class org/jetbrains/exposed/sql/javatime/JavaDateFunctionsKt {
 	public static final fun minute (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/javatime/Minute;
 	public static final fun month (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/javatime/Month;
 	public static final fun second (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/javatime/Second;
+	public static final fun time (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/javatime/Time;
 	public static final fun timeLiteral (Ljava/time/LocalTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun timeParam (Ljava/time/LocalTime;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun timestampLiteral (Ljava/time/Instant;)Lorg/jetbrains/exposed/sql/LiteralOp;

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -100,9 +100,14 @@ private val MYSQL_FRACTION_OFFSET_DATE_TIME_AS_DEFAULT_FORMATTER by lazy {
     ).withZone(ZoneId.of("UTC"))
 }
 
-private fun formatterForDateString(date: String) = dateTimeWithFractionFormat(date.substringAfterLast('.', "").length)
-private fun dateTimeWithFractionFormat(fraction: Int): DateTimeFormatter {
-    val baseFormat = "yyyy-MM-d HH:mm:ss"
+private fun formatterForDateString(date: String) = dateTimeWithFractionFormat(
+    date,
+    date.substringAfterLast('.', "").length
+)
+
+private fun dateTimeWithFractionFormat(date: String, fraction: Int): DateTimeFormatter {
+    val containsDatePart = date.contains("T") || date.contains(" ")
+    val baseFormat = if (containsDatePart) "yyyy-MM-dd HH:mm:ss" else "HH:mm:ss"
     val newFormat = if (fraction in 1..9) {
         (1..fraction).joinToString(prefix = "$baseFormat.", separator = "") { "S" }
     } else {

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.jodatime.*
 import org.jetbrains.exposed.sql.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.sql.statements.BatchInsertStatement
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.constraintNamePart
 import org.jetbrains.exposed.sql.tests.currentDialectTest
@@ -32,7 +33,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class JodaTimeDefaultsTest : JodaTimeBaseTest() {
+class JodaTimeDefaultsTest : DatabaseTestsBase() {
     object TableWithDBDefault : IntIdTable() {
         var cIndex = 0
         val field = varchar("field", 100)

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeMiscTableTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeMiscTableTest.kt
@@ -5,6 +5,7 @@ package org.jetbrains.exposed
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.jodatime.date
 import org.jetbrains.exposed.sql.jodatime.datetime
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.MiscTable
 import org.jetbrains.exposed.sql.tests.shared.checkInsert
@@ -23,7 +24,7 @@ object Misc : MiscTable() {
     val tn = datetime("tn").nullable()
 }
 
-class JodaTimeMiscTableTest : JodaTimeBaseTest() {
+class JodaTimeMiscTableTest : DatabaseTestsBase() {
     @Test
     fun testInsert01() {
         val tbl = Misc

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -30,7 +30,7 @@ import org.joda.time.DateTimeZone
 import org.junit.Test
 import kotlin.test.assertEquals
 
-open class JodaTimeBaseTest : DatabaseTestsBase() {
+class JodaTimeTests : DatabaseTestsBase() {
     init {
         DateTimeZone.setDefault(DateTimeZone.UTC)
     }

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -48,6 +48,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions
 	public static final fun InstantMonthFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun InstantSecondExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun InstantSecondFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
+	public static final fun InstantTimeExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun InstantTimeFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun InstantYearExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun InstantYearFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
@@ -67,6 +68,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions
 	public static final fun LocalDateTimeDateFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeDayExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeDayFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
+	public static final fun LocalDateTimeExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeHourExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeHourFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
@@ -76,6 +78,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions
 	public static final fun LocalDateTimeMonthFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeSecondExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeSecondFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
+	public static final fun LocalDateTimeTimeExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeTimeFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeYearExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun LocalDateTimeYearFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
@@ -93,6 +96,7 @@ public final class org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions
 	public static final fun OffsetDateTimeMonthFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun OffsetDateTimeSecondExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun OffsetDateTimeSecondFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
+	public static final fun OffsetDateTimeTimeExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun OffsetDateTimeTimeFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun OffsetDateTimeYearExt (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;
 	public static final fun OffsetDateTimeYearFunction (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Function;

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -107,9 +107,14 @@ private val MYSQL_OFFSET_DATE_TIME_AS_DEFAULT_FORMATTER by lazy {
     ).withZone(ZoneId.of("UTC"))
 }
 
-private fun formatterForDateString(date: String) = dateTimeWithFractionFormat(date.substringAfterLast('.', "").length)
-private fun dateTimeWithFractionFormat(fraction: Int): DateTimeFormatter {
-    val baseFormat = "yyyy-MM-d HH:mm:ss"
+private fun formatterForDateString(date: String) = dateTimeWithFractionFormat(
+    date,
+    date.substringAfterLast('.', "").length
+)
+
+private fun dateTimeWithFractionFormat(date: String, fraction: Int): DateTimeFormatter {
+    val containsDatePart = date.contains("T") || date.contains(" ")
+    val baseFormat = if (containsDatePart) "yyyy-MM-dd HH:mm:ss" else "HH:mm:ss"
     val newFormat = if (fraction in 1..9) {
         (1..fraction).joinToString(prefix = "$baseFormat.", separator = "") { "S" }
     } else {


### PR DESCRIPTION
- Added `time` extension functions for temporal expressions in Kotlin and Java.
- Modified `Time` function to make it work for all database dialects.
- Modified `JodaTimeMiscTableTest` and `JodaTimeDefaultsTest` to extend `DatabaseTestsBase` instead of `JodaTimeBaseTest` to match the way it is in the Kotlin and Java tests.
- H2 V1 is excluded from the tests because of a bug in the driver that messes up the fractional seconds.

I'm planning to add more tests to cover more types in later pull requests.