### PR TITLE
feat: EXPOSED-459 Open AbstractQuery.copyTo() to allow custom Query class extension

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -121,7 +121,7 @@ public abstract class org/jetbrains/exposed/sql/AbstractQuery : org/jetbrains/ex
 	public fun <init> (Ljava/util/List;)V
 	public synthetic fun arguments ()Ljava/lang/Iterable;
 	public fun arguments ()Ljava/util/List;
-	protected final fun copyTo (Lorg/jetbrains/exposed/sql/AbstractQuery;)V
+	public fun copyTo (Lorg/jetbrains/exposed/sql/AbstractQuery;)V
 	public final fun fetchSize (I)Lorg/jetbrains/exposed/sql/AbstractQuery;
 	public fun forUpdate (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	protected final fun getCount ()Z
@@ -1838,6 +1838,8 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 	public static synthetic fun comment$default (Lorg/jetbrains/exposed/sql/Query;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Query$CommentPosition;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Query;
 	public fun copy ()Lorg/jetbrains/exposed/sql/Query;
 	public synthetic fun copy ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public synthetic fun copyTo (Lorg/jetbrains/exposed/sql/AbstractQuery;)V
+	public fun copyTo (Lorg/jetbrains/exposed/sql/Query;)V
 	public fun count ()J
 	public fun empty ()Z
 	public synthetic fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/Object;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
@@ -31,7 +31,12 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
     /** The set of columns on which a query should be executed, contained by a [ColumnSet]. */
     abstract val set: FieldSet
 
-    protected fun copyTo(other: AbstractQuery<T>) {
+    /**
+     * Copies all stored properties of this `SELECT` query into the properties of [other].
+     *
+     * Override this function to additionally copy any properties that are not part of the primary constructor.
+     */
+    open fun copyTo(other: T) {
         other.orderByExpressions = orderByExpressions.toMutableList()
         other.limit = limit
         other.offset = offset

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -55,11 +55,15 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     /** Creates a new [Query] instance using all stored properties of this `SELECT` query. */
     override fun copy(): Query = Query(set, where).also { copy ->
         copyTo(copy)
-        copy.distinct = distinct
-        copy.groupedByColumns = groupedByColumns.toMutableList()
-        copy.having = having
-        copy.forUpdate = forUpdate
-        copy.comments = comments.toMutableMap()
+    }
+
+    override fun copyTo(other: Query) {
+        super.copyTo(other)
+        other.distinct = distinct
+        other.groupedByColumns = groupedByColumns.toMutableList()
+        other.having = having
+        other.forUpdate = forUpdate
+        other.comments = comments.toMutableMap()
     }
 
     override fun forUpdate(option: ForUpdateOption): Query {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/mysql/MysqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/mysql/MysqlTests.kt
@@ -2,23 +2,19 @@ package org.jetbrains.exposed.sql.tests.mysql
 
 import com.mysql.cj.conf.PropertyKey
 import com.mysql.cj.jdbc.ConnectionImpl
-import org.jetbrains.exposed.sql.batchInsert
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
-import org.jetbrains.exposed.sql.tests.RepeatableTestRule
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.transactions.TransactionManager
-import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class MysqlTests : DatabaseTestsBase() {
-
-    @get:Rule
-    val repeatRule = RepeatableTestRule()
-
     @Test
     fun testEmbeddedConnection() {
         withDb(TestDB.MYSQL_V5) {
@@ -46,6 +42,60 @@ class MysqlTests : DatabaseTestsBase() {
             generatedValues.forEach {
                 assertNotNull(it.getOrNull(DMLTestsData.Cities.id))
             }
+        }
+    }
+
+    private class IndexHintQuery(
+        val source: Query,
+        val indexHint: String
+    ) : Query(source.set, source.where) {
+
+        init {
+            source.copyTo(this)
+        }
+
+        override fun prepareSQL(builder: QueryBuilder): String {
+            val originalSql = super.prepareSQL(builder)
+            val fromTableSql = " FROM ${transaction.identity(set.source as Table)} "
+            return originalSql.replace(fromTableSql, "$fromTableSql$indexHint ")
+        }
+
+        override fun copy(): IndexHintQuery = IndexHintQuery(source.copy(), indexHint).also { copy ->
+            copyTo(copy)
+        }
+    }
+
+    private fun Query.indexHint(hint: String) = IndexHintQuery(this, hint)
+
+    @Test
+    fun testCustomSelectQueryWithHint() {
+        val tester = object : IntIdTable("tester") {
+            val item = varchar("item", 32).uniqueIndex()
+            val amount = integer("amount")
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_MYSQL_MARIADB, tester) {
+            val originalText = "Original SQL"
+            val originalQuery = tester.selectAll().withDistinct().where { tester.id eq 2 }.limit(1).comment(originalText)
+
+            val hint1 = "FORCE INDEX (PRIMARY)"
+            val hintQuery1 = originalQuery.indexHint(hint1)
+            val hintQuery1Sql = hintQuery1.prepareSQL(this)
+            assertTrue { listOf(originalText, hint1, " WHERE ", " DISTINCT ", " LIMIT ").all { it in hintQuery1Sql } }
+            hintQuery1.toList()
+
+            val itemIndex = tester.indices.first { it.columns == listOf(tester.item) }.indexName
+            val hint2 = "USE INDEX ($itemIndex)"
+            val hintQuery2 = tester
+                .selectAll()
+                .indexHint(hint2)
+                .where { (tester.id eq 1) and (tester.item eq "Item A") }
+                .groupBy(tester.id)
+                .having { tester.id.count() eq 1 }
+                .orderBy(tester.amount)
+            val hintQuery2Sql = hintQuery2.prepareSQL(this)
+            assertTrue { listOf(hint2, " WHERE ", " GROUP BY ", " HAVING ", " ORDER BY ").all { it in hintQuery2Sql } }
+            hintQuery2.toList()
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**:
Allows implementation of custom Query classes that do not lose stored properties of the original query. This may be useful for users that need niched or very database-specific clauses, for example MySQL [query index hints](https://dev.mysql.com/doc/refman/8.0/en/index-hints.html).

**Detailed description**:
- **Why**:
While it is possible to customize extension functions on the Query class, built-in class properties with private setters will not be copied to the new query instance when chaining/query building. The only properties copied would be those stored in base `AbstractQuery`. So these custom functions could not be used with original queries:
```kt
val originalQuery = TestTable.selectAll().where { TestTable.id eq 2 }.groupBy(TestTable.amount)

// when executed, there will be a WHERE clause (it is provided to Query constructor) but no GROUP BY clause
originalQuery
    .myCustomClause()
    .limit(1)
    .toList()
```
- **What**:
This PR makes it possible to copy over all stored properties (not passed as an argument to the constructor) whenever a query instance is created or copied.
- **How**:
The visibility modifier of `AbstractQuery.copyTo()` was made open and overriden in the Query class.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [X] New feature
- [X] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [X] SqlServer
- [X] H2
- [X] SQLLight

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-459]()
