### PR TITLE
EXPOSED-457 The column default value always compares unequal

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -797,6 +797,8 @@ public final class org/jetbrains/exposed/sql/DivideOp$Companion {
 
 public final class org/jetbrains/exposed/sql/DoubleColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
+	public fun nonNullValueAsDefaultString (D)Ljava/lang/String;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Double;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -972,6 +974,8 @@ public final class org/jetbrains/exposed/sql/FirstValue : org/jetbrains/exposed/
 
 public final class org/jetbrains/exposed/sql/FloatColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> ()V
+	public fun nonNullValueAsDefaultString (F)Ljava/lang/String;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Float;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -501,6 +501,18 @@ class FloatColumnType : ColumnType<Float>() {
         is String -> value.toFloat()
         else -> error("Unexpected value of type Float: $value of ${value::class.qualifiedName}")
     }
+
+    override fun nonNullValueAsDefaultString(value: Float): String {
+        return value.toString().let {
+            when {
+                // MySQL returns floating-point numbers from metadata without a decimal part as integer strings, whereas other databases
+                // append a trailing zero.
+                // For example, the value 30f would be `"30"` in MySQL but `"30.0"` in other databases.
+                currentDialect is MysqlDialect && it.endsWith(".0") -> it.replace(".0", "")
+                else -> it
+            }
+        }
+    }
 }
 
 /**
@@ -515,6 +527,18 @@ class DoubleColumnType : ColumnType<Double>() {
         is Number -> value.toDouble()
         is String -> value.toDouble()
         else -> error("Unexpected value of type Double: $value of ${value::class.qualifiedName}")
+    }
+
+    override fun nonNullValueAsDefaultString(value: Double): String {
+        return value.toString().let {
+            when {
+                // MySQL returns floating-point numbers from metadata without a decimal part as integer strings, whereas other databases
+                // append a trailing zero.
+                // For example, the value 30f would be `"30"` in MySQL but `"30.0"` in other databases.
+                currentDialect is MysqlDialect && it.endsWith(".0") -> it.replace(".0", "")
+                else -> it
+            }
+        }
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -199,15 +199,6 @@ object SchemaUtils {
                         else -> processForDefaultValue(exp)
                     }
 
-                    is Float, is Double -> value.toString().let {
-                        when {
-                            // MySQL returns floating-point numbers without a decimal part as integer strings, whereas other databases append a trailing zero.
-                            // For example, the value 30f would be `"30"` in MySQL but `"30.0"` in other databases.
-                            currentDialect is MysqlDialect && it.endsWith(".0") -> it.replace(".0", "")
-                            else -> it
-                        }
-                    }
-
                     else -> {
                         when {
                             column.columnType is JsonColumnMarker -> {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -199,6 +199,15 @@ object SchemaUtils {
                         else -> processForDefaultValue(exp)
                     }
 
+                    is Float, is Double -> value.toString().let {
+                        when {
+                            // MySQL returns floating-point numbers without a decimal part as integer strings, whereas other databases append a trailing zero.
+                            // For example, the value 30f would be `"30"` in MySQL but `"30.0"` in other databases.
+                            currentDialect is MysqlDialect && it.endsWith(".0") -> it.replace(".0", "")
+                            else -> it
+                        }
+                    }
+
                     else -> {
                         when {
                             column.columnType is JsonColumnMarker -> {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -797,4 +797,17 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             }
         }
     }
+
+    @Test
+    fun testFloatDefaultColumnValue() {
+        val tester = object : Table("testFloatDefaultColumnValue") {
+            val float = float("float_value").default(30.0f)
+            val double = double("double_value").default(30.0)
+            val floatExpression = float("float_expression_value").defaultExpression(floatLiteral(30.0f))
+            val doubleExpression = double("double_expression_value").defaultExpression(doubleLiteral(30.0))
+        }
+        withTables(tester) {
+            assertEqualLists(emptyList(), SchemaUtils.statementsRequiredToActualizeScheme(tester))
+        }
+    }
 }


### PR DESCRIPTION
#### Description

`SchemaUtils.statementsRequiredToActualizeScheme()` was working incorrectly for MySql in the case a table has default float/double values. The reason is that MySQL returns a default float / double value without trailing zeros, when other databases return it with 1 trailing `0`. For example, the value `30f` returned from metadata for MySQL as `"30"` and for other databases as `"30.0"`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix

Affected databases:
- [x] Mysql
- [x] MariaDB

#### Checklist

---

#### Related Issues

[EXPOSED-457](https://youtrack.jetbrains.com/issue/EXPOSED-457) The column default value always compares unequal
