### PR TITLE
fix: EXPOSED-407 compositeMoney() nullability definition issues

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -241,7 +241,8 @@ public final class org/jetbrains/exposed/sql/Between : org/jetbrains/exposed/sql
 }
 
 public abstract class org/jetbrains/exposed/sql/BiCompositeColumn : org/jetbrains/exposed/sql/CompositeColumn {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun getColumn1 ()Lorg/jetbrains/exposed/sql/Column;
 	protected final fun getColumn2 ()Lorg/jetbrains/exposed/sql/Column;
 	public fun getRealColumns ()Ljava/util/List;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/CompositeColumn.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/CompositeColumn.kt
@@ -39,8 +39,12 @@ abstract class BiCompositeColumn<C1, C2, T>(
     /** Transformation that receives the column's composite value and returns the parsed values of the underlying columns. */
     val transformFromValue: (T) -> Pair<C1?, C2?>,
     /** Transformation that receives the retrieved values of [column1] and [column2] and returns a composite value. */
-    val transformToValue: (Any?, Any?) -> T
+    val transformToValue: (Any?, Any?) -> T,
+    nullable: Boolean = false
 ) : CompositeColumn<T>() {
+    init {
+        this.nullable = nullable
+    }
 
     override fun getRealColumns(): List<Column<*>> = listOf(column1, column2)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1176,6 +1176,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /** Marks this [CompositeColumn] as nullable. */
     @Suppress("UNCHECKED_CAST")
+    @LowPriorityInOverloadResolution
     fun <T : Any, C : CompositeColumn<T>> C.nullable(): CompositeColumn<T?> = apply {
         nullable = true
         getRealColumns().filter { !it.columnType.nullable }.forEach { (it as Column<Any>).nullable() }

--- a/exposed-money/api/exposed-money.api
+++ b/exposed-money/api/exposed-money.api
@@ -1,11 +1,13 @@
 public final class org/jetbrains/exposed/sql/money/CompositeMoneyColumn : org/jetbrains/exposed/sql/BiCompositeColumn {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Column;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Column;Z)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Column;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAmount ()Lorg/jetbrains/exposed/sql/Column;
 	public final fun getCurrency ()Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/sql/money/CompositeMoneyColumnKt {
 	public static final fun CompositeMoneyColumn (Lorg/jetbrains/exposed/sql/Table;IILjava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/money/CompositeMoneyColumn;
+	public static final fun nullable (Lorg/jetbrains/exposed/sql/money/CompositeMoneyColumn;)Lorg/jetbrains/exposed/sql/money/CompositeMoneyColumn;
 }
 
 public final class org/jetbrains/exposed/sql/money/CompositeMoneyColumnTypeKt {

--- a/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CompositeMoneyColumnType.kt
+++ b/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CompositeMoneyColumnType.kt
@@ -16,7 +16,11 @@ import javax.money.MonetaryAmount
 fun Table.compositeMoney(precision: Int, scale: Int, amountName: String, currencyName: String = amountName + "_C") =
     registerCompositeColumn(CompositeMoneyColumn(this, precision, scale, amountName, currencyName))
 
-/** Creates a composite column made up of a decimal column and a currency column. */
+/**
+ * Creates a composite column made up of a decimal column and a currency column.
+ *
+ * @sample org.jetbrains.exposed.sql.money.MoneyBaseTest.testUsingManualCompositeMoneyColumns
+ */
 fun Table.compositeMoney(
     amountColumn: Column<BigDecimal>,
     currencyColumn: Column<CurrencyUnit>
@@ -28,13 +32,17 @@ fun Table.compositeMoney(
     }
 }
 
-/** Creates a composite column made up of a nullable decimal column and a nullable currency column. */
+/**
+ * Creates a composite column made up of a nullable decimal column and a nullable currency column.
+ *
+ * @sample org.jetbrains.exposed.sql.money.MoneyBaseTest.testUsingManualCompositeMoneyColumns
+ */
 @JvmName("compositeMoneyNullable")
 fun Table.compositeMoney(
     amountColumn: Column<BigDecimal?>,
     currencyColumn: Column<CurrencyUnit?>
 ): CompositeMoneyColumn<BigDecimal?, CurrencyUnit?, MonetaryAmount?> {
-    return CompositeMoneyColumn<BigDecimal?, CurrencyUnit?, MonetaryAmount?>(amountColumn, currencyColumn).also {
+    return CompositeMoneyColumn<BigDecimal?, CurrencyUnit?, MonetaryAmount?>(amountColumn, currencyColumn, true).also {
         if (amountColumn !in columns && currencyColumn !in columns) {
             registerCompositeColumn(it)
         }

--- a/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyTests.kt
+++ b/exposed-money/src/test/kotlin/org/jetbrains/exposed/sql/money/MoneyTests.kt
@@ -6,12 +6,17 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.exceptions.ExposedSQLException
-import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.update
 import org.junit.Test
 import java.math.BigDecimal
 import javax.money.CurrencyUnit
@@ -134,8 +139,11 @@ open class MoneyBaseTest : DatabaseTestsBase() {
                 it[money] = compositeMoney
                 it[nullableMoney] = null
             }
+            tester.insert {
+                it[money] = compositeMoney
+            }
 
-            assertEquals(1, tester.selectAll().where { tester.nullableMoney eq null }.count())
+            assertEquals(2, tester.selectAll().where { tester.nullableMoney eq null }.count())
         }
     }
 


### PR DESCRIPTION
Defining a composite money column as nullable returns a different type:
```kt
// non-nullable column
val money: CompositeMoneyColumn<BigDecimal, CurrencyUnit, MonetaryAmount> = compositeMoney()

// actual nullable column
val nullableMoney: CompositeMoneyColumn<MonetaryAmount?> = compositeMoney().nullable()

// expected nullable column
val money: CompositeMoneyColumn<BigDecimal?, CurrencyUnit?, MonetaryAmount?> = compositeMoney().nullable()
```

The current setup works as long as the insert value is a composite `Money` value, as the individual columns will not be able to be resolved.

If the component values (`BigDecimal` and `CurrencyUnit`) are inserted individually into the component columns, it will only work for either a non-nullable column or a nullable column with a non-null value. This happens because each component column is correctly nullable, but not the actual composite expression itself, resulting in the error:
```
Can't set null value to non-nullable CompositeMoneyColumn column
```

This fix adds an overload so that `compositeMoney().nullable()` returns the expected type and adds the ability to modify the internal `nullable` property in `BiCompositeColumns`.

None of the current tests included inserts/updates that targeted the individual component columns, so this has been included too.