### PR TITLE
fix: EXPOSED-432 CurrentDate default is generated as null in MariaDB

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateFunctions.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.sql.javatime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MariaDBDialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
@@ -55,6 +56,7 @@ sealed class CurrentTimestampBase<T>(columnType: IColumnType<T & Any>) : Functio
 object CurrentDate : Function<LocalDate>(JavaLocalDateColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when (currentDialect) {
+            is MariaDBDialect -> "curdate()"
             is MysqlDialect -> "CURRENT_DATE()"
             is SQLServerDialect -> "GETDATE()"
             else -> "CURRENT_DATE"

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -368,8 +368,7 @@ class DefaultsTest : DatabaseTestsBase() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
             val defaultDate = date("default_date").defaultExpression(CurrentDate)
-            val defaultDateTime1 = datetime("default_date_time_1").defaultExpression(CurrentDateTime)
-            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentDateTime)
+            val defaultDateTime = datetime("default_date_time").defaultExpression(CurrentDateTime)
             val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp)
         }
 
@@ -379,16 +378,7 @@ class DefaultsTest : DatabaseTestsBase() {
 
                 val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
 
-                if (currentDialectTest is MysqlDialect) {
-                    // MySQL and MariaDB do not support CURRENT_DATE as default
-                    // so the column is created with a NULL marker, which correctly triggers 1 alter statement
-                    val tableName = foo.nameInDatabaseCase()
-                    val dateColumnName = foo.defaultDate.nameInDatabaseCase()
-                    val alter = "ALTER TABLE $tableName MODIFY COLUMN $dateColumnName DATE NULL"
-                    assertEquals(alter, actual.single())
-                } else {
-                    assertTrue(actual.isEmpty())
-                }
+                assertTrue(actual.isEmpty())
             } finally {
                 SchemaUtils.drop(foo)
             }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
@@ -591,6 +592,17 @@ class JavaTimeTests : DatabaseTestsBase() {
                     .where { tableWithTime.time eq localTimeLiteral }
                     .single()[tableWithTime.time]
             )
+        }
+    }
+
+    @Test
+    fun testCurrentDateAsDefaultExpression() {
+        val testTable = object : LongIdTable("test_table") {
+            val date: Column<LocalDate> = date("date").index().defaultExpression(CurrentDate)
+        }
+        withTables(testTable) {
+            val statements = SchemaUtils.statementsRequiredForDatabaseMigration(testTable)
+            assertTrue(statements.isEmpty())
         }
     }
 }

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateFunctions.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.sql.jodatime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MariaDBDialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
@@ -38,6 +39,7 @@ object CurrentDateTime : Function<DateTime>(DateColumnType(true)) {
 object CurrentDate : Function<DateTime>(DateColumnType(false)) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when (currentDialect) {
+            is MariaDBDialect -> "curdate()"
             is MysqlDialect -> "CURRENT_DATE()"
             is SQLServerDialect -> "GETDATE()"
             else -> "CURRENT_DATE"

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -428,6 +428,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
     fun testConsistentSchemeWithFunctionAsDefaultExpression() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
+            val defaultDate = date("default_date").defaultExpression(CurrentDate)
             val defaultDateTime = datetime("defaultDateTime").defaultExpression(CurrentDateTime)
         }
 
@@ -436,6 +437,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
                 SchemaUtils.create(foo)
 
                 val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
+
                 assertTrue(actual.isEmpty())
             } finally {
                 SchemaUtils.drop(foo)

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateFunctions.kt
@@ -9,6 +9,7 @@ import kotlinx.datetime.LocalTime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.vendors.H2Dialect
+import org.jetbrains.exposed.sql.vendors.MariaDBDialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
@@ -107,7 +108,8 @@ object CurrentTimestampWithTimeZone : CurrentTimestampBase<OffsetDateTime>(Kotli
 object CurrentDate : Function<LocalDate>(KotlinLocalDateColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         +when (currentDialect) {
-            is MysqlDialect -> "CURRENT_DATE()"
+            is MariaDBDialect -> "curdate()"
+            is MysqlDialect -> "CURRENT_DATE"
             is SQLServerDialect -> "GETDATE()"
             else -> "CURRENT_DATE"
         }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -372,8 +372,7 @@ class DefaultsTest : DatabaseTestsBase() {
         val foo = object : IntIdTable("foo") {
             val name = text("name")
             val defaultDate = date("default_date").defaultExpression(CurrentDate)
-            val defaultDateTime1 = datetime("default_date_time_1").defaultExpression(CurrentDateTime)
-            val defaultDateTime2 = datetime("default_date_time_2").defaultExpression(CurrentDateTime)
+            val defaultDateTime = datetime("default_date_time").defaultExpression(CurrentDateTime)
             val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp)
         }
 
@@ -383,16 +382,7 @@ class DefaultsTest : DatabaseTestsBase() {
 
                 val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
 
-                if (currentDialectTest is MysqlDialect) {
-                    // MySQL and MariaDB do not support CURRENT_DATE as default
-                    // so the column is created with a NULL marker, which correctly triggers 1 alter statement
-                    val tableName = foo.nameInDatabaseCase()
-                    val dateColumnName = foo.defaultDate.nameInDatabaseCase()
-                    val alter = "ALTER TABLE $tableName MODIFY COLUMN $dateColumnName DATE NULL"
-                    assertEquals(alter, actual.single())
-                } else {
-                    assertTrue(actual.isEmpty())
-                }
+                assertTrue(actual.isEmpty())
             } finally {
                 SchemaUtils.drop(foo)
             }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.between
@@ -608,6 +609,17 @@ class KotlinTimeTests : DatabaseTestsBase() {
                     .where { tableWithTime.time eq localTimeLiteral }
                     .single()[tableWithTime.time]
             )
+        }
+    }
+
+    @Test
+    fun testCurrentDateAsDefaultExpression() {
+        val testTable = object : LongIdTable("test_table") {
+            val date: Column<LocalDate> = date("date").index().defaultExpression(CurrentDate)
+        }
+        withTables(testTable) {
+            val statements = SchemaUtils.statementsRequiredForDatabaseMigration(testTable)
+            assertTrue(statements.isEmpty())
         }
     }
 }


### PR DESCRIPTION
As of [MySQL 8.0.13](https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#:~:text=Expression%20Evaluation%E2%80%9D.-,Explicit%20Default%20Handling%20Prior%20to%20MySQL%208.0.13,-With%20one%20exception) and [MariaDB 10.2.1](https://mariadb.com/kb/en/create-table/#default-column-option), the default value specified in a DEFAULT clause can be a function or an expression.