### PR TITLE
fix: EXPOSED-452 Flaky H2_Oracle test `testTimestampWithTimeZoneDefaults`

### DIFF
--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -391,7 +391,7 @@ class DefaultsTest : DatabaseTestsBase() {
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
         assertEquals("UTC", ZoneId.systemDefault().id)
 
-        val nowWithTimeZone = OffsetDateTime.now()
+        val nowWithTimeZone = OffsetDateTime.parse("2024-07-18T13:19:44.000+00:00")
         val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
 
         val testTable = object : IntIdTable("t") {

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
@@ -213,10 +213,10 @@ class DateTimeWithTimeZoneColumnType : ColumnType<DateTime>(), IDateColumnType {
     override fun nonNullValueAsDefaultString(value: DateTime): String {
         val dialect = currentDialect
         return when {
-            dialect is PostgreSQLDialect ->
-                "'${DEFAULT_DATE_TIME_STRING_FORMATTER.print(value).trimEnd('0')}+00'::timestamp with time zone"
+            dialect is PostgreSQLDialect -> // +00 appended because PostgreSQL stores it in UTC time zone
+                "'${DEFAULT_DATE_TIME_STRING_FORMATTER.print(value).trimEnd('0').trimEnd('.')}+00'::timestamp with time zone"
             (dialect as? H2Dialect)?.h2Mode == H2Dialect.H2CompatibilityMode.Oracle ->
-                "'${DEFAULT_DATE_TIME_STRING_FORMATTER.print(value).trimEnd('0')}'"
+                "'${DEFAULT_DATE_TIME_STRING_FORMATTER.print(value)}'"
             dialect is MysqlDialect -> "'${MYSQL_FRACTION_DATE_TIME_AS_DEFAULT_FORMATTER.print(value)}'"
             else -> super.nonNullValueAsDefaultString(value)
         }

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -371,7 +371,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
         DateTimeZone.setDefault(DateTimeZone.UTC)
         assertEquals("UTC", DateTimeZone.getDefault().id)
 
-        val nowWithTimeZone = DateTime.now()
+        val nowWithTimeZone = DateTime.parse("2024-07-18T13:19:44.000").withZone(DateTimeZone.UTC)
         val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
 
         val testTable = object : IntIdTable("t") {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -395,7 +395,7 @@ class DefaultsTest : DatabaseTestsBase() {
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
         assertEquals("UTC", ZoneId.systemDefault().id)
 
-        val nowWithTimeZone = OffsetDateTime.now()
+        val nowWithTimeZone = OffsetDateTime.parse("2024-07-18T13:19:44.000+00:00")
         val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
 
         val testTable = object : IntIdTable("t") {


### PR DESCRIPTION
-  Joda-Time: Handled the case when the default value for a `timestampWithTimeZone` column has trailing zeros after the last dot ("2024-07-18T13:19:44.000"), which was the reason the test was failing. The zeros were being removed without removing the dot, which resulted in a parsing error. To fix this, I chose not to remove the zeros at all.
- Modifed `POSTGRESQL_OFFSET_DATE_TIME_AS_DEFAULT_FORMATTER` and `nonNullValueAsDefaultString` in KotlinDateColumnType.kt to match that of JavaDateColumnType.kt.