### PR TITLE
feat: EXPOSED-367 SubQuery inside OrderBy clause

### DIFF
--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -349,6 +349,20 @@ Example:
 StarWarsFilms.selectAll().orderBy(StarWarsFilms.sequelId to SortOrder.ASC)
 ```
 
+### Order-by with query
+
+SQL allows ordering by a subquery, which in Exposed translates to the following statement
+(in the following query, the actors are ordered by the number of roles they play):
+
+```kotlin
+val rolesCountExpression = Roles.characterName.count()
+val orderExpression = Roles.select(rolesCountExpression)
+    .where { Roles.actorId eq Actors.id }
+    .expression(rolesCountExpression.columnType)
+Actors.selectAll()
+    .orderBy(orderExpression, SortOrder.DESC)
+```
+
 ## Group-by
 
 In group-by, define fields and their functions (such as `count`) by the `select()` method.

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -151,6 +151,8 @@ public final class org/jetbrains/exposed/sql/AliasKt {
 	public static final fun alias (Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/QueryAlias;
 	public static final fun alias (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/ExpressionAlias;
 	public static final fun alias (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Alias;
+	public static final fun expression (Lorg/jetbrains/exposed/sql/AbstractQuery;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/QueryExpression;
+	public static final fun expression (Lorg/jetbrains/exposed/sql/AbstractQuery;Lorg/jetbrains/exposed/sql/IColumnType;)Lorg/jetbrains/exposed/sql/QueryExpression;
 	public static final fun getLastQueryAlias (Lorg/jetbrains/exposed/sql/Join;)Lorg/jetbrains/exposed/sql/QueryAlias;
 	public static final fun joinQuery (Lorg/jetbrains/exposed/sql/Join;Lkotlin/jvm/functions/Function2;Lorg/jetbrains/exposed/sql/JoinType;ZLkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/sql/Join;
 	public static final fun joinQuery (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function2;Lorg/jetbrains/exposed/sql/JoinType;ZLkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/sql/Join;
@@ -1846,6 +1848,13 @@ public final class org/jetbrains/exposed/sql/QueryBuilder {
 	public final fun unaryPlus (C)Lorg/jetbrains/exposed/sql/QueryBuilder;
 	public final fun unaryPlus (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/QueryBuilder;
 	public final fun unaryPlus (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/QueryBuilder;
+}
+
+public final class org/jetbrains/exposed/sql/QueryExpression : org/jetbrains/exposed/sql/ExpressionWithColumnType {
+	public fun <init> (Lorg/jetbrains/exposed/sql/AbstractQuery;Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public fun getColumnType ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public final fun getQuery ()Lorg/jetbrains/exposed/sql/AbstractQuery;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
 public final class org/jetbrains/exposed/sql/QueryKt {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1849,13 +1849,6 @@ public final class org/jetbrains/exposed/sql/QueryBuilder {
 	public final fun unaryPlus (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/QueryBuilder;
 }
 
-public final class org/jetbrains/exposed/sql/QueryExpression : org/jetbrains/exposed/sql/ExpressionWithColumnType {
-	public fun <init> (Lorg/jetbrains/exposed/sql/AbstractQuery;Lorg/jetbrains/exposed/sql/IColumnType;)V
-	public fun getColumnType ()Lorg/jetbrains/exposed/sql/IColumnType;
-	public final fun getQuery ()Lorg/jetbrains/exposed/sql/AbstractQuery;
-	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
-}
-
 public final class org/jetbrains/exposed/sql/QueryKt {
 	public static final fun andHaving (Lorg/jetbrains/exposed/sql/Query;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun andWhere (Lorg/jetbrains/exposed/sql/Query;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -151,8 +151,7 @@ public final class org/jetbrains/exposed/sql/AliasKt {
 	public static final fun alias (Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/QueryAlias;
 	public static final fun alias (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/ExpressionAlias;
 	public static final fun alias (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Alias;
-	public static final fun expression (Lorg/jetbrains/exposed/sql/AbstractQuery;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/QueryExpression;
-	public static final fun expression (Lorg/jetbrains/exposed/sql/AbstractQuery;Lorg/jetbrains/exposed/sql/IColumnType;)Lorg/jetbrains/exposed/sql/QueryExpression;
+	public static final fun asExpression (Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun getLastQueryAlias (Lorg/jetbrains/exposed/sql/Join;)Lorg/jetbrains/exposed/sql/QueryAlias;
 	public static final fun joinQuery (Lorg/jetbrains/exposed/sql/Join;Lkotlin/jvm/functions/Function2;Lorg/jetbrains/exposed/sql/JoinType;ZLkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/sql/Join;
 	public static final fun joinQuery (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function2;Lorg/jetbrains/exposed/sql/JoinType;ZLkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/sql/Join;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -158,6 +158,32 @@ fun <T : Table> T.alias(alias: String) = Alias(this, alias)
 fun <T : AbstractQuery<*>> T.alias(alias: String) = QueryAlias(this, alias)
 
 /**
+ * Creates an instance of [QueryExpression] that can be used among other [Expression]s.
+ *
+ * Known usages are:
+ * - inside `SELECT` clause of query like `SELECT (SELECT ...) FROM table`
+ * - inside `ORDER BY` clause of query like `SELECT * FROM table ORDER BY (SELECT ...)`
+ *
+ * [QueryExpression] can be also aliased to get [ExpressionAlias] and used like other expression aliases.
+ *
+ * Example: `box.select(box.id).orderBy(coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.expression(coin.cost))`
+ */
+fun <T : AbstractQuery<*>, P : Any> T.expression(type: ExpressionWithColumnType<P>) = QueryExpression(this, type.columnType)
+
+/**
+ * Creates an instance of [QueryExpression] that can be used among other [Expression]s.
+ *
+ * Known usages are:
+ * - inside `SELECT` clause of query like `SELECT (SELECT ...) FROM table`
+ * - inside `ORDER BY` clause of query like `SELECT * FROM table ORDER BY (SELECT ...)`
+ *
+ * [QueryExpression] can be also aliased to get [ExpressionAlias] and used like other expression aliases.
+ *
+ * Example: `box.select(box.id).orderBy(coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.expression(coin.cost.columnType))`
+ */
+fun <T : AbstractQuery<*>, P : Any> T.expression(type: IColumnType<P>) = QueryExpression(this, type)
+
+/**
  * Creates a temporary identifier, [alias], for [this] expression.
  *
  * The alias will be used on the database-side if the alias object is used to generate an SQL statement,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -158,32 +158,6 @@ fun <T : Table> T.alias(alias: String) = Alias(this, alias)
 fun <T : AbstractQuery<*>> T.alias(alias: String) = QueryAlias(this, alias)
 
 /**
- * Creates an instance of [QueryExpression] that can be used among other [Expression]s.
- *
- * Known usages are:
- * - inside `SELECT` clause of query like `SELECT (SELECT ...) FROM table`
- * - inside `ORDER BY` clause of query like `SELECT * FROM table ORDER BY (SELECT ...)`
- *
- * [QueryExpression] can be also aliased to get [ExpressionAlias] and used like other expression aliases.
- *
- * Example: `box.select(box.id).orderBy(coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.expression(coin.cost))`
- */
-fun <T : AbstractQuery<*>, P : Any> T.expression(type: ExpressionWithColumnType<P>) = QueryExpression(this, type.columnType)
-
-/**
- * Creates an instance of [QueryExpression] that can be used among other [Expression]s.
- *
- * Known usages are:
- * - inside `SELECT` clause of query like `SELECT (SELECT ...) FROM table`
- * - inside `ORDER BY` clause of query like `SELECT * FROM table ORDER BY (SELECT ...)`
- *
- * [QueryExpression] can be also aliased to get [ExpressionAlias] and used like other expression aliases.
- *
- * Example: `box.select(box.id).orderBy(coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.expression(coin.cost.columnType))`
- */
-fun <T : AbstractQuery<*>, P : Any> T.expression(type: IColumnType<P>) = QueryExpression(this, type)
-
-/**
  * Creates a temporary identifier, [alias], for [this] expression.
  *
  * The alias will be used on the database-side if the alias object is used to generate an SQL statement,
@@ -247,3 +221,10 @@ fun <T : Any> wrapAsExpression(query: AbstractQuery<*>) = object : Expression<T?
         append(")")
     }
 }
+
+/**
+ * Wraps the query into [Expression] so that it can be used as part of an SQL statement or in another query clause.
+ *
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.OrderByTests.testOrderByExpressions
+ */
+fun <T : Any> AbstractQuery<*>.asExpression() = wrapAsExpression<T>(this)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
@@ -170,13 +170,3 @@ abstract class ExpressionWithColumnType<T> : Expression<T>() {
     /** Returns the column type of this expression. Used for operations with literals. */
     abstract val columnType: IColumnType<T & Any>
 }
-
-class QueryExpression<T>(val query: AbstractQuery<*>, override val columnType: IColumnType<T & Any>) : ExpressionWithColumnType<T>() {
-    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
-        with(queryBuilder) {
-            append("(")
-            query.prepareSQL(this)
-            append(")")
-        }
-    }
-}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Expression.kt
@@ -170,3 +170,13 @@ abstract class ExpressionWithColumnType<T> : Expression<T>() {
     /** Returns the column type of this expression. Used for operations with literals. */
     abstract val columnType: IColumnType<T & Any>
 }
+
+class QueryExpression<T>(val query: AbstractQuery<*>, override val columnType: IColumnType<T & Any>) : ExpressionWithColumnType<T>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+        with(queryBuilder) {
+            append("(")
+            query.prepareSQL(this)
+            append(")")
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/OrderByTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/OrderByTests.kt
@@ -232,7 +232,7 @@ class OrderByTests : DatabaseTestsBase() {
             // SELECT OrderByQueryBox.id, (SELECT SUM(OrderByQueryCoin.cost)
             //   FROM OrderByQueryCoin WHERE OrderByQueryBox.id = OrderByQueryCoin.box_id) cost_sum FROM OrderByQueryBox
             //   ORDER BY cost_sum ASC
-            val expressionAlias = coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.expression(coin.cost).alias("cost_sum")
+            val expressionAlias = coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.asExpression<Int>().alias("cost_sum")
 
             val variant1Asc = box.select(box.id, expressionAlias)
                 .orderBy(expressionAlias, SortOrder.ASC)
@@ -248,7 +248,7 @@ class OrderByTests : DatabaseTestsBase() {
             // SELECT OrderByQueryBox.id
             //   FROM OrderByQueryBox
             //   ORDER BY (SELECT SUM(OrderByQueryCoin.cost) FROM OrderByQueryCoin WHERE OrderByQueryBox.id = OrderByQueryCoin.box_id) DESC
-            val expression = coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.expression(coin.cost)
+            val expression = coin.select(coin.cost.sum()).where { coin.boxId eq box.id }.asExpression<Int>()
 
             val variant2Asc = box.select(box.id)
                 .orderBy(expression, SortOrder.ASC)


### PR DESCRIPTION
Here is the feature with support of query like expressions.

It allows covering sql queries like (from tests):

```sql
SELECT 
    OrderByQueryBox.id, 
    (
        SELECT SUM(OrderByQueryCoin.cost) 
        FROM OrderByQueryCoin 
        WHERE OrderByQueryBox.id = OrderByQueryCoin.box_id
    ) cost_sum 
    FROM OrderByQueryBox
    ORDER BY cost_sum ASC
