### PR TITLE
docs: EXPOSED-445 Add documentation for DSL & DAO composite primary keys

### DIFF
--- a/documentation-website/Writerside/hi.tree
+++ b/documentation-website/Writerside/hi.tree
@@ -10,7 +10,8 @@
     <toc-element topic="Getting-Started-with-Exposed.md"/>
     <toc-element topic="Exposed-Modules.md"/>
     <toc-element topic="Database-and-DataSource.md"/>
-    <toc-element topic="Table-Definition.md">
+    <toc-element toc-title="Working with Tables">
+        <toc-element topic="Table-Definition.md"/>
         <toc-element topic="Data-Types.md"/>
         <toc-element topic="SQL-Functions.md"/>
     </toc-element>

--- a/documentation-website/Writerside/hi.tree
+++ b/documentation-website/Writerside/hi.tree
@@ -8,14 +8,15 @@
 
     <toc-element topic="Home.topic"/>
     <toc-element topic="Getting-Started-with-Exposed.md"/>
+    <toc-element topic="Exposed-Modules.md"/>
     <toc-element topic="Database-and-DataSource.md"/>
-    <toc-element topic="Transactions.md"/>
-    <toc-element topic="Deep-Dive-into-DSL.md"/>
-    <toc-element topic="Deep-Dive-into-DAO.md"/>
-    <toc-element topic="Exposed-Modules.md">
+    <toc-element topic="Table-Definition.md">
         <toc-element topic="Data-Types.md"/>
         <toc-element topic="SQL-Functions.md"/>
     </toc-element>
+    <toc-element topic="Transactions.md"/>
+    <toc-element topic="Deep-Dive-into-DSL.md"/>
+    <toc-element topic="Deep-Dive-into-DAO.md"/>
     <toc-element topic="Frequently-Asked-Questions.md"/>
     <toc-element topic="Samples.md"/>
     <toc-element topic="Migration-Guide.md"/>

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -369,7 +369,7 @@ root.children = SizedCollection(listOf(child1, child2)) // assign children
 
 ### Composite primary key reference
 
-Let's say we have the following `CompositeIdTable`:
+Assuming that we have the following `CompositeIdTable`:
 ```kotlin
 object Directors : CompositeIdTable("directors") {
     val name = varchar("name", 50).entityId()

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -40,11 +40,14 @@ class StarWarsFilm(id: EntityID<Int>) : IntEntity(id) {
 
 ## Table types
 In addition to `IntIdTable`, the following `IdTable` subclasses are available:
-* `LongIdTable` - `Long` id column
-* `UIntIdTable` - `UInt` id column
-* `ULongIdTable` - `ULong` id column
-* `UUIDTable` - `UUID` id column
-* `CompositeIdTable` - multiple columns make up the table id
+
+<deflist type="medium">
+<def title="LongIdTable"><code>Long</code> id column</def>
+<def title="UIntIdTable"><code>UInt</code> id column</def>
+<def title="ULongIdTable"><code>ULong</code> id column</def>
+<def title="UUIDTable"><code>UUID</code> id column</def>
+<def title="CompositeIdTable">Multiple columns make up the table id</def>
+</deflist>
 
 To define a custom column type as the primary key and id, use a typed `IdTable` directly and override the `id` column:
 ```kotlin
@@ -114,7 +117,7 @@ val movies = StarWarsFilm.all()
 val movies = StarWarsFilm.find { StarWarsFilms.sequelId eq 8 }
 val movie = StarWarsFilm.findById(5)
 ```
-* For a list of available predicates, see [DSL Where expression](Deep-Dive-into-DSL.md#where-expression).
+<tip>For a list of available predicates, see <a href="Deep-Dive-into-DSL.md#where-expression">DSL Where expression</a>.</tip>
 
 Read a value from a property similar to any property in a Kotlin class:
 ```kotlin
