### PR TITLE
fix: EXPOSED-430 Insert and BatchInsert do not return default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # 0.52.0
 
+Breaking changes: 
+* feat: EXPOSED-295 Support subqueries with preceding LATERAL by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2095
+
 Features:
 * feat: EXPOSED-334 Support MERGE statement by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2047
 * feat: EXPOSED-368 Ordering on References by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2083
 * Feat: EXPOSED-396 Supports fetchBatchedResults with sorting order  by @roharon in https://github.com/JetBrains/Exposed/pull/2102
 * feat: Add OffsetDateTime extension functions by @joc-a in https://github.com/JetBrains/Exposed/pull/2118
-* feat: EXPOSED-295 Support subqueries with preceding LATERAL by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2095
 * feat: EXPOSED-336 Support Where clause with batchUpsert by @bog-walk in https://github.com/JetBrains/Exposed/pull/2120
 * feat: EXPOSED-416 Support adding special database-specific column definitions by @bog-walk in https://github.com/JetBrains/Exposed/pull/2125
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -615,6 +615,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <T : Comparable<T>> Column<T>.entityId(): Column<EntityID<T>> {
         val newColumn = Column<EntityID<T>>(table, name, EntityIDColumnType(this)).also {
             it.defaultValueFun = defaultValueFun?.let { { EntityIDFunctionProvider.createEntityID(it(), table as IdTable<T>) } }
+            it.dbDefaultValue = dbDefaultValue?.let { it as Expression<EntityID<T>> }
             it.extraDefinitions = extraDefinitions
         }
         (table as IdTable<T>).addIdColumn(newColumn)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -735,4 +735,19 @@ class InsertTests : DatabaseTestsBase() {
             assertNotNull(entry[tester.defaultDate])
         }
     }
+
+    @Test
+    fun testDatabaseGeneratedUUIDasPrimaryKey() {
+        val randomPGUUID = object : CustomFunction<UUID>("gen_random_uuid", UUIDColumnType()) {}
+
+        val tester = object : IdTable<UUID>("testTestTest") {
+            override val id = uuid("id").defaultExpression(randomPGUUID).entityId()
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            val result = tester.insert {}
+            assertNotNull(result[tester.id])
+        }
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -8,6 +8,8 @@ import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.kotlin.datetime.CurrentTimestamp
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 import org.jetbrains.exposed.sql.statements.BatchInsertStatement
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
@@ -718,6 +720,19 @@ class InsertTests : DatabaseTestsBase() {
             }.single()
             assertEquals("custom-id-value", result1[tester.id].value)
             assertEquals("custom-id-value", result1[tester.customId])
+        }
+    }
+
+    @Test
+    fun testInsertReturnsValuesFromDefaultExpression() {
+        val tester = object : Table() {
+            val defaultDate = timestamp(name = "default_date").defaultExpression(CurrentTimestamp)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            val entry = tester.insert {}
+
+            assertNotNull(entry[tester.defaultDate])
         }
     }
 }


### PR DESCRIPTION
Here is a small fix before a bigger way of improving default values. 

We have a small regression for Postgres. Before it was possible to take default values generated on the DB side (columns with `defaultExpression()` or `databaseGenerated()` definitions) from insert statement. It was broken some weeks ago. Here is a corresponding test with the fix added.

Also updated the changelog a bit because it was mentioned in Slack that one of PRs added a breaking change (the one with the lateral joins feature)