### PR TITLE
Support for using custom types as tables ids

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -234,6 +234,9 @@ class EntityIDColumnType<T : Comparable<T>>(
 
     override fun readObject(rs: ResultSet, index: Int): Any? = idColumn.columnType.readObject(rs, index)
 
+    override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) =
+        idColumn.columnType.setParameter(stmt, index, value)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CustomIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CustomIdTableEntityTest.kt
@@ -1,0 +1,94 @@
+package org.jetbrains.exposed.sql.tests.shared.entities
+
+import org.jetbrains.exposed.dao.Entity
+import org.jetbrains.exposed.dao.EntityClass
+import org.jetbrains.exposed.dao.UUIDEntity
+import org.jetbrains.exposed.dao.UUIDEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.with
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.entities.UUIDTables.Cities
+import org.jetbrains.exposed.sql.tests.shared.entities.UUIDTables.City.Companion.referrersOn
+import org.jetbrains.exposed.sql.tests.shared.entities.UUIDTables.Town
+import org.jetbrains.exposed.sql.tests.shared.entities.UUIDTables.Towns
+import org.junit.Test
+import java.sql.ResultSet
+import java.util.*
+import kotlin.test.assertNotNull
+
+data class CityId(
+    val value: String
+) : Comparable<CityId> {
+    override fun toString() = value
+    override fun compareTo(other: CityId) = value.compareTo(other.value)
+}
+
+fun Table.cityId(name: String): Column<CityId> = registerColumn(name, CityIdColumnType())
+
+class CityIdColumnType : ColumnType<CityId>() {
+    private val varcharColumnType = VarCharColumnType(10)
+
+    override fun sqlType() = varcharColumnType.sqlType()
+
+    override fun valueFromDB(value: Any): CityId = varcharColumnType.valueFromDB(value).let { CityId(it) }
+
+    override fun nonNullValueToString(value: CityId) = varcharColumnType.nonNullValueToString(value.value)
+
+    override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?): Unit =
+        varcharColumnType.setParameter(stmt, index, value?.toString())
+
+    override fun readObject(rs: ResultSet, index: Int) = varcharColumnType.readObject(rs, index)
+}
+
+
+@Suppress("MemberNameEqualsClassName")
+object CustomIdTables {
+    object Cities : IdTable<CityId>() {
+        override val id = cityId("id").entityId()
+        override val primaryKey = PrimaryKey(id)
+
+        val name = varchar("name", 50)
+    }
+
+    class City(id: EntityID<CityId>) : Entity<CityId>(id) {
+        companion object : EntityClass<CityId, City>(Cities)
+
+        var name by Cities.name
+    }
+}
+
+class CustomIdTableEntityTest : DatabaseTestsBase() {
+    @Test
+    fun `create tables`() {
+        withTables(CustomIdTables.Cities) {
+            assertEquals(true, CustomIdTables.Cities.exists())
+        }
+    }
+
+    @Test
+    fun `create records`() {
+        withTables(CustomIdTables.Cities) {
+            CustomIdTables.City.new(CityId("M")) { name = "Mumbai" }
+
+            val allCities = CustomIdTables.City.all().map { it.name }
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+        }
+    }
+
+    @Test
+    fun `find by id`() {
+        withTables(CustomIdTables.Cities) {
+            CustomIdTables.City.new(CityId("M")) { name = "Mumbai" }
+
+            val city = CustomIdTables.City.findById(CityId("M"))
+
+            assertNotNull(city)
+            assertEquals("Mumbai", city.name)
+        }
+    }
+
+}


### PR DESCRIPTION
Sometimes it is suitable to use custom types as table ids (however test example is synthetic).
Right now a lot of operations fail with exception:
```
Can't infer the SQL type to use for an instance of org.jetbrains.exposed.sql.tests.shared.entities.CityId. Use setObject() with an explicit Types value to specify the type to use.
org.postgresql.util.PSQLException: Can't infer the SQL type to use for an instance of org.jetbrains.exposed.sql.tests.shared.entities.CityId. Use setObject() with an explicit Types value to specify the type to use.
	at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:1076)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcPreparedStatementImpl.set(JdbcPreparedStatementImpl.kt:69)
	at org.jetbrains.exposed.sql.IColumnType$DefaultImpls.setParameter(ColumnType.kt:90)
	at org.jetbrains.exposed.sql.ColumnType.setParameter(ColumnType.kt:115)
	at org.jetbrains.exposed.sql.statements.api.PreparedStatementApi$DefaultImpls.fillParameters(PreparedStatementApi.kt:24)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcPreparedStatementImpl.fillParameters(JdbcPreparedStatementImpl.kt:22)
	at org.jetbrains.exposed.sql.statements.Statement.executeIn$exposed_core(Statement.kt:86)
	at org.jetbrains.exposed.sql.Transaction.exec(Transaction.kt:292)
	at org.jetbrains.exposed.sql.Transaction.exec(Transaction.kt:269)
	at org.jetbrains.exposed.sql.statements.Statement.execute(Statement.kt:59)
	at org.jetbrains.exposed.sql.QueriesKt.executeBatch(Queries.kt:308)
	at org.jetbrains.exposed.sql.QueriesKt.batchInsert(Queries.kt:218)
	at org.jetbrains.exposed.sql.QueriesKt.batchInsert(Queries.kt:193)
	at org.jetbrains.exposed.sql.QueriesKt.batchInsert$default(Queries.kt:188)
	at org.jetbrains.exposed.dao.EntityCache$flushInserts$ids$1.invoke(EntityCache.kt:242)
	at org.jetbrains.exposed.dao.EntityCache$flushInserts$ids$1.invoke(EntityCache.kt:241)
	at org.jetbrains.exposed.dao.EntityLifecycleInterceptorKt.executeAsPartOfEntityLifecycle(EntityLifecycleInterceptor.kt:18)
	at org.jetbrains.exposed.dao.EntityCache.flushInserts$exposed_dao(EntityCache.kt:241)
	at org.jetbrains.exposed.dao.EntityCache.flush(EntityCache.kt:194)
	at org.jetbrains.exposed.dao.EntityCache.flush(EntityCache.kt:154)
	at org.jetbrains.exposed.dao.EntityCacheKt.flushCache(EntityCache.kt:331)
	at org.jetbrains.exposed.dao.EntityLifecycleInterceptor.beforeCommit(EntityLifecycleInterceptor.kt:90)
	at org.jetbrains.exposed.sql.Transaction.commit(Transaction.kt:168)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase$withTables$1.invoke(DatabaseTestsBase.kt:111)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase$withTables$1.invoke(DatabaseTestsBase.kt:102)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase$withDb$2.invoke(DatabaseTestsBase.kt:76)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase$withDb$2.invoke(DatabaseTestsBase.kt:72)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$run(ThreadLocalTransactionManager.kt:324)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.access$inTopLevelTransaction$run(ThreadLocalTransactionManager.kt:1)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt$inTopLevelTransaction$1.invoke(ThreadLocalTransactionManager.kt:371)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:379)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction(ThreadLocalTransactionManager.kt:370)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt$transaction$1.invoke(ThreadLocalTransactionManager.kt:279)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:379)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction(ThreadLocalTransactionManager.kt:249)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction$default(ThreadLocalTransactionManager.kt:244)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withDb(DatabaseTestsBase.kt:72)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withTables(DatabaseTestsBase.kt:102)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withTables(DatabaseTestsBase.kt:154)
	at org.jetbrains.exposed.sql.tests.shared.entities.CustomIdTableEntityTest.find by id(CustomIdTableEntityTest.kt:84)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```