```

```sql
SELECT OrderByQueryBox.id
    FROM OrderByQueryBox
    ORDER BY (
        SELECT SUM(OrderByQueryCoin.cost) 
            FROM OrderByQueryCoin WHERE OrderByQueryBox.id = OrderByQueryCoin.box_id
        ) DESC
```


Implementation is quite simple, a new kind of `Expression` was added: `QueryExpression<T>(query: AbstractQuery, columnType: IColumnType<T>) : ExpressionWithColumnType<T>` that appends the whole query into the query builder.

Since it's an expression, it can be used with `ExpressionAlias`, so it can be accessed via alias from `ResultRow`.

But about the public part I'm not completely sure with this PR.

The first moment is requiring `columnType` as a parameter. The reason is type safety and getting result from the query. Expression like query must have only one column returned, and the type of the whole expression is the type of that column actually, but I don't see a way to infer this type from random query, so user has to specify it manually what leads to the pattern:

```kotlin
val columnExpression = table.id.count()
val queryExpression = table.select(columnExpression).expression(columnExpression.columnType)
```

The second moment is adding new method `expression(type)` to the query(`AbstractQuery`). I feel like one more "expression" may confuse users even if they already used them via `count()`, `sum()` and many others.

Now it's possible to create query alias via `query.alias()` and query expression alias `query.expression().alias()`, and it would be different aliases. I had some thoughts that `Query/AbstractQuery` may also implement `Expression` and be used interchangeably with other expressions.. One of variants to do that is convert `Expression` into interface (or create bore basic interface `IExpression`) and use this expression across the code. But it looks like it will cause many changes, I started to do that but stopped at the current moment, if you also see that it makes sence I can clean it and push in different branch.