### PR TITLE
chore: [SQL Server] Fix MultipleInListOp logic when isInList = false

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/InListOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/InListOps.kt
@@ -167,18 +167,21 @@ class MultipleInListOp(
                 // Built-in exists(AbstractQuery) cannot be used because above row value constructors are not supported
 
                 val valueEqualityOps = mutableListOf<Op<Boolean>>()
-                val eqOp = if (isInList) ::EqOp else ::NeqOp
 
                 iterator.forEach { value ->
                     val valueEqualityOp = Op.build {
                         expr.zip(value).map { (column, value) ->
-                            Op.build { eqOp(column, column.wrap(value)) }
+                            Op.build { EqOp(column, column.wrap(value)) }
                         }.compoundAnd()
                     }
                     valueEqualityOps.add(if (isInList) valueEqualityOp else not(valueEqualityOp))
                 }
 
-                +valueEqualityOps.compoundOr()
+                if (isInList) {
+                    +valueEqualityOps.compoundOr()
+                } else {
+                    +valueEqualityOps.compoundAnd()
+                }
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/SelectTests.kt
@@ -256,6 +256,12 @@ class SelectTests : DatabaseTestsBase() {
 
             val result4 = tester.selectAll().where { tester.columns notInList emptyList() }.toList()
             assertEquals(expected, result4.size)
+
+            val result5 = tester.selectAll().where { tester.columns notInList allSameNumbers }.toList()
+            assertEquals(0, result5.size)
+
+            val result6 = tester.selectAll().where { tester.columns inList emptyList() }.toList()
+            assertEquals(0, result6.size)
         }
     }
 


### PR DESCRIPTION
#### Description

**Summary of the change**:
Fixes compound operator logic in SQL Server branch of `MultipleInListOp`

**Detailed description**:
- **Why**:
Current logic uses the following construct with `notInList()`:
`WHERE NOT(col_1 != ? AND ...) OR NOT(col_1 != ? AND ...) OR ...`
This was not being tested for properly and does not produce expected results.
Can be additionally observed by replacing any existing `notInList` test (pair/triple) with the list overload.

- **How**:
Logic has been switched to:
`WHERE NOT(col_1 == ? AND ...) AND NOT(col_1 == ? AND ...) AND ...`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [X] SqlServer
- [ ] H2
- [ ] SQLight

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
PR #2157 