### PR TITLE
feat: EXPOSED-461 Add time column in Joda-Time module

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -73,7 +73,19 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
     ): Unit = TransactionManager.current().throwUnsupportedException("SQLite doesn't provide built in REGEXP expression, use LIKE instead.")
 
     override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
-        append("SUBSTR(", expr, ", INSTR(", expr, ", ' ') + 1, LENGTH(", expr, ") - INSTR(", expr, ", ' ') - 1)")
+        append(
+            "SUBSTR(", expr, ", INSTR(", expr, ", ' ') + 1,\n",
+            "CASE\n",
+            "    WHEN INSTR(", expr, ", 'Z') > 0 THEN\n",
+            "        INSTR(", expr, ", 'Z') - 1\n",
+            "    WHEN INSTR(", expr, ", '+') > 0 THEN\n",
+            "        INSTR(", expr, ", '+') - 1\n",
+            "    WHEN INSTR(", expr, ", '-') > 0 THEN\n",
+            "        INSTR(", expr, ", '-') - 1\n",
+            "    ELSE\n",
+            "        LENGTH(", expr, ")\n",
+            "END- INSTR(", expr, ", ' '))"
+        )
     }
 
     override fun <T> year(expr: Expression<T>, queryBuilder: QueryBuilder): Unit = queryBuilder {

--- a/exposed-jodatime/api/exposed-jodatime.api
+++ b/exposed-jodatime/api/exposed-jodatime.api
@@ -35,12 +35,14 @@ public final class org/jetbrains/exposed/sql/jodatime/DateColumnType : org/jetbr
 public final class org/jetbrains/exposed/sql/jodatime/DateColumnTypeKt {
 	public static final fun date (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static final fun datetime (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public static final fun time (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static final fun timestampWithTimeZone (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/DateFunctionsKt {
 	public static final fun CustomDateFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomDateTimeFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
+	public static final fun CustomTimeFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun CustomTimestampWithTimeZoneFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/CustomFunction;
 	public static final fun date (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Date;
 	public static final fun dateLiteral (Lorg/joda/time/DateTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
@@ -52,6 +54,9 @@ public final class org/jetbrains/exposed/sql/jodatime/DateFunctionsKt {
 	public static final fun minute (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Minute;
 	public static final fun month (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Month;
 	public static final fun second (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Second;
+	public static final fun time (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Time;
+	public static final fun timeLiteral (Lorg/joda/time/LocalTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
+	public static final fun timeParam (Lorg/joda/time/LocalTime;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun timestampWithTimeZoneLiteral (Lorg/joda/time/DateTime;)Lorg/jetbrains/exposed/sql/LiteralOp;
 	public static final fun timestampWithTimeZoneParam (Lorg/joda/time/DateTime;)Lorg/jetbrains/exposed/sql/Expression;
 	public static final fun year (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/jodatime/Year;
@@ -84,6 +89,20 @@ public final class org/jetbrains/exposed/sql/jodatime/Hour : org/jetbrains/expos
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 }
 
+public final class org/jetbrains/exposed/sql/jodatime/LocalTimeColumnType : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/IDateColumnType {
+	public fun <init> ()V
+	public fun getHasTimePart ()Z
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lorg/joda/time/LocalTime;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lorg/joda/time/LocalTime;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lorg/joda/time/LocalTime;)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Lorg/joda/time/LocalTime;
+}
+
 public final class org/jetbrains/exposed/sql/jodatime/Minute : org/jetbrains/exposed/sql/Function {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;)V
 	public final fun getExpr ()Lorg/jetbrains/exposed/sql/Expression;
@@ -97,6 +116,12 @@ public final class org/jetbrains/exposed/sql/jodatime/Month : org/jetbrains/expo
 }
 
 public final class org/jetbrains/exposed/sql/jodatime/Second : org/jetbrains/exposed/sql/Function {
+	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;)V
+	public final fun getExpr ()Lorg/jetbrains/exposed/sql/Expression;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+}
+
+public final class org/jetbrains/exposed/sql/jodatime/Time : org/jetbrains/exposed/sql/Function {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;)V
 	public final fun getExpr ()Lorg/jetbrains/exposed/sql/Expression;
 	public fun toQueryBuilder (Lorg/jetbrains/exposed/sql/QueryBuilder;)V


### PR DESCRIPTION
#### Description

**Summary of the change**:
Added time column in Joda-Time module

**Detailed description**:
- **Why**:
The feature was missing in the Joda-Time module.

- **What**:
It's now possible to create a time column when using Joda-Time with Exposed.
While working on this feature, I found that the time function for SQLite did not handle all kinds of time zones (Z, +00:00, +04:00, -03:00), so I fixed it and included that fix in this PR.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLight

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
