### PR TITLE
fix: EXPOSED-464 `CurrentTimestampWithTimeZone` expression does not work as a default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Affected databases:
 - [ ] Postgres
 - [ ] SqlServer
 - [ ] H2
-- [ ] SQLight
+- [ ] SQLite
 
 #### Checklist
 

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/Versions.kt
@@ -18,7 +18,7 @@ object Versions {
     const val oracle12 = "12.2.0.1"
     const val postgre = "42.6.0"
     const val postgreNG = "0.8.9"
-    const val sqlLite3 = "3.43.0.0"
+    const val sqlite3 = "3.43.0.0"
     const val sqlserver = "9.4.1.jre8"
 
     /** Spring **/

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -24,6 +24,7 @@ import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
+import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.jetbrains.exposed.sql.vendors.h2Mode
 import org.junit.Test
 import java.time.OffsetDateTime
@@ -197,6 +198,7 @@ class DefaultsTest : DatabaseTestsBase() {
                     is OracleDialect -> "SYSDATE"
                     is SQLServerDialect -> "GETDATE()"
                     is MysqlDialect -> if (dialect.isFractionDateTimeSupported()) "NOW(6)" else "NOW()"
+                    is SQLiteDialect -> "CURRENT_TIMESTAMP"
                     else -> "NOW()"
                 }
             }
