### PR TITLE
feat: EXPOSED-416 Support adding special database-specific column definitions

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2445,6 +2445,7 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public final fun uuid (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun varchar (Ljava/lang/String;ILjava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun varchar$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun withDefinition (Lorg/jetbrains/exposed/sql/Column;[Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/sql/Table$Dual : org/jetbrains/exposed/sql/Table {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -17,6 +17,7 @@ class Alias<out T : Table>(val delegate: T, val alias: String) : Table() {
         it.dbDefaultValue = dbDefaultValue
         it.isDatabaseGenerated = isDatabaseGenerated
         it.foreignKey = foreignKey
+        it.extraDefinitions = extraDefinitions
     }
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -46,6 +46,8 @@ class Column<T>(
     /** Returns whether this column's value will be generated in the database. */
     fun isDatabaseGenerated() = isDatabaseGenerated
 
+    internal var extraDefinitions = mutableListOf<Any>()
+
     /** Appends the SQL representation of this column to the specified [queryBuilder]. */
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = TransactionManager.current().fullIdentity(this@Column, queryBuilder)
 
@@ -141,6 +143,10 @@ class Column<T>(
             }
         }
 
+        if (extraDefinitions.isNotEmpty()) {
+            append(extraDefinitions.joinToString(separator = " ", prefix = " ") { "$it" })
+        }
+
         if (columnType.nullable || (defaultValue != null && defaultValueFun == null && !currentDialect.isAllowedAsColumnDefault(defaultValue))) {
             append(" NULL")
         } else if (!isPKColumn || (currentDialect is SQLiteDialect && !isSQLiteAutoIncColumn)) {
@@ -164,6 +170,7 @@ class Column<T>(
         it.defaultValueFun = this.defaultValueFun
         it.dbDefaultValue = this.dbDefaultValue
         it.isDatabaseGenerated = this.isDatabaseGenerated
+        it.extraDefinitions = this.extraDefinitions
     }
 
     override fun compareTo(other: Column<*>): Int = comparator.compare(this, other)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnDefinitionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnDefinitionTests.kt
@@ -1,0 +1,195 @@
+package org.jetbrains.exposed.sql.tests.shared.ddl
+
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.statements.StatementType
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertFalse
+import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.junit.Test
+import java.sql.SQLException
+import kotlin.test.assertContains
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ColumnDefinitionTests : DatabaseTestsBase() {
+    @Test
+    fun testColumnComment() {
+        val comment = "Amount of testers"
+        val tester = object : Table("tester") {
+            val amount = integer("amount").withDefinition("COMMENT", stringLiteral(comment))
+        }
+
+        val columnCommentSupportedDB = TestDB.ALL_H2.toSet() + TestDB.ALL_MYSQL_MARIADB + TestDB.SQLITE
+
+        withTables(excludeSettings = TestDB.ALL - columnCommentSupportedDB, tester) { testDb ->
+            assertTrue { SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
+
+            tester.insert { it[amount] = 9 }
+            assertEquals(9, tester.selectAll().single()[tester.amount])
+
+            val tableName = tester.nameInDatabaseCase()
+            val showStatement = when (testDb) {
+                in TestDB.ALL_MYSQL_MARIADB -> "SHOW FULL COLUMNS FROM $tableName"
+                TestDB.SQLITE -> "PRAGMA table_info($tableName)"
+                else -> "SELECT REMARKS FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '$tableName'"
+            }
+            val resultLabel = when (testDb) {
+                in TestDB.ALL_MYSQL_MARIADB -> "Comment"
+                TestDB.SQLITE -> "type"
+                else -> "REMARKS"
+            }
+
+            val result = exec(showStatement) { rs ->
+                rs.next()
+                rs.getString(resultLabel)
+            }
+            assertNotNull(result)
+            assertContains(result, comment)
+        }
+    }
+
+    @Test
+    fun testColumnDataMasking() {
+        val tester = object : Table("tester") {
+            val email = varchar("email", 128).uniqueIndex().withDefinition("MASKED WITH (FUNCTION = 'email()')")
+        }
+
+        withTables(TestDB.ALL - TestDB.SQLSERVER, tester) {
+            assertTrue { SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
+
+            val testEmail = "mysecretemail123@gmail.com"
+            tester.insert {
+                it[email] = testEmail
+            }
+
+            // create a new user with limited permissions
+            exec("CREATE USER MaskingTestUser WITHOUT LOGIN;")
+            exec("GRANT SELECT ON ${tester.nameInDatabaseCase()} TO MaskingTestUser;")
+            exec("EXECUTE AS USER = 'MaskingTestUser';", explicitStatementType = StatementType.OTHER)
+
+            // Email function obfuscates data of all length to form 'aXXX@XXXX.com', where 'a' is original first letter
+            val maskedEmail = "${testEmail.first()}XXX@XXXX.com"
+            val maskedResult = tester.selectAll().single()[tester.email]
+            assertEquals(maskedEmail, maskedResult)
+
+            exec("REVERT;")
+            exec("DROP USER MaskingTestUser;")
+        }
+    }
+
+    @Test
+    fun testColumnDefaultOnNull() {
+        val itemA = "Item A"
+        val tester = object : Table("tester") {
+            val amount = integer("amount")
+            var item: Column<String> = varchar("item", 32)
+
+            fun initItemColumn() {
+                (columns as MutableList<Column<*>>).remove(item)
+                item = if (currentDialectTest is H2Dialect) {
+                    varchar("item", 32).default(itemA).withDefinition("DEFAULT ON NULL")
+                } else {
+                    varchar("item", 32).withDefinition("DEFAULT ON NULL", stringLiteral(itemA))
+                }
+            }
+        }
+
+        withDb(TestDB.ALL_H2_V2 + TestDB.ORACLE) { testDb ->
+            tester.initItemColumn()
+            SchemaUtils.create(tester)
+
+            if (testDb != TestDB.ORACLE) {
+                // Oracle would not work with this use case as special DEFAULT syntax is not registered & causes mismatch
+                assertTrue { SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
+            }
+
+            tester.insert {
+                it[amount] = 111
+            }
+
+            exec(
+                """
+                    INSERT INTO ${tester.nameInDatabaseCase()}
+                    (${tester.amount.nameInDatabaseCase()}, ${tester.item.nameInDatabaseCase()})
+                    VALUES (222, null)
+                """.trimIndent()
+            )
+
+            val result1 = tester.selectAll().map { it[tester.item] }.distinct().single()
+            assertEquals(itemA, result1)
+
+            // when Docker image is updated to Oracle23+, this can be removed to test update as well
+            if (testDb != TestDB.ORACLE) {
+                tester.insert {
+                    it[amount] = 333
+                    it[item] = "Item B"
+                }
+
+                exec(
+                    """
+                        UPDATE ${tester.nameInDatabaseCase()}
+                        SET ${tester.amount.nameInDatabaseCase()} = 999,
+                        ${tester.item.nameInDatabaseCase()} = null
+                    """.trimIndent()
+                )
+
+                val (singleAmount, singleItem) = tester.selectAll().map {
+                    it[tester.amount] to it[tester.item]
+                }.distinct().single()
+                assertEquals(999, singleAmount)
+                assertEquals(itemA, singleItem)
+            }
+
+            SchemaUtils.drop(tester)
+        }
+    }
+
+    @Test
+    fun testColumnVisibility() {
+        val tester = object : Table("tester") {
+            val amount = integer("amount")
+            val active = bool("active").nullable().withDefinition("INVISIBLE")
+        }
+
+        // this Query uses SELECT * FROM instead of the usual SELECT column_1, column_2, ... FROM
+        class ImplicitQuery(set: FieldSet, where: Op<Boolean>?) : Query(set, where) {
+            override fun prepareSQL(builder: QueryBuilder): String {
+                return super.prepareSQL(builder).replaceBefore(" FROM ", "SELECT *")
+            }
+        }
+        fun FieldSet.selectImplicitAll(): Query = ImplicitQuery(this, null)
+
+        val invisibilitySupportedDB = TestDB.ALL_H2.toSet() + TestDB.ALL_MARIADB + TestDB.MYSQL_V8 + TestDB.ORACLE
+
+        withTables(excludeSettings = TestDB.ALL - invisibilitySupportedDB, tester) { testDb ->
+            if (testDb == TestDB.MYSQL_V8 || testDb == TestDB.ORACLE) {
+                // H2 metadata query does not return invisible column info
+                // Bug in MariaDB with nullable column - metadata default value returns as NULL - EXPOSED-415
+                assertTrue { SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
+            }
+
+            tester.insert {
+                it[amount] = 999
+            }
+
+            // an invisible column is only returned in ResultSet if explicitly named
+            val result1 = tester.selectAll().where { tester.amount greater 100 }.execute(this)
+            assertNotNull(result1)
+            result1.next()
+            assertEquals(999, result1.getInt(tester.amount.name))
+            assertFalse(result1.getBoolean(tester.active.name))
+            result1.close()
+
+            val result2 = tester.selectImplicitAll().where { tester.amount greater 100 }.execute(this)
+            assertNotNull(result2)
+            result2.next()
+            assertEquals(999, result2.getInt(tester.amount.name))
+            expectException<SQLException> { result2.getBoolean(tester.active.name) }
+            result2.close()
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnDefinitionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnDefinitionTests.kt
@@ -4,11 +4,9 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
-import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertFalse
 import org.jetbrains.exposed.sql.tests.shared.expectException
-import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.junit.Test
 import java.sql.SQLException
 import kotlin.test.assertContains

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -11,7 +11,6 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.statements.BatchInsertStatement
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
-import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.currentTestDB
 import org.jetbrains.exposed.sql.tests.inProperCase
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
@@ -21,8 +20,6 @@ import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.entities.EntityTests
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
-import org.jetbrains.exposed.sql.vendors.H2Dialect
-import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.junit.Assume
 import org.junit.Test
 import java.sql.SQLException


### PR DESCRIPTION
Column definition in `CREATE TABLE` DDL currently covers the following:
_column_name column_type column_default null_constraint key_constraint_

There are some very niched database-specific keywords or syntax that can be appended to a column definition, which are not available to the user unless introduced by feature requests. Some of these would just require hard-coding the additional feature in `Column` class for the specific database.

This proposal attempts to give user's the ability to customize column definitions that fit the following criteria:

1. It is very database-specific, but low priority.
2. It does not affect any further logic, like column insert/update values, prepared statement, etc.
3. It fits standard ordering rule shared by most databases, i.e. it follows _column_name column_type column_default_ but comes before any constraints.

***

This will not solve all use cases, but gives user's access to the following example features:

**MySQL:**  `ON UPDATE CURRENT_TIMESTAMP`
_Specifies default value when row is updated_
```kt
object : Table("tester") {
    val created = timestamp("created")
        .defaultExpression(CurrentTimestamp)
        .withDefinition("ON UPDATE", CurrentTimestamp)
}

// generates SQL:
// CREATE TABLE IF NOT EXISTS tester (created DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) NOT NULL)
```

***

**Oracle:**  `DEFAULT ON NULL` (also H2)
_Specifies default value when row is inserted (or updated) with null value_
```kt
object : Table("tester") {
    val item = varchar("item", 32).withDefinition("DEFAULT ON NULL", stringLiteral("Item A"))
}

// generates SQL:
// CREATE TABLE TESTER (ITEM VARCHAR2(32 CHAR) DEFAULT ON NULL 'Item A' NOT NULL)
```

***

**SQL Server:**  `MASKED WITH`
_Masks data returned by SELECT statements for users without proper permissions_
```kt
object : Table("tester") {
    val email = varchar("email", 128)
        .uniqueIndex()
        .withDefinition("MASKED WITH (FUNCTION = 'email()')")
}

// generates SQL:
// CREATE TABLE tester (email VARCHAR(128) MASKED WITH (FUNCTION = 'email()') NOT NULL)
```

***

**MySQL:**  `COMMENT` (also H2, SQLite)
_Adds comment to column only_
```kt
object : Table("tester") {
    val amount = integer("amount").withDefinition("COMMENT", stringLiteral("Amount of testers"))
}

// generates SQL:
// CREATE TABLE IF NOT EXISTS tester (amount INT COMMENT 'Amount of testers' NOT NULL)
```

***

**MySQL:**  `INVISIBLE` (also H2, Oracle)
_Sets a column's visibility to hidden (so it's not available unless named)_
```kt
object : Table("tester") {
    val active = bool("active").nullable().withDefinition("INVISIBLE")
}

// generates SQL:
// CREATE TABLE IF NOT EXISTS tester (active BOOLEAN INVISIBLE NULL)
```

***

**PostgreSQL**  `GENERATED ALWAYS AS (...)` (supported by all DB actually)
_Creates a generated column on database-side based on provided computation_
```kt
object : Table("tester") {
    val amount = integer("amount").nullable()
    val computedAmount = integer("computed_amount")
        .nullable()
        .databaseGenerated()
        .withDefinition("GENERATED ALWAYS AS (AMOUNT + 1) STORED")
}

// generates SQL:
// CREATE TABLE IF NOT EXISTS tester (
//     amount INT NULL,
//     computed_amount INT GENERATED ALWAYS AS (AMOUNT + 1) STORED NULL
// )
```

***

The ordering rule works if either a foreign key or check constraint is chained to the column, because these are implemented as generated SQL following the `CONSTRAINT` keyword, which is separate from the column definition clause itself.
