### PR TITLE
fix: EXPOSED-411 ClassCastException when `uuid().references()` is used with `referrersOn`

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
@@ -20,7 +20,9 @@ object LongIdTables {
 
     class City(id: EntityID<Long>) : LongEntity(id) {
         companion object : LongEntityClass<City>(Cities)
+
         var name by Cities.name
+        val towns by Town referrersOn Towns.cityId
     }
 
     object People : LongIdTable() {
@@ -30,6 +32,7 @@ object LongIdTables {
 
     class Person(id: EntityID<Long>) : LongEntity(id) {
         companion object : LongEntityClass<Person>(People)
+
         var name by People.name
         var city by City referencedOn People.cityId
     }
@@ -40,9 +43,11 @@ object LongIdTables {
 
     class Town(id: EntityID<Long>) : LongEntity(id) {
         companion object : LongEntityClass<Town>(Towns)
+
         var city by City referencedOn Towns.cityId
     }
 }
+
 class LongIdTableEntityTest : DatabaseTestsBase() {
     @Test
     fun `create tables`() {
@@ -129,6 +134,10 @@ class LongIdTableEntityTest : DatabaseTestsBase() {
             // eager loaded reference
             val town1WithCity = LongIdTables.Town.all().with(LongIdTables.Town::city).single()
             assertEquals(cId, town1WithCity.city.id)
+
+            val city1 = LongIdTables.City.all().single()
+            val towns = city1.towns
+            assertEquals(cId, towns.first().city.id)
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/UuidTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/UuidTableEntityTest.kt
@@ -24,6 +24,7 @@ object UUIDTables {
         companion object : UUIDEntityClass<City>(Cities)
 
         var name by Cities.name
+        val towns by Town referrersOn Towns.cityId
     }
 
     object People : UUIDTable() {
@@ -58,6 +59,7 @@ object UUIDTables {
 
     class Town(id: EntityID<UUID>) : UUIDEntity(id) {
         companion object : UUIDEntityClass<Town>(Towns)
+
         var city by City referencedOn Towns.cityId
     }
 }
@@ -179,6 +181,10 @@ class UUIDTableEntityTest : DatabaseTestsBase() {
             // eager loaded reference
             val town1WithCity = UUIDTables.Town.all().with(UUIDTables.Town::city).single()
             assertEquals(cId, town1WithCity.city.id)
+
+            val city1 = UUIDTables.City.all().single()
+            val towns = city1.towns
+            assertEquals(cId, towns.first().city.id)
         }
     }
 }


### PR DESCRIPTION
This fix allows using `referrersOn` or `backReferencedOn` in the parent table when a column of type `T` in the child table references a column of type `EntityID<T>` in the parent table.

This use case was not working even before any refactor was done. The location from which the error is coming _is_ different now after the [type safety refactor](https://github.com/JetBrains/Exposed/commit/42ac41b14c632e745c58d234641e9a2862d3204a), but it's essentially the same problem: the type mismatch.