@@ -233,19 +235,21 @@ class DefaultsTest : DatabaseTestsBase() {
         fun Expression<*>.itOrNull() = when {
             currentDialectTest.isAllowedAsColumnDefault(this) ->
                 "DEFAULT ${currentDialectTest.dataTypeProvider.processForDefaultValue(this)} NOT NULL"
-
             else -> "NULL"
         }
 
-        withTables(listOf(TestDB.SQLITE), testTable) {
+        withTables(testTable) { testDb ->
             val dtType = currentDialectTest.dataTypeProvider.dateTimeType()
+            val dType = currentDialectTest.dataTypeProvider.dateType()
             val longType = currentDialectTest.dataTypeProvider.longType()
             val timeType = currentDialectTest.dataTypeProvider.timeType()
             val varCharType = currentDialectTest.dataTypeProvider.varcharType(100)
             val q = db.identifierManager.quoteString
             val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
                 "${"t".inProperCase()} (" +
-                "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
+                "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()}${
+                    testDb.takeIf { it != TestDB.SQLITE }?.let { " PRIMARY KEY" } ?: ""
+                }, " +
                 "${"s".inProperCase()} $varCharType${testTable.s.constraintNamePart()} DEFAULT 'test' NOT NULL, " +
                 "${"sn".inProperCase()} $varCharType${testTable.sn.constraintNamePart()} DEFAULT 'testNullable' NULL, " +
                 "${"l".inProperCase()} ${currentDialectTest.dataTypeProvider.longType()}${testTable.l.constraintNamePart()} DEFAULT 42 NOT NULL, " +
@@ -253,7 +257,7 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t1".inProperCase()} $dtType${testTable.t1.constraintNamePart()} ${currentDT.itOrNull()}, " +
                 "${"t2".inProperCase()} $dtType${testTable.t2.constraintNamePart()} ${nowExpression.itOrNull()}, " +
                 "${"t3".inProperCase()} $dtType${testTable.t3.constraintNamePart()} ${dtLiteral.itOrNull()}, " +
-                "${"t4".inProperCase()} DATE${testTable.t4.constraintNamePart()} ${dLiteral.itOrNull()}, " +
+                "${"t4".inProperCase()} $dType${testTable.t4.constraintNamePart()} ${dLiteral.itOrNull()}, " +
                 "${"t5".inProperCase()} $dtType${testTable.t5.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
                 "${"t6".inProperCase()} $dtType${testTable.t6.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
                 "${"t7".inProperCase()} $longType${testTable.t7.constraintNamePart()} ${durLiteral.itOrNull()}, " +
@@ -395,7 +399,7 @@ class DefaultsTest : DatabaseTestsBase() {
         java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
         assertEquals("UTC", ZoneId.systemDefault().id)
 
-        val nowWithTimeZone = OffsetDateTime.parse("2024-07-18T13:19:44.000+00:00")
+        val nowWithTimeZone = OffsetDateTime.parse("2024-07-18T13:19:44.100+00:00")
         val timestampWithTimeZoneLiteral = timestampWithTimeZoneLiteral(nowWithTimeZone)
 
         val testTable = object : IntIdTable("t") {
@@ -410,12 +414,14 @@ class DefaultsTest : DatabaseTestsBase() {
             else -> "NULL"
         }
 
-        withTables(excludeSettings = TestDB.ALL_MARIADB + TestDB.SQLITE + TestDB.MYSQL_V5, testTable) {
+        withTables(excludeSettings = TestDB.ALL_MARIADB + TestDB.MYSQL_V5, testTable) { testDb ->
             val timestampWithTimeZoneType = currentDialectTest.dataTypeProvider.timestampWithTimeZoneType()
 
             val baseExpression = "CREATE TABLE " + addIfNotExistsIfSupported() +
                 "${"t".inProperCase()} (" +
-                "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()} PRIMARY KEY, " +
+                "${"id".inProperCase()} ${currentDialectTest.dataTypeProvider.integerAutoincType()}${
+                    testDb.takeIf { it != TestDB.SQLITE }?.let { " PRIMARY KEY" } ?: ""
+                }, " +
                 "${"t1".inProperCase()} $timestampWithTimeZoneType${testTable.t1.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
                 "${"t2".inProperCase()} $timestampWithTimeZoneType${testTable.t2.constraintNamePart()} ${timestampWithTimeZoneLiteral.itOrNull()}, " +
                 "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
@@ -437,8 +443,8 @@ class DefaultsTest : DatabaseTestsBase() {
             val id1 = testTable.insertAndGetId { }
 
             val row1 = testTable.selectAll().where { testTable.id eq id1 }.single()
-            assertEqualDateTime(nowWithTimeZone, row1[testTable.t1])
-            assertEqualDateTime(nowWithTimeZone, row1[testTable.t2])
+            assertEquals(nowWithTimeZone, row1[testTable.t1])
+            assertEquals(nowWithTimeZone, row1[testTable.t2])
             val dbDefault = row1[testTable.t3]
             assertEquals(dbDefault.offset, nowWithTimeZone.offset)
             assertTrue { dbDefault.toLocalDateTime().toKotlinLocalDateTime() >= nowWithTimeZone.toLocalDateTime().toKotlinLocalDateTime() }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ThreadLocalManagerTest.kt
@@ -48,7 +48,7 @@ class ThreadLocalManagerTest : DatabaseTestsBase() {
 
     @Test
     fun testReadOnly() {
-        // Explanation: MariaDB driver never set readonly to true, MSSQL silently ignores the call, SQLLite does not
+        // Explanation: MariaDB driver never set readonly to true, MSSQL silently ignores the call, SQLite does not
         // promise anything, H2 has very limited functionality
         val excludeSettings = TestDB.ALL_H2 + TestDB.ALL_MARIADB +
             listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ mysql80 = "8.0.33"
 oracle12 = "12.2.0.1"
 postgre = "42.7.3"
 postgreNG = "0.8.9"
-sqlLite3 = "3.46.0.1"
+sqlite3 = "3.46.0.1"
 sqlserver = "9.4.1.jre8"
 
 springFramework = "6.1.11"
@@ -74,7 +74,7 @@ mysql51 = { group = "mysql", name = "mysql-connector-java", version.ref = "mysql
 mysql = { group = "mysql", name = "mysql-connector-java", version.ref = "mysql80" }
 pgjdbc-ng = { group = "com.impossibl.pgjdbc-ng", name = "pgjdbc-ng", version.ref = "postgreNG" }
 postgre = { group = "org.postgresql", name = "postgresql", version.ref = "postgre" }
-sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqlLite3" }
+sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqlite3" }
 maria-db2 = { group = "org.mariadb.jdbc", name = "mariadb-java-client", version.ref = "mariaDB_v2" }
 maria-db3 = { group = "org.mariadb.jdbc", name = "mariadb-java-client", version.ref = "mariaDB_v3" }
 oracle12 = { group = "com.oracle.database.jdbc", name = "ojdbc8", version.ref = "oracle12" }


### PR DESCRIPTION
#### Description

**Summary of the change**:
When the value of a `timestampWithTimeZone` column is set from `CURRENT_TIMESTAMP`, the format of the value is different than when a different value is set as a default or a value is set during insertion, and the column type was not handling that case before for SQLite and Oracle.

**Detailed description**:
- **What**:
Make `timestampWithTimeZone` column work when `CurrentTimestampWithTimeZone` expression is used as a default in SQLite and Oracle.
- **Why**:
Error was being thrown before.
- **How**:
Modify formatters to handle when `timestampWithTimeZone` column is set from `CURRENT_TIMESTAMP`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [x] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [x] SQLight

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
