### PR TITLE
fix: EXPOSED-439 Outer transaction commits rows from failed inner transaction

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Affected databases:
 - [ ] Postgres
 - [ ] SqlServer
 - [ ] H2
-- [ ] SQLight
+- [ ] SQLite
 
 #### Checklist
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
@@ -1,14 +1,25 @@
 package org.jetbrains.exposed.sql.tests.shared
 
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.shared.dml.DMLTestsData
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.transactions.transactionManager
+import org.junit.Assume
 import org.junit.Test
+import java.sql.SQLException
+import kotlin.test.assertContains
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.fail
 
 class NestedTransactionsTest : DatabaseTestsBase() {
 
@@ -68,6 +79,77 @@ class NestedTransactionsTest : DatabaseTestsBase() {
             }
 
             assertNotNull(TransactionManager.currentOrNull())
+        }
+    }
+
+    @Test
+    fun testNestedTransactionNotCommittedAfterFailure() {
+        Assume.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+        val db = Database.connect(
+            "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;", "org.h2.Driver", "root", "",
+            databaseConfig = DatabaseConfig {
+                useNestedTransactions = true
+                defaultMaxAttempts = 1
+            }
+        )
+
+        fun assertSingleRecordInNewTransactionAndReset() = transaction(db) {
+            val result = DMLTestsData.Cities.selectAll().single()[DMLTestsData.Cities.name]
+            assertEquals("City A", result)
+            DMLTestsData.Cities.deleteAll()
+        }
+        val fakeSQLString = "BROKEN_SQL_THAT_CAUSES_EXCEPTION"
+
+        transaction(db) {
+            SchemaUtils.create(DMLTestsData.Cities)
+        }
+
+        transaction(db) {
+            val outerTxId = this.id
+
+            DMLTestsData.Cities.insert { it[name] = "City A" }
+            assertEquals(1, DMLTestsData.Cities.selectAll().count())
+
+            try {
+                inTopLevelTransaction(db.transactionManager.defaultIsolationLevel, db = db) {
+                    val innerTxId = this.id
+                    assertNotEquals(outerTxId, innerTxId)
+
+                    DMLTestsData.Cities.insert { it[name] = "City B" }
+                    exec("$fakeSQLString()")
+                }
+                fail("Should have thrown an exception")
+            } catch (cause: SQLException) {
+                assertContains(cause.toString(), fakeSQLString)
+            }
+        }
+
+        assertSingleRecordInNewTransactionAndReset()
+
+        transaction(db) {
+            val outerTxId = this.id
+
+            DMLTestsData.Cities.insert { it[name] = "City A" }
+            assertEquals(1, DMLTestsData.Cities.selectAll().count())
+
+            try {
+                transaction(db) {
+                    val innerTxId = this.id
+                    assertNotEquals(outerTxId, innerTxId)
+
+                    DMLTestsData.Cities.insert { it[name] = "City B" }
+                    exec("$fakeSQLString()")
+                }
+                fail("Should have thrown an exception")
+            } catch (cause: SQLException) {
+                assertContains(cause.toString(), fakeSQLString)
+            }
+        }
+
+        assertSingleRecordInNewTransactionAndReset()
+
+        transaction(db) {
+            SchemaUtils.drop(DMLTestsData.Cities)
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**:
Nested transactions wrapped in a try-catch block that fail no longer commit their failed operations to the outer transaction block.

**Detailed description**:
- **Why**:
Wrapping a nested transaction (`transaction` + `useNestedTransaction = true`) in a try-catch block would successfully catch and log any exception, but any operations performed within the failed transaction would still be committed. Whereas the expected behavior (that any failed operations would undergo rollback) would be achieved if `inTopLevelTransaction` is used instead of the nested transaction.
- **How**:
Branch for nested transaction logic now includes a catch block, similar to try-catch logic already in `inTopLevelTransaction`, rather than being ignored and caught by the outer transaction only after comitting.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-439](https://youtrack.jetbrains.com/issue/EXPOSED-439)