### PR TITLE
fix: Change IdTable idColumns to read-only and add validation on access

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -6,6 +6,7 @@ public final class org/jetbrains/exposed/dao/id/CompositeID : java/lang/Comparab
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun get (Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/Comparable;
 	public fun hashCode ()I
+	public final fun setWithEntityID (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/id/EntityID;)V
 	public final fun setWithEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)V
 	public final fun setWithNullableEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)V
 	public fun toString ()Ljava/lang/String;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -51,8 +51,9 @@ public abstract class org/jetbrains/exposed/dao/id/IdTable : org/jetbrains/expos
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected final fun addIdColumn (Lorg/jetbrains/exposed/sql/Column;)V
 	public abstract fun getId ()Lorg/jetbrains/exposed/sql/Column;
-	public final fun getIdColumns ()Ljava/util/HashSet;
+	public final fun getIdColumns ()Ljava/util/Set;
 }
 
 public class org/jetbrains/exposed/dao/id/IntIdTable : org/jetbrains/exposed/dao/id/IdTable {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/CompositeID.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/CompositeID.kt
@@ -24,6 +24,14 @@ class CompositeID private constructor() : Comparable<CompositeID> {
         values[column] = value?.let { EntityID(value, column.table as IdTable<T>) }
     }
 
+    @JvmName("setWithEntityID")
+    operator fun <T : Comparable<T>, ID : EntityID<T>> set(column: Column<ID>, value: ID) {
+        require(values.isEmpty() || values.keys.first().table == column.table) {
+            "CompositeID key columns must all come from the same IdTable ${values.keys.first().table.tableName}"
+        }
+        values[column] = value
+    }
+
     @Suppress("UNCHECKED_CAST")
     operator fun <T : Comparable<T>> get(column: Column<T>): T = values[column] as T
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -618,7 +618,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
             it.dbDefaultValue = dbDefaultValue?.let { it as Expression<EntityID<T>> }
             it.extraDefinitions = extraDefinitions
         }
-        (table as IdTable<T>).addIdColumn(newColumn)
+        (table as IdTable<T>).addIdColumnInternal(newColumn)
         return replaceColumn(this, newColumn)
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
@@ -304,6 +304,11 @@ class ViaTests : DatabaseTestsBase() {
         val approved = bool("approved")
 
         override val primaryKey = PrimaryKey(project, task)
+
+        init {
+            addIdColumn(project)
+            addIdColumn(task)
+        }
     }
     class ProjectTask(id: EntityID<CompositeID>) : CompositeEntity(id) {
         companion object : CompositeEntityClass<ProjectTask>(ProjectTasks)


### PR DESCRIPTION
#### Description

**Summary of the change**:
Adds validation of `IdTable.idColumns` on every access to ensure that a `CompositeIdTable` is not defined without any.

**Detailed description**:
- **Why**:
When testing many-to-many relations with an extra column, the user might choose to use a `CompositeIdTable` as the intermediate table, with a composite primary key including a `reference()` column for each child table. In this case, since `entityId()` would not be called on either, `idColumns` would be empty. This would cause errors the first time the `id` column is accessed.

- **What**:
This PR proposes validating the id columns and throwing an exception with suggestions to use `Column.entityId()` or call `Table.addIdColumn()`.

- **How**:
    - Make `idColumns` publicly read-only and change visibility modifier of `addIdColumn()` to protected 
    - Add test for many-to-many with extra column workaround using `CompositeIdTable` that fails without validation & manual addition of id columns
    - Validate every time `idColumns` is accessed
    - Add `CompositeID` setter for right hand side `entityID` value, as shown missing based on new test

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
