### PR TITLE
fix: EXPOSED-447 Eager loading does not work with composite PK entity

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1107,6 +1107,8 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun inList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun inList (Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun inList (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public abstract fun inListCompositeEntityIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public abstract fun inListCompositeIDs (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun inListIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun inSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/InSubQueryOp;
 	public abstract fun inTable (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/ops/InTableOp;
@@ -1161,6 +1163,8 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun notInList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun notInList (Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun notInList (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public abstract fun notInListCompositeEntityIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public abstract fun notInListCompositeIDs (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun notInListIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun notInSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/NotInSubQueryOp;
 	public abstract fun notInTable (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/ops/InTableOp;
@@ -1236,6 +1240,8 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun inList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun inList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun inList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public static fun inListCompositeEntityIds (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public static fun inListCompositeIDs (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun inListIds (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun inSubQuery (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/InSubQueryOp;
 	public static fun inTable (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/ops/InTableOp;
@@ -1292,6 +1298,8 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun notInList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun notInList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun notInList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public static fun notInListCompositeEntityIds (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public static fun notInListCompositeIDs (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun notInListIds (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun notInSubQuery (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/NotInSubQueryOp;
 	public static fun notInTable (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/ops/InTableOp;
@@ -2250,6 +2258,8 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun inList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun inList (Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun inList (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public fun inListCompositeEntityIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public fun inListCompositeIDs (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun inListIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun inSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/InSubQueryOp;
 	public fun inTable (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/ops/InTableOp;
@@ -2304,6 +2314,8 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun notInList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun notInList (Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun notInList (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public fun notInListCompositeEntityIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
+	public fun notInListCompositeIDs (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun notInListIds (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun notInSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/NotInSubQueryOp;
 	public fun notInTable (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Table;)Lorg/jetbrains/exposed/sql/ops/InTableOp;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -2,6 +2,7 @@
 
 package org.jetbrains.exposed.sql
 
+import org.jetbrains.exposed.dao.id.CompositeID
 import org.jetbrains.exposed.dao.id.CompositeIdTable
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
@@ -899,6 +900,26 @@ interface ISqlExpressionBuilder {
         MultipleInListOp(this, list, isInList = true)
 
     /**
+     * Checks if all columns in this `List` are equal to any of the [CompositeID]s from [list].
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.testInListWithCompositeIdEntities
+     **/
+    @Suppress("UNCHECKED_CAST")
+    @JvmName("inListCompositeIDs")
+    @LowPriorityInOverloadResolution
+    infix fun List<Column<*>>.inList(list: Iterable<CompositeID>): InListOrNotInListBaseOp<List<*>> {
+        val componentList = list.map { id ->
+            List(this.size) { i ->
+                val component = id[this[i] as Column<Comparable<Any>>]
+                component.takeIf {
+                    it !is EntityID<*> || this[i].columnType is EntityIDColumnType<*>
+                } ?: (component as EntityID<*>).value
+            }
+        }
+        return this inList componentList
+    }
+
+    /**
      * Checks if this [EntityID] column is equal to any element from [list].
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testInListWithEntityIDColumns
@@ -908,6 +929,18 @@ interface ISqlExpressionBuilder {
     infix fun <T : Comparable<T>, ID : EntityID<T>?> Column<ID>.inList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return SingleValueInListOp(this, list.map { EntityIDFunctionProvider.createEntityID(it, idTable) }, isInList = true)
+    }
+
+    /**
+     * Checks if this [EntityID] column is equal to any element from [list].
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.testInListWithCompositeIdEntities
+     */
+    @Suppress("UNCHECKED_CAST")
+    @JvmName("inListCompositeEntityIds")
+    infix fun <ID : EntityID<CompositeID>> Column<ID>.inList(list: Iterable<CompositeID>): InListOrNotInListBaseOp<List<*>> {
+        val idTable = (columnType as EntityIDColumnType<CompositeID>).idColumn.table as CompositeIdTable
+        return idTable.idColumns.toList() inList list
     }
 
     /**
@@ -949,6 +982,26 @@ interface ISqlExpressionBuilder {
         MultipleInListOp(this, list, isInList = false)
 
     /**
+     * Checks if all columns in this `List` are not equal to any of the [CompositeID]s from [list].
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.testInListWithCompositeIdEntities
+     **/
+    @Suppress("UNCHECKED_CAST")
+    @JvmName("notInListCompositeIDs")
+    @LowPriorityInOverloadResolution
+    infix fun List<Column<*>>.notInList(list: Iterable<CompositeID>): InListOrNotInListBaseOp<List<*>> {
+        val componentList = list.map { id ->
+            List(this.size) { i ->
+                val component = id[this[i] as Column<Comparable<Any>>]
+                component.takeIf {
+                    it !is EntityID<*> || this[i].columnType is EntityIDColumnType<*>
+                } ?: (component as EntityID<*>).value
+            }
+        }
+        return this notInList componentList
+    }
+
+    /**
      * Checks if this [EntityID] column is not equal to any element from [list].
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testInListWithEntityIDColumns
@@ -958,6 +1011,18 @@ interface ISqlExpressionBuilder {
     infix fun <T : Comparable<T>, ID : EntityID<T>?> Column<ID>.notInList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return SingleValueInListOp(this, list.map { EntityIDFunctionProvider.createEntityID(it, idTable) }, isInList = false)
+    }
+
+    /**
+     * Checks if this [EntityID] column is not equal to any element from [list].
+     *
+     * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.testInListWithCompositeIdEntities
+     */
+    @Suppress("UNCHECKED_CAST")
+    @JvmName("notInListCompositeEntityIds")
+    infix fun <ID : EntityID<CompositeID>> Column<ID>.notInList(list: Iterable<CompositeID>): InListOrNotInListBaseOp<List<*>> {
+        val idTable = (columnType as EntityIDColumnType<CompositeID>).idColumn.table as CompositeIdTable
+        return idTable.idColumns.toList() notInList list
     }
 
     // "IN (TABLE ...)" comparisons

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -911,9 +911,7 @@ interface ISqlExpressionBuilder {
         val componentList = list.map { id ->
             List(this.size) { i ->
                 val component = id[this[i] as Column<Comparable<Any>>]
-                component.takeIf {
-                    it !is EntityID<*> || this[i].columnType is EntityIDColumnType<*>
-                } ?: (component as EntityID<*>).value
+                component.takeIf { this[i].columnType is EntityIDColumnType<*> } ?: (component as EntityID<*>).value
             }
         }
         return this inList componentList
@@ -993,9 +991,7 @@ interface ISqlExpressionBuilder {
         val componentList = list.map { id ->
             List(this.size) { i ->
                 val component = id[this[i] as Column<Comparable<Any>>]
-                component.takeIf {
-                    it !is EntityID<*> || this[i].columnType is EntityIDColumnType<*>
-                } ?: (component as EntityID<*>).value
+                component.takeIf { this[i].columnType is EntityIDColumnType<*> } ?: (component as EntityID<*>).value
             }
         }
         return this notInList componentList

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -305,6 +305,7 @@ public final class org/jetbrains/exposed/dao/ReferencesKt {
 public class org/jetbrains/exposed/dao/Referrers : kotlin/properties/ReadOnlyProperty {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/EntityClass;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllReferences ()Ljava/util/Map;
 	public final fun getCache ()Z
 	public final fun getFactory ()Lorg/jetbrains/exposed/dao/EntityClass;
 	public final fun getReference ()Lorg/jetbrains/exposed/sql/Column;


### PR DESCRIPTION
#### Description

**Summary of the change**:
It is now possible to use eager loading with references involving `CompositeIdTable`.

**Detailed description**:
- **Why**:
Initial implementation of `CompositeIdTable` was already very large, so the necessary logic to use `.load()` and `.with()` was not included. `preloadRelations()` also relied heavily on `inList`, which was not capable of accepting an unknown-sized list of columns on the left hand side: PR #2157 

- **How**:
    - Add `inList` overloads for `List<CompositeID>` and for deconstructed `CompositeIdTable.id`
        - Unit test commented out due to SQL Server bug:  PR #2176 
    - Refactor `preloadRelations()` to handle `CompositeIdTable` references (both parent and child)
    - Add variant to `warmupReferences()` that can work with multiple-column ids.
---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-447]()