### PR TITLE
fix: Allow column reference in default expressions for MySQL and MariaDB

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -230,7 +230,7 @@ open class InsertStatement<Key : Any>(
             val nullableColumns = table.columns.filter { it.columnType.nullable && !it.isDatabaseGenerated }
             val valuesAndDefaults = valuesAndDefaults() as MutableMap
             valuesAndDefaults.putAll((nullableColumns - valuesAndDefaults.keys).associateWith { null })
-            val result = valuesAndDefaults.toList().sortedBy { it.first }
+            val result = valuesAndDefaults.toList()
             listOf(result).apply { field = this }
         }
 


### PR DESCRIPTION
MySQL and MariaDB are the only supported databases that allow referencing another column in a default expression, but for this to work, the referenced column must be one that occurs earlier in the table definition. This was not working because Exposed was sorting the columns by column name for the insert statement. Not sorting fixes this issue.