### PR TITLE
test: EXPOSED-249 Add MySQL8 to tests for AllAnyFromBaseOp feature

### DIFF
--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
@@ -143,10 +143,10 @@ enum class TestDB(
 
         fun enabledDialects(): Set<TestDB> {
             if (TEST_DIALECTS.isEmpty()) {
-                return values().toSet()
+                return entries.toSet()
             }
 
-            return values().filterTo(enumSetOf()) { it.name in TEST_DIALECTS }
+            return entries.filterTo(enumSetOf()) { it.name in TEST_DIALECTS }
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -270,7 +270,7 @@ class SelectTests : DatabaseTestsBase() {
         }
     }
 
-    private val testDBsSupportingInAnyAllFromTables = TestDB.ALL_POSTGRES + TestDB.ALL_H2
+    private val testDBsSupportingInAnyAllFromTables = TestDB.ALL_POSTGRES + TestDB.ALL_H2 + TestDB.MYSQL_V8
 
     @Test
     fun testInTable() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -32,7 +32,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testCreateAndDropArrayColumns() {
-        withDb(excludeSettings = arrayTypeUnsupportedDb) { db ->
+        withDb(excludeSettings = arrayTypeUnsupportedDb) {
             try {
                 SchemaUtils.create(ArrayTestTable)
                 assertTrue(ArrayTestTable.exists())
@@ -219,7 +219,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testArrayColumnUpdate() {
-        withTestTableAndExcludeSettings { db ->
+        withTestTableAndExcludeSettings {
             val id1 = ArrayTestTable.insertAndGetId {
                 it[doubles] = null
             }


### PR DESCRIPTION
MySQL8 was previously excluded from all tests for the following recently added functions:
- `anyFrom()` - only for Table variant, as MySQL does not support ARRAY
- `allFrom()` - only for Table variant, as MySQL does not support ARRAY
- `inTable`
- `notInTable`

These syntax are not supported by earlier version or MariaDB.