### PR TITLE
fix: EXPOSED-412 Remove all the usage of isOldMySql function in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,7 @@ subprojects {
         }
     }
 
-    testDb("mysql") {
+    testDb("mysql5") {
         port = 3001
         dialects("MYSQL_V5")
         dependencies {

--- a/buildScripts/docker/docker-compose-mysql5.yml
+++ b/buildScripts/docker/docker-compose-mysql5.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 
 services:
-    mysql:
+    mysql5:
         platform: linux/x86_64
         restart: always
         image: mysql:5.7

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -416,44 +416,38 @@ class DefaultsTest : DatabaseTestsBase() {
             else -> "NULL"
         }
 
-        withDb(excludeSettings = listOf(TestDB.SQLITE, TestDB.MARIADB)) {
-            if (!isOldMySql()) {
-                SchemaUtils.create(testTable)
+        withTables(excludeSettings = TestDB.ALL_MARIADB + TestDB.MYSQL_V5 + TestDB.SQLITE, testTable) {
+            val timestampWithTimeZoneType = currentDialectTest.dataTypeProvider.timestampWithTimeZoneType()
 
-                val timestampWithTimeZoneType = currentDialectTest.dataTypeProvider.timestampWithTimeZoneType()
+            val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
+                "${"t".inProperCase()} (" +
+                "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
+                "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
+                ")"
 
-                val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
-                    "${"t".inProperCase()} (" +
-                    "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
-                    "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
-                    ")"
-
-                val expected = if (currentDialectTest is OracleDialect ||
-                    currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
-                ) {
-                    arrayListOf(
-                        "CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
-                        baseExpression
-                    )
-                } else {
-                    arrayListOf(baseExpression)
-                }
-
-                assertEqualLists(expected, testTable.ddl)
-
-                val id1 = testTable.insertAndGetId { }
-
-                val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
-                assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
-                assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
-                val dbDefault = row1[testTable.t3]
-                assertEquals(dbDefault.offset, nowWithTimeZone.offset)
-                assertTrue { dbDefault.toLocalDateTime() >= nowWithTimeZone.toLocalDateTime() }
-
-                SchemaUtils.drop(testTable)
+            val expected = if (currentDialectTest is OracleDialect ||
+                currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+            ) {
+                arrayListOf(
+                    "CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                    baseExpression
+                )
+            } else {
+                arrayListOf(baseExpression)
             }
+
+            assertEqualLists(expected, testTable.ddl)
+
+            val id1 = testTable.insertAndGetId { }
+
+            val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
+            assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
+            assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+            val dbDefault = row1[testTable.t3]
+            assertEquals(dbDefault.offset, nowWithTimeZone.offset)
+            assertTrue { dbDefault.toLocalDateTime() >= nowWithTimeZone.toLocalDateTime() }
         }
     }
 
@@ -558,18 +552,10 @@ class DefaultsTest : DatabaseTestsBase() {
 
         // SQLite does not support ALTER TABLE on a column that has a default value
         // MariaDB does not support TIMESTAMP WITH TIME ZONE column type
-        val unsupportedDatabases = listOf(TestDB.SQLITE, TestDB.MARIADB)
-        withDb(excludeSettings = unsupportedDatabases) {
-            if (!isOldMySql()) {
-                try {
-                    SchemaUtils.drop(tester)
-                    SchemaUtils.create(tester)
-                    val statements = SchemaUtils.addMissingColumnsStatements(tester)
-                    assertEquals(0, statements.size)
-                } finally {
-                    SchemaUtils.drop(tester)
-                }
-            }
+        val unsupportedDatabases = TestDB.ALL_MARIADB + listOf(TestDB.SQLITE, TestDB.MYSQL_V5)
+        withTables(excludeSettings = unsupportedDatabases, tester) {
+            val statements = SchemaUtils.addMissingColumnsStatements(tester)
+            assertEquals(0, statements.size)
         }
     }
 }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -35,6 +35,8 @@ import kotlin.test.assertEquals
 
 open class JavaTimeBaseTest : DatabaseTestsBase() {
 
+    private val timestampWithTimeZoneUnsupportedDB = TestDB.ALL_MARIADB + TestDB.MYSQL_V5
+
     @Test
     fun javaTimeFunctions() {
         withTables(CitiesTime) {
@@ -363,82 +365,72 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withDb(excludeSettings = listOf(TestDB.MARIADB, TestDB.MYSQL_V8)) { testDB ->
-            if (!isOldMySql()) {
-                SchemaUtils.create(testTable)
+        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB, testTable) { testDB ->
+            // Cairo time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+            assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
 
-                // Cairo time zone
-                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
-                assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
+            val cairoNow = OffsetDateTime.now(ZoneId.systemDefault())
 
-                val cairoNow = OffsetDateTime.now(ZoneId.systemDefault())
-
-                val cairoId = testTable.insertAndGetId {
-                    it[timestampWithTimeZone] = cairoNow
-                }
-
-                val cairoNowInsertedInCairoTimeZone = testTable.selectAll().where { testTable.id eq cairoId }
-                    .single()[testTable.timestampWithTimeZone]
-
-                // UTC time zone
-                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
-                assertEquals("UTC", ZoneId.systemDefault().id)
-
-                val cairoNowRetrievedInUTCTimeZone = testTable.selectAll().where { testTable.id eq cairoId }
-                    .single()[testTable.timestampWithTimeZone]
-
-                val utcID = testTable.insertAndGetId {
-                    it[timestampWithTimeZone] = cairoNow
-                }
-
-                val cairoNowInsertedInUTCTimeZone = testTable.selectAll().where { testTable.id eq utcID }
-                    .single()[testTable.timestampWithTimeZone]
-
-                // Tokyo time zone
-                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Tokyo"))
-                assertEquals("Asia/Tokyo", ZoneId.systemDefault().id)
-
-                val cairoNowRetrievedInTokyoTimeZone = testTable.selectAll().where { testTable.id eq cairoId }
-                    .single()[testTable.timestampWithTimeZone]
-
-                val tokyoID = testTable.insertAndGetId {
-                    it[timestampWithTimeZone] = cairoNow
-                }
-
-                val cairoNowInsertedInTokyoTimeZone = testTable.selectAll().where { testTable.id eq tokyoID }
-                    .single()[testTable.timestampWithTimeZone]
-
-                // PostgreSQL and MySQL always store the timestamp in UTC, thereby losing the original time zone.
-                // To preserve the original time zone, store the time zone information in a separate column.
-                val isOriginalTimeZonePreserved = testDB !in listOf(
-                    TestDB.POSTGRESQL,
-                    TestDB.POSTGRESQLNG,
-                    TestDB.MYSQL_V5
-                )
-                if (isOriginalTimeZonePreserved) {
-                    // Assert that time zone is preserved when the same value is inserted in different time zones
-                    assertEqualDateTime(cairoNow, cairoNowInsertedInCairoTimeZone)
-                    assertEqualDateTime(cairoNow, cairoNowInsertedInUTCTimeZone)
-                    assertEqualDateTime(cairoNow, cairoNowInsertedInTokyoTimeZone)
-
-                    // Assert that time zone is preserved when the same record is retrieved in different time zones
-                    assertEqualDateTime(cairoNow, cairoNowRetrievedInUTCTimeZone)
-                    assertEqualDateTime(cairoNow, cairoNowRetrievedInTokyoTimeZone)
-                } else {
-                    // Assert equivalence in UTC when the same value is inserted in different time zones
-                    assertEqualDateTime(cairoNowInsertedInCairoTimeZone, cairoNowInsertedInUTCTimeZone)
-                    assertEqualDateTime(cairoNowInsertedInUTCTimeZone, cairoNowInsertedInTokyoTimeZone)
-
-                    // Assert equivalence in UTC when the same record is retrieved in different time zones
-                    assertEqualDateTime(cairoNowRetrievedInUTCTimeZone, cairoNowRetrievedInTokyoTimeZone)
-                }
-
-                // Reset to original time zone as set up in DatabaseTestsBase init block
-                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
-                assertEquals("UTC", ZoneId.systemDefault().id)
-
-                SchemaUtils.drop(testTable)
+            val cairoId = testTable.insertAndGetId {
+                it[timestampWithTimeZone] = cairoNow
             }
+
+            val cairoNowInsertedInCairoTimeZone = testTable.selectAll().where { testTable.id eq cairoId }
+                .single()[testTable.timestampWithTimeZone]
+
+            // UTC time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+            assertEquals("UTC", ZoneId.systemDefault().id)
+
+            val cairoNowRetrievedInUTCTimeZone = testTable.selectAll().where { testTable.id eq cairoId }
+                .single()[testTable.timestampWithTimeZone]
+
+            val utcID = testTable.insertAndGetId {
+                it[timestampWithTimeZone] = cairoNow
+            }
+
+            val cairoNowInsertedInUTCTimeZone = testTable.selectAll().where { testTable.id eq utcID }
+                .single()[testTable.timestampWithTimeZone]
+
+            // Tokyo time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Tokyo"))
+            assertEquals("Asia/Tokyo", ZoneId.systemDefault().id)
+
+            val cairoNowRetrievedInTokyoTimeZone = testTable.selectAll().where { testTable.id eq cairoId }
+                .single()[testTable.timestampWithTimeZone]
+
+            val tokyoID = testTable.insertAndGetId {
+                it[timestampWithTimeZone] = cairoNow
+            }
+
+            val cairoNowInsertedInTokyoTimeZone = testTable.selectAll().where { testTable.id eq tokyoID }
+                .single()[testTable.timestampWithTimeZone]
+
+            // PostgreSQL and MySQL always store the timestamp in UTC, thereby losing the original time zone.
+            // To preserve the original time zone, store the time zone information in a separate column.
+            val isOriginalTimeZonePreserved = testDB !in (TestDB.ALL_MYSQL + TestDB.ALL_POSTGRES)
+            if (isOriginalTimeZonePreserved) {
+                // Assert that time zone is preserved when the same value is inserted in different time zones
+                assertEqualDateTime(cairoNow, cairoNowInsertedInCairoTimeZone)
+                assertEqualDateTime(cairoNow, cairoNowInsertedInUTCTimeZone)
+                assertEqualDateTime(cairoNow, cairoNowInsertedInTokyoTimeZone)
+
+                // Assert that time zone is preserved when the same record is retrieved in different time zones
+                assertEqualDateTime(cairoNow, cairoNowRetrievedInUTCTimeZone)
+                assertEqualDateTime(cairoNow, cairoNowRetrievedInTokyoTimeZone)
+            } else {
+                // Assert equivalence in UTC when the same value is inserted in different time zones
+                assertEqualDateTime(cairoNowInsertedInCairoTimeZone, cairoNowInsertedInUTCTimeZone)
+                assertEqualDateTime(cairoNowInsertedInUTCTimeZone, cairoNowInsertedInTokyoTimeZone)
+
+                // Assert equivalence in UTC when the same record is retrieved in different time zones
+                assertEqualDateTime(cairoNowRetrievedInUTCTimeZone, cairoNowRetrievedInTokyoTimeZone)
+            }
+
+            // Reset to original time zone as set up in DatabaseTestsBase init block
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+            assertEquals("UTC", ZoneId.systemDefault().id)
         }
     }
 
@@ -448,7 +440,7 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withDb(db = listOf(TestDB.MYSQL_V5, TestDB.MARIADB)) { testDB ->
+        withDb(db = timestampWithTimeZoneUnsupportedDB) {
             expectException<UnsupportedByDialectException> {
                 SchemaUtils.create(testTable)
             }
@@ -461,58 +453,56 @@ open class JavaTimeBaseTest : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withDb(excludeSettings = listOf(TestDB.MARIADB)) {
-            if (!isOldMySql()) {
-                try {
-                    // UTC time zone
-                    java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
-                    assertEquals("UTC", ZoneId.systemDefault().id)
+        withDb(excludeSettings = timestampWithTimeZoneUnsupportedDB) {
+            try {
+                // UTC time zone
+                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+                assertEquals("UTC", ZoneId.systemDefault().id)
 
-                    SchemaUtils.create(testTable)
+                SchemaUtils.create(testTable)
 
-                    val now = OffsetDateTime.parse("2023-05-04T05:04:01.700+00:00")
-                    val nowId = testTable.insertAndGetId {
-                        it[timestampWithTimeZone] = now
-                    }
-
-                    assertEquals(
-                        now.toLocalDate(),
-                        testTable.select(testTable.timestampWithTimeZone.date()).where { testTable.id eq nowId }
-                            .single()[testTable.timestampWithTimeZone.date()]
-                    )
-
-                    assertEquals(
-                        now.month.value,
-                        testTable.select(testTable.timestampWithTimeZone.month()).where { testTable.id eq nowId }
-                            .single()[testTable.timestampWithTimeZone.month()]
-                    )
-
-                    assertEquals(
-                        now.dayOfMonth,
-                        testTable.select(testTable.timestampWithTimeZone.day()).where { testTable.id eq nowId }
-                            .single()[testTable.timestampWithTimeZone.day()]
-                    )
-
-                    assertEquals(
-                        now.hour,
-                        testTable.select(testTable.timestampWithTimeZone.hour()).where { testTable.id eq nowId }
-                            .single()[testTable.timestampWithTimeZone.hour()]
-                    )
-
-                    assertEquals(
-                        now.minute,
-                        testTable.select(testTable.timestampWithTimeZone.minute()).where { testTable.id eq nowId }
-                            .single()[testTable.timestampWithTimeZone.minute()]
-                    )
-
-                    assertEquals(
-                        now.second,
-                        testTable.select(testTable.timestampWithTimeZone.second()).where { testTable.id eq nowId }
-                            .single()[testTable.timestampWithTimeZone.second()]
-                    )
-                } finally {
-                    SchemaUtils.drop(testTable)
+                val now = OffsetDateTime.parse("2023-05-04T05:04:01.700+00:00")
+                val nowId = testTable.insertAndGetId {
+                    it[timestampWithTimeZone] = now
                 }
+
+                assertEquals(
+                    now.toLocalDate(),
+                    testTable.select(testTable.timestampWithTimeZone.date()).where { testTable.id eq nowId }
+                        .single()[testTable.timestampWithTimeZone.date()]
+                )
+
+                assertEquals(
+                    now.month.value,
+                    testTable.select(testTable.timestampWithTimeZone.month()).where { testTable.id eq nowId }
+                        .single()[testTable.timestampWithTimeZone.month()]
+                )
+
+                assertEquals(
+                    now.dayOfMonth,
+                    testTable.select(testTable.timestampWithTimeZone.day()).where { testTable.id eq nowId }
+                        .single()[testTable.timestampWithTimeZone.day()]
+                )
+
+                assertEquals(
+                    now.hour,
+                    testTable.select(testTable.timestampWithTimeZone.hour()).where { testTable.id eq nowId }
+                        .single()[testTable.timestampWithTimeZone.hour()]
+                )
+
+                assertEquals(
+                    now.minute,
+                    testTable.select(testTable.timestampWithTimeZone.minute()).where { testTable.id eq nowId }
+                        .single()[testTable.timestampWithTimeZone.minute()]
+                )
+
+                assertEquals(
+                    now.second,
+                    testTable.select(testTable.timestampWithTimeZone.second()).where { testTable.id eq nowId }
+                        .single()[testTable.timestampWithTimeZone.second()]
+                )
+            } finally {
+                SchemaUtils.drop(testTable)
             }
         }
     }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class JsonBColumnTests : DatabaseTestsBase() {
-    private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE, TestDB.MYSQL_V5)
+    private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)
 
     @Test
     fun testInsertAndSelect() {
@@ -238,7 +238,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
             val user2 = jsonb<User>("user_2", Json.Default).clientDefault { defaultUser }
         }
 
-        withDb { testDb ->
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) { testDb ->
             if (testDb in binaryJsonNotSupportedDB) {
                 expectException<UnsupportedByDialectException> {
                     SchemaUtils.createMissingTablesAndColumns(defaultTester)

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonBColumnTests.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class JsonBColumnTests : DatabaseTestsBase() {
-    private val binaryJsonNotSupportedDB = TestDB.ALL_H2_V1 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE
+    private val binaryJsonNotSupportedDB = listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE, TestDB.MYSQL_V5)
 
     @Test
     fun testInsertAndSelect() {
@@ -55,7 +55,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWithSliceExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, user1, data1, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, user1, data1, _ ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
             val isActive = tester.jsonBColumn.extract<Boolean>("${pathPrefix}active", toScalar = false)
             val result1 = tester.select(isActive).singleOrNull()
@@ -74,7 +74,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWhereWithExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, data1, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, data1, _ ->
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(logins = 1000)
             }
@@ -97,7 +97,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
         val dataTable = JsonTestsData.JsonBTable
         val dataEntity = JsonTestsData.JsonBEntity
 
-        withTables(excludeSettings = binaryJsonNotSupportedDB, dataTable) { testDb ->
+        withTables(excludeSettings = binaryJsonNotSupportedDB + TestDB.ALL_H2_V1, dataTable) { testDb ->
             val dataA = DataHolder(User("Admin", "Alpha"), 10, true, null)
             val newUser = dataEntity.new {
                 jsonBColumn = dataA
@@ -127,7 +127,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonContains() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, user1, data1, testDb ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, user1, data1, testDb ->
             val alphaTeamUser = user1.copy(team = "Alpha")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(user = alphaTeamUser)
@@ -151,7 +151,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExists() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, data1, testDb ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, data1, testDb ->
             val maximumLogins = 1000
             val teamA = "A"
             val newId = tester.insertAndGetId {
@@ -187,7 +187,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExtractWithArrays() {
-        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, singleId, _, _ ->
+        withJsonBArrays(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, singleId, _, testDb ->
             val path1 = if (currentDialectTest is PostgreSQLDialect) {
                 arrayOf("users", "0", "team")
             } else {
@@ -197,8 +197,9 @@ class JsonBColumnTests : DatabaseTestsBase() {
             assertEquals(singleId, tester.selectAll().where { firstIsOnTeamA }.single()[tester.id])
 
             // older MySQL and MariaDB versions require non-scalar extracted value from JSON Array
+            val toScalar = testDb != TestDB.MYSQL_V5
             val path2 = if (currentDialectTest is PostgreSQLDialect) "0" else "[0]"
-            val firstNumber = tester.numbers.extract<Int>(path2, toScalar = !isOldMySql())
+            val firstNumber = tester.numbers.extract<Int>(path2, toScalar = toScalar)
             assertEqualCollections(listOf(100, 3), tester.select(firstNumber).map { it[firstNumber] })
         }
     }
@@ -237,8 +238,8 @@ class JsonBColumnTests : DatabaseTestsBase() {
             val user2 = jsonb<User>("user_2", Json.Default).clientDefault { defaultUser }
         }
 
-        withDb(excludeSettings = binaryJsonNotSupportedDB) {
-            if (isOldMySql()) {
+        withDb { testDb ->
+            if (testDb in binaryJsonNotSupportedDB) {
                 expectException<UnsupportedByDialectException> {
                     SchemaUtils.createMissingTablesAndColumns(defaultTester)
                 }
@@ -321,7 +322,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonBWithUpsert() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, _, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V1) { tester, _, _, _ ->
             val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = newData

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonTestsData.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonTestsData.kt
@@ -45,7 +45,7 @@ object JsonTestsData {
 }
 
 fun DatabaseTestsBase.withJsonTable(
-    exclude: List<TestDB> = emptyList(),
+    exclude: Collection<TestDB> = emptyList(),
     statement: Transaction.(tester: JsonTestsData.JsonTable, user1: User, data1: DataHolder, testDb: TestDB) -> Unit
 ) {
     val tester = JsonTestsData.JsonTable
@@ -61,7 +61,7 @@ fun DatabaseTestsBase.withJsonTable(
 }
 
 fun DatabaseTestsBase.withJsonBTable(
-    exclude: List<TestDB> = emptyList(),
+    exclude: Collection<TestDB> = emptyList(),
     statement: Transaction.(tester: JsonTestsData.JsonBTable, user1: User, data1: DataHolder, testDb: TestDB) -> Unit
 ) {
     val tester = JsonTestsData.JsonBTable
@@ -77,7 +77,7 @@ fun DatabaseTestsBase.withJsonBTable(
 }
 
 fun DatabaseTestsBase.withJsonArrays(
-    exclude: List<TestDB> = emptyList(),
+    exclude: Collection<TestDB> = emptyList(),
     statement: Transaction.(
         tester: JsonTestsData.JsonArrays,
         singleId: EntityID<Int>,
@@ -102,7 +102,7 @@ fun DatabaseTestsBase.withJsonArrays(
 }
 
 fun DatabaseTestsBase.withJsonBArrays(
-    exclude: List<TestDB> = emptyList(),
+    exclude: Collection<TestDB> = emptyList(),
     statement: Transaction.(
         tester: JsonTestsData.JsonBArrays,
         singleId: EntityID<Int>,

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -420,44 +420,38 @@ class DefaultsTest : DatabaseTestsBase() {
             else -> "NULL"
         }
 
-        withDb(excludeSettings = listOf(TestDB.SQLITE, TestDB.MARIADB)) {
-            if (!isOldMySql()) {
-                SchemaUtils.create(testTable)
+        withTables(excludeSettings = TestDB.ALL_MARIADB + TestDB.SQLITE + TestDB.MYSQL_V5, testTable) {
+            val timestampWithTimeZoneType = currentDialectTest.dataTypeProvider.timestampWithTimeZoneType()
 
-                val timestampWithTimeZoneType = currentDialectTest.dataTypeProvider.timestampWithTimeZoneType()
+            val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
+                "${"t".inProperCase()} (" +
+                "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
+                "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
+                "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
+                ")"
 
-                val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
-                    "${"t".inProperCase()} (" +
-                    "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
-                    "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
-                    "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
-                    ")"
-
-                val expected = if (currentDialectTest is OracleDialect ||
-                    currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
-                ) {
-                    arrayListOf(
-                        "CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
-                        baseExpression
-                    )
-                } else {
-                    arrayListOf(baseExpression)
-                }
-
-                assertEqualLists(expected, testTable.ddl)
-
-                val id1 = testTable.insertAndGetId { }
-
-                val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
-                assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
-                assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
-                val dbDefault = row1[testTable.t3]
-                assertEquals(dbDefault.offset, nowWithTimeZone.offset)
-                assertTrue { dbDefault.toLocalDateTime().toKotlinLocalDateTime() >= nowWithTimeZone.toLocalDateTime().toKotlinLocalDateTime() }
-
-                SchemaUtils.drop(testTable)
+            val expected = if (currentDialectTest is OracleDialect ||
+                currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
+            ) {
+                arrayListOf(
+                    "CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                    baseExpression
+                )
+            } else {
+                arrayListOf(baseExpression)
             }
+
+            assertEqualLists(expected, testTable.ddl)
+
+            val id1 = testTable.insertAndGetId { }
+
+            val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
+            assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
+            assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+            val dbDefault = row1[testTable.t3]
+            assertEquals(dbDefault.offset, nowWithTimeZone.offset)
+            assertTrue { dbDefault.toLocalDateTime().toKotlinLocalDateTime() >= nowWithTimeZone.toLocalDateTime().toKotlinLocalDateTime() }
         }
     }
 
@@ -562,17 +556,15 @@ class DefaultsTest : DatabaseTestsBase() {
 
         // SQLite does not support ALTER TABLE on a column that has a default value
         // MariaDB does not support TIMESTAMP WITH TIME ZONE column type
-        val unsupportedDatabases = listOf(TestDB.SQLITE, TestDB.MARIADB)
+        val unsupportedDatabases = TestDB.ALL_MARIADB + TestDB.SQLITE + TestDB.MYSQL_V5
         withDb(excludeSettings = unsupportedDatabases) {
-            if (!isOldMySql()) {
-                try {
-                    SchemaUtils.drop(tester)
-                    SchemaUtils.create(tester)
-                    val statements = SchemaUtils.addMissingColumnsStatements(tester)
-                    assertEquals(0, statements.size)
-                } finally {
-                    SchemaUtils.drop(tester)
-                }
+            try {
+                SchemaUtils.drop(tester)
+                SchemaUtils.create(tester)
+                val statements = SchemaUtils.addMissingColumnsStatements(tester)
+                assertEquals(0, statements.size)
+            } finally {
+                SchemaUtils.drop(tester)
             }
         }
     }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/DatabaseTestsBase.kt
@@ -6,12 +6,10 @@ import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.sql.transactions.nullableTransactionScope
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.transactions.transactionManager
-import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.junit.Assume
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
-import java.math.BigDecimal
 import java.util.*
 import kotlin.concurrent.thread
 
@@ -79,7 +77,7 @@ abstract class DatabaseTestsBase {
         }
     }
 
-    fun withDb(db: List<TestDB>? = null, excludeSettings: Collection<TestDB> = emptyList(), statement: Transaction.(TestDB) -> Unit) {
+    fun withDb(db: Collection<TestDB>? = null, excludeSettings: Collection<TestDB> = emptyList(), statement: Transaction.(TestDB) -> Unit) {
         if (db != null && dialect !in db) {
             Assume.assumeFalse(true)
             return
@@ -166,9 +164,7 @@ abstract class DatabaseTestsBase {
         ""
     }
 
-    fun withH2V1(testDB: List<TestDB>) = (testDB + TestDB.ALL_H2_V1).toSet()
-
-    fun Transaction.isOldMySql(version: String = "8.0") = currentDialectTest is MysqlDialect && !db.isVersionCovers(BigDecimal(version))
+    fun withH2V1(testDB: Collection<TestDB>) = (testDB + TestDB.ALL_H2_V1).toSet()
 
     protected fun prepareSchemaForTest(schemaName: String): Schema = Schema(
         schemaName,

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/sql/tests/TestDB.kt
@@ -128,18 +128,18 @@ enum class TestDB(
     }
 
     companion object {
-        val ALL_H2_V1 = listOf(H2_V1, H2_V1_MYSQL)
-        val ALL_H2_V2 = listOf(H2_V2, H2_V2_MYSQL, H2_V2_PSQL, H2_V2_MARIADB, H2_V2_ORACLE, H2_V2_SQLSERVER)
+        val ALL_H2_V1 = setOf(H2_V1, H2_V1_MYSQL)
+        val ALL_H2_V2 = setOf(H2_V2, H2_V2_MYSQL, H2_V2_PSQL, H2_V2_MARIADB, H2_V2_ORACLE, H2_V2_SQLSERVER)
         val ALL_H2 = ALL_H2_V1 + ALL_H2_V2
-        val ALL_MYSQL = listOf(MYSQL_V5, MYSQL_V8)
-        val ALL_MARIADB = listOf(MARIADB)
+        val ALL_MYSQL = setOf(MYSQL_V5, MYSQL_V8)
+        val ALL_MARIADB = setOf(MARIADB)
         val ALL_MYSQL_MARIADB = ALL_MYSQL + ALL_MARIADB
-        val ALL_MYSQL_LIKE = ALL_MYSQL_MARIADB + listOf(H2_V2_MYSQL, H2_V2_MARIADB, H2_V1_MYSQL)
-        val ALL_POSTGRES = listOf(POSTGRESQL, POSTGRESQLNG)
-        val ALL_POSTGRES_LIKE = ALL_POSTGRES + listOf(H2_V2_PSQL)
-        val ALL_ORACLE_LIKE = listOf(ORACLE, H2_V2_ORACLE)
-        val ALL_SQLSERVER_LIKE = listOf(SQLSERVER, H2_V2_SQLSERVER)
-        val ALL = TestDB.entries.toList()
+        val ALL_MYSQL_LIKE = ALL_MYSQL_MARIADB + setOf(H2_V2_MYSQL, H2_V2_MARIADB, H2_V1_MYSQL)
+        val ALL_POSTGRES = setOf(POSTGRESQL, POSTGRESQLNG)
+        val ALL_POSTGRES_LIKE = ALL_POSTGRES + setOf(H2_V2_PSQL)
+        val ALL_ORACLE_LIKE = setOf(ORACLE, H2_V2_ORACLE)
+        val ALL_SQLSERVER_LIKE = setOf(SQLSERVER, H2_V2_SQLSERVER)
+        val ALL = TestDB.entries.toSet()
 
         fun enabledDialects(): Set<TestDB> {
             if (TEST_DIALECTS.isEmpty()) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ParameterizationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ParameterizationTests.kt
@@ -18,7 +18,7 @@ class ParameterizationTests : DatabaseTestsBase() {
     }
 
     private val supportMultipleStatements by lazy {
-        setOf(TestDB.MYSQL_V5, TestDB.MARIADB, TestDB.POSTGRESQL, TestDB.SQLSERVER)
+        TestDB.ALL_MARIADB + TestDB.SQLSERVER + TestDB.ALL_MYSQL + TestDB.POSTGRESQL
     }
 
     @Test
@@ -38,13 +38,8 @@ class ParameterizationTests : DatabaseTestsBase() {
         Assume.assumeTrue(supportMultipleStatements.containsAll(TestDB.enabledDialects()))
 
         val dialect = TestDB.enabledDialects().first()
-        val urlExtra = when (dialect) {
-            TestDB.MYSQL_V5 -> "&allowMultiQueries=true"
-            TestDB.MARIADB -> "?&allowMultiQueries=true"
-            else -> ""
-        }
         val db = Database.connect(
-            dialect.connection.invoke().plus(urlExtra),
+            dialect.connection.invoke().plus(urlExtra(dialect)),
             dialect.driver,
             dialect.user,
             dialect.pass
@@ -99,13 +94,8 @@ class ParameterizationTests : DatabaseTestsBase() {
         }
 
         val dialect = TestDB.enabledDialects().first()
-        val urlExtra = when (dialect) {
-            TestDB.MYSQL_V5 -> "&allowMultiQueries=true"
-            TestDB.MARIADB -> "?&allowMultiQueries=true"
-            else -> ""
-        }
         val db = Database.connect(
-            dialect.connection.invoke().plus(urlExtra),
+            dialect.connection.invoke().plus(urlExtra(dialect)),
             dialect.driver,
             dialect.user,
             dialect.pass
@@ -160,6 +150,14 @@ class ParameterizationTests : DatabaseTestsBase() {
             )
 
             assertNull(TempTable.selectAll().single()[TempTable.name])
+        }
+    }
+
+    private fun urlExtra(testDB: TestDB): String {
+        return when (testDB) {
+            in TestDB.ALL_MYSQL -> "&allowMultiQueries=true"
+            in TestDB.ALL_MARIADB -> "?&allowMultiQueries=true"
+            else -> ""
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -50,10 +50,8 @@ class ThreadLocalManagerTest : DatabaseTestsBase() {
     fun testReadOnly() {
         // Explanation: MariaDB driver never set readonly to true, MSSQL silently ignores the call, SQLLite does not
         // promise anything, H2 has very limited functionality
-        val excludeSettings = TestDB.ALL_H2 + listOf(
-            TestDB.MARIADB, TestDB.SQLITE,
-            TestDB.SQLSERVER, TestDB.ORACLE
-        )
+        val excludeSettings = TestDB.ALL_H2 + TestDB.ALL_MARIADB +
+            listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)
         withTables(excludeSettings = excludeSettings, RollbackTable) {
             assertFails {
                 inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, true) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionExecTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/TransactionExecTests.kt
@@ -58,10 +58,10 @@ class TransactionExecTests : DatabaseTestsBase() {
 
     @Test
     fun testExecWithMultiStatementQueryUsingMySQL() {
-        Assume.assumeTrue(setOf(TestDB.MYSQL_V5, TestDB.MARIADB).containsAll(TestDB.enabledDialects()))
+        Assume.assumeTrue(TestDB.ALL_MYSQL_MARIADB.containsAll(TestDB.enabledDialects()))
 
         val dialect = TestDB.enabledDialects().first()
-        val extra = if (dialect == TestDB.MARIADB) "?" else ""
+        val extra = if (dialect in TestDB.ALL_MARIADB) "?" else ""
         val db = Database.connect(
             dialect.connection.invoke().plus("$extra&allowMultiQueries=true"),
             dialect.driver,

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateIndexTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateIndexTests.kt
@@ -269,21 +269,19 @@ class CreateIndexTests : DatabaseTestsBase() {
             }
         }
 
-        val functionsNotSupported = TestDB.ALL_H2 + TestDB.SQLSERVER + TestDB.MARIADB
+        val functionsNotSupported = TestDB.ALL_MARIADB + TestDB.ALL_H2 + TestDB.SQLSERVER + TestDB.MYSQL_V5
         withTables(excludeSettings = functionsNotSupported, tester) {
-            if (!isOldMySql()) {
-                SchemaUtils.createMissingTablesAndColumns()
-                assertTrue(tester.exists())
+            SchemaUtils.createMissingTablesAndColumns()
+            assertTrue(tester.exists())
 
-                var indices = getIndices(tester)
-                assertEquals(3, indices.size)
+            var indices = getIndices(tester)
+            assertEquals(3, indices.size)
 
-                val dropStatements = indices.map { it.dropStatement().first() }
-                expect(Unit) { execInBatch(dropStatements) }
+            val dropStatements = indices.map { it.dropStatement().first() }
+            expect(Unit) { execInBatch(dropStatements) }
 
-                indices = getIndices(tester)
-                assertEquals(0, indices.size)
-            }
+            indices = getIndices(tester)
+            assertEquals(0, indices.size)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -290,7 +290,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun columnsWithDefaultValuesThatHavenNotChangedShouldnNotTriggerChange() {
+    fun columnsWithDefaultValuesThatHaveNotChangedShouldNotTriggerChange() {
         var table by Delegates.notNull<Table>()
         withDb { testDb ->
             try {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -140,7 +140,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun columnsWithDefaultValuesThatHavenNotChangedShouldnNotTriggerChange() {
+    fun columnsWithDefaultValuesThatHaveNotChangedShouldNotTriggerChange() {
         var table by Delegates.notNull<Table>()
         withDb { testDb ->
             try {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -140,13 +140,12 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `columns with default values that haven't changed shouldn't trigger change`() {
+    fun columnsWithDefaultValuesThatHavenNotChangedShouldnNotTriggerChange() {
         var table by Delegates.notNull<Table>()
-        // TODO probably could be fixed for MySql 8
-        withDb(excludeSettings = listOf(TestDB.MYSQL_V8)) { testDb ->
+        withDb { testDb ->
             try {
                 // MySQL doesn't support default values on text columns, hence excluded
-                table = if (testDb != TestDB.MYSQL_V5) {
+                table = if (testDb !in TestDB.ALL_MYSQL) {
                     object : Table("varchar_test") {
                         val varchar = varchar("varchar_column", 255).default(" ")
                         val text = text("text_column").default(" ")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -254,7 +254,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testInsertWithPredefinedId() {
+    @Test
+    fun testInsertWithPredefinedId() {
         val stringTable = object : IdTable<String>("stringTable") {
             override val id = varchar("id", 15).entityId()
             val name = varchar("name", 10)
@@ -280,7 +281,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testInsertWithForeignId() {
+    @Test
+    fun testInsertWithForeignId() {
         val idTable = object : IntIdTable("idTable") {}
         val standardTable = object : Table("standardTable") {
             val externalId = reference("externalId", idTable.id)
@@ -297,7 +299,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testInsertWithExpression() {
+    @Test
+    fun testInsertWithExpression() {
         val tbl = object : IntIdTable("testInsert") {
             val nullableInt = integer("nullableIntCol").nullable()
             val string = varchar("stringCol", 20)
@@ -333,7 +336,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testInsertWithColumnExpression() {
+    @Test
+    fun testInsertWithColumnExpression() {
         val tbl1 = object : IntIdTable("testInsert1") {
             val string1 = varchar("stringCol", 20)
         }
@@ -373,7 +377,8 @@ class InsertTests : DatabaseTestsBase() {
     }
 
     // https://github.com/JetBrains/Exposed/issues/192
-    @Test fun testInsertWithColumnNamedWithKeyword() {
+    @Test
+    fun testInsertWithColumnNamedWithKeyword() {
         withTables(OrderedDataTable) {
             val foo = OrderedData.new {
                 name = "foo"
@@ -388,14 +393,15 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testInsertEmojis() {
+    @Test
+    fun testInsertEmojis() {
         val table = object : Table("tmp") {
             val emoji = varchar("emoji", 16)
         }
         val emojis = "\uD83D\uDC68\uD83C\uDFFF\u200D\uD83D\uDC69\uD83C\uDFFF\u200D\uD83D\uDC67\uD83C\uDFFF\u200D\uD83D\uDC66\uD83C\uDFFF"
 
-        withTables(TestDB.ALL_H2 + TestDB.SQLSERVER + TestDB.ORACLE, table) {
-            if (isOldMySql()) {
+        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.SQLSERVER, table) { testDb ->
+            if (testDb == TestDB.MYSQL_V5) {
                 exec("ALTER TABLE ${table.nameInDatabaseCase()} DEFAULT CHARSET utf8mb4, MODIFY emoji VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
             }
             table.insert {
@@ -406,7 +412,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testInsertEmojisWithInvalidLength() {
+    @Test
+    fun testInsertEmojisWithInvalidLength() {
         val table = object : Table("tmp") {
             val emoji = varchar("emoji", 10)
         }
@@ -437,7 +444,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun `test subquery in an insert or update statement`() {
+    @Test
+    fun `test subquery in an insert or update statement`() {
         val tab1 = object : Table("tab1") {
             val id = varchar("id", 10)
         }
@@ -466,7 +474,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun testGeneratedKey04() {
+    @Test
+    fun testGeneratedKey04() {
         val charIdTable = object : IdTable<String>("charId") {
             override val id = varchar("id", 50)
                 .clientDefault { UUID.randomUUID().toString() }
@@ -554,7 +563,8 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
-    @Test fun `test optReference allows null values`() {
+    @Test
+    fun `test optReference allows null values`() {
         withTables(EntityTests.Posts) {
             val id1 = EntityTests.Posts.insertAndGetId {
                 it[board] = null

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/MergeBaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/MergeBaseTest.kt
@@ -10,17 +10,17 @@ import org.jetbrains.exposed.sql.tests.TestDB
 val TEST_DEFAULT_DATE_TIME = LocalDateTime(2000, 1, 1, 0, 0, 0, 0)
 
 abstract class MergeBaseTest : DatabaseTestsBase() {
-    protected fun allDbExcept(includeSettings: List<TestDB>) = TestDB.entries - includeSettings.toSet()
+    protected fun allDbExcept(includeSettings: Collection<TestDB>) = TestDB.ALL - includeSettings.toSet()
 
     protected val defaultExcludeSettings = TestDB.ALL_MARIADB + TestDB.ALL_MYSQL + TestDB.SQLITE + TestDB.ALL_H2_V1
 
-    protected fun withMergeTestTables(excludeSettings: List<TestDB> = emptyList(), statement: Transaction.(dest: Dest, source: Source) -> Unit) = withTables(
+    protected fun withMergeTestTables(excludeSettings: Collection<TestDB> = emptyList(), statement: Transaction.(dest: Dest, source: Source) -> Unit) = withTables(
         excludeSettings = defaultExcludeSettings + excludeSettings, Source, Dest
     ) { db ->
         statement(Dest, Source)
     }
 
-    protected fun withMergeTestTablesAndDefaultData(excludeSettings: List<TestDB> = emptyList(), statement: Transaction.(dest: Dest, source: Source) -> Unit) {
+    protected fun withMergeTestTablesAndDefaultData(excludeSettings: Collection<TestDB> = emptyList(), statement: Transaction.(dest: Dest, source: Source) -> Unit) {
         withMergeTestTables(excludeSettings) { dest, source ->
             source.insert(key = "only-in-source-1", value = 1)
             source.insert(key = "only-in-source-2", value = 2)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReplaceTests.kt
@@ -11,8 +11,7 @@ import java.util.*
 
 class ReplaceTests : DatabaseTestsBase() {
 
-    private val mysqlLikeDialects = listOf(TestDB.MYSQL_V5, TestDB.MARIADB, TestDB.H2_V2_MYSQL, TestDB.H2_V2_MARIADB)
-    private val replaceNotSupported = TestDB.ALL - mysqlLikeDialects - TestDB.SQLITE
+    private val replaceNotSupported = TestDB.ALL - TestDB.ALL_MYSQL_LIKE - TestDB.SQLITE + TestDB.ALL_H2_V1
 
     private object NewAuth : Table("new_auth") {
         val username = varchar("username", 16)
@@ -112,7 +111,7 @@ class ReplaceTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(id)
         }
 
-        withTables(replaceNotSupported, tester) { db ->
+        withTables(replaceNotSupported, tester) {
             tester.replace { }
 
             assertEquals(1, tester.selectAll().count())

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/MathFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/MathFunctionTests.kt
@@ -127,7 +127,7 @@ class MathFunctionTests : FunctionsTestBase() {
             assertExpressionEqual(BigDecimal("11.2"), SqrtFunction(decimalLiteral(BigDecimal("125.44"))))
 
             when (testDb) {
-                TestDB.MYSQL_V5, TestDB.MYSQL_V8, TestDB.MARIADB, TestDB.SQLITE -> {
+                in (TestDB.ALL_MYSQL_MARIADB + TestDB.SQLITE) -> {
                     assertExpressionEqual(null, SqrtFunction(intLiteral(-100)))
                 }
                 else -> {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/TrigonometricalFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/TrigonometricalFunctionTests.kt
@@ -79,7 +79,7 @@ class TrigonometricalFunctionTests : FunctionsTestBase() {
     fun testPiFunction() {
         withTable(excludeDB = TestDB.ORACLE) { testDb ->
             when (testDb) {
-                TestDB.MYSQL_V5, TestDB.MYSQL_V8, TestDB.MARIADB -> assertExpressionEqual(BigDecimal("3.141593"), PiFunction)
+                in TestDB.ALL_MYSQL_MARIADB -> assertExpressionEqual(BigDecimal("3.141593"), PiFunction)
                 else -> assertExpressionEqual(BigDecimal("3.141592653589793"), PiFunction)
             }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/WindowFunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/WindowFunctionsTests.kt
@@ -15,8 +15,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.plus
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.rank
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.rowNumber
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
-import org.jetbrains.exposed.sql.tests.TestDB.*
-import org.jetbrains.exposed.sql.tests.TestDB.Companion.ALL_H2
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.tests.shared.dml.withSales
@@ -27,19 +26,18 @@ import java.math.RoundingMode
 
 class WindowFunctionsTests : DatabaseTestsBase() {
 
-    private val supportsCountDistinctAsWindowFunction = ALL_H2 + ORACLE
-    private val supportsStatisticsAggregateFunctions = entries - listOf(SQLSERVER, SQLITE)
-    private val supportsNthValueFunction = entries - listOf(SQLSERVER)
-    private val supportsExpressionsInWindowFunctionArguments = entries - listOf(MYSQL_V5)
-    private val supportsExpressionsInWindowFrameClause = entries - listOf(MYSQL_V5, SQLSERVER, MARIADB)
-    private val supportsDefaultValueInLeadLagFunctions = entries - listOf(MARIADB)
-    private val supportsRangeModeWithOffsetFrameBound = entries - listOf(SQLSERVER)
+    private val supportsCountDistinctAsWindowFunction = TestDB.ALL_H2 + TestDB.ORACLE
+    private val supportsStatisticsAggregateFunctions = TestDB.ALL - listOf(TestDB.SQLSERVER, TestDB.SQLITE)
+    private val supportsNthValueFunction = TestDB.ALL - TestDB.SQLSERVER
+    private val supportsExpressionsInWindowFunctionArguments = TestDB.ALL - TestDB.ALL_MYSQL
+    private val supportsExpressionsInWindowFrameClause = TestDB.ALL - TestDB.ALL_MYSQL_MARIADB - TestDB.SQLSERVER
+    private val supportsDefaultValueInLeadLagFunctions = TestDB.ALL - TestDB.ALL_MARIADB
+    private val supportsRangeModeWithOffsetFrameBound = TestDB.ALL - TestDB.SQLSERVER
 
-    // TODO probably could be fixed for MySql 8
     @Suppress("LongMethod")
     @Test
-    fun testWindowFunctions() = withSales(excludeSettings = listOf(MYSQL_V8)) { testDb, sales ->
-        if (!isOldMySql()) {
+    fun testWindowFunctions() {
+        withSales(excludeSettings = listOf(TestDB.MYSQL_V5)) { testDb, sales ->
             sales.assertWindowFunctionDefinition(
                 rowNumber().over().partitionBy(sales.year, sales.product).orderBy(sales.amount),
                 listOf(1, 1, 2, 1, 1, 1, 2)
@@ -133,8 +131,8 @@ class WindowFunctionsTests : DatabaseTestsBase() {
 
     @Suppress("LongMethod")
     @Test
-    fun testAggregateFunctionsAsWindowFunctions() = withSales { testDb, sales ->
-        if (!isOldMySql()) {
+    fun testAggregateFunctionsAsWindowFunctions() {
+        withSales(excludeSettings = listOf(TestDB.MYSQL_V5)) { testDb, sales ->
             sales.assertWindowFunctionDefinition(
                 sales.amount.min().over().partitionBy(sales.year, sales.product),
                 listOfBigDecimal("550.1", "1500.25", "550.1", "1620.1", "650.7", "10.2", "1620.1")
@@ -185,8 +183,8 @@ class WindowFunctionsTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testPartitionByClause() = withSales { _, sales ->
-        if (!isOldMySql()) {
+    fun testPartitionByClause() {
+        withSales(excludeSettings = listOf(TestDB.MYSQL_V5)) { _, sales ->
             sales.assertWindowFunctionDefinition(
                 sales.amount.sum().over(),
                 listOfBigDecimal("7102.55", "7102.55", "7102.55", "7102.55", "7102.55", "7102.55", "7102.55")
@@ -207,8 +205,8 @@ class WindowFunctionsTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testOrderByClause() = withSales { _, sales ->
-        if (!isOldMySql()) {
+    fun testOrderByClause() {
+        withSales(excludeSettings = listOf(TestDB.MYSQL_V5)) { _, sales ->
             sales.assertWindowFunctionDefinition(
                 sales.amount.sum().over(),
                 listOfBigDecimal("7102.55", "7102.55", "7102.55", "7102.55", "7102.55", "7102.55", "7102.55")
@@ -229,11 +227,10 @@ class WindowFunctionsTests : DatabaseTestsBase() {
         }
     }
 
-    // TODO probably could be fixed for MySql 8
     @Suppress("LongMethod")
     @Test
-    fun testWindowFrameClause() = withSales(excludeSettings = listOf(MYSQL_V8)) { testDb, sales ->
-        if (!isOldMySql()) {
+    fun testWindowFrameClause() {
+        withSales(excludeSettings = listOf(TestDB.MYSQL_V5)) { testDb, sales ->
             sales.assertWindowFunctionDefinition(
                 sumAmountPartitionByYearProductOrderByAmount(sales).rows(WindowFrameBound.unboundedPreceding()),
                 listOfBigDecimal("550.1", "1500.25", "1450.4", "1620.1", "650.7", "10.2", "3491")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -314,7 +314,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
 
     private fun withTestTableAndExcludeSettings(
         vararg tables: Table = arrayOf(ArrayTestTable),
-        excludeSettings: List<TestDB> = arrayTypeUnsupportedDb,
+        excludeSettings: Collection<TestDB> = arrayTypeUnsupportedDb,
         statement: Transaction.(TestDB) -> Unit
     ) {
         withTables(excludeSettings = excludeSettings, *tables) { db ->

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -153,7 +153,7 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testPreviousUShortColumnTypeWorksWithNewIntType() {
-        withDb(excludeSettings = listOf(TestDB.MYSQL_V5, TestDB.MARIADB)) { testDb ->
+        withDb { testDb ->
             try {
                 val tableName = UShortTable.nameInDatabaseCase()
                 val columnName = UShortTable.unsignedShort.nameInDatabaseCase()
@@ -231,7 +231,7 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
     @Test
     fun testPreviousUIntColumnTypeWorksWithNewBigIntType() {
         // Oracle was already previously constrained to NUMBER(13)
-        withDb(excludeSettings = listOf(TestDB.MYSQL_V5, TestDB.MARIADB, TestDB.ORACLE)) { testDb ->
+        withDb(excludeSettings = listOf(TestDB.ORACLE)) { testDb ->
             try {
                 val tableName = UIntTable.nameInDatabaseCase()
                 val columnName = UIntTable.unsignedInt.nameInDatabaseCase()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Assume
 import org.junit.Test
-import kotlin.test.assertContains
 
 class ForeignKeyConstraintTests : DatabaseTestsBase() {
 
@@ -194,10 +193,9 @@ class ForeignKeyConstraintTests : DatabaseTestsBase() {
                     list.forEach {
                         // According to the documentation: "NO ACTION: A keyword from standard SQL. For InnoDB, this is equivalent to RESTRICT;"
                         // https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html
-if (testDb == TestDB.MYSQL_V5) {
-    assertEquals(ReferenceOption.NO_ACTION, it.updateRule)
-    assertEquals(ReferenceOption.NO_ACTION, it.deleteRule)
-}
+                        if (testDb == TestDB.MYSQL_V5) {
+                            assertEquals(ReferenceOption.NO_ACTION, it.updateRule)
+                            assertEquals(ReferenceOption.NO_ACTION, it.deleteRule)
                         } else {
                             assertEquals(currentDialectTest.defaultReferenceOption, it.updateRule)
                             assertEquals(currentDialectTest.defaultReferenceOption, it.deleteRule)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
@@ -194,9 +194,10 @@ class ForeignKeyConstraintTests : DatabaseTestsBase() {
                     list.forEach {
                         // According to the documentation: "NO ACTION: A keyword from standard SQL. For InnoDB, this is equivalent to RESTRICT;"
                         // https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html
-                        if (testDb == TestDB.MYSQL_V5 && currentDialectTest.defaultReferenceOption in listOf(ReferenceOption.RESTRICT, ReferenceOption.NO_ACTION)) {
-                            assertContains(listOf(ReferenceOption.RESTRICT, ReferenceOption.NO_ACTION), it.updateRule)
-                            assertContains(listOf(ReferenceOption.RESTRICT, ReferenceOption.NO_ACTION), it.deleteRule)
+if (testDb == TestDB.MYSQL_V5) {
+    assertEquals(ReferenceOption.NO_ACTION, it.updateRule)
+    assertEquals(ReferenceOption.NO_ACTION, it.deleteRule)
+}
                         } else {
                             assertEquals(currentDialectTest.defaultReferenceOption, it.updateRule)
                             assertEquals(currentDialectTest.defaultReferenceOption, it.deleteRule)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/ForeignKeyConstraintTests.kt
@@ -185,7 +185,7 @@ class ForeignKeyConstraintTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(id)
         }
 
-        withTables(excludeSettings = listOf(), category, item) { testDb ->
+        withTables(category, item) { testDb ->
             if (currentDialectTest.supportsOnUpdate) {
                 val constraints = connection.metadata {
                     tableConstraints(listOf(item))


### PR DESCRIPTION
The main purpose of this PR is to remove usage of `isOldMySql()` function, because now there are different enum constants for different MySql versions in TestDB. 

Some other changes: 
- the tests excluded for MySql V8 were rechecked and fixed if it's possible.
- usages of `TestDB.MARIADB` were replaced with `TestDB.ALL_MARIADB` to find failed tests faster if we add different versions for MariaDB
- `TestDB.ALL*` constants are `Set`s now. Idea always suggests to convert `List`s with these constants into `Set`s, so it should make Idea complain less.



