### PR TITLE
fix: EXPOSED-424 ClassCastException exception when using `fetchBatchedResults` with `alias`

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -393,18 +393,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is less than some [t] value. */
     @JvmName("lessEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.less(t: T): LessOp =
-        LessOp(
-            this,
-            wrap(
-                EntityID(
-                    t,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            )
-        )
+        LessOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is less than some [other] expression. */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.less(
@@ -428,18 +417,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is less than or equal to some [t] value */
     @JvmName("lessEqEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.lessEq(t: T): LessEqOp =
-        LessEqOp(
-            this,
-            wrap(
-                EntityID(
-                    t,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            )
-        )
+        LessEqOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is less than or equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.lessEq(
@@ -463,18 +441,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is greater than some [t] value. */
     @JvmName("greaterEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.greater(t: T): GreaterOp =
-        GreaterOp(
-            this,
-            wrap(
-                EntityID(
-                    t,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            )
-        )
+        GreaterOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is greater than some [other] expression. */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.greater(
@@ -498,18 +465,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is greater than or equal to some [t] value */
     @JvmName("greaterEqEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.greaterEq(t: T): GreaterEqOp =
-        GreaterEqOp(
-            this,
-            wrap(
-                EntityID(
-                    t,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            )
-        )
+        GreaterEqOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is greater than or equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.greaterEq(
@@ -528,27 +484,7 @@ interface ISqlExpressionBuilder {
 
     /** Returns `true` if this [EntityID] expression is between the values [from] and [to], `false` otherwise. */
     fun <T : Comparable<T>, E : EntityID<T>?> Column<E>.between(from: T, to: T): Between =
-        Between(
-            this,
-            wrap(
-                EntityID(
-                    from,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            ),
-            wrap(
-                EntityID(
-                    to,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            )
-        )
+        Between(this, wrap(EntityID(from, this.idTable())), wrap(EntityID(to, this.idTable())))
 
     /** Returns `true` if this expression is null, `false` otherwise. */
     fun <T> Expression<T>.isNull(): IsNullOp = IsNullOp(this)
@@ -566,18 +502,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this expression is equal to some [t] value, with `null` treated as a comparable value */
     @JvmName("isNotDistinctFromEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.isNotDistinctFrom(t: T): IsNotDistinctFromOp =
-        IsNotDistinctFromOp(
-            this,
-            wrap(
-                EntityID(
-                    t,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            )
-        )
+        IsNotDistinctFromOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isNotDistinctFrom(
@@ -599,18 +524,7 @@ interface ISqlExpressionBuilder {
     /** Checks if this expression is not equal to some [t] value, with `null` treated as a comparable value */
     @JvmName("isDistinctFromEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.isDistinctFrom(t: T): IsDistinctFromOp =
-        IsDistinctFromOp(
-            this,
-            wrap(
-                EntityID(
-                    t,
-                    when (val table = this.foreignKey?.targetTable ?: this.table) {
-                        is Alias<*> -> table.delegate
-                        else -> table
-                    } as IdTable<T>
-                )
-            )
-        )
+        IsDistinctFromOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is not equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isDistinctFrom(
@@ -1015,6 +929,12 @@ interface ISqlExpressionBuilder {
 
     fun ExpressionWithColumnType<Int>.intToDecimal(): NoOpConversion<Int, BigDecimal> =
         NoOpConversion(this, DecimalColumnType(precision = 15, scale = 0))
+
+    private fun <T : Comparable<T>, E : EntityID<T>> Column<out E?>.idTable(): IdTable<T> =
+        when (val table = this.foreignKey?.targetTable ?: this.table) {
+            is Alias<*> -> table.delegate
+            else -> table
+        } as IdTable<T>
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -393,7 +393,18 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is less than some [t] value. */
     @JvmName("lessEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.less(t: T): LessOp =
-        LessOp(this, wrap(EntityID(t, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>)))
+        LessOp(
+            this,
+            wrap(
+                EntityID(
+                    t,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            )
+        )
 
     /** Checks if this [EntityID] expression is less than some [other] expression. */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.less(
@@ -417,7 +428,18 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is less than or equal to some [t] value */
     @JvmName("lessEqEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.lessEq(t: T): LessEqOp =
-        LessEqOp(this, wrap(EntityID(t, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>)))
+        LessEqOp(
+            this,
+            wrap(
+                EntityID(
+                    t,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            )
+        )
 
     /** Checks if this [EntityID] expression is less than or equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.lessEq(
@@ -441,7 +463,18 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is greater than some [t] value. */
     @JvmName("greaterEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.greater(t: T): GreaterOp =
-        GreaterOp(this, wrap(EntityID(t, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>)))
+        GreaterOp(
+            this,
+            wrap(
+                EntityID(
+                    t,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            )
+        )
 
     /** Checks if this [EntityID] expression is greater than some [other] expression. */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.greater(
@@ -465,7 +498,18 @@ interface ISqlExpressionBuilder {
     /** Checks if this [EntityID] expression is greater than or equal to some [t] value */
     @JvmName("greaterEqEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.greaterEq(t: T): GreaterEqOp =
-        GreaterEqOp(this, wrap(EntityID(t, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>)))
+        GreaterEqOp(
+            this,
+            wrap(
+                EntityID(
+                    t,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            )
+        )
 
     /** Checks if this [EntityID] expression is greater than or equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.greaterEq(
@@ -486,8 +530,24 @@ interface ISqlExpressionBuilder {
     fun <T : Comparable<T>, E : EntityID<T>?> Column<E>.between(from: T, to: T): Between =
         Between(
             this,
-            wrap(EntityID(from, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>)),
-            wrap(EntityID(to, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>))
+            wrap(
+                EntityID(
+                    from,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            ),
+            wrap(
+                EntityID(
+                    to,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            )
         )
 
     /** Returns `true` if this expression is null, `false` otherwise. */
@@ -506,7 +566,18 @@ interface ISqlExpressionBuilder {
     /** Checks if this expression is equal to some [t] value, with `null` treated as a comparable value */
     @JvmName("isNotDistinctFromEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.isNotDistinctFrom(t: T): IsNotDistinctFromOp =
-        IsNotDistinctFromOp(this, wrap(EntityID(t, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>)))
+        IsNotDistinctFromOp(
+            this,
+            wrap(
+                EntityID(
+                    t,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            )
+        )
 
     /** Checks if this [EntityID] expression is equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isNotDistinctFrom(
@@ -528,7 +599,18 @@ interface ISqlExpressionBuilder {
     /** Checks if this expression is not equal to some [t] value, with `null` treated as a comparable value */
     @JvmName("isDistinctFromEntityID")
     infix fun <T : Comparable<T>> Column<EntityID<T>>.isDistinctFrom(t: T): IsDistinctFromOp =
-        IsDistinctFromOp(this, wrap(EntityID(t, (this.foreignKey?.targetTable ?: this.table) as IdTable<T>)))
+        IsDistinctFromOp(
+            this,
+            wrap(
+                EntityID(
+                    t,
+                    when (val table = this.foreignKey?.targetTable ?: this.table) {
+                        is Alias<*> -> table.delegate
+                        else -> table
+                    } as IdTable<T>
+                )
+            )
+        )
 
     /** Checks if this [EntityID] expression is not equal to some [other] expression */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isDistinctFrom(

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/FetchBatchedResultsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/FetchBatchedResultsTests.kt
@@ -1,7 +1,12 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
 import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.alias
+import org.jetbrains.exposed.sql.batchInsert
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.junit.Test
@@ -115,6 +120,18 @@ class FetchBatchedResultsTests : DatabaseTestsBase() {
 
         withTables(tester1, tester2) {
             (tester2 innerJoin tester1).selectAll().fetchBatchedResults(10_000).flatten()
+        }
+    }
+
+    @Test
+    fun testFetchBatchedResultsWithAlias() {
+        val tester = object : IntIdTable("tester") {
+            val name = varchar("name", 1)
+        }
+        withTables(tester) {
+            tester.insert { it[name] = "a" }
+            tester.insert { it[name] = "b" }
+            tester.alias("tester_alias").selectAll().fetchBatchedResults(1).flatten()
         }
     }
 }


### PR DESCRIPTION
Added an additional check to see if the table is an alias and use the alias' delegate in that case.

I wanted to change the same logic in `UpdateBuilder`, but I couldn't think of a usage of the `set` functions where this change would be necessary. Please let me know if you think of a case where it is.