@@ -284,7 +287,7 @@ class User(id: EntityID<Int>) : IntEntity(id) {
 }
 ```
 
-Without using the `infix` call, the `orderBy` method is chained after `referrersOn`:
+Without using the [infix notation](https://kotlinlang.org/docs/functions.html#infix-notation), the `orderBy` method is chained after `referrersOn`:
 
 ```kotlin
 class User(id: EntityID<Int>) : IntEntity(id) {
@@ -404,7 +407,7 @@ class StarWarsFilm(id: EntityID<Int>) : IntEntity(id) {
   var director by Director referencedOn StarWarsFilms
 }
 ```
-* For more information on creating table foreign key constraints, see [DSL Foreign Key](Table-Definition.md#foreign-key).
+<tip>For more information on creating table foreign key constraints, see <a href="Table-Definition.md#foreign-key">DSL Foreign Key</a>.</tip>
 
 Now you can get the director for a `StarWarsFilm` object, `movie`, in the same way you would get any other field:
 ```kotlin
@@ -422,8 +425,9 @@ You can then access this field on a `Director` object, `director`:
 ```kotlin
 director.films // returns all StarWarsFilm objects that reference this director
 ```
-Using other previously mentioned infix functions, like `optionalReferencedOn`, `backReferencedOn`, and `optionalReferrersOn`,
-is also supported for referencing or referenced `CompositeEntity` objects, by using the respective overloads that accept an `IdTable` as an argument.
+Using other previously mentioned [infix functions](https://kotlinlang.org/docs/functions.html#infix-notation),
+like `optionalReferencedOn`, `backReferencedOn`, and `optionalReferrersOn`, is also supported for referencing or referenced `CompositeEntity` objects,
+by using the respective overloads that accept an `IdTable` as an argument.
 These overloads will automatically resolve the foreign key constraint associated with the composite primary key.
 
 ### Eager Loading

--- a/documentation-website/Writerside/topics/Frequently-Asked-Questions.md
+++ b/documentation-website/Writerside/topics/Frequently-Asked-Questions.md
@@ -10,8 +10,7 @@ A: Yes. See [Transactions](Transactions.md#working-with-multiple-databases)
 
 ### Q: Is `Array` column type supported?
 
-A: Not at the moment. More info here: [https://github.com/JetBrains/Exposed/issues/150](https://github.com/JetBrains/Exposed/issues/150)  
-The complete list of supported data types can be found here: [Data Types](Data-Types.md#how-to-use-array-types).
+A: Yes. See [Data Types](Data-Types.md#how-to-use-array-types).
 
 ### Q: Is `upsert` supported?
 
@@ -87,11 +86,6 @@ dependencies {
     implementation 'com.github.JetBrains:Exposed:-SNAPSHOT'
 }
 ```
-
-### Q: How can I specify a primary key column type e.g StringIdTable?
-A: You need to define your own! See examples:  
-[#855](https://github.com/JetBrains/Exposed/issues/855)  
-[https://stackoverflow.com/a/61940820/1155026](https://github.com/JetBrains/Exposed/issues/118)
 
 ### Q: How can I create a custom column type?
 A: Just implements [IColumnType](https://github.com/JetBrains/Exposed/blob/76a671e57a0105d6aed79e256c088690bd4a56b6/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt#L25)

--- a/documentation-website/Writerside/topics/Table-Definition.md
+++ b/documentation-website/Writerside/topics/Table-Definition.md
@@ -1,6 +1,6 @@
 # Table Definition
 
-This page shows what table types Exposed supports and how to define and create tables. It also contains tips on configuring 
+This page shows what table types Exposed supports and how to define and create these tables. It also contains tips on configuring 
 constraints, such as `PRIMARY KEY`, `DEFAULT`, and `INDEX`. All examples use the H2 database to generate SQL.
 
 ## Table Types
@@ -9,7 +9,7 @@ The most primitive table type is `Table`. It is located in the **org.jetbrains.e
 To configure a custom name for a table, which will be used in actual SQL queries, pass it to the `name` parameter of the `Table()` constructor.
 Otherwise, Exposed will generate it from the full class name or the class name without the suffix 'Table', if present.
 
-For example, to create a simple table with an integer `id` column and a string `name` column, use the following code depending on the table name of choice:
+For example, to create a simple table with an integer `id` column and a string `name` column, use any of the following code, depending on the table name of choice:
 ```kotlin
 // Table name will be taken from object name
 object Cities : Table() {
@@ -41,7 +41,7 @@ object Cities : Table("all_cities") {
 //          "name" VARCHAR(50) NOT NULL
 //      )
 
-// Some databases, like H2, fold unquoted names to upper case
+// Some databases, like H2, fold unquoted names to upper case.
 // To keep case-sensitivity, manually quote the provided argument
 object Cities : Table("\"all_cities\"") {
     val id = integer("id")
@@ -53,12 +53,17 @@ object Cities : Table("\"all_cities\"") {
 //      )
 ```
 
-Exposed also provides the base `IdTable` class which is inherited by `IntIdTable`, `LongIdTable` (and their unsigned variants), `UUIDTable`, and `CompositeIdTable` classes from the 
-**org.jetbrains.exposed.dao.id** package of the **exposed-core** module. These tables could be declared without the `id` column, and
-IDs of the appropriate type will be generated automatically when creating new table rows. To configure a custom name 
-for the `id` column, pass it to the `columnName` parameter of the appropriate table constructor.
+Depending on what DBMS you use, the types of columns could be different in actual SQL queries.
 
-The `Cities` table could instead be defined as an `IntIdTable`, which would make the `id` column both auto-incrementing and the table's primary key:
+### IdTable Types
+
+Exposed also provides the base `IdTable` class, which is inherited by `IntIdTable`, `LongIdTable` (and their unsigned variants), `UUIDTable`, and `CompositeIdTable` classes from the 
+**org.jetbrains.exposed.dao.id** package of the **exposed-core** module.
+
+These tables could be declared without the `id` column, and IDs of the appropriate type would be generated automatically when creating new table rows.
+To configure a custom name for the `id` column, pass it to the `columnName` parameter of the appropriate table constructor.
+
+For example, the `Cities` table could instead be defined as an `IntIdTable`, which would make the `id` column both auto-incrementing and the table's primary key:
 ```kotlin
 object Cities : IntIdTable() {
     val name = varchar("name", 50)
@@ -69,7 +74,7 @@ object Cities : IntIdTable() {
 //      )
 ```
 
-Depending on what DBMS you use, the types of columns could be different in actual SQL queries.
+* For more information on `IdTable` types, see [DAO Table Types](Deep-Dive-into-DAO.md#table-types).
 
 ## Constraints
 
@@ -205,11 +210,11 @@ It is also possible to define a primary key on a table using multiple columns:
 override val primaryKey = PrimaryKey(id, name)
 ```
 
-Each kind of table in Exposed that is inherited from `IdTable` has the `primaryKey` field automatically defined.
+Except for `CompositeIdTable`, each available class in Exposed that inherits from `IdTable` has the `primaryKey` field automatically defined.
 For example, the `IntIdTable` by default has an auto-incrementing integer column, `id`, which is defined as the primary key.
 
 An `IdTable` that requires a primary key with multiple columns can be defined using `CompositeIdTable`.
-In this case, each column that is a component of the table's `id` column should be identified by `entityId()`:
+In this case, each column that is a component of the table's `id` should be identified by `entityId()`:
 ```kotlin
 object Towns : CompositeIdTable("towns") {
     val areaCode = integer("area_code").autoIncrement().entityId()
@@ -225,7 +230,8 @@ object Towns : CompositeIdTable("towns") {
 
 The `FOREIGN KEY` SQL constraint links two tables. A foreign key is a column from one table that refers to the primary key 
 or columns with a unique index from another table. To configure a foreign key on a column, use `reference()` or `optReference()` 
-methods. The latter lets the foreign key accept a `null` value.
+methods. The latter lets the foreign key accept a `null` value. To configure a foreign key on multiple columns,
+use `foreignKey()` directly within an `init` block.
 
 `reference()` and `optReference()` methods have several parameters:
 
@@ -255,7 +261,7 @@ object Citizens : IntIdTable() {
 
 If any `Cities` row will be deleted, the appropriate `Citizens` row will be deleted too.
 
-If instead the `Cities` table has configured multiple columns as the primary key (for example, both `id` and `name` columns as in the above section),
+If instead the `Cities` table has configured multiple columns as the primary key (for example, both `id` and `name` columns as in the above [section](#primary-key)),
 the `Citizens` table can refer to it by using a table-level foreign key constraint. In this case, the `Citizens` table must have defined matching columns
 to store each component value of the `Cities` table's primary key:
 ```kotlin

--- a/documentation-website/Writerside/topics/Table-Definition.md
+++ b/documentation-website/Writerside/topics/Table-Definition.md
@@ -1,32 +1,75 @@
 # Table Definition
 
-This topic shows what table types Exposed supports and how to define and create tables. Also, it contains tips on configuring 
-constraints, such as `PRIMARY KEY`, `DEFAULT`, `INDEX` and so on.
+This page shows what table types Exposed supports and how to define and create tables. It also contains tips on configuring 
+constraints, such as `PRIMARY KEY`, `DEFAULT`, and `INDEX`. All examples use the H2 database to generate SQL.
 
 ## Table Types
 
-The most primitive table type is `Table()`. It's located in **org.jetbrains.exposed.sql** package and has `NOT NULL` SQL constraint 
-configured by default on all columns. To configure a custom name for the table, which will be used in actual SQL queries, pass 
-it to the `name` parameter of the `Table()` constructor. Otherwise, Exposed will generate it from a class name.
+The most primitive table type is `Table`. It is located in the **org.jetbrains.exposed.sql** package of the **exposed-core** module.
+To configure a custom name for a table, which will be used in actual SQL queries, pass it to the `name` parameter of the `Table()` constructor.
+Otherwise, Exposed will generate it from the full class name or the class name without the suffix 'Table', if present.
 
-For example, to create a simple table called `"citiesTable"` with integer `id` column and string `name` column, use the 
-following code.
+For example, to create a simple table with an integer `id` column and a string `name` column, use the following code depending on the table name of choice:
 ```kotlin
-// SQL: CREATE TABLE IF NOT EXISTS CITIESTABLE (
-//          ID INT NOT NULL,
-//          "NAME" VARCHAR(50) NOT NULL
-//      )
-object Cities : Table(name = "citiesTable") {
+// Table name will be taken from object name
+object Cities : Table() {
     val id = integer("id")
     val name = varchar("name", 50)
 }
-```
-Also, Exposed provides `IdTable` class which is inherited by `IntIdTable()`, `LongIdTable()`, and `UUIDTable(`) classes from 
-**org.jetbrains.exposed.dao.id** package of **exposed-core** module. These tables could be declared without the `id` attribute. 
-IDs of appropriate type will be generated automatically when creating new table rows. To configure a custom name 
-for the `id` attribute, pass it to the `columnName` parameter of the appropriate table constructor.
+// SQL: CREATE TABLE IF NOT EXISTS CITIES (
+//          ID INT NOT NULL,
+//          "name" VARCHAR(50) NOT NULL
+//      )
 
-Depending on what DBMS you use, types of columns could be different in actual SQL queries. We use H2 database in our examples.
+// Table name will be taken from object name without 'Table' suffix
+object CitiesTable : Table() {
+    val id = integer("id")
+    val name = varchar("name", 50)
+}
+// SQL: CREATE TABLE IF NOT EXISTS CITIES (
+//          ID INT NOT NULL,
+//          "name" VARCHAR(50) NOT NULL
+//      )
+
+// Table name will be taken from provided argument
+object Cities : Table("all_cities") {
+    val id = integer("id")
+    val name = varchar("name", 50)
+}
+// SQL: CREATE TABLE IF NOT EXISTS ALL_CITIES (
+//          ID INT NOT NULL,
+//          "name" VARCHAR(50) NOT NULL
+//      )
+
+// Some databases, like H2, fold unquoted names to upper case
+// To keep case-sensitivity, manually quote the provided argument
+object Cities : Table("\"all_cities\"") {
+    val id = integer("id")
+    val name = varchar("name", 50)
+}
+// SQL: CREATE TABLE IF NOT EXISTS "all_cities" (
+//          ID INT NOT NULL,
+//          "name" VARCHAR(50) NOT NULL
+//      )
+```
+
+Exposed also provides the base `IdTable` class which is inherited by `IntIdTable`, `LongIdTable` (and their unsigned variants), `UUIDTable`, and `CompositeIdTable` classes from the 
+**org.jetbrains.exposed.dao.id** package of the **exposed-core** module. These tables could be declared without the `id` column, and
+IDs of the appropriate type will be generated automatically when creating new table rows. To configure a custom name 
+for the `id` column, pass it to the `columnName` parameter of the appropriate table constructor.
+
+The `Cities` table could instead be defined as an `IntIdTable`, which would make the `id` column both auto-incrementing and the table's primary key:
+```kotlin
+object Cities : IntIdTable() {
+    val name = varchar("name", 50)
+}
+// SQL: CREATE TABLE IF NOT EXISTS CITIES (
+//          ID INT AUTO_INCREMENT PRIMARY KEY,
+//          "name" VARCHAR(50) NOT NULL
+//      )
+```
+
+Depending on what DBMS you use, the types of columns could be different in actual SQL queries.
 
 ## Constraints
 
@@ -146,42 +189,62 @@ val name = varchar("name", 50).uniqueIndex()
 
 ### Primary Key
 
-The `PRIMARY KEY` SQL constraint applied to columns means each value in a column identifies the row. It's the composition 
-of `NOT NULL` and `UNIQUE` constraints. Each kind of table in Exposed, inherited from `IdTable()`, has the `primaryKey` 
-field. For example, the `IntIdTable` has default integer `id` primary key. If you want to change column set, add columns, 
-or change primary key name to a custom one, you need to override this field of the appropriate table class.
+The `PRIMARY KEY` SQL constraint applied to a column means each value in that column identifies the row. This constraint is the composition
+of `NOT NULL` and `UNIQUE` constraints.  To change the column set, add columns, or change the primary key name to a custom one, override this field of the table class.
 
-For example, if you want to define the `name` column as a primary key, use the following code. The "Cities_name" string 
-will be used in actual SQL query.
+For example, to define the `name` column as the primary key, use the following code. The "Cities_name" string 
+will be used as the constraint name in the actual SQL query, if provided; otherwise a name will be generated based on the table's name.
 ```kotlin
-// SQL: CONSTRAINT Cities_name PRIMARY KEY ("NAME")
+// SQL: CONSTRAINT Cities_name PRIMARY KEY ("name")
 override val primaryKey = PrimaryKey(name, name = "Cities_name")
+```
+
+It is also possible to define a primary key on a table using multiple columns:
+```kotlin
+// SQL: CONSTRAINT pk_Cities PRIMARY KEY (ID, "name")
+override val primaryKey = PrimaryKey(id, name)
+```
+
+Each kind of table in Exposed that is inherited from `IdTable` has the `primaryKey` field automatically defined.
+For example, the `IntIdTable` by default has an auto-incrementing integer column, `id`, which is defined as the primary key.
+
+An `IdTable` that requires a primary key with multiple columns can be defined using `CompositeIdTable`.
+In this case, each column that is a component of the table's `id` column should be identified by `entityId()`:
+```kotlin
+object Towns : CompositeIdTable("towns") {
+    val areaCode = integer("area_code").autoIncrement().entityId()
+    val latitude = decimal("latitude", 9, 6).entityId()
+    val longitude = decimal("longitude", 9, 6).entityId()
+    val name = varchar("name", 32)
+
+    override val primaryKey = PrimaryKey(areaCode, latitude, longitude)
+}
 ```
 
 ### Foreign Key
 
-The `FOREIGN KEY` SQL constraint links two tables. Foreign key is a column from one table that refers to the primary key 
-or columns with a unique index from another table. To configure the foreign key, use `reference()` or `optReference()` 
-method. The second one let the foreign key accept the `null` value.
+The `FOREIGN KEY` SQL constraint links two tables. A foreign key is a column from one table that refers to the primary key 
+or columns with a unique index from another table. To configure a foreign key on a column, use `reference()` or `optReference()` 
+methods. The latter lets the foreign key accept a `null` value.
 
 `reference()` and `optReference()` methods have several parameters:
 
-* `name: String` is a name for foreign key column, which will be used in actual SQL queries.
+* `name: String` is a name for the foreign key column, which will be used in actual SQL queries.
 * `ref: Column<T>` is a target column from another parent table.
-* `onDelete: ReferenceOption? = null` is an action to the case when linked row from a parent table can be deleted.
-* `onUpdate: ReferenceOption? = null` is an action to the case when value in a referenced column can be changed.
-* `fkName: String? = null` is a foreign key constraint name.
+* `onDelete: ReferenceOption? = null` is an action for when a linked row from a parent table will be deleted.
+* `onUpdate: ReferenceOption? = null` is an action for when a value in a referenced column will be changed.
+* `fkName: String? = null` is a name for the foreign key constraint.
 
-Enum class `ReferenceOption` has four values:
+Enum class `ReferenceOption` has five values:
 
-* `RESTRICT` is an option that restricts changes on a referenced column, and the default option for MySQL dialect.
-* `NO_ACTION` is the same as RESTRICT, and the default option for Oracle and SQL Server dialects.
+* `RESTRICT` is an option that restricts changes on a referenced column, and the default option for most dialects.
+* `NO_ACTION` is the same as RESTRICT in some, but not all, databases, and the default option for Oracle and SQL Server dialects.
 * `CASCADE` is an option that allows updating or deleting the referring rows.
 * `SET_NULL` is an option that sets the referring column values to null.
 * `SET_DEFAULT` is an option that sets the referring column values to the default value.
 
-Consider the following `Citizens` table. This table has the `name` and `city` columns. Since the `Cities` table has 
-configured `name` primary key, the `Citizens` table can refer to it by its `city` column, which is a foreign key. To 
+Consider the following `Citizens` table. This table has the `name` and `city` columns. If the `Cities` table has 
+configured the `name` column as the primary key, the `Citizens` table can refer to it by its `city` column, which is a foreign key. To 
 configure such reference and make it nullable, use the `optReference()` method:
 ```kotlin
 object Citizens : IntIdTable() {
@@ -191,6 +254,29 @@ object Citizens : IntIdTable() {
 ```
 
 If any `Cities` row will be deleted, the appropriate `Citizens` row will be deleted too.
+
+If instead the `Cities` table has configured multiple columns as the primary key (for example, both `id` and `name` columns as in the above section),
+the `Citizens` table can refer to it by using a table-level foreign key constraint. In this case, the `Citizens` table must have defined matching columns
+to store each component value of the `Cities` table's primary key:
+```kotlin
+object Citizens : IntIdTable() {
+    val name = varchar("name", 50)
+    val cityId = integer("city_id")
+    val cityName = varchar("city_name", 50)
+
+    init {
+        foreignKey(cityId, cityName, target = Cities.primaryKey)
+    }
+}
+```
+
+In the above example, the order of the referencing columns in `foreignKey()` must match the order of columns defined in the target primary key.
+If this order is uncertain, the foreign key can be defined with explicit column associations instead:
+```kotlin
+init {
+    foreignKey(cityId to Cities.id, cityName to Cities.name)
+}
+```
 
 ### Check
 


### PR DESCRIPTION
Adds details about new `CompositeIdTable` and how it relates to:

- Available `IdTable` types
- DAO CRUD operations
- DAO references
- Creating primary keys
- Creating foreign keys

Additional:
- Update incorrect FAQ about ARRAY column type
- Replace FAQ about custom `IdTable` with a direct example
- Restructure `hi.tree` to include existing, but unused, `Table-Definitions.md`