### PR TITLE
EXPOSED-409 Custom primary key. Access to the primary key fails with …

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Column.kt
@@ -181,7 +181,6 @@ class Column<T>(
 
         if (table != other.table) return false
         if (name != other.name) return false
-        if (columnType != other.columnType) return false
 
         return true
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -235,13 +235,9 @@ class EntityIDColumnType<T : Comparable<T>>(
     override fun readObject(rs: ResultSet, index: Int): Any? = idColumn.columnType.readObject(rs, index)
 
     override fun equals(other: Any?): Boolean {
-        if (this === other) return true
+        if (other !is EntityIDColumnType<*>) return false
 
-        return when (other) {
-            is EntityIDColumnType<*> -> idColumn == other.idColumn
-            is IColumnType<*> -> idColumn.columnType == other
-            else -> false
-        }
+        return idColumn == other.idColumn
     }
 
     override fun hashCode(): Int = 31 * super.hashCode() + idColumn.hashCode()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -239,7 +239,6 @@ class EntityIDColumnType<T : Comparable<T>>(
 
         return when (other) {
             is EntityIDColumnType<*> -> idColumn == other.idColumn
-            is IColumnType<*> -> idColumn.columnType == other
             else -> false
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -239,6 +239,7 @@ class EntityIDColumnType<T : Comparable<T>>(
 
         return when (other) {
             is EntityIDColumnType<*> -> idColumn == other.idColumn
+            is IColumnType<*> -> idColumn.columnType == other
             else -> false
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
@@ -103,7 +103,6 @@ class ResultRow(
         return fieldIndex[expression]
             ?: fieldIndex.keys.firstOrNull { exp ->
                 when (exp) {
-                    // exp is Column<*> && exp.table is Alias<*> -> exp.table.delegate == c
                     is Column<*> -> (exp.columnType as? EntityIDColumnType<*>)?.idColumn == expression
                     is ExpressionAlias<*> -> exp.delegate == expression
                     else -> false

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
@@ -1,8 +1,5 @@
 package org.jetbrains.exposed.sql.tests.shared.dml
 
-import junit.framework.TestCase
-import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.times
@@ -158,26 +155,6 @@ class ReturningTests : DatabaseTestsBase() {
             }.map { it[newPrice] }
             assertEquals(3, result3.size)
             assertTrue { result3.all { it == 0.0 } }
-        }
-    }
-
-    @Test
-    fun testCustomEntityIdColumnAccess() {
-        val tester = object : IdTable<String>() {
-
-            val value = varchar("value", 128)
-
-            override val primaryKey: PrimaryKey = PrimaryKey(value)
-            override val id: Column<EntityID<String>> = value.entityId()
-        }
-
-        withTables(tester) {
-            tester.insert {
-                it[tester.value] = "test-value"
-            }
-            val entry = tester.selectAll().first()
-            TestCase.assertEquals("test-value", entry[tester.value])
-            TestCase.assertEquals("test-value", entry[tester.id].value)
         }
     }
 }


### PR DESCRIPTION
Fixes the problem of accessing column with custom entity id. 

Before the fix two sequential accesses like `entry[tester.value]` and `entry[tester.id].value` to the column cause class cast exception due to caching by the column. 

After the fix the column value would be cached twice by different keys. Before the fix the `expression` that used for data access was taken as a key of caching. After the fix the key was extended with the column type, because two "equal" (in terms of `Object::equal()`) expressions (actually columns) may have a different column type and must return different values (value and entity id of that value).