### PR TITLE
feat: EXPOSED-388 Support for column type converters

### DIFF
--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -766,3 +766,65 @@ The values specified in the statement block will be used for the insert statemen
 In the example above, if the original row was inserted with a user-defined <code>rating</code>, then <code>replace()</code> was executed with a block that omitted the <code>rating</code> column, 
 the newly inserted row would store the default rating value. This is because the old row was completely deleted first.
 </note>
+
+## Column transformation
+
+Column transformations allow to define custom transformations between database column types and application's data types. 
+This can be particularly useful when you need to store data in one format but work with it in another format within your application.
+
+Consider the following example, where we define a table to store meal times and transform these times into meal types:
+
+```kotlin
+enum class Meal {
+    BREAKFAST,
+    LUNCH,
+    DINNER
+}
+
+object Meals : Table() {
+    val mealTime = time("meal_time")
+        .transform(
+            toReal = {
+                when {
+                    it.hour < 10 -> Meal.BREAKFAST
+                    it.hour < 15 -> Meal.LUNCH
+                    else -> Meal.DINNER
+                }
+            },
+            toColumn = {
+                when (it) {
+                    Meal.BREAKFAST -> LocalTime(8, 0)
+                    Meal.LUNCH -> LocalTime(12, 0)
+                    Meal.DINNER -> LocalTime(18, 0)
+                }
+            }
+        )
+}
+```
+
+The `transform` function is used to apply custom transformations to the `mealTime` column:
+
+- The `toReal` function transforms the stored `LocalTime` values into `Meal` enums. It checks the hour of the stored time and returns the corresponding meal type.
+- The `toColumn` function transforms `Meal` enums back into `LocalTime` values for storage in the database.
+
+Transformation could be also defined as an implementation of `ColumnTransformer` interface and reused among different tables:
+
+```kotlin
+class MealTimeTransformer : ColumnTransformer<Meal, LocalTime> {
+    override fun fromColumn(value: LocalTime): Meal = when {
+        value.hour < 10 -> Meal.BREAKFAST
+        value.hour < 15 -> Meal.LUNCH
+        else -> Meal.DINNER
+    }
+
+    override fun toColumn(value: Meal): LocalTime = when (value) {
+        Meal.BREAKFAST -> LocalTime(8, 0)
+        Meal.LUNCH -> LocalTime(12, 0)
+        Meal.DINNER -> LocalTime(18, 0)
+    }
+}
+
+object Meals : Table() {
+    val mealTime = time("meal_time").transform(MealTimeTransformer())
+}
+```

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -811,7 +811,7 @@ Transformation could be also defined as an implementation of `ColumnTransformer`
 
 ```kotlin
 class MealTimeTransformer : ColumnTransformer<Meal, LocalTime> {
-    override fun fromColumn(value: LocalTime): Meal = when {
+    override fun toReal(value: LocalTime): Meal = when {
         value.hour < 10 -> Meal.BREAKFAST
         value.hour < 15 -> Meal.LUNCH
         else -> Meal.DINNER

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -782,7 +782,7 @@ enum class Meal {
 }
 
 object Meals : Table() {
-    val mealTime = time("meal_time")
+    val mealTime: Column<Meal> = time("meal_time")
         .transform(
             toReal = {
                 when {
@@ -825,6 +825,6 @@ class MealTimeTransformer : ColumnTransformer<Meal, LocalTime> {
 }
 
 object Meals : Table() {
-    val mealTime = time("meal_time").transform(MealTimeTransformer())
+    val mealTime: Column<Meal> = time("meal_time").transform(MealTimeTransformer())
 }
 ```

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -784,7 +784,7 @@ enum class Meal {
 object Meals : Table() {
     val mealTime: Column<Meal> = time("meal_time")
         .transform(
-            toReal = {
+            toTarget = {
                 when {
                     it.hour < 10 -> Meal.BREAKFAST
                     it.hour < 15 -> Meal.LUNCH
@@ -804,20 +804,20 @@ object Meals : Table() {
 
 The `transform` function is used to apply custom transformations to the `mealTime` column:
 
-- The `toReal` function transforms the stored `LocalTime` values into `Meal` enums. It checks the hour of the stored time and returns the corresponding meal type.
+- The `toTarget` function transforms the stored `LocalTime` values into `Meal` enums. It checks the hour of the stored time and returns the corresponding meal type.
 - The `toColumn` function transforms `Meal` enums back into `LocalTime` values for storage in the database.
 
 Transformation could be also defined as an implementation of `ColumnTransformer` interface and reused among different tables:
 
 ```kotlin
-class MealTimeTransformer : ColumnTransformer<Meal, LocalTime> {
-    override fun toReal(value: LocalTime): Meal = when {
+class MealTimeTransformer : ColumnTransformer<LocalTime, Meal> {
+    override fun toTarget(value: LocalTime): Meal = when {
         value.hour < 10 -> Meal.BREAKFAST
         value.hour < 15 -> Meal.LUNCH
         else -> Meal.DINNER
     }
 
-    override fun toColumn(value: Meal): LocalTime = when (value) {
+    override fun toSource(value: Meal): LocalTime = when (value) {
         Meal.BREAKFAST -> LocalTime(8, 0)
         Meal.LUNCH -> LocalTime(12, 0)
         Meal.DINNER -> LocalTime(18, 0)

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -784,14 +784,14 @@ enum class Meal {
 object Meals : Table() {
     val mealTime: Column<Meal> = time("meal_time")
         .transform(
-            toTarget = {
+            wrap = {
                 when {
                     it.hour < 10 -> Meal.BREAKFAST
                     it.hour < 15 -> Meal.LUNCH
                     else -> Meal.DINNER
                 }
             },
-            toColumn = {
+            unwrap = {
                 when (it) {
                     Meal.BREAKFAST -> LocalTime(8, 0)
                     Meal.LUNCH -> LocalTime(12, 0)
@@ -804,20 +804,20 @@ object Meals : Table() {
 
 The `transform` function is used to apply custom transformations to the `mealTime` column:
 
-- The `toTarget` function transforms the stored `LocalTime` values into `Meal` enums. It checks the hour of the stored time and returns the corresponding meal type.
-- The `toColumn` function transforms `Meal` enums back into `LocalTime` values for storage in the database.
+- The `wrap` function transforms the stored `LocalTime` values into `Meal` enums. It checks the hour of the stored time and returns the corresponding meal type.
+- The `unwrap` function transforms `Meal` enums back into `LocalTime` values for storage in the database.
 
 Transformation could be also defined as an implementation of `ColumnTransformer` interface and reused among different tables:
 
 ```kotlin
 class MealTimeTransformer : ColumnTransformer<LocalTime, Meal> {
-    override fun toTarget(value: LocalTime): Meal = when {
+    override fun wrap(value: LocalTime): Meal = when {
         value.hour < 10 -> Meal.BREAKFAST
         value.hour < 15 -> Meal.LUNCH
         else -> Meal.DINNER
     }
 
-    override fun toSource(value: Meal): LocalTime = when (value) {
+    override fun unwrap(value: Meal): LocalTime = when (value) {
         Meal.BREAKFAST -> LocalTime(8, 0)
         Meal.LUNCH -> LocalTime(12, 0)
         Meal.DINNER -> LocalTime(18, 0)

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -491,6 +491,14 @@ public abstract interface class org/jetbrains/exposed/sql/ColumnTransformer {
 	public abstract fun toReal (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class org/jetbrains/exposed/sql/ColumnTransformerImpl : org/jetbrains/exposed/sql/ColumnTransformer {
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final fun getToColumnFn ()Lkotlin/jvm/functions/Function1;
+	public final fun getToRealFn ()Lkotlin/jvm/functions/Function1;
+	public fun toColumn (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toReal (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/exposed/sql/IColumnType {
 	public fun <init> ()V
 	public fun <init> (Z)V

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -487,16 +487,8 @@ public abstract class org/jetbrains/exposed/sql/ColumnSet : org/jetbrains/expose
 }
 
 public abstract interface class org/jetbrains/exposed/sql/ColumnTransformer {
-	public abstract fun toSource (Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun toTarget (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class org/jetbrains/exposed/sql/ColumnTransformerImpl : org/jetbrains/exposed/sql/ColumnTransformer {
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public final fun getToSourceFn ()Lkotlin/jvm/functions/Function1;
-	public final fun getToTargetFn ()Lkotlin/jvm/functions/Function1;
-	public fun toSource (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun toTarget (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/exposed/sql/IColumnType {
@@ -521,26 +513,24 @@ public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/expos
 }
 
 public final class org/jetbrains/exposed/sql/ColumnTypeKt {
+	public static final fun columnTransformer (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/ColumnTransformer;
 	public static final fun getAutoIncColumnType (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/AutoIncColumnType;
 	public static final fun isAutoInc (Lorg/jetbrains/exposed/sql/IColumnType;)Z
 	public static final fun resolveColumnType (Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/ColumnType;
 	public static synthetic fun resolveColumnType$default (Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/ColumnType;
 }
 
-public abstract class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/ColumnTransformer {
-	public static final field Companion Lorg/jetbrains/exposed/sql/ColumnWithTransform$Companion;
-	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;)V
+public final class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/ColumnTransformer {
+	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)V
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public fun getNullable ()Z
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun setNullable (Z)V
 	public fun sqlType ()Ljava/lang/String;
+	public fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class org/jetbrains/exposed/sql/ColumnWithTransform$Companion {
-	public final fun create (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/sql/ColumnWithTransform;
+	public fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class org/jetbrains/exposed/sql/ComparisonOp : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -486,6 +486,11 @@ public abstract class org/jetbrains/exposed/sql/ColumnSet : org/jetbrains/expose
 	public final fun slice (Lorg/jetbrains/exposed/sql/Expression;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/FieldSet;
 }
 
+public abstract interface class org/jetbrains/exposed/sql/ColumnTransformer {
+	public abstract fun toColumn (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun toReal (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/exposed/sql/IColumnType {
 	public fun <init> ()V
 	public fun <init> (Z)V
@@ -2456,6 +2461,10 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public final fun short (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun text (Ljava/lang/String;Ljava/lang/String;Z)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun text$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun transformNullable (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun transformNullable (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun ubyte (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun uinteger (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun ulong (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
@@ -2567,6 +2576,22 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 }
 
 public final class org/jetbrains/exposed/sql/Transaction$Companion {
+}
+
+public abstract class org/jetbrains/exposed/sql/TransformColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/ColumnTransformer {
+	public static final field Companion Lorg/jetbrains/exposed/sql/TransformColumnType$Companion;
+	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public fun getNullable ()Z
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun setNullable (Z)V
+	public fun sqlType ()Ljava/lang/String;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/sql/TransformColumnType$Companion {
+	public final fun create (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/sql/TransformColumnType;
 }
 
 public final class org/jetbrains/exposed/sql/Trim : org/jetbrains/exposed/sql/Function {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -487,16 +487,16 @@ public abstract class org/jetbrains/exposed/sql/ColumnSet : org/jetbrains/expose
 }
 
 public abstract interface class org/jetbrains/exposed/sql/ColumnTransformer {
-	public abstract fun toColumn (Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun toReal (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun toSource (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun toTarget (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/sql/ColumnTransformerImpl : org/jetbrains/exposed/sql/ColumnTransformer {
 	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public final fun getToColumnFn ()Lkotlin/jvm/functions/Function1;
-	public final fun getToRealFn ()Lkotlin/jvm/functions/Function1;
-	public fun toColumn (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun toReal (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getToSourceFn ()Lkotlin/jvm/functions/Function1;
+	public final fun getToTargetFn ()Lkotlin/jvm/functions/Function1;
+	public fun toSource (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toTarget (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class org/jetbrains/exposed/sql/ColumnType : org/jetbrains/exposed/sql/IColumnType {
@@ -525,6 +525,22 @@ public final class org/jetbrains/exposed/sql/ColumnTypeKt {
 	public static final fun isAutoInc (Lorg/jetbrains/exposed/sql/IColumnType;)Z
 	public static final fun resolveColumnType (Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;)Lorg/jetbrains/exposed/sql/ColumnType;
 	public static synthetic fun resolveColumnType$default (Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/ColumnType;
+}
+
+public abstract class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/ColumnTransformer {
+	public static final field Companion Lorg/jetbrains/exposed/sql/ColumnWithTransform$Companion;
+	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;)V
+	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/IColumnType;
+	public fun getNullable ()Z
+	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun setNullable (Z)V
+	public fun sqlType ()Ljava/lang/String;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/sql/ColumnWithTransform$Companion {
+	public final fun create (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/sql/ColumnWithTransform;
 }
 
 public abstract class org/jetbrains/exposed/sql/ComparisonOp : org/jetbrains/exposed/sql/Op, org/jetbrains/exposed/sql/ComplexExpression, org/jetbrains/exposed/sql/Op$OpBoolean {
@@ -2584,22 +2600,6 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 }
 
 public final class org/jetbrains/exposed/sql/Transaction$Companion {
-}
-
-public abstract class org/jetbrains/exposed/sql/TransformColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/ColumnTransformer {
-	public static final field Companion Lorg/jetbrains/exposed/sql/TransformColumnType$Companion;
-	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;)V
-	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/IColumnType;
-	public fun getNullable ()Z
-	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun setNullable (Z)V
-	public fun sqlType ()Ljava/lang/String;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class org/jetbrains/exposed/sql/TransformColumnType$Companion {
-	public final fun create (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/sql/TransformColumnType;
 }
 
 public final class org/jetbrains/exposed/sql/Trim : org/jetbrains/exposed/sql/Function {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -314,7 +314,7 @@ abstract class TransformColumnType<TReal : Any, TColumn : Any>(val delegate: ICo
          * @param transformer The transformer that provides the transformation logic.
          * @return A new instance of [TransformColumnType] with the specified transformations.
          */
-        fun <Real : Any, Column : Any>create(delegate: IColumnType<Column>, transformer: ColumnTransformer<Real, Column>): TransformColumnType<Real, Column> {
+        fun <Real : Any, Column : Any> create(delegate: IColumnType<Column>, transformer: ColumnTransformer<Real, Column>): TransformColumnType<Real, Column> {
             return object : TransformColumnType<Real, Column>(delegate), ColumnTransformer<Real, Column> by transformer {}
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -259,7 +259,7 @@ class EntityIDColumnType<T : Comparable<T>>(
  */
 interface ColumnTransformer<Unwrapped, Wrapped> {
     /**
-     * Applies back transformation to the value of the transformed type [Wrapped] to the column type [Unwrapped] ([Wrapped] -> [Unwrapped])
+     * Returns the underlying column value without a transformation applied ([Wrapped] -> [Unwrapped]).
      */
     fun unwrap(value: Wrapped): Unwrapped
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -251,6 +251,66 @@ class EntityIDColumnType<T : Comparable<T>>(
     override fun hashCode(): Int = 31 * super.hashCode() + idColumn.hashCode()
 }
 
+/**
+ * An interface defining the transformation between a database column type and a real type.
+ *
+ * @param TReal The real type to which the column value is transformed.
+ * @param TColumn The column type provided by underlying `ColumnType`.
+ */
+interface ColumnTransformer<TReal : Any, TColumn : Any> {
+    /**
+     * Transforms a column value from the underlying `ColumnType` into the real type.
+     */
+    fun toReal(value: TColumn): TReal
+
+    /**
+     * Transforms a real type value into a column value.
+     */
+    fun toColumn(value: TReal): TColumn
+}
+
+/**
+ * A class that provides a transformation between a database column type and a real type.
+ *
+ * `TransformColumnType` is `ColumnType` by itself and can be used for defining columns.
+ *
+ * @param TReal The real type to which the column value is transformed.
+ * @param TColumn The column type provided by underlying `ColumnType`.
+ * @param delegate The original column type to be transformed.
+ */
+abstract class TransformColumnType<TReal : Any, TColumn : Any>(val delegate: IColumnType<TColumn>) : ColumnType<TReal>(), ColumnTransformer<TReal, TColumn> {
+    override fun sqlType() = delegate.sqlType()
+
+    override fun valueFromDB(value: Any): TReal? {
+        return delegate.valueFromDB(value)?.let { toReal(it) }
+    }
+
+    override fun notNullValueToDB(value: TReal): Any {
+        return delegate.notNullValueToDB(toColumn(value))
+    }
+
+    override fun nonNullValueToString(value: TReal): String {
+        return delegate.nonNullValueToString(toColumn(value))
+    }
+
+    override var nullable = delegate.nullable
+
+    companion object {
+        /**
+         * Creates a new instance of [TransformColumnType] with the given column type and transformer.
+         *
+         * @param Real The real type to which the column value is transformed.
+         * @param Column The type of delegated column type.
+         * @param delegate The original column type to be transformed.
+         * @param transformer The transformer that provides the transformation logic.
+         * @return A new instance of [TransformColumnType] with the specified transformations.
+         */
+        fun <Real : Any, Column : Any>create(delegate: IColumnType<Column>, transformer: ColumnTransformer<Real, Column>): TransformColumnType<Real, Column> {
+            return object : TransformColumnType<Real, Column>(delegate), ColumnTransformer<Real, Column> by transformer {}
+        }
+    }
+}
+
 // Numeric columns
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -257,7 +257,7 @@ class EntityIDColumnType<T : Comparable<T>>(
  * @param TReal The real type to which the column value is transformed.
  * @param TColumn The column type provided by underlying `ColumnType`.
  */
-interface ColumnTransformer<TReal : Any, TColumn : Any> {
+interface ColumnTransformer<TReal, TColumn> {
     /**
      * Transforms a column value from the underlying `ColumnType` into the real type.
      */
@@ -267,6 +267,15 @@ interface ColumnTransformer<TReal : Any, TColumn : Any> {
      * Transforms a real type value into a column value.
      */
     fun toColumn(value: TReal): TColumn
+}
+
+class ColumnTransformerImpl<TReal, TColumn>(
+    val toColumnFn: (TReal) -> TColumn,
+    val toRealFn: (TColumn) -> TReal
+) : ColumnTransformer<TReal, TColumn> {
+    override fun toReal(value: TColumn) = toRealFn(value)
+
+    override fun toColumn(value: TReal) = toColumnFn(value)
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1202,6 +1202,117 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         extraDefinitions.addAll(definition)
     }
 
+    /**
+     * Transforms a column by specifying transformation functions.
+     *
+     * @param TReal The target type of the transformation.
+     * @param TColumn The source type of the column.
+     * @param toReal A function to transform from the source type [TColumn] to the target type [TReal].
+     * @param toColumn A function to transform from the target type [TReal] to the source type [TColumn].
+     * @return A new column of type [TReal] with the applied transformations.
+     */
+    fun <TReal : Any, TColumn : Any> Column<TColumn>.transform(
+        toReal: (TColumn) -> TReal,
+        toColumn: (TReal) -> TColumn
+    ): Column<TReal> {
+        val transformer = object : ColumnTransformer<TReal, TColumn> {
+            override fun toReal(value: TColumn): TReal = toReal(value)
+
+            override fun toColumn(value: TReal): TColumn = toColumn(value)
+        }
+
+        return transform(transformer)
+    }
+
+    /**
+     * Transforms a column by specifying a transformer.
+     *
+     * @param TReal The target type of the transformation.
+     * @param TColumn The source type of the column.
+     * @param transformer An instance of [ColumnTransformer] to handle the transformations.
+     * @return A new column of type [TReal] with the applied transformations.
+     */
+    fun <TReal : Any, TColumn : Any> Column<TColumn>.transform(
+        transformer: ColumnTransformer<TReal, TColumn>
+    ): Column<TReal> = transform(TransformColumnType.create(columnType, transformer))
+
+    /**
+     * Applies the transformation column type to the column.
+     *
+     * @param TReal The target type of the transformation.
+     * @param TColumn The source type of the column.
+     * @param toColumnType The [TransformColumnType] instance with the transformation logic.
+     * @return A new column of type [TReal] with the applied transformation column type.
+     */
+    private fun <TReal : Any, TColumn : Any> Column<TColumn>.transform(toColumnType: TransformColumnType<TReal, TColumn>): Column<TReal> {
+        val newColumn: Column<TReal> = Column(table, name, toColumnType)
+        newColumn.foreignKey = foreignKey
+        newColumn.defaultValueFun = defaultValueFun?.let { { toColumnType.toReal(it()) } }
+        @Suppress("UNCHECKED_CAST")
+        newColumn.dbDefaultValue = dbDefaultValue as Expression<TReal>?
+        newColumn.isDatabaseGenerated = isDatabaseGenerated
+        newColumn.extraDefinitions = extraDefinitions
+        return replaceColumn(this, newColumn)
+    }
+
+    /**
+     * Transforms a nullable column by specifying transformation functions.
+     *
+     * @param TReal The target type of the transformation.
+     * @param TColumn The source type of the column.
+     * @param toReal A function to transform from the source type [TColumn] to the target type [TReal].
+     * @param toColumn A function to transform from the target type [TReal] to the source type [TColumn].
+     * @return A new column of type [TReal?] with the applied transformations.
+     */
+    @JvmName("transformNullable")
+    fun <TReal : Any, TColumn : Any> Column<TColumn?>.transform(
+        toReal: (TColumn) -> TReal,
+        toColumn: (TReal) -> TColumn
+    ): Column<TReal?> {
+        val transformer = object : ColumnTransformer<TReal, TColumn> {
+            override fun toReal(value: TColumn): TReal = toReal(value)
+
+            override fun toColumn(value: TReal): TColumn = toColumn(value)
+        }
+
+        return transform(transformer)
+    }
+
+    /**
+     * Transforms a nullable column by specifying a transformer.
+     *
+     * @param TReal The target type of the transformation.
+     * @param TColumn The source type of the column.
+     * @param transformer An instance of [ColumnTransformer] to handle the transformations.
+     * @return A new column of type [TReal?] with the applied transformations.
+     */
+    @JvmName("transformNullable")
+    fun <TReal : Any, TColumn : Any> Column<TColumn?>.transform(
+        transformer: ColumnTransformer<TReal, TColumn>
+    ): Column<TReal?> = transform(TransformColumnType.create(columnType, transformer))
+
+    /**
+     * Applies the transformation column type to the nullable column.
+     *
+     * @param TReal The target type of the transformation.
+     * @param TColumn The source type of the column.
+     * @param toColumnType The [TransformColumnType] instance with the transformation logic.
+     * @return A new column of type [TReal?] with the applied transformation column type.
+     */
+    @JvmName("transformNullable")
+    private fun <TReal : Any, TColumn : Any> Column<TColumn?>.transform(
+        toColumnType: TransformColumnType<TReal, TColumn>
+    ): Column<TReal?> {
+        val newColumn = Column<TReal?>(table, name, toColumnType)
+        newColumn.foreignKey = foreignKey
+        newColumn.defaultValueFun = defaultValueFun?.let { { it()?.let { it1 -> toColumnType.toReal(it1) } } }
+        @Suppress("UNCHECKED_CAST")
+        newColumn.dbDefaultValue = dbDefaultValue as Expression<TReal?>?
+        newColumn.isDatabaseGenerated = isDatabaseGenerated
+        newColumn.extraDefinitions = extraDefinitions
+        return replaceColumn(this, newColumn)
+    }
+
     // Indices
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1214,15 +1214,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <TReal : Any, TColumn : Any> Column<TColumn>.transform(
         toReal: (TColumn) -> TReal,
         toColumn: (TReal) -> TColumn
-    ): Column<TReal> {
-        val transformer = object : ColumnTransformer<TReal, TColumn> {
-            override fun toReal(value: TColumn): TReal = toReal(value)
-
-            override fun toColumn(value: TReal): TColumn = toColumn(value)
-        }
-
-        return transform(transformer)
-    }
+    ): Column<TReal> = transform(ColumnTransformerImpl(toColumn, toReal))
 
     /**
      * Transforms a column by specifying a transformer.
@@ -1268,15 +1260,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <TReal : Any, TColumn : Any> Column<TColumn?>.transform(
         toReal: (TColumn) -> TReal,
         toColumn: (TReal) -> TColumn
-    ): Column<TReal?> {
-        val transformer = object : ColumnTransformer<TReal, TColumn> {
-            override fun toReal(value: TColumn): TReal = toReal(value)
-
-            override fun toColumn(value: TReal): TColumn = toColumn(value)
-        }
-
-        return transform(transformer)
-    }
+    ): Column<TReal?> = transform(ColumnTransformerImpl(toColumn, toReal))
 
     /**
      * Transforms a nullable column by specifying a transformer.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1205,6 +1205,14 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /**
      * Transforms a column by specifying transformation functions.
      *
+     * Sample:
+     * ```kotlin
+     * object TestTable : IntIdTable() {
+     *     val stringToInteger = integer("stringToInteger")
+     *         .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+     * }
+     * ```
+     *
      * @param TReal The target type of the transformation.
      * @param TColumn The source type of the column.
      * @param toReal A function to transform from the source type [TColumn] to the target type [TReal].
@@ -1218,6 +1226,22 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /**
      * Transforms a column by specifying a transformer.
+     *
+     * Sample:
+     * ```kotlin
+     * object IntListColumnType : ColumnTransformer<List<Int>, String> {
+     *     override fun toReal(value: String): List<Int> {
+     *         val result = value.split(",").map { it.toInt() }
+     *         return result
+     *     }
+     *
+     *     override fun toColumn(value: List<Int>): String = value.joinToString(",")
+     * }
+     *
+     * object TestTable : IntIdTable() {
+     *     val numbers = text("numbers").transform(IntListColumnType)
+     * }
+     * ```
      *
      * @param TReal The target type of the transformation.
      * @param TColumn The source type of the column.
@@ -1250,6 +1274,15 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     /**
      * Transforms a nullable column by specifying transformation functions.
      *
+     * Sample:
+     * ```kotlin
+     * object TestTable : IntIdTable() {
+     *     val nullableStringToInteger = integer("nullableStringToInteger")
+     *         .nullable()
+     *         .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+     * }
+     * ```
+     *
      * @param TReal The target type of the transformation.
      * @param TColumn The source type of the column.
      * @param toReal A function to transform from the source type [TColumn] to the target type [TReal].
@@ -1264,6 +1297,22 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /**
      * Transforms a nullable column by specifying a transformer.
+     *
+     * Sample:
+     * ```kotlin
+     * object IntListColumnType : ColumnTransformer<List<Int>, String> {
+     *     override fun toReal(value: String): List<Int> {
+     *         val result = value.split(",").map { it.toInt() }
+     *         return result
+     *     }
+     *
+     *     override fun toColumn(value: List<Int>): String = value.joinToString(",")
+     * }
+     *
+     * object TestTable : IntIdTable() {
+     *     val numbers = text("numbers").nullable().transform(IntListColumnType)
+     * }
+     * ```
      *
      * @param TReal The target type of the transformation.
      * @param TColumn The source type of the column.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1214,7 +1214,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * ```
      *
      * @param Wrapped The type into which the value of the underlying column will be transformed.
-     * @param Unwrapped The source type of the column.
+     * @param Unwrapped The type of the original column.
      * @param wrap A function to transform from the source type [Unwrapped] to the target type [Wrapped].
      * @param unwrap A function to transform from the target type [Wrapped] to the source type [Unwrapped].
      * @return A new column of type [Wrapped] with the applied transformations.

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -1,3 +1,12 @@
+public abstract class org/jetbrains/exposed/dao/CompositeEntity : org/jetbrains/exposed/dao/Entity {
+	public fun <init> (Lorg/jetbrains/exposed/dao/id/EntityID;)V
+}
+
+public abstract class org/jetbrains/exposed/dao/CompositeEntityClass : org/jetbrains/exposed/dao/EntityClass {
+	public fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class org/jetbrains/exposed/dao/DaoEntityID : org/jetbrains/exposed/dao/id/EntityID {
 	public fun <init> (Ljava/lang/Comparable;Lorg/jetbrains/exposed/dao/id/IdTable;)V
 }
@@ -106,6 +115,7 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun all ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public final fun backReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lkotlin/properties/ReadOnlyProperty;
 	public final fun backReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lkotlin/properties/ReadOnlyProperty;
 	public final fun backReferencedOnOpt (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lkotlin/properties/ReadOnlyProperty;
 	public final fun count (Lorg/jetbrains/exposed/sql/Op;)J
@@ -131,13 +141,21 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
 	public fun new (Ljava/lang/Comparable;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun new (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
+	public final fun optionalBackReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
 	public final fun optionalBackReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
 	public final fun optionalBackReferencedOnOpt (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
+	public final fun optionalReferencedOn (Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalReference;
 	public final fun optionalReferencedOn (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalReference;
+	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
+	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;Z)Lorg/jetbrains/exposed/dao/OptionalReferrers;
 	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
 	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;Z)Lorg/jetbrains/exposed/dao/OptionalReferrers;
+	public static synthetic fun optionalReferrersOn$default (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;ZILjava/lang/Object;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
 	public static synthetic fun optionalReferrersOn$default (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;ZILjava/lang/Object;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
+	public final fun referencedOn (Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/Reference;
 	public final fun referencedOn (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/Reference;
+	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/Referrers;
+	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;Z)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;Z)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun reload (Lorg/jetbrains/exposed/dao/Entity;Z)Lorg/jetbrains/exposed/dao/Entity;
@@ -252,23 +270,29 @@ public abstract class org/jetbrains/exposed/dao/LongEntityClass : org/jetbrains/
 }
 
 public final class org/jetbrains/exposed/dao/OptionalBackReference : kotlin/properties/ReadOnlyProperty {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/dao/Entity;
 }
 
 public final class org/jetbrains/exposed/dao/OptionalReference {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllReferences ()Ljava/util/Map;
 	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/dao/OptionalReferrers : org/jetbrains/exposed/dao/Referrers {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class org/jetbrains/exposed/dao/Reference {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllReferences ()Ljava/util/Map;
 	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
 }
@@ -279,7 +303,8 @@ public final class org/jetbrains/exposed/dao/ReferencesKt {
 }
 
 public class org/jetbrains/exposed/dao/Referrers : kotlin/properties/ReadOnlyProperty {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCache ()Z
 	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -1,6 +1,6 @@
 public class org/jetbrains/exposed/dao/ColumnWithTransform {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;Z)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun getCacheResult ()Z
 	public final fun getColumn ()Lorg/jetbrains/exposed/sql/Column;
 	public final fun getToColumn ()Lkotlin/jvm/functions/Function1;
@@ -145,7 +145,9 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public fun getDependsOnTables ()Lorg/jetbrains/exposed/sql/ColumnSet;
 	public final fun getTable ()Lorg/jetbrains/exposed/dao/id/IdTable;
 	public final fun isAssignableTo (Lorg/jetbrains/exposed/dao/EntityClass;)Z
+	public final fun memoizedTransform (Lorg/jetbrains/exposed/dao/ColumnWithTransform;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
 	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
+	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
 	public fun new (Ljava/lang/Comparable;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun new (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun optionalBackReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
@@ -171,7 +173,9 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public fun searchQuery (Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun testCache (Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
 	public final fun testCache (Lorg/jetbrains/exposed/dao/id/EntityID;)Lorg/jetbrains/exposed/dao/Entity;
+	public final fun transform (Lorg/jetbrains/exposed/dao/ColumnWithTransform;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
 	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
+	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
 	public final fun view (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/View;
 	protected fun warmCache ()Lorg/jetbrains/exposed/dao/EntityCache;
 	public final fun warmUpLinkedReferences (Ljava/util/List;Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Boolean;Z)Ljava/util/List;

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -1,21 +1,3 @@
-public class org/jetbrains/exposed/dao/ColumnWithTransform {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;Z)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected final fun getCacheResult ()Z
-	public final fun getColumn ()Lorg/jetbrains/exposed/sql/Column;
-	public final fun getToColumn ()Lkotlin/jvm/functions/Function1;
-	public final fun getToReal ()Lkotlin/jvm/functions/Function1;
-}
-
-public abstract class org/jetbrains/exposed/dao/CompositeEntity : org/jetbrains/exposed/dao/Entity {
-	public fun <init> (Lorg/jetbrains/exposed/dao/id/EntityID;)V
-}
-
-public abstract class org/jetbrains/exposed/dao/CompositeEntityClass : org/jetbrains/exposed/dao/EntityClass {
-	public fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
 public final class org/jetbrains/exposed/dao/DaoEntityID : org/jetbrains/exposed/dao/id/EntityID {
 	public fun <init> (Ljava/lang/Comparable;Lorg/jetbrains/exposed/dao/id/IdTable;)V
 }
@@ -34,7 +16,7 @@ public class org/jetbrains/exposed/dao/Entity {
 	public final fun getId ()Lorg/jetbrains/exposed/dao/id/EntityID;
 	public final fun getKlass ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReadValues ()Lorg/jetbrains/exposed/sql/ResultRow;
-	public final fun getValue (Lorg/jetbrains/exposed/dao/ColumnWithTransform;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public final fun getValue (Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public final fun getValue (Lorg/jetbrains/exposed/dao/OptionalReference;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun getValue (Lorg/jetbrains/exposed/dao/Reference;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun getValue (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
@@ -45,7 +27,7 @@ public class org/jetbrains/exposed/dao/Entity {
 	public final fun lookupInReadValues (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun refresh (Z)V
 	public static synthetic fun refresh$default (Lorg/jetbrains/exposed/dao/Entity;ZILjava/lang/Object;)V
-	public final fun setValue (Lorg/jetbrains/exposed/dao/ColumnWithTransform;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
+	public final fun setValue (Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
 	public final fun setValue (Lorg/jetbrains/exposed/dao/OptionalReference;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;Lorg/jetbrains/exposed/dao/Entity;)V
 	public final fun setValue (Lorg/jetbrains/exposed/dao/Reference;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;Lorg/jetbrains/exposed/dao/Entity;)V
 	public final fun setValue (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
@@ -124,7 +106,6 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Class;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun all ()Lorg/jetbrains/exposed/sql/SizedIterable;
-	public final fun backReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lkotlin/properties/ReadOnlyProperty;
 	public final fun backReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lkotlin/properties/ReadOnlyProperty;
 	public final fun backReferencedOnOpt (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lkotlin/properties/ReadOnlyProperty;
 	public final fun count (Lorg/jetbrains/exposed/sql/Op;)J
@@ -145,26 +126,18 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public fun getDependsOnTables ()Lorg/jetbrains/exposed/sql/ColumnSet;
 	public final fun getTable ()Lorg/jetbrains/exposed/dao/id/IdTable;
 	public final fun isAssignableTo (Lorg/jetbrains/exposed/dao/EntityClass;)Z
-	public final fun memoizedTransform (Lorg/jetbrains/exposed/dao/ColumnWithTransform;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
-	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
-	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
+	public final fun memoizedTransform (Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
+	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
+	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
 	public fun new (Ljava/lang/Comparable;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun new (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
-	public final fun optionalBackReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
 	public final fun optionalBackReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
 	public final fun optionalBackReferencedOnOpt (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
-	public final fun optionalReferencedOn (Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalReference;
 	public final fun optionalReferencedOn (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalReference;
-	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
-	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;Z)Lorg/jetbrains/exposed/dao/OptionalReferrers;
 	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
 	public final fun optionalReferrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;Z)Lorg/jetbrains/exposed/dao/OptionalReferrers;
-	public static synthetic fun optionalReferrersOn$default (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;ZILjava/lang/Object;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
 	public static synthetic fun optionalReferrersOn$default (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;ZILjava/lang/Object;)Lorg/jetbrains/exposed/dao/OptionalReferrers;
-	public final fun referencedOn (Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/Reference;
 	public final fun referencedOn (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/Reference;
-	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/Referrers;
-	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;Z)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun referrersOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;Z)Lorg/jetbrains/exposed/dao/Referrers;
 	public final fun reload (Lorg/jetbrains/exposed/dao/Entity;Z)Lorg/jetbrains/exposed/dao/Entity;
@@ -173,9 +146,9 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public fun searchQuery (Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun testCache (Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
 	public final fun testCache (Lorg/jetbrains/exposed/dao/id/EntityID;)Lorg/jetbrains/exposed/dao/Entity;
-	public final fun transform (Lorg/jetbrains/exposed/dao/ColumnWithTransform;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
-	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
-	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/ColumnWithTransform;
+	public final fun transform (Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
+	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
+	public final fun transform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
 	public final fun view (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/View;
 	protected fun warmCache ()Lorg/jetbrains/exposed/dao/EntityCache;
 	public final fun warmUpLinkedReferences (Ljava/util/List;Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Boolean;Z)Ljava/util/List;
@@ -191,6 +164,15 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public final fun wrapRows (Lorg/jetbrains/exposed/sql/SizedIterable;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun wrapRows (Lorg/jetbrains/exposed/sql/SizedIterable;Lorg/jetbrains/exposed/sql/Alias;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun wrapRows (Lorg/jetbrains/exposed/sql/SizedIterable;Lorg/jetbrains/exposed/sql/QueryAlias;)Lorg/jetbrains/exposed/sql/SizedIterable;
+}
+
+public class org/jetbrains/exposed/dao/EntityFieldWithTransform : org/jetbrains/exposed/sql/ColumnTransformer {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;Z)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected final fun getCacheResult ()Z
+	public final fun getColumn ()Lorg/jetbrains/exposed/sql/Column;
+	public fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/dao/EntityHook {
@@ -270,29 +252,23 @@ public abstract class org/jetbrains/exposed/dao/LongEntityClass : org/jetbrains/
 }
 
 public final class org/jetbrains/exposed/dao/OptionalBackReference : kotlin/properties/ReadOnlyProperty {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;)V
 	public synthetic fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
 	public fun getValue (Lorg/jetbrains/exposed/dao/Entity;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/dao/Entity;
 }
 
 public final class org/jetbrains/exposed/dao/OptionalReference {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAllReferences ()Ljava/util/Map;
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;)V
 	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/dao/OptionalReferrers : org/jetbrains/exposed/dao/Referrers {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
 }
 
 public final class org/jetbrains/exposed/dao/Reference {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAllReferences ()Ljava/util/Map;
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;)V
 	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;
 }
@@ -303,8 +279,7 @@ public final class org/jetbrains/exposed/dao/ReferencesKt {
 }
 
 public class org/jetbrains/exposed/dao/Referrers : kotlin/properties/ReadOnlyProperty {
-	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;Z)V
 	public final fun getCache ()Z
 	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -728,86 +728,137 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     )
 
     /**
-     * Returns a [EntityFieldWithTransform] delegate that transforms this stored [TColumn] value on every read.
+     * Returns a [EntityFieldWithTransform] delegate that transforms this stored [Unwrapped] value on every read.
      *
      * @param transformer An instance of [ColumnTransformer] to handle the transformations.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, Target : Any?> Column<TColumn>.transform(
-        transformer: ColumnTransformer<TColumn, Target>
-    ): EntityFieldWithTransform<TColumn, Target> = EntityFieldWithTransform(this, transformer, false)
+    @Deprecated(
+        "This function was replaced with more general alternative on DSL layer. " +
+            "DAOs transform() is deprecated and will be removed in future releases. " +
+            "Please use the transform function from the DSL layer.",
+        ReplaceWith(
+            "object : Table() { val c = column().transform(transformer) }"
+        )
+    )
+    fun <Unwrapped : Any?, Wrapped : Any?> Column<Unwrapped>.transform(
+        transformer: ColumnTransformer<Unwrapped, Wrapped>
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = EntityFieldWithTransform(this, transformer, false)
 
     /**
-     * Returns a [EntityFieldWithTransform] delegate that transforms this stored [TColumn] value on every read.
+     * Returns a [EntityFieldWithTransform] delegate that transforms this stored [Unwrapped] value on every read.
      *
-     * @param toColumn A pure function that converts a transformed value to a value that can be stored
+     * @param unwrap A pure function that converts a transformed value to a value that can be stored
      * in this original column type.
-     * @param toTarget A pure function that transforms a value stored in this original column type.
+     * @param wrap A pure function that transforms a value stored in this original column type.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, Target : Any?> Column<TColumn>.transform(
-        toColumn: (Target) -> TColumn,
-        toTarget: (TColumn) -> Target
-    ): EntityFieldWithTransform<TColumn, Target> = transform(ColumnTransformerImpl(toColumn, toTarget))
+    @Deprecated(
+        "This function was replaced with more general alternative on DSL layer. " +
+            "DAOs transform() is deprecated and will be removed in future releases. " +
+            "Please use the transform function from the DSL layer.",
+        ReplaceWith(
+            "object : Table() { val c = column().transform(wrap, unwrap) }"
+        )
+    )
+    fun <Unwrapped : Any?, Wrapped : Any?> Column<Unwrapped>.transform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = transform(columnTransformer(unwrap, wrap))
 
     /**
      * Returns a [EntityFieldWithTransform] that extends transformation of existing [EntityFieldWithTransform].
      *
-     * @param toCurrentTarget A function that transforms the value to the target type of previously defined transformation
-     * @param toNextTarget A function that transforms value to the target type
+     * @param unwrap A function that transforms the value to the wrapping type of previously defined transformation
+     * @param wrap A function that transforms value to the wrapping type
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, CurrentTarget : Any?, NextTarget : Any?> EntityFieldWithTransform<TColumn, CurrentTarget>.transform(
-        toCurrentTarget: (NextTarget) -> CurrentTarget,
-        toNextTarget: (CurrentTarget) -> NextTarget
-    ): EntityFieldWithTransform<TColumn, NextTarget> =
-        EntityFieldWithTransform(this.column, ColumnTransformerImpl({ this.toColumn(toCurrentTarget(it)) }, { toNextTarget(this.toTarget(it)) }), false)
+    @Deprecated(
+        "This function was replaced with more general alternative on DSL layer. " +
+            "DAOs transform() is deprecated and will be removed in future releases. " +
+            "Please use the transform function from the DSL layer.",
+        ReplaceWith(
+            "object : Table() { val c = column().transform(wrap, unwrap) }"
+        )
+    )
+    fun <TColumn : Any?, Unwrapped : Any?, Wrapped : Any?> EntityFieldWithTransform<TColumn, Unwrapped>.transform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<TColumn, Wrapped> =
+        EntityFieldWithTransform(this.column, columnTransformer({ this.unwrap(unwrap(it)) }, { wrap(this.wrap(it)) }), false)
 
     /**
      * Returns a [EntityFieldWithTransform] delegate that will cache the transformed value on first read of
-     * this same stored [TColumn] value.
+     * this same stored [Unwrapped] value.
      *
      * @param transformer An instance of [ColumnTransformer] to handle the transformations.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, Target : Any?> Column<TColumn>.memoizedTransform(
-        transformer: ColumnTransformer<TColumn, Target>
-    ): EntityFieldWithTransform<TColumn, Target> = EntityFieldWithTransform(this, transformer, true)
+    @Deprecated(
+        "This function was replaced with more general alternative on DSL layer. " +
+            "DAOs transform() is deprecated and will be removed in future releases. " +
+            "Please use the transform function from the DSL layer." +
+            "Memoization will not be a part of column transformation API anymore.",
+        ReplaceWith(
+            "object : Table() { val c = column().transform(transformer) }"
+        )
+    )
+    fun <Unwrapped : Any?, Wrapped : Any?> Column<Unwrapped>.memoizedTransform(
+        transformer: ColumnTransformer<Unwrapped, Wrapped>
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = EntityFieldWithTransform(this, transformer, true)
 
     /**
      * Returns a [EntityFieldWithTransform] delegate that will cache the transformed value on first read of
-     * this same stored [TColumn] value.
+     * this same stored [Unwrapped] value.
      *
-     * @param toColumn A pure function that converts a transformed value to a value that can be stored
+     * @param unwrap A pure function that converts a transformed value to a value that can be stored
      * in this original column type.
-     * @param toTarget A pure function that transforms a value stored in this original column type.
+     * @param wrap A pure function that transforms a value stored in this original column type.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, Target : Any?> Column<TColumn>.memoizedTransform(
-        toColumn: (Target) -> TColumn,
-        toTarget: (TColumn) -> Target
-    ): EntityFieldWithTransform<TColumn, Target> = memoizedTransform(ColumnTransformerImpl(toColumn, toTarget))
+    @Deprecated(
+        "This function was replaced with more general alternative on DSL layer. " +
+            "DAOs transform() is deprecated and will be removed in future releases. " +
+            "Please use the transform function from the DSL layer." +
+            "Memoization will not be a part of column transformation API anymore.",
+        ReplaceWith(
+            "object : Table() { val c = column().transform(wrap, unwrap) }"
+        )
+    )
+    fun <Unwrapped : Any?, Wrapped : Any?> Column<Unwrapped>.memoizedTransform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = memoizedTransform(columnTransformer(unwrap, wrap))
 
     /**
      * Returns a [EntityFieldWithTransform] that extends transformation of existing [EntityFieldWithTransform]
      * and caches the transformed value on first read.
      *
-     * @param toCurrentTarget A function that transforms the value to the target type of previously defined transformation
-     * @param toNextTarget A function that transforms value to the target type
+     * @param unwrap A function that transforms the value to the wrapping type of previously defined transformation
+     * @param wrap A function that transforms value to the wrapping type
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, CurrentTarget : Any?, NextTarget : Any?> EntityFieldWithTransform<TColumn, CurrentTarget>.memoizedTransform(
-        toCurrentTarget: (NextTarget) -> CurrentTarget,
-        toNextTarget: (CurrentTarget) -> NextTarget
-    ): EntityFieldWithTransform<TColumn, NextTarget> = EntityFieldWithTransform(
+    @Deprecated(
+        "This function was replaced with more general alternative on DSL layer. " +
+            "DAOs transform() is deprecated and will be removed in future releases. " +
+            "Please use the transform function from the DSL layer." +
+            "Memoization will not be a part of column transformation API anymore.",
+        ReplaceWith(
+            "object : Table() { val c = column().transform(wrap, unwrap) }"
+        )
+    )
+    fun <TColumn : Any?, Unwrapped : Any?, Wrapped : Any?> EntityFieldWithTransform<TColumn, Unwrapped>.memoizedTransform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<TColumn, Wrapped> = EntityFieldWithTransform(
         this.column,
-        ColumnTransformerImpl({ this.toColumn(toCurrentTarget(it)) }, { toNextTarget(this.toTarget(it)) }),
+        columnTransformer({ this.unwrap(unwrap(it)) }, { wrap(this.wrap(it)) }),
         true
     )
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -737,7 +737,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     @Deprecated(
         "This function was replaced with more general alternative on DSL layer. " +
             "DAOs transform() is deprecated and will be removed in future releases. " +
-            "Please use the transform function from the DSL layer.",
+            "Please use the transform function from the DSL layer. " +
+            "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
+            "if a use-case cannot be sufficiently covered by the DSL transform().",
         ReplaceWith(
             "object : Table() { val c = column().transform(transformer) }"
         )
@@ -758,7 +760,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     @Deprecated(
         "This function was replaced with more general alternative on DSL layer. " +
             "DAOs transform() is deprecated and will be removed in future releases. " +
-            "Please use the transform function from the DSL layer.",
+            "Please use the transform function from the DSL layer. " +
+            "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
+            "if a use-case cannot be sufficiently covered by the DSL transform().",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )
@@ -779,7 +783,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     @Deprecated(
         "This function was replaced with more general alternative on DSL layer. " +
             "DAOs transform() is deprecated and will be removed in future releases. " +
-            "Please use the transform function from the DSL layer.",
+            "Please use the transform function from the DSL layer. " +
+            "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
+            "if a use-case cannot be sufficiently covered by the DSL transform().",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )
@@ -801,8 +807,10 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     @Deprecated(
         "This function was replaced with more general alternative on DSL layer. " +
             "DAOs transform() is deprecated and will be removed in future releases. " +
-            "Please use the transform function from the DSL layer." +
-            "Memoization will not be a part of column transformation API anymore.",
+            "Please use the transform function from the DSL layer. " +
+            "Memoization will not be a part of column transformation API anymore. " +
+            "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
+            "if a use-case cannot be sufficiently covered by the DSL transform().",
         ReplaceWith(
             "object : Table() { val c = column().transform(transformer) }"
         )
@@ -824,8 +832,10 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     @Deprecated(
         "This function was replaced with more general alternative on DSL layer. " +
             "DAOs transform() is deprecated and will be removed in future releases. " +
-            "Please use the transform function from the DSL layer." +
-            "Memoization will not be a part of column transformation API anymore.",
+            "Please use the transform function from the DSL layer. " +
+            "Memoization will not be a part of column transformation API anymore. " +
+            "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
+            "if a use-case cannot be sufficiently covered by the DSL transform().",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )
@@ -847,8 +857,10 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     @Deprecated(
         "This function was replaced with more general alternative on DSL layer. " +
             "DAOs transform() is deprecated and will be removed in future releases. " +
-            "Please use the transform function from the DSL layer." +
-            "Memoization will not be a part of column transformation API anymore.",
+            "Please use the transform function from the DSL layer. " +
+            "Memoization will not be a part of column transformation API anymore. " +
+            "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
+            "if a use-case cannot be sufficiently covered by the DSL transform().",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -728,88 +728,86 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     )
 
     /**
-     * Returns a [ColumnWithTransform] delegate that transforms this stored [TColumn] value on every read.
+     * Returns a [EntityFieldWithTransform] delegate that transforms this stored [TColumn] value on every read.
      *
      * @param transformer An instance of [ColumnTransformer] to handle the transformations.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, TReal : Any?> Column<TColumn>.transform(
-        transformer: ColumnTransformer<TReal, TColumn>
-    ): ColumnWithTransform<TColumn, TReal> = ColumnWithTransform(this, transformer, false)
+    fun <TColumn : Any?, Target : Any?> Column<TColumn>.transform(
+        transformer: ColumnTransformer<TColumn, Target>
+    ): EntityFieldWithTransform<TColumn, Target> = EntityFieldWithTransform(this, transformer, false)
 
     /**
-     * Returns a [ColumnWithTransform] delegate that transforms this stored [TColumn] value on every read.
+     * Returns a [EntityFieldWithTransform] delegate that transforms this stored [TColumn] value on every read.
      *
      * @param toColumn A pure function that converts a transformed value to a value that can be stored
      * in this original column type.
-     * @param toReal A pure function that transforms a value stored in this original column type.
+     * @param toTarget A pure function that transforms a value stored in this original column type.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, TReal : Any?> Column<TColumn>.transform(
-        toColumn: (TReal) -> TColumn,
-        toReal: (TColumn) -> TReal
-    ): ColumnWithTransform<TColumn, TReal> = transform(ColumnTransformerImpl(toColumn, toReal))
+    fun <TColumn : Any?, Target : Any?> Column<TColumn>.transform(
+        toColumn: (Target) -> TColumn,
+        toTarget: (TColumn) -> Target
+    ): EntityFieldWithTransform<TColumn, Target> = transform(ColumnTransformerImpl(toColumn, toTarget))
 
     /**
-     * Returns a [ColumnWithTransform] that extends transformation of existing [ColumnWithTransform].
+     * Returns a [EntityFieldWithTransform] that extends transformation of existing [EntityFieldWithTransform].
      *
-     * @param toColumn A pure function that converts a transformed value to a value that can be stored
-     * in this original column type.
-     * @param toReal A pure function that transforms a value stored in this original column type.
+     * @param toCurrentTarget A function that transforms the value to the target type of previously defined transformation
+     * @param toNextTarget A function that transforms value to the target type
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, TReal : Any?, TNextReal : Any?> ColumnWithTransform<TColumn, TReal>.transform(
-        toColumn: (TNextReal) -> TReal,
-        toReal: (TReal) -> TNextReal
-    ): ColumnWithTransform<TColumn, TNextReal> =
-        ColumnWithTransform(this.column, ColumnTransformerImpl({ this.toColumn(toColumn(it)) }, { toReal(this.toReal(it)) }), false)
+    fun <TColumn : Any?, CurrentTarget : Any?, NextTarget : Any?> EntityFieldWithTransform<TColumn, CurrentTarget>.transform(
+        toCurrentTarget: (NextTarget) -> CurrentTarget,
+        toNextTarget: (CurrentTarget) -> NextTarget
+    ): EntityFieldWithTransform<TColumn, NextTarget> =
+        EntityFieldWithTransform(this.column, ColumnTransformerImpl({ this.toColumn(toCurrentTarget(it)) }, { toNextTarget(this.toTarget(it)) }), false)
 
     /**
-     * Returns a [ColumnWithTransform] delegate that will cache the transformed value on first read of
+     * Returns a [EntityFieldWithTransform] delegate that will cache the transformed value on first read of
      * this same stored [TColumn] value.
      *
      * @param transformer An instance of [ColumnTransformer] to handle the transformations.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, TReal : Any?> Column<TColumn>.memoizedTransform(
-        transformer: ColumnTransformer<TReal, TColumn>
-    ): ColumnWithTransform<TColumn, TReal> = ColumnWithTransform(this, transformer, true)
+    fun <TColumn : Any?, Target : Any?> Column<TColumn>.memoizedTransform(
+        transformer: ColumnTransformer<TColumn, Target>
+    ): EntityFieldWithTransform<TColumn, Target> = EntityFieldWithTransform(this, transformer, true)
 
     /**
-     * Returns a [ColumnWithTransform] delegate that will cache the transformed value on first read of
+     * Returns a [EntityFieldWithTransform] delegate that will cache the transformed value on first read of
      * this same stored [TColumn] value.
      *
      * @param toColumn A pure function that converts a transformed value to a value that can be stored
      * in this original column type.
-     * @param toReal A pure function that transforms a value stored in this original column type.
+     * @param toTarget A pure function that transforms a value stored in this original column type.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, TReal : Any?> Column<TColumn>.memoizedTransform(
-        toColumn: (TReal) -> TColumn,
-        toReal: (TColumn) -> TReal
-    ): ColumnWithTransform<TColumn, TReal> = memoizedTransform(ColumnTransformerImpl(toColumn, toReal))
+    fun <TColumn : Any?, Target : Any?> Column<TColumn>.memoizedTransform(
+        toColumn: (Target) -> TColumn,
+        toTarget: (TColumn) -> Target
+    ): EntityFieldWithTransform<TColumn, Target> = memoizedTransform(ColumnTransformerImpl(toColumn, toTarget))
 
     /**
-     * Returns a [ColumnWithTransform] that extends transformation of existing [ColumnWithTransform]
+     * Returns a [EntityFieldWithTransform] that extends transformation of existing [EntityFieldWithTransform]
      * and caches the transformed value on first read.
      *
-     * @param toColumn A pure function that converts a transformed value to a value that can be stored
-     * in this original column type.
-     * @param toReal A pure function that transforms a value stored in this original column type.
+     * @param toCurrentTarget A function that transforms the value to the target type of previously defined transformation
+     * @param toNextTarget A function that transforms value to the target type
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationsTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.TransformationEntity
      */
-    fun <TColumn : Any?, TReal : Any?, TNextReal : Any?> ColumnWithTransform<TColumn, TReal>.memoizedTransform(
-        toColumn: (TNextReal) -> TReal,
-        toReal: (TReal) -> TNextReal
-    ): ColumnWithTransform<TColumn, TNextReal> = ColumnWithTransform(
+    fun <TColumn : Any?, CurrentTarget : Any?, NextTarget : Any?> EntityFieldWithTransform<TColumn, CurrentTarget>.memoizedTransform(
+        toCurrentTarget: (NextTarget) -> CurrentTarget,
+        toNextTarget: (CurrentTarget) -> NextTarget
+    ): EntityFieldWithTransform<TColumn, NextTarget> = EntityFieldWithTransform(
         this.column,
-        ColumnTransformerImpl({ this.toColumn(toColumn(it)) }, { toReal(this.toReal(it)) }),
+        ColumnTransformerImpl({ this.toColumn(toCurrentTarget(it)) }, { toNextTarget(this.toTarget(it)) }),
         true
     )
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnTransformTest.kt
@@ -2,8 +2,6 @@ package org.jetbrains.exposed.sql.tests.shared.ddl
 
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.ColumnTransformer
-import org.jetbrains.exposed.sql.StdOutSqlLogger
-import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
@@ -104,7 +102,6 @@ class ColumnTransformTest : DatabaseTestsBase() {
         }
 
         withTables(tester) {
-            addLogger(StdOutSqlLogger)
             val id1 = tester.insertAndGetId {
                 it[tester.numbers] = listOf(1, 2, 3)
                 it[tester.numbersNullable] = listOf(4, 5, 6)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnTransformTest.kt
@@ -1,0 +1,131 @@
+package org.jetbrains.exposed.sql.tests.shared.ddl
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.ColumnTransformer
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+import kotlin.test.assertNull
+
+class ColumnTransformTest : DatabaseTestsBase() {
+    @Test
+    fun testSimpleTransforms() {
+        val tester = object : IntIdTable("SimpleTransforms") {
+            val stringToInteger = integer("stringToInteger")
+                .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+            val nullableStringToInteger = integer("nullableStringToInteger")
+                .nullable()
+                .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+            val stringToIntegerNullable = integer("stringToIntegerNullable")
+                .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+                .nullable()
+        }
+
+        withTables(tester) {
+            val id1 = tester.insertAndGetId {
+                it[stringToInteger] = "1"
+                it[nullableStringToInteger] = "2"
+                it[stringToIntegerNullable] = "3"
+            }
+            val entry1 = tester.selectAll().where { tester.id eq id1 }.first()
+            assertEquals("1", entry1[tester.stringToInteger])
+            assertEquals("2", entry1[tester.nullableStringToInteger])
+            assertEquals("3", entry1[tester.stringToIntegerNullable])
+
+            val id2 = tester.insertAndGetId {
+                it[stringToInteger] = "1"
+                it[nullableStringToInteger] = null
+                it[stringToIntegerNullable] = null
+            }
+            val entry2 = tester.selectAll().where { tester.id eq id2 }.first()
+            assertEquals(null, entry2[tester.nullableStringToInteger])
+            assertEquals(null, entry2[tester.stringToIntegerNullable])
+        }
+    }
+
+    @Test
+    fun testNestedTransforms() {
+        val tester = object : IntIdTable("NestedTransforms") {
+            val booleanToInteger = integer("stringToInteger")
+                .transform(toReal = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
+                .transform(toReal = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
+
+            val booleanToIntegerNullable = integer("booleanToIntegerNullable")
+                .transform(toReal = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
+                .nullable()
+                .transform(toReal = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
+        }
+
+        withTables(tester) {
+            val id1 = tester.insertAndGetId {
+                it[booleanToInteger] = true
+                it[booleanToIntegerNullable] = true
+            }
+            val entry1 = tester.selectAll().where { tester.id eq id1 }.first()
+            assertEquals(true, entry1[tester.booleanToInteger])
+            assertEquals(true, entry1[tester.booleanToIntegerNullable])
+
+            val id2 = tester.insertAndGetId {
+                it[booleanToInteger] = false
+                it[booleanToIntegerNullable] = null
+            }
+            val entry2 = tester.selectAll().where { tester.id eq id2 }.first()
+            assertEquals(false, entry2[tester.booleanToInteger])
+            assertEquals(null, entry2[tester.booleanToIntegerNullable])
+        }
+    }
+
+    object IntListColumnType : ColumnTransformer<List<Int>, String> {
+        override fun toReal(value: String): List<Int> {
+            val result = value.split(",").map { it.toInt() }
+            return result
+        }
+
+        override fun toColumn(value: List<Int>): String = value.joinToString(",")
+    }
+
+    @Test
+    fun testTransformViaColumnTransformer() {
+        val tester = object : IntIdTable("TransformViaColumnTransformer") {
+            val numbers = text("numbers")
+                .transform(IntListColumnType)
+            val numbersNullable = text("numbersNullable")
+                .transform(IntListColumnType)
+                .nullable()
+
+            val nullableNumbers = text("nullableNumbers")
+                .nullable()
+                .transform(IntListColumnType)
+        }
+
+        withTables(tester) {
+            addLogger(StdOutSqlLogger)
+            val id1 = tester.insertAndGetId {
+                it[tester.numbers] = listOf(1, 2, 3)
+                it[tester.numbersNullable] = listOf(4, 5, 6)
+                it[tester.nullableNumbers] = listOf(7, 8, 9)
+            }
+
+            val entry1 = tester.selectAll().where { tester.id eq id1 }.single()
+            assertEqualLists(listOf(1, 2, 3), entry1[tester.numbers])
+            assertEqualLists(listOf(4, 5, 6), entry1[tester.numbersNullable] ?: emptyList())
+            assertEqualLists(listOf(7, 8, 9), entry1[tester.nullableNumbers] ?: emptyList())
+
+            val id2 = tester.insertAndGetId {
+                it[tester.numbers] = listOf(1, 2, 3)
+                it[tester.numbersNullable] = null
+                it[tester.nullableNumbers] = null
+            }
+
+            val entry2 = tester.selectAll().where { tester.id eq id2 }.single()
+            assertEqualLists(listOf(1, 2, 3), entry2[tester.numbers])
+            assertNull(entry2[tester.numbersNullable])
+            assertNull(entry2[tester.nullableNumbers])
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnWithTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnWithTransformTest.kt
@@ -10,17 +10,17 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.junit.Test
 import kotlin.test.assertNull
 
-class ColumnTransformTest : DatabaseTestsBase() {
+class ColumnWithTransformTest : DatabaseTestsBase() {
     @Test
     fun testSimpleTransforms() {
         val tester = object : IntIdTable("SimpleTransforms") {
             val stringToInteger = integer("stringToInteger")
-                .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+                .transform(toColumn = { it.toInt() }, toTarget = { it.toString() })
             val nullableStringToInteger = integer("nullableStringToInteger")
                 .nullable()
-                .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+                .transform(toColumn = { it.toInt() }, toTarget = { it.toString() })
             val stringToIntegerNullable = integer("stringToIntegerNullable")
-                .transform(toColumn = { it.toInt() }, toReal = { it.toString() })
+                .transform(toColumn = { it.toInt() }, toTarget = { it.toString() })
                 .nullable()
         }
 
@@ -50,13 +50,13 @@ class ColumnTransformTest : DatabaseTestsBase() {
     fun testNestedTransforms() {
         val tester = object : IntIdTable("NestedTransforms") {
             val booleanToInteger = integer("stringToInteger")
-                .transform(toReal = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
-                .transform(toReal = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
+                .transform(toTarget = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
+                .transform(toTarget = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
 
             val booleanToIntegerNullable = integer("booleanToIntegerNullable")
-                .transform(toReal = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
+                .transform(toTarget = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
                 .nullable()
-                .transform(toReal = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
+                .transform(toTarget = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
         }
 
         withTables(tester) {
@@ -78,13 +78,13 @@ class ColumnTransformTest : DatabaseTestsBase() {
         }
     }
 
-    object IntListColumnType : ColumnTransformer<List<Int>, String> {
-        override fun toReal(value: String): List<Int> {
+    object IntListColumnType : ColumnTransformer<String, List<Int>> {
+        override fun toTarget(value: String): List<Int> {
             val result = value.split(",").map { it.toInt() }
             return result
         }
 
-        override fun toColumn(value: List<Int>): String = value.joinToString(",")
+        override fun toSource(value: List<Int>): String = value.joinToString(",")
     }
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnWithTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ColumnWithTransformTest.kt
@@ -15,12 +15,12 @@ class ColumnWithTransformTest : DatabaseTestsBase() {
     fun testSimpleTransforms() {
         val tester = object : IntIdTable("SimpleTransforms") {
             val stringToInteger = integer("stringToInteger")
-                .transform(toColumn = { it.toInt() }, toTarget = { it.toString() })
+                .transform(unwrap = { it.toInt() }, wrap = { it.toString() })
             val nullableStringToInteger = integer("nullableStringToInteger")
                 .nullable()
-                .transform(toColumn = { it.toInt() }, toTarget = { it.toString() })
+                .transform(unwrap = { it.toInt() }, wrap = { it.toString() })
             val stringToIntegerNullable = integer("stringToIntegerNullable")
-                .transform(toColumn = { it.toInt() }, toTarget = { it.toString() })
+                .transform(unwrap = { it.toInt() }, wrap = { it.toString() })
                 .nullable()
         }
 
@@ -50,13 +50,13 @@ class ColumnWithTransformTest : DatabaseTestsBase() {
     fun testNestedTransforms() {
         val tester = object : IntIdTable("NestedTransforms") {
             val booleanToInteger = integer("stringToInteger")
-                .transform(toTarget = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
-                .transform(toTarget = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
+                .transform(wrap = { if (it != 0) "TRUE" else "FALSE" }, unwrap = { if (it == "TRUE") 1 else 0 })
+                .transform(wrap = { it == "TRUE" }, unwrap = { if (it) "TRUE" else "FALSE" })
 
             val booleanToIntegerNullable = integer("booleanToIntegerNullable")
-                .transform(toTarget = { if (it != 0) "TRUE" else "FALSE" }, toColumn = { if (it == "TRUE") 1 else 0 })
+                .transform(wrap = { if (it != 0) "TRUE" else "FALSE" }, unwrap = { if (it == "TRUE") 1 else 0 })
                 .nullable()
-                .transform(toTarget = { it == "TRUE" }, toColumn = { if (it) "TRUE" else "FALSE" })
+                .transform(wrap = { it == "TRUE" }, unwrap = { if (it) "TRUE" else "FALSE" })
         }
 
         withTables(tester) {
@@ -79,12 +79,12 @@ class ColumnWithTransformTest : DatabaseTestsBase() {
     }
 
     object IntListColumnType : ColumnTransformer<String, List<Int>> {
-        override fun toTarget(value: String): List<Int> {
+        override fun wrap(value: String): List<Int> {
             val result = value.split(",").map { it.toInt() }
             return result
         }
 
-        override fun toSource(value: List<Int>): String = value.joinToString(",")
+        override fun unwrap(value: List<Int>): String = value.joinToString(",")
     }
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityFieldWithTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityFieldWithTransformTest.kt
@@ -25,16 +25,16 @@ class TransformationEntity(id: EntityID<Int>) : IntEntity(id) {
     companion object : IntEntityClass<TransformationEntity>(TransformationsTable)
 
     var value by TransformationsTable.value.transform(
-        toColumn = { "transformed-$it" },
-        toTarget = { it.replace("transformed-", "") }
+        unwrap = { "transformed-$it" },
+        wrap = { it.replace("transformed-", "") }
     )
 }
 
 class NullableTransformationEntity(id: EntityID<Int>) : IntEntity(id) {
     companion object : IntEntityClass<NullableTransformationEntity>(NullableTransformationsTable)
     var value by NullableTransformationsTable.value.transform(
-        toColumn = { "transformed-$it" },
-        toTarget = { it?.replace("transformed-", "") }
+        unwrap = { "transformed-$it" },
+        wrap = { it?.replace("transformed-", "") }
     )
 }
 
@@ -91,12 +91,12 @@ class EntityFieldWithTransformTest : DatabaseTestsBase() {
 
     object TableWithTransforms : IntIdTable() {
         val value = varchar("value", 50)
-            .transform(toTarget = { it.toBigDecimal() }, toColumn = { it.toString() })
+            .transform(wrap = { it.toBigDecimal() }, unwrap = { it.toString() })
     }
 
     class TableWithTransform(id: EntityID<Int>) : IntEntity(id) {
         companion object : IntEntityClass<TableWithTransform>(TableWithTransforms)
-        var value by TableWithTransforms.value.transform(toTarget = { it.toInt() }, toColumn = { it.toBigDecimal() })
+        var value by TableWithTransforms.value.transform(wrap = { it.toInt() }, unwrap = { it.toBigDecimal() })
     }
 
     @Test
@@ -119,12 +119,12 @@ class EntityFieldWithTransformTest : DatabaseTestsBase() {
 
         var value by TransformationsTable.value
             .transform(
-                toColumn = { "transformed-$it" },
-                toTarget = { it.replace("transformed-", "") }
+                unwrap = { "transformed-$it" },
+                wrap = { it.replace("transformed-", "") }
             )
             .transform(
-                toCurrentTarget = { if (it.length > 5) it.slice(0..4) else it },
-                toNextTarget = { it }
+                unwrap = { if (it.length > 5) it.slice(0..4) else it },
+                wrap = { it }
             )
     }
 
@@ -144,12 +144,12 @@ class EntityFieldWithTransformTest : DatabaseTestsBase() {
 
         var value by TransformationsTable.value
             .transform(
-                toColumn = { "transformed-$it" },
-                toTarget = { it.replace("transformed-", "") }
+                unwrap = { "transformed-$it" },
+                wrap = { it.replace("transformed-", "") }
             )
             .memoizedTransform(
-                toCurrentTarget = { it + Random(10).nextInt(0, 100) },
-                toNextTarget = { it }
+                unwrap = { it + Random(10).nextInt(0, 100) },
+                wrap = { it }
             )
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityFieldWithTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityFieldWithTransformTest.kt
@@ -26,7 +26,7 @@ class TransformationEntity(id: EntityID<Int>) : IntEntity(id) {
 
     var value by TransformationsTable.value.transform(
         toColumn = { "transformed-$it" },
-        toReal = { it.replace("transformed-", "") }
+        toTarget = { it.replace("transformed-", "") }
     )
 }
 
@@ -34,11 +34,11 @@ class NullableTransformationEntity(id: EntityID<Int>) : IntEntity(id) {
     companion object : IntEntityClass<NullableTransformationEntity>(NullableTransformationsTable)
     var value by NullableTransformationsTable.value.transform(
         toColumn = { "transformed-$it" },
-        toReal = { it?.replace("transformed-", "") }
+        toTarget = { it?.replace("transformed-", "") }
     )
 }
 
-class ColumnWithTransformTest : DatabaseTestsBase() {
+class EntityFieldWithTransformTest : DatabaseTestsBase() {
 
     @Test
     fun `set and get value`() {
@@ -91,12 +91,12 @@ class ColumnWithTransformTest : DatabaseTestsBase() {
 
     object TableWithTransforms : IntIdTable() {
         val value = varchar("value", 50)
-            .transform(toReal = { it.toBigDecimal() }, toColumn = { it.toString() })
+            .transform(toTarget = { it.toBigDecimal() }, toColumn = { it.toString() })
     }
 
     class TableWithTransform(id: EntityID<Int>) : IntEntity(id) {
         companion object : IntEntityClass<TableWithTransform>(TableWithTransforms)
-        var value by TableWithTransforms.value.transform(toReal = { it.toInt() }, toColumn = { it.toBigDecimal() })
+        var value by TableWithTransforms.value.transform(toTarget = { it.toInt() }, toColumn = { it.toBigDecimal() })
     }
 
     @Test
@@ -120,11 +120,11 @@ class ColumnWithTransformTest : DatabaseTestsBase() {
         var value by TransformationsTable.value
             .transform(
                 toColumn = { "transformed-$it" },
-                toReal = { it.replace("transformed-", "") }
+                toTarget = { it.replace("transformed-", "") }
             )
             .transform(
-                toColumn = { if (it.length > 5) it.slice(0..4) else it },
-                toReal = { it }
+                toCurrentTarget = { if (it.length > 5) it.slice(0..4) else it },
+                toNextTarget = { it }
             )
     }
 
@@ -145,11 +145,11 @@ class ColumnWithTransformTest : DatabaseTestsBase() {
         var value by TransformationsTable.value
             .transform(
                 toColumn = { "transformed-$it" },
-                toReal = { it.replace("transformed-", "") }
+                toTarget = { it.replace("transformed-", "") }
             )
             .memoizedTransform(
-                toColumn = { it + Random(10).nextInt(0, 100) },
-                toReal = { it }
+                toCurrentTarget = { it + Random(10).nextInt(0, 100) },
+                toNextTarget = { it }
             )
     }
 


### PR DESCRIPTION
Here is the PR that allows to transform columns from their original types to another. 

Transformations could be nested, and could be applied to nullable columns. Transformation of a non-nullable column produces a non-nullable column, and transformation of a nullable column produces a nullable one. Creating nullable columns requires not only types changing, but also set field `nullable` into true, so still the method `nullable()` must be used.

We already have `transform()` for columns on the DAO layer, so I took naming from there (`toColumn`, `toReal` methods):

```kotlin
.transform(
    toColumn: (TReal) -> TColumn,
    toReal: (TColumn) -> TReal
)
```

But probably it's not the perfect variant. I was initially thinking about `Target`/`Source` instead of `TReal`/`TColumn` respectively. If you prefer the first variant (or have other suggestions) I'd be happy to know. It would be breaking change, but it could be changed for DAO as well if needed.