### PR TITLE
fix: EXPOSED-363 LocalTime and literal(LocalTime) are not the same

### DIFF
--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -567,6 +567,32 @@ class JavaTimeTests : DatabaseTestsBase() {
             assertEqualLists(result2[firstTwoDatetimes], datetimeInput.take(2))
         }
     }
+
+    @Test
+    fun testSelectByTimeLiteralEquality() {
+        val tableWithTime = object : IntIdTable("TableWithTime") {
+            val time = time("time")
+        }
+        withTables(tableWithTime) {
+            val localTime = LocalTime.of(13, 0)
+            val localTimeLiteral = timeLiteral(localTime)
+
+            // UTC time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+            assertEquals("UTC", ZoneId.systemDefault().id)
+
+            tableWithTime.insert {
+                it[time] = localTime
+            }
+
+            assertEquals(
+                localTime,
+                tableWithTime.select(tableWithTime.id, tableWithTime.time)
+                    .where { tableWithTime.time eq localTimeLiteral }
+                    .single()[tableWithTime.time]
+            )
+        }
+    }
 }
 
 fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -584,6 +584,32 @@ class KotlinTimeTests : DatabaseTestsBase() {
             assertEqualLists(result2[firstTwoDatetimes], datetimeInput.take(2))
         }
     }
+
+    @Test
+    fun testSelectByTimeLiteralEquality() {
+        val tableWithTime = object : IntIdTable("TableWithTime") {
+            val time = time("time")
+        }
+        withTables(tableWithTime) {
+            val localTime = LocalTime(13, 0)
+            val localTimeLiteral = timeLiteral(localTime)
+
+            // UTC time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+            assertEquals("UTC", ZoneId.systemDefault().id)
+
+            tableWithTime.insert {
+                it[time] = localTime
+            }
+
+            assertEquals(
+                localTime,
+                tableWithTime.select(tableWithTime.id, tableWithTime.time)
+                    .where { tableWithTime.time eq localTimeLiteral }
+                    .single()[tableWithTime.time]
+            )
+        }
+    }
 }
 
 fun <T> assertEqualDateTime(d1: T?, d2: T?) {


### PR DESCRIPTION
Fixed for Oracle and SQLite