### PR TITLE
feat!: EXPOSED-476 Update Kotlin to 2.0.0

### DIFF
--- a/documentation-website/Writerside/snippets/get-started-with-exposed/gradle/libs.versions.toml
+++ b/documentation-website/Writerside/snippets/get-started-with-exposed/gradle/libs.versions.toml
@@ -13,4 +13,4 @@ exposed-core = { module= "org.jetbrains.exposed:exposed-core", version.ref = "ex
 exposed-jdbc = { module= "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed"}
 
 [plugins]
-jvm = { id = "org.jetbrains.kotlin.jvm", version = "1.9.22" }
+jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,6 +1,11 @@
 # Breaking Changes
 
+## 0.54.0
+
+* All objects that are part of the sealed class `ForUpdateOption` are now converted to `data object`.
+
 ## 0.51.0
+
 * The `exposed-spring-boot-starter` module no longer provides the entire [spring-boot-starter-data-jdbc](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jdbc) module.
   It now provides just the [spring-boot-starter-jdbc](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-jdbc).
   If there was a reliance on this transitive dependency, please directly include a dependency on Spring Data JDBC in your build files.
@@ -18,7 +23,7 @@
 
 ## 0.49.0
 
-For SQLite database, Exposed now requires bumping the SQLite JDBC driver version to a minimum of 3.45.0.0.
+* For SQLite database, Exposed now requires bumping the SQLite JDBC driver version to a minimum of 3.45.0.0.
 
 ## 0.48.0
 
@@ -39,10 +44,10 @@ For SQLite database, Exposed now requires bumping the SQLite JDBC driver version
 
 ## 0.47.0
 
-The function `SchemaUtils.checkExcessiveIndices` is used to check both excessive indices and excessive foreign key
-constraints. It now has a different behavior and deals with excessive indices only. Also, its return type is now
-`List<Index>` instead of `Unit`. A new function, `SchemaUtils.checkExcessiveForeignKeyConstraints`, deals with excessive
-foreign key constraints and has a return type `List<ForeignKeyConstraint>`.
+* The function `SchemaUtils.checkExcessiveIndices` is used to check both excessive indices and excessive foreign key 
+  constraints. It now has a different behavior and deals with excessive indices only. Also, its return type is now
+  `List<Index>` instead of `Unit`. A new function, `SchemaUtils.checkExcessiveForeignKeyConstraints`, deals with excessive
+  foreign key constraints and has a return type `List<ForeignKeyConstraint>`.
 
 ## 0.46.0
 

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3783,6 +3783,9 @@ public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption {
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdate : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MariaDB {
@@ -3791,6 +3794,9 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MariaDB {
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MariaDB$LockInShareMode : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MariaDB$LockInShareMode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL {
@@ -3799,10 +3805,16 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL {
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$LockInShareMode : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$LockInShareMode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$Oracle {
@@ -3811,6 +3823,9 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$Oracle {
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$Oracle$ForUpdateNoWait : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$Oracle$ForUpdateNoWait;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$Oracle$ForUpdateWait : org/jetbrains/exposed/sql/vendors/ForUpdateOption {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -987,9 +987,7 @@ class EnumerationColumnType<T : Enum<T>>(
 
         other as EnumerationColumnType<*>
 
-        if (klass != other.klass) return false
-
-        return true
+        return klass == other.klass
     }
 
     override fun hashCode(): Int {
@@ -1044,9 +1042,7 @@ class EnumerationNameColumnType<T : Enum<T>>(
 
         other as EnumerationNameColumnType<*>
 
-        if (klass != other.klass) return false
-
-        return true
+        return klass == other.klass
     }
 
     override fun hashCode(): Int {
@@ -1134,7 +1130,7 @@ class ArrayColumnType<E>(
 
     override fun notNullValueToDB(value: List<E>): Any = value.map { e -> e?.let { delegate.notNullValueToDB(it) } }.toTypedArray()
 
-    override fun valueToString(value: List<E>?): String = if (value != null) nonNullValueToString(value) else super.valueToString(value)
+    override fun valueToString(value: List<E>?): String = if (value != null) nonNullValueToString(value) else super.valueToString(null)
 
     override fun nonNullValueToString(value: List<E>): String {
         val prefix = if (currentDialect is H2Dialect) "ARRAY [" else "ARRAY["

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -103,7 +103,7 @@ class DatabaseConfig private constructor(
         /**
          * Amount of entities to keep in an EntityCache per an Entity class.
          * Applicable only when `exposed-dao` module is used.
-         * This can be overridden on a per-transaction basis via [EntityCache.maxEntitiesToStore].
+         * This can be overridden on a per-transaction basis via `EntityCache.maxEntitiesToStore`.
          * All entities will be kept by default.
          */
         var maxEntitiesToStoreInCachePerEntity: Int = Int.MAX_VALUE,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -392,7 +392,6 @@ class CaseWhen<T>(
     val cases: MutableList<Pair<Expression<Boolean>, Expression<out T>>> = mutableListOf()
 
     /** Adds a conditional expression with a [result] if the expression evaluates to `true`. */
-    @Suppress("UNCHECKED_CAST")
     fun When(cond: Expression<Boolean>, result: Expression<T>): CaseWhen<T> {
         cases.add(cond to result)
         return this

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -427,7 +427,7 @@ fun <T : Table> T.update(where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null
  * @param where Condition that determines which rows to update.
  * @param limit Maximum number of rows to update.
  * @return The number of updated rows.
- * @sample org.jetbrains.exposed.sql.tests.shared.dml.UpdateTests.testUpdateWithJoin01
+ * @sample org.jetbrains.exposed.sql.tests.shared.dml.UpdateTests.testUpdateWithSingleJoin
  */
 fun Join.update(where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null, limit: Int? = null, body: (UpdateStatement) -> Unit): Int {
     val query = UpdateStatement(this, limit, where?.let { SqlExpressionBuilder.it() })

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -342,7 +342,7 @@ interface ISqlExpressionBuilder {
 
     /** Checks if this [EntityID] expression is equal to some [other] expression. */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.eq(
-        other: Expression<in V>
+        other: Expression<V>
     ): Op<Boolean> = when (other as Expression<*>) {
         is Op.NULL -> isNull()
         else -> EqOp(this, other)
@@ -380,7 +380,7 @@ interface ISqlExpressionBuilder {
 
     /** Checks if this [EntityID] expression is not equal to some [other] expression. */
     infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.neq(
-        other: Expression<in V>
+        other: Expression<V>
     ): Op<Boolean> = when (other as Expression<*>) {
         is Op.NULL -> isNotNull()
         else -> NeqOp(this, other)
@@ -751,7 +751,7 @@ interface ISqlExpressionBuilder {
     infix fun Expression<EntityID<String>>.notLike(pattern: LikePattern): LikeEscapeOp =
         LikeEscapeOp(this, stringParam(pattern.pattern), false, pattern.escapeChar)
 
-    /** Checks if this expression doesn't match the specified [pattern]. */
+    /** Checks if this expression doesn't match the specified pattern. */
     infix fun <T : String?> Expression<T>.notLike(expression: ExpressionWithColumnType<String>): LikeEscapeOp =
         LikeEscapeOp(this, expression, false, null)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -616,7 +616,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <T : Comparable<T>> Column<T>.entityId(): Column<EntityID<T>> {
         val newColumn = Column<EntityID<T>>(table, name, EntityIDColumnType(this)).also {
             it.defaultValueFun = defaultValueFun?.let { { EntityIDFunctionProvider.createEntityID(it(), table as IdTable<T>) } }
-            it.dbDefaultValue = dbDefaultValue?.let { it as Expression<EntityID<T>> }
+            it.dbDefaultValue = dbDefaultValue?.let { default -> default as Expression<EntityID<T>> }
             it.extraDefinitions = extraDefinitions
         }
         (table as IdTable<T>).addIdColumnInternal(newColumn)
@@ -677,7 +677,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * database's 2-byte integer type with a check constraint that ensures storage of only values
      * between 0 and [UByte.MAX_VALUE] inclusive.
      */
-    fun ubyte(name: String): Column<UByte> = registerColumn<UByte>(name, UByteColumnType()).apply {
+    fun ubyte(name: String): Column<UByte> = registerColumn(name, UByteColumnType()).apply {
         check("${generatedCheckPrefix}byte_$name") { it.between(0u, UByte.MAX_VALUE) }
     }
 
@@ -689,7 +689,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * **Note:** If the database being used is not MySQL or MariaDB, this column will use the database's 4-byte
      * integer type with a check constraint that ensures storage of only values between 0 and [UShort.MAX_VALUE] inclusive.
      */
-    fun ushort(name: String): Column<UShort> = registerColumn<UShort>(name, UShortColumnType()).apply {
+    fun ushort(name: String): Column<UShort> = registerColumn(name, UShortColumnType()).apply {
         check("$generatedCheckPrefix$name") { it.between(0u, UShort.MAX_VALUE) }
     }
 
@@ -702,7 +702,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * 8-byte integer type with a check constraint that ensures storage of only values
      * between 0 and [UInt.MAX_VALUE] inclusive.
      */
-    fun uinteger(name: String): Column<UInt> = registerColumn<UInt>(name, UIntegerColumnType()).apply {
+    fun uinteger(name: String): Column<UInt> = registerColumn(name, UIntegerColumnType()).apply {
         check("$generatedCheckPrefix$name") { it.between(0u, UInt.MAX_VALUE) }
     }
 
@@ -816,7 +816,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * If [useObjectIdentifier] is `true`, then the column will use the `OID` type on PostgreSQL
      * for storing large binary objects. The parameter must not be `true` for other databases.
      *
-     * @sample org.jetbrains.exposed.sql.tests.shared.DDLTests.testBlob
+     * @sample org.jetbrains.exposed.sql.tests.shared.types.BlobColumnTypeTests.testBlob
      */
     fun blob(name: String, useObjectIdentifier: Boolean = false): Column<ExposedBlob> =
         registerColumn(name, BlobColumnType(useObjectIdentifier))
@@ -891,7 +891,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      *
      * **Note** This column type is only supported by H2 and PostgreSQL dialects.
      *
-     * **Note** The base column type associated with storing elements of type [T] will be resolved according to
+     * **Note** The base column type associated with storing elements of type [E] will be resolved according to
      * the internal mapping in [resolveColumnType]. To avoid this type reflection, or if a mapping does not exist
      * for the elements being stored, please provide an explicit column type to the [array] overload. If the elements
      * to be stored are nullable, an explicit column type will also need to be provided.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/InListOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/InListOps.kt
@@ -169,9 +169,9 @@ class MultipleInListOp(
                 val valueEqualityOps = mutableListOf<Op<Boolean>>()
 
                 iterator.forEach { value ->
-                    val valueEqualityOp = Op.build {
+                    val valueEqualityOp = build {
                         expr.zip(value).map { (column, value) ->
-                            Op.build { EqOp(column, column.wrap(value)) }
+                            build { EqOp(column, column.wrap(value)) }
                         }.compoundAnd()
                     }
                     valueEqualityOps.add(if (isInList) valueEqualityOp else not(valueEqualityOp))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/MergeStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/MergeStatement.kt
@@ -123,7 +123,7 @@ abstract class MergeStatement(val table: Table) : Statement<Int>(
  * Here is only the part specific for the Table as a source implementation.
  * Look into [MergeStatement] to find the base implementation of that command.
  *
- * @property dest The destination [Table] where records will be merged into.
+ * @param dest The destination [Table] where records will be merged into.
  * @property source The source [Table] from which records are taken to compare with `dest`.
  * @property on The join condition [Op<Boolean>] that specifies how to match records in both `source` and `dest`.
  */
@@ -144,7 +144,7 @@ open class MergeTableStatement(
  * Here is only the part specific for the Query as a source implementation.
  * Look into [MergeStatement] to find the base implementation of that command.
  *
- * @property dest The destination [Table] where records will be merged into.
+ * @param dest The destination [Table] where records will be merged into.
  * @property selectQuery The source [QueryAlias] from which records are taken to compare with `dest`.
  * @property on The join condition [Op<Boolean>] that specifies how to match records in both `source` and `dest`.
  */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
@@ -64,7 +64,7 @@ abstract class IdentifierManagerApi {
     private val identifiersInProperCaseCache = IdentifiersCache<String>()
     private val quotedIdentifiersCache = IdentifiersCache<String>()
 
-    private fun String.isIdentifier() = !isEmpty() && first().isIdentifierStart() && all { it.isIdentifierStart() || it in '0'..'9' }
+    private fun String.isIdentifier() = isNotEmpty() && first().isIdentifierStart() && all { it.isIdentifierStart() || it in '0'..'9' }
     private fun Char.isIdentifierStart(): Boolean = this in 'a'..'z' || this in 'A'..'Z' || this == '_' || this in extraNameCharacters
 
     private fun String.isAKeyword(): Boolean = checkedKeywordsCache.getOrPut(lowercase()) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -109,7 +109,7 @@ interface TransactionManager {
      * Returns a [Transaction] instance.
      *
      * The returned value may be a new transaction, or it may return the [outerTransaction] if called from within
-     * an existing transaction with the database not configured to [useNestedTransactions].
+     * an existing transaction with the database not configured to `useNestedTransactions`.
      */
     fun newTransaction(
         isolation: Int = defaultIsolationLevel,
@@ -252,7 +252,7 @@ internal inline fun TransactionInterface.closeLoggingException(log: (Exception) 
 }
 
 /**
- * The [TransactionManager] instance that is associated with [this] database.
+ * The [TransactionManager] instance that is associated with this [Database].
  *
  * @throws [RuntimeException] If a manager has not been registered for the database.
  */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionScope.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionScope.kt
@@ -22,7 +22,7 @@ fun <T : Any> nullableTransactionScope() = TransactionStore<T>()
 
 /**
  * Class responsible for implementing property delegates of read-write properties in
- * the current transaction's [UserDataHolder].
+ * the current transaction's `UserDataHolder`.
  */
 class TransactionStore<T : Any>(val init: (Transaction.() -> T)? = null) : ReadWriteProperty<Any?, T?> {
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/ForUpdateOption.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/ForUpdateOption.kt
@@ -9,26 +9,26 @@ import org.jetbrains.exposed.sql.Table
  */
 sealed class ForUpdateOption(open val querySuffix: String) {
 
-    internal object NoForUpdateOption : ForUpdateOption("") {
+    internal data object NoForUpdateOption : ForUpdateOption("") {
         override val querySuffix: String get() = error("querySuffix should not be called for NoForUpdateOption object")
     }
 
     /** Common clause that locks the rows retrieved by a SELECT statement against concurrent updates. */
-    object ForUpdate : ForUpdateOption("FOR UPDATE")
+    data object ForUpdate : ForUpdateOption("FOR UPDATE")
 
     // https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html for clarification
     object MySQL {
         /** MySQL clause that acquires a shared lock for each row retrieved. */
-        object ForShare : ForUpdateOption("FOR SHARE")
+        data object ForShare : ForUpdateOption("FOR SHARE")
 
         /** This MySQL clause is equivalent to [ForShare] but exists for backward compatibility. */
-        object LockInShareMode : ForUpdateOption("LOCK IN SHARE MODE")
+        data object LockInShareMode : ForUpdateOption("LOCK IN SHARE MODE")
     }
 
     // https://mariadb.com/kb/en/select/#lock-in-share-modefor-update
     object MariaDB {
         /** MariaDB clause that acquires a shared lock for each row retrieved. */
-        object LockInShareMode : ForUpdateOption("LOCK IN SHARE MODE")
+        data object LockInShareMode : ForUpdateOption("LOCK IN SHARE MODE")
     }
 
     // https://www.postgresql.org/docs/current/sql-select.html
@@ -95,7 +95,7 @@ sealed class ForUpdateOption(open val querySuffix: String) {
     // https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_10002.htm#i2066346
     object Oracle {
         /** Oracle clause that never waits to acquire a row lock. */
-        object ForUpdateNoWait : ForUpdateOption("FOR UPDATE NOWAIT")
+        data object ForUpdateNoWait : ForUpdateOption("FOR UPDATE NOWAIT")
 
         /** Oracle clause that waits for the provided timeout until the row becomes available. */
         class ForUpdateWait(timeout: Int) : ForUpdateOption("FOR UPDATE WAIT $timeout")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -64,7 +64,7 @@ internal object H2FunctionProvider : FunctionProvider() {
                 super.insert(false, table, columns, expr, transaction).replace("INSERT", "INSERT IGNORE")
             }
             ignore -> transaction.throwUnsupportedException("INSERT IGNORE supported only on H2 v1.4.197+ with MODE=MYSQL.")
-            else -> super.insert(ignore, table, columns, expr, transaction)
+            else -> super.insert(false, table, columns, expr, transaction)
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -301,7 +301,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
         if (limit != null) {
             transaction.throwUnsupportedException("Oracle doesn't support LIMIT in DELETE clause.")
         }
-        return super.delete(ignore, table, where, limit, transaction)
+        return super.delete(ignore, table, where, null, transaction)
     }
 
     override fun queryLimit(size: Int, offset: Long, alreadyOrdered: Boolean): String {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -210,7 +210,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         }
     }
 
-    private const val onConflictIgnore = "ON CONFLICT DO NOTHING"
+    private const val ON_CONFLICT_IGNORE = "ON CONFLICT DO NOTHING"
 
     override fun insert(
         ignore: Boolean,
@@ -220,7 +220,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         transaction: Transaction
     ): String {
         val def = super.insert(false, table, columns, expr, transaction)
-        return if (ignore) "$def $onConflictIgnore" else def
+        return if (ignore) "$def $ON_CONFLICT_IGNORE" else def
     }
 
     override fun update(
@@ -233,7 +233,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         if (limit != null) {
             transaction.throwUnsupportedException("PostgreSQL doesn't support LIMIT in UPDATE clause.")
         }
-        return super.update(target, columnsAndValues, limit, where, transaction)
+        return super.update(target, columnsAndValues, null, where, transaction)
     }
 
     override fun update(
@@ -313,7 +313,7 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         if (limit != null) {
             transaction.throwUnsupportedException("PostgreSQL doesn't support LIMIT in DELETE clause.")
         }
-        return super.delete(ignore, table, where, limit, transaction)
+        return super.delete(ignore, table, where, null, transaction)
     }
 
     override fun explain(

--- a/exposed-crypt/build.gradle.kts
+++ b/exposed-crypt/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -24,7 +25,7 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/Algorithms.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/Algorithms.kt
@@ -12,7 +12,7 @@ import kotlin.math.ceil
 /**
  * Symmetric-key block ciphers for performing encryption and decryption.
  *
- * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testEncryptedColumnTypeWithAString
+ * @sample org.jetbrains.exposed.crypt.EncryptedColumnTests.testEncryptedColumnTypeWithAString
  */
 object Algorithms {
     @Suppress("MagicNumber")

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedBinaryColumnType.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedBinaryColumnType.kt
@@ -35,9 +35,7 @@ class EncryptedBinaryColumnType(
 
         other as EncryptedBinaryColumnType
 
-        if (encryptor != other.encryptor) return false
-
-        return true
+        return encryptor == other.encryptor
     }
 
     override fun hashCode(): Int {

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedVarCharColumnType.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/EncryptedVarCharColumnType.kt
@@ -38,9 +38,7 @@ class EncryptedVarCharColumnType(
 
         other as EncryptedVarCharColumnType
 
-        if (encryptor != other.encryptor) return false
-
-        return true
+        return encryptor == other.encryptor
     }
 
     override fun hashCode(): Int {

--- a/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/Tables.kt
+++ b/exposed-crypt/src/main/kotlin/org/jetbrains/exposed/crypt/Tables.kt
@@ -9,7 +9,7 @@ import org.jetbrains.exposed.sql.Table
  * @param name Name of the column
  * @param cipherTextLength Maximum expected length of encrypted value
  * @param encryptor [Encryptor] responsible for performing encryption and decryption of stored values
- * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testEncryptedColumnTypeWithAString
+ * @sample org.jetbrains.exposed.crypt.EncryptedColumnTests.testEncryptedColumnTypeWithAString
  */
 fun Table.encryptedVarchar(name: String, cipherTextLength: Int, encryptor: Encryptor): Column<String> =
     registerColumn(name, EncryptedVarCharColumnType(encryptor, cipherTextLength))
@@ -20,7 +20,7 @@ fun Table.encryptedVarchar(name: String, cipherTextLength: Int, encryptor: Encry
  * @param name Name of the column
  * @param cipherByteLength Maximum expected length of encrypted value in bytes
  * @param encryptor [Encryptor] responsible for performing encryption and decryption of stored values
- * @sample org.jetbrains.exposed.sql.tests.shared.dml.SelectTests.testEncryptedColumnTypeWithAString
+ * @sample org.jetbrains.exposed.crypt.EncryptedColumnTests.testEncryptedColumnTypeWithAString
  */
 fun Table.encryptedBinary(name: String, cipherByteLength: Int, encryptor: Encryptor): Column<ByteArray> =
     registerColumn(name, EncryptedBinaryColumnType(encryptor, cipherByteLength))

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -217,7 +217,7 @@ class JavaTimeTests : DatabaseTestsBase() {
                     it[event] = "B"
                 }
 
-                val inYear2000 = testTable.defaultDate.castTo<String>(TextColumnType()) like "2000%"
+                val inYear2000 = testTable.defaultDate.castTo(TextColumnType()) like "2000%"
                 assertEquals(1, testTable.selectAll().where { inYear2000 }.count())
 
                 val todayResult1 = testTable.selectAll().where { testTable.defaultDate eq today }.single()
@@ -277,7 +277,7 @@ class JavaTimeTests : DatabaseTestsBase() {
 
             val year2023 = if (currentDialectTest is PostgreSQLDialect) {
                 // PostgreSQL requires explicit type cast to resolve function date_part
-                dateParam(mayTheFourth).castTo<LocalDate>(JavaLocalDateColumnType()).year()
+                dateParam(mayTheFourth).castTo(JavaLocalDateColumnType()).year()
             } else {
                 dateParam(mayTheFourth).year()
             }
@@ -526,7 +526,7 @@ class JavaTimeTests : DatabaseTestsBase() {
     fun testCurrentDateTimeFunction() {
         val fakeTestTable = object : IntIdTable("fakeTable") {}
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) { db ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) {
             fun currentDbDateTime(): LocalDateTime {
                 return fakeTestTable.select(CurrentDateTime).first()[CurrentDateTime]
             }
@@ -542,8 +542,8 @@ class JavaTimeTests : DatabaseTestsBase() {
         val defaultDates = listOf(today)
         val defaultDateTimes = listOf(LocalDateTime.now())
         val tester = object : Table("array_tester") {
-            val dates = array<LocalDate>("dates", JavaLocalDateColumnType()).default(defaultDates)
-            val datetimes = array<LocalDateTime>("datetimes", JavaLocalDateTimeColumnType()).default(defaultDateTimes)
+            val dates = array("dates", JavaLocalDateColumnType()).default(defaultDates)
+            val datetimes = array("datetimes", JavaLocalDateTimeColumnType()).default(defaultDateTimes)
         }
 
         withTables(excludeSettings = TestDB.entries - TestDB.POSTGRESQL - TestDB.H2_V2, tester) {

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/sqlserver/SQLServerDefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/sqlserver/SQLServerDefaultsTest.kt
@@ -42,7 +42,7 @@ class SQLServerDefaultsTest : DatabaseTestsBase() {
 
                 val names = listOf("name")
                 val batchInsert: List<ResultRow> =
-                    temporalTable.batchInsert(names, shouldReturnGeneratedValues = true) { name ->
+                    temporalTable.batchInsert(names, shouldReturnGeneratedValues = true) {
                         this[temporalTable.name] = "name"
                     }
                 val id = batchInsert.first()[temporalTable.id]

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -128,7 +128,7 @@ class JodaTimeTests : DatabaseTestsBase() {
                     it[event] = "B"
                 }
 
-                val inYear2000 = testTable.defaultDate.castTo<String>(TextColumnType()) like "2000%"
+                val inYear2000 = testTable.defaultDate.castTo(TextColumnType()) like "2000%"
                 assertEquals(1, testTable.selectAll().where { inYear2000 }.count())
 
                 val todayResult1 = testTable.selectAll().where { testTable.defaultDate eq today }.single()
@@ -188,7 +188,7 @@ class JodaTimeTests : DatabaseTestsBase() {
 
             val year2023 = if (currentDialectTest is PostgreSQLDialect) {
                 // PostgreSQL requires explicit type cast to resolve function date_part
-                dateParam(mayTheFourth).castTo<DateTime>(DateColumnType(false)).year()
+                dateParam(mayTheFourth).castTo(DateColumnType(false)).year()
             } else {
                 dateParam(mayTheFourth).year()
             }
@@ -389,7 +389,7 @@ class JodaTimeTests : DatabaseTestsBase() {
     fun testCurrentDateTimeFunction() {
         val fakeTestTable = object : IntIdTable("fakeTable") {}
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) { db ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) {
             fun currentDbDateTime(): DateTime {
                 return fakeTestTable.select(CurrentDateTime).first()[CurrentDateTime]
             }
@@ -405,8 +405,8 @@ class JodaTimeTests : DatabaseTestsBase() {
         val defaultDates = listOf(today)
         val defaultDateTimes = listOf(DateTime.now())
         val tester = object : Table("array_tester") {
-            val dates = array<DateTime>("dates", DateColumnType(false)).default(defaultDates)
-            val datetimes = array<DateTime>("datetimes", DateColumnType(true)).default(defaultDateTimes)
+            val dates = array("dates", DateColumnType(false)).default(defaultDates)
+            val datetimes = array("datetimes", DateColumnType(true)).default(defaultDateTimes)
         }
 
         withTables(excludeSettings = TestDB.ALL - TestDB.POSTGRESQL - TestDB.H2_V2 - TestDB.H2_V2_PSQL, tester) {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -213,7 +213,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
                     it[event] = "B"
                 }
 
-                val inYear2000 = testTable.defaultDate.castTo<String>(TextColumnType()) like "2000%"
+                val inYear2000 = testTable.defaultDate.castTo(TextColumnType()) like "2000%"
                 assertEquals(1, testTable.selectAll().where { inYear2000 }.count())
 
                 val todayResult1 = testTable.selectAll().where { testTable.defaultDate eq today }.single()
@@ -271,7 +271,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
 
             val year2023 = if (currentDialectTest is PostgreSQLDialect) {
                 // PostgreSQL requires explicit type cast to resolve function date_part
-                dateParam(mayTheFourth).castTo<LocalDate>(KotlinLocalDateColumnType()).year()
+                dateParam(mayTheFourth).castTo(KotlinLocalDateColumnType()).year()
             } else {
                 dateParam(mayTheFourth).year()
             }
@@ -438,7 +438,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withDb(db = timestampWithTimeZoneUnsupportedDB) { testDB ->
+        withDb(db = timestampWithTimeZoneUnsupportedDB) {
             expectException<UnsupportedByDialectException> {
                 SchemaUtils.create(testTable)
             }
@@ -529,7 +529,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
     fun testCurrentDateTimeFunction() {
         val fakeTestTable = object : IntIdTable("fakeTable") {}
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) { db ->
+        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) {
             fun currentDbDateTime(): LocalDateTime {
                 return fakeTestTable.select(CurrentDateTime).first()[CurrentDateTime]
             }
@@ -559,8 +559,8 @@ class KotlinTimeTests : DatabaseTestsBase() {
         val defaultDates = listOf(now().date)
         val defaultDateTimes = listOf(now())
         val tester = object : Table("array_tester") {
-            val dates = array<LocalDate>("dates", KotlinLocalDateColumnType()).default(defaultDates)
-            val datetimes = array<LocalDateTime>("datetimes", KotlinLocalDateTimeColumnType()).default(defaultDateTimes)
+            val dates = array("dates", KotlinLocalDateColumnType()).default(defaultDates)
+            val datetimes = array("datetimes", KotlinLocalDateTimeColumnType()).default(defaultDateTimes)
         }
 
         withTables(excludeSettings = TestDB.entries - TestDB.POSTGRESQL - TestDB.H2_V2, tester) {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/sqlserver/SQLServerDefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/sqlserver/SQLServerDefaultsTest.kt
@@ -43,7 +43,7 @@ class SQLServerDefaultsTest : DatabaseTestsBase() {
 
                 val names = listOf("name")
                 val batchInsert: List<ResultRow> =
-                    temporalTable.batchInsert(names, shouldReturnGeneratedValues = true) { name ->
+                    temporalTable.batchInsert(names, shouldReturnGeneratedValues = true) {
                         this[temporalTable.name] = "name"
                     }
                 val id = batchInsert.first()[temporalTable.id]

--- a/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CurrencyColumnType.kt
+++ b/exposed-money/src/main/kotlin/org/jetbrains/exposed/sql/money/CurrencyColumnType.kt
@@ -16,13 +16,13 @@ import javax.money.Monetary
 @Suppress("MagicNumber")
 class CurrencyColumnType : ColumnType<CurrencyUnit>() {
 
-    override fun sqlType(): String = currentDialect.dataTypeProvider.varcharType(colLength)
+    override fun sqlType(): String = currentDialect.dataTypeProvider.varcharType(COLUMN_LENGTH)
 
     override fun validateValueBeforeUpdate(value: CurrencyUnit?) {
         if (value is CurrencyUnit) {
             val valueLength = value.currencyCode.codePointCount(0, value.currencyCode.length)
-            require(valueLength <= colLength) {
-                "Value can't be stored to database column because exceeds length ($valueLength > $colLength)"
+            require(valueLength <= COLUMN_LENGTH) {
+                "Value can't be stored to database column because exceeds length ($valueLength > $COLUMN_LENGTH)"
             }
         }
     }
@@ -50,19 +50,19 @@ class CurrencyColumnType : ColumnType<CurrencyUnit>() {
 
         other as VarCharColumnType
 
-        return colLength == other.colLength
+        return COLUMN_LENGTH == other.colLength
     }
 
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + colLength
+        result = 31 * result + COLUMN_LENGTH
         return result
     }
 
     private fun escape(value: String): String = value.map { charactersToEscape[it] ?: it }.joinToString("")
 
     companion object {
-        private const val colLength = 3
+        private const val COLUMN_LENGTH = 3
 
         private val charactersToEscape = mapOf(
             '\'' to "\'\'",

--- a/exposed-spring-boot-starter/build.gradle.kts
+++ b/exposed-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,7 @@
-import org.gradle.api.tasks.testing.logging.*
-import org.jetbrains.kotlin.gradle.tasks.*
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm")
@@ -29,8 +31,8 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
+++ b/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.CompletableFuture
 
 @SpringBootTest(
-    classes = [org.jetbrains.exposed.spring.Application::class, ExposedAutoConfigurationTest.CustomDatabaseConfigConfiguration::class],
+    classes = [Application::class, ExposedAutoConfigurationTest.CustomDatabaseConfigConfiguration::class],
     properties = ["spring.datasource.url=jdbc:h2:mem:test", "spring.datasource.driver-class-name=org.h2.Driver"]
 )
 open class ExposedAutoConfigurationTest {
@@ -87,7 +87,7 @@ open class ExposedAutoConfigurationTest {
 }
 
 @SpringBootTest(
-    classes = [org.jetbrains.exposed.spring.Application::class],
+    classes = [Application::class],
     properties = [
         "spring.datasource.url=jdbc:h2:mem:test",
         "spring.datasource.driver-class-name=org.h2.Driver",

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
@@ -19,7 +19,7 @@ class H2Tests : DatabaseTestsBase() {
     @Test
     fun testH2VersionIsCorrect() {
         val systemTestName = System.getProperty("exposed.test.name")
-        withDb(TestDB.ALL_H2) { db ->
+        withDb(TestDB.ALL_H2) {
             val dialect = currentDialect
             if (dialect is H2Dialect) {
                 val version = exec("SELECT H2VERSION();") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/MultiDatabaseTest.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.exposed.sql.tests.h2
 
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.sql.*
@@ -246,6 +248,7 @@ class MultiDatabaseTest {
         TransactionManager.defaultDatabase = null
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
     @Test // this test always fails for one reason or another
     fun `when the default database is changed, coroutines should respect that`(): Unit = runBlocking {
         assertEquals("jdbc:h2:mem:db1", db1.name) // These two asserts fail sometimes for reasons that escape me

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionExceptions.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionExceptions.kt
@@ -64,7 +64,7 @@ class ConnectionExceptions {
 
     private fun `_transaction repetition works even if rollback throws exception`(connectionDecorator: (Connection) -> ConnectionSpy) {
         Assume.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
-        Class.forName(TestDB.H2_V2.driver).newInstance()
+        Class.forName(TestDB.H2_V2.driver).getDeclaredConstructor().newInstance()
 
         val wrappingDataSource = WrappingDataSource(TestDB.H2_V2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
@@ -100,7 +100,7 @@ class ConnectionExceptions {
 
     private fun `_transaction repetition works when commit throws exception`(connectionDecorator: (Connection) -> ConnectionSpy) {
         Assume.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
-        Class.forName(TestDB.H2_V2.driver).newInstance()
+        Class.forName(TestDB.H2_V2.driver).getDeclaredConstructor().newInstance()
 
         val wrappingDataSource = WrappingDataSource(TestDB.H2_V2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
@@ -126,7 +126,7 @@ class ConnectionExceptions {
 
     private fun `_transaction throws exception if all commits throws exception`(connectionDecorator: (Connection) -> ConnectionSpy) {
         Assume.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
-        Class.forName(TestDB.H2_V2.driver).newInstance()
+        Class.forName(TestDB.H2_V2.driver).getDeclaredConstructor().newInstance()
 
         val wrappingDataSource = WrappingDataSource(TestDB.H2_V2, connectionDecorator)
         val db = Database.connect(datasource = wrappingDataSource)
@@ -182,7 +182,7 @@ class ConnectionExceptions {
     }
 
     @After
-    fun `teardown`() {
+    fun teardown() {
         TransactionManager.resetCurrent(null)
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/DDLTests.kt
@@ -645,7 +645,7 @@ class DDLTests : DatabaseTestsBase() {
             val byteCol = binary("byteCol", 1).clientDefault { byteArrayOf(0) }
         }
 
-        fun SizedIterable<ResultRow>.readAsString() = map { it[t.binary]?.let { String(it) } }
+        fun SizedIterable<ResultRow>.readAsString() = map { result -> result[t.binary]?.let { String(it) } }
 
         withTables(t) {
             t.insert { it[t.binary] = "Hello!".toByteArray() }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ReplaceColumnTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/ReplaceColumnTests.kt
@@ -15,7 +15,7 @@ class ReplaceColumnTests : DatabaseTestsBase() {
         withTables(IDTable) {
             expectException<DuplicateColumnException> {
                 // Duplicate the id column by replacing the IDTable.code by a column with the name "id"
-                val id = Column<Int>(IDTable, IDTable.id.name, (IDTable.id.columnType as EntityIDColumnType<Int>).idColumn.columnType)
+                val id = Column(IDTable, IDTable.id.name, (IDTable.id.columnType as EntityIDColumnType<Int>).idColumn.columnType)
                 IDTable.replaceColumn(IDTable.code, id)
             }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DMLTestData.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DMLTestData.kt
@@ -66,7 +66,7 @@ fun DatabaseTestsBase.withCitiesAndUsers(
     val cities = DMLTestsData.Cities
     val userData = DMLTestsData.UserData
 
-    withTables(exclude, cities, users, userData) { db ->
+    withTables(exclude, cities, users, userData) {
         val saintPetersburgId = cities.insert {
             it[name] = "St. Petersburg"
         } get cities.id

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ExistsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ExistsTests.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 class ExistsTests : DatabaseTestsBase() {
     @Test
     fun testExists01() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, users, userData ->
             val r = users.selectAll().where {
                 exists(userData.selectAll().where((userData.user_id eq users.id) and (userData.comment like "%here%")))
             }.toList()
@@ -49,7 +49,7 @@ class ExistsTests : DatabaseTestsBase() {
 
     @Test
     fun testExists02() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, users, userData ->
             val r = users
                 .selectAll()
                 .where {
@@ -68,7 +68,7 @@ class ExistsTests : DatabaseTestsBase() {
 
     @Test
     fun testExists03() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, users, userData ->
             val r = users.selectAll().where {
                 exists(userData.selectAll().where((userData.user_id eq users.id) and (userData.comment like "%here%"))) or
                     exists(userData.selectAll().where((userData.user_id eq users.id) and (userData.comment like "%Sergey")))

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/GroupByTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/GroupByTests.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
 class GroupByTests : DatabaseTestsBase() {
     @Test
     fun testGroupBy01() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, users, _ ->
             val cAlias = users.id.count().alias("c")
             ((cities innerJoin users).select(cities.name, users.id.count(), cAlias).groupBy(cities.name)).forEach {
                 val cityName = it[cities.name]
@@ -35,7 +35,7 @@ class GroupByTests : DatabaseTestsBase() {
 
     @Test
     fun testGroupBy02() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, users, _ ->
             val r = (cities innerJoin users).select(cities.name, users.id.count())
                 .groupBy(cities.name)
                 .having { users.id.count() eq 1 }
@@ -49,7 +49,7 @@ class GroupByTests : DatabaseTestsBase() {
 
     @Test
     fun testGroupBy03() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, users, _ ->
             val maxExpr = cities.id.max()
             val r = (cities innerJoin users).select(cities.name, users.id.count(), maxExpr)
                 .groupBy(cities.name)
@@ -77,7 +77,7 @@ class GroupByTests : DatabaseTestsBase() {
 
     @Test
     fun testGroupBy04() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, users, _ ->
             val r = (cities innerJoin users).select(cities.name, users.id.count(), cities.id.max())
                 .groupBy(cities.name)
                 .having { users.id.count() lessEq 42L }
@@ -100,7 +100,7 @@ class GroupByTests : DatabaseTestsBase() {
 
     @Test
     fun testGroupBy05() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, users, _ ->
             val maxNullableCityId = users.cityId.max()
 
             users.select(maxNullableCityId)
@@ -119,7 +119,7 @@ class GroupByTests : DatabaseTestsBase() {
 
     @Test
     fun testGroupBy06() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, _, _ ->
             val maxNullableId = cities.id.max()
 
             cities.select(maxNullableId)
@@ -138,7 +138,7 @@ class GroupByTests : DatabaseTestsBase() {
 
     @Test
     fun testGroupBy07() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, _, _ ->
             val avgIdExpr = cities.id.avg()
             val avgId = BigDecimal.valueOf(cities.selectAll().map { it[cities.id] }.average())
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertSelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertSelectTests.kt
@@ -10,7 +10,7 @@ import java.math.BigDecimal
 class InsertSelectTests : DatabaseTestsBase() {
     @Test
     fun testInsertSelect01() {
-        withCitiesAndUsers(exclude = listOf(TestDB.ORACLE)) { cities, users, userData ->
+        withCitiesAndUsers(exclude = listOf(TestDB.ORACLE)) { cities, users, _ ->
             val nextVal = cities.id.autoIncColumnType?.nextValExpression
             val substring = users.name.substring(1, 2)
             val slice = listOfNotNull(nextVal, substring)
@@ -25,7 +25,7 @@ class InsertSelectTests : DatabaseTestsBase() {
 
     @Test
     fun testInsertSelect02() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, _, userData ->
             val allUserData = userData.selectAll().count()
             userData.insert(userData.select(userData.user_id, userData.comment, intParam(42)))
 
@@ -41,7 +41,7 @@ class InsertSelectTests : DatabaseTestsBase() {
             val nullableExpression = Random() as Expression<BigDecimal?>
             users.insert(
                 users.select(
-                    nullableExpression.castTo<String>(VarCharColumnType()).substring(1, 10),
+                    nullableExpression.castTo(VarCharColumnType()).substring(1, 10),
                     stringParam("Foo"), intParam(1), intLiteral(0)
                 )
             )
@@ -52,10 +52,10 @@ class InsertSelectTests : DatabaseTestsBase() {
 
     @Test
     fun testInsertSelect04() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, users, _ ->
             val userCount = users.selectAll().count()
             users.insert(
-                users.select(stringParam("Foo"), Random().castTo<String>(VarCharColumnType()).substring(1, 10)),
+                users.select(stringParam("Foo"), Random().castTo(VarCharColumnType()).substring(1, 10)),
                 columns = listOf(users.name, users.id)
             )
             val r = users.selectAll().where { users.name eq "Foo" }.toList()
@@ -65,7 +65,7 @@ class InsertSelectTests : DatabaseTestsBase() {
 
     @Test
     fun `insert-select with same columns in a query`() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, users, _ ->
             val fooParam = stringParam("Foo")
             users.insert(users.select(fooParam, fooParam).limit(1), columns = listOf(users.name, users.id))
             assertEquals(1, users.selectAll().where { users.name eq "Foo" }.count())

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/JoinTests.kt
@@ -13,7 +13,7 @@ class JoinTests : DatabaseTestsBase() {
     // manual join
     @Test
     fun testJoin01() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, users, _ ->
             (users innerJoin cities).select(users.name, cities.name)
                 .where { (users.id.eq("andrey") or users.name.eq("Sergey")) and users.cityId.eq(cities.id) }
                 .forEach {
@@ -31,7 +31,7 @@ class JoinTests : DatabaseTestsBase() {
     // join with foreign key
     @Test
     fun testJoin02() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, users, _ ->
             val stPetersburgUser = (users innerJoin cities).select(users.name, users.cityId, cities.name)
                 .where { cities.name.eq("St. Petersburg") or users.cityId.isNull() }.single()
             assertEquals("Andrey", stPetersburgUser[users.name])
@@ -165,7 +165,7 @@ class JoinTests : DatabaseTestsBase() {
 
     @Test
     fun testJoinWithAlias01() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { _, users, _ ->
             val usersAlias = users.alias("u2")
             val resultRow = Join(users).join(usersAlias, JoinType.LEFT, usersAlias[users.id], stringLiteral("smth"))
                 .selectAll().where { users.id eq "alex" }.single()
@@ -185,7 +185,7 @@ class JoinTests : DatabaseTestsBase() {
 
     @Test
     fun testJoinWithAdditionalConstraint() {
-        withCitiesAndUsers { cities, users, userData ->
+        withCitiesAndUsers { cities, users, _ ->
             val usersAlias = users.alias("name")
             val join = cities.join(usersAlias, JoinType.INNER, cities.id, usersAlias[users.cityId]) {
                 cities.id greater 1 and (cities.name.neq(usersAlias[users.name]))

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/LateralJoinTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/LateralJoinTests.kt
@@ -14,7 +14,7 @@ class LateralJoinTests : DatabaseTestsBase() {
 
     @Test
     fun testLateralJoinQuery() {
-        withTestTablesAndDefaultData { parent, child, testDb ->
+        withTestTablesAndDefaultData { parent, child, _ ->
             val query = parent.joinQuery(
                 joinType = JoinType.CROSS,
                 lateral = true
@@ -30,7 +30,7 @@ class LateralJoinTests : DatabaseTestsBase() {
 
     @Test
     fun testLateralJoinQueryAlias() {
-        withTestTablesAndDefaultData { parent, child, testDb ->
+        withTestTablesAndDefaultData { parent, child, _ ->
             // Cross join
             child.selectAll().where { child.value greater parent.value }.limit(1).alias("subquery")
                 .let { subqueryAlias ->
@@ -61,7 +61,7 @@ class LateralJoinTests : DatabaseTestsBase() {
 
     @Test
     fun testLateralDirectTableJoin() {
-        withTestTables { parent, child, testDb ->
+        withTestTables { parent, child, _ ->
             // Explicit notation
             expectException<IllegalArgumentException> {
                 parent.join(child, JoinType.LEFT, onColumn = parent.id, otherColumn = child.parent, lateral = true)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/MergeBaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/MergeBaseTest.kt
@@ -16,7 +16,7 @@ abstract class MergeBaseTest : DatabaseTestsBase() {
 
     protected fun withMergeTestTables(excludeSettings: Collection<TestDB> = emptyList(), statement: Transaction.(dest: Dest, source: Source) -> Unit) = withTables(
         excludeSettings = defaultExcludeSettings + excludeSettings, Source, Dest
-    ) { db ->
+    ) {
         statement(Dest, Source)
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/MergeSelectTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/MergeSelectTest.kt
@@ -101,7 +101,7 @@ class MergeSelectTest : MergeBaseTest() {
 
     @Test
     fun testDelete() {
-        withMergeTestTablesAndDefaultData(excludeSettings = TestDB.ALL_ORACLE_LIKE) { dest, source ->
+        withMergeTestTablesAndDefaultData(excludeSettings = TestDB.ALL_ORACLE_LIKE) { dest, _ ->
             dest.mergeFrom(
                 sourceQuery,
                 on = { defaultOnCondition() },

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityHookTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityHookTest.kt
@@ -222,7 +222,7 @@ class EntityHookTest : DatabaseTestsBase() {
             }
 
             val (_, events, txId) = trackChanges {
-                val spb = EntityHookTestData.City.find({ EntityHookTestData.Cities.name eq "St. Petersburg" }).single()
+                val spb = EntityHookTestData.City.find { EntityHookTestData.Cities.name eq "St. Petersburg" }.single()
                 val john = EntityHookTestData.User.all().single()
                 john.cities = SizedCollection(listOf(spb))
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -269,7 +269,7 @@ class EntityTests : DatabaseTestsBase() {
 
             Board.all().forEach {
                 it.posts.count() to it.posts.toList()
-                Post.find { Posts.board eq it.id }.joinToString { it.board?.name.orEmpty() }
+                Post.find { Posts.board eq it.id }.joinToString { post -> post.board?.name.orEmpty() }
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/FunctionsTests.kt
@@ -560,7 +560,7 @@ class FunctionsTests : DatabaseTestsBase() {
     fun testCustomOperator() {
         // implement a + operator using CustomOperator
         infix fun Expression<*>.plus(operand: Int) =
-            CustomOperator<Int>("+", IntegerColumnType(), this, intParam(operand))
+            CustomOperator("+", IntegerColumnType(), this, intParam(operand))
 
         withCitiesAndUsers { _, _, userData ->
             userData
@@ -587,7 +587,7 @@ class FunctionsTests : DatabaseTestsBase() {
                 }
             }
 
-            val coalesceExp2 = Coalesce(users.cityId, Op.nullOp<Int>(), intLiteral(1000))
+            val coalesceExp2 = Coalesce(users.cityId, Op.nullOp(), intLiteral(1000))
 
             users.select(users.cityId, coalesceExp2).forEach {
                 val cityId = it[users.cityId]

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/TrigonometricalFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/functions/TrigonometricalFunctionTests.kt
@@ -42,7 +42,7 @@ class TrigonometricalFunctionTests : FunctionsTestBase() {
 
     @Test
     fun testCosFunction() {
-        withTable { testDb ->
+        withTable {
             assertExpressionEqual(BigDecimal("1"), CosFunction(intLiteral(0)))
             assertExpressionEqual(BigDecimal("0.5403023"), CosFunction(intLiteral(1)))
             assertExpressionEqual(BigDecimal("0.96638998"), CosFunction(doubleLiteral(0.26)))

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -27,7 +27,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
         val numbers = array<Int>("numbers").default(listOf(5))
         val strings = array<String?>("strings", TextColumnType()).default(emptyList())
         val doubles = array<Double>("doubles").nullable()
-        val byteArray = array<ByteArray>("byte_array", BinaryColumnType(32)).nullable()
+        val byteArray = array("byte_array", BinaryColumnType(32)).nullable()
     }
 
     @Test
@@ -99,7 +99,7 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
     fun testArrayMaxSize() {
         val maxArraySize = 5
         val sizedTester = object : Table("sized_tester") {
-            val numbers = array<Int>("numbers", IntegerColumnType(), maxArraySize).default(emptyList())
+            val numbers = array("numbers", IntegerColumnType(), maxArraySize).default(emptyList())
         }
 
         withTestTableAndExcludeSettings(sizedTester) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/MultipleDatabaseBugTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/sqlite/MultipleDatabaseBugTest.kt
@@ -39,7 +39,7 @@ class MultipleDatabaseBugTest {
         Assume.assumeTrue(TestDB.SQLITE in TestDB.enabledDialects())
         val filename = folder.newFile("foo.db").absolutePath
         val ds = SQLiteDataSource()
-        ds.url = "jdbc:sqlite:" + filename
+        ds.url = "jdbc:sqlite:$filename"
         db = Database.connect(ds)
 
         // SQLite supports only TRANSACTION_SERIALIZABLE and TRANSACTION_READ_UNCOMMITTED

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.21"
+kotlin = "2.0.0"
 dokka = "1.9.20"
 detekt = "1.23.6" # When upgrading, also upgrade in detekt.yml and add corresponding detekt-formatting jar file.
 binary-compatibility-validator = "0.16.3"

--- a/samples/exposed-ktor/build.gradle.kts
+++ b/samples/exposed-ktor/build.gradle.kts
@@ -5,8 +5,8 @@ val exposedVersion: String by project
 val h2Version: String by project
 
 plugins {
-    kotlin("jvm") version "1.9.21"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.21"
+    kotlin("jvm") version "2.0.0"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
     id("io.ktor.plugin") version "2.3.4"
 }
 

--- a/samples/exposed-ktor/gradle.properties
+++ b/samples/exposed-ktor/gradle.properties
@@ -1,6 +1,6 @@
-ktorVersion=2.3.4
-kotlinVersion=1.8.10
-logbackVersion=1.2.11
+ktorVersion=2.3.12
+kotlinVersion=2.0.0
+logbackVersion=1.4.12
 kotlin.code.style=official
 exposedVersion=0.53.0
 h2Version=2.1.214

--- a/samples/exposed-migration/build.gradle.kts
+++ b/samples/exposed-migration/build.gradle.kts
@@ -4,7 +4,7 @@ val flywayVersion: String by project
 
 plugins {
     id("application")
-    kotlin("jvm") version "1.9.21"
+    kotlin("jvm") version "2.0.0"
 }
 
 group = "org.jetbrains.exposed.samples.migration"

--- a/samples/exposed-spring/build.gradle.kts
+++ b/samples/exposed-spring/build.gradle.kts
@@ -3,10 +3,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 val exposedVersion: String by project
 
 plugins {
-    id("org.springframework.boot") version "3.1.2"
-    id("io.spring.dependency-management") version "1.1.2"
-    kotlin("jvm") version "1.8.21"
-    kotlin("plugin.spring") version "1.8.21"
+    id("org.springframework.boot") version "3.3.2"
+    id("io.spring.dependency-management") version "1.1.6"
+    kotlin("jvm") version "2.0.0"
+    kotlin("plugin.spring") version "2.0.0"
 }
 
 group = "org.jetbrains.exposed"
@@ -36,8 +36,8 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs += "-Xjsr305=strict"
+    compilerOptions {
+        freeCompilerArgs.set(listOf("-Xjsr305=strict"))
     }
 }
 

--- a/samples/exposed-spring/gradle.properties
+++ b/samples/exposed-spring/gradle.properties
@@ -1,2 +1,2 @@
 exposedVersion=0.53.0
-kotlinVersion=1.8.21
+kotlinVersion=2.0.0

--- a/spring-transaction/build.gradle.kts
+++ b/spring-transaction/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.logging.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.*
 
 plugins {
@@ -36,8 +37,8 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = "17"
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Bump Kotlin version to 2.0.0 in all places (as well as kotlinx.serialization plugin)

**Detailed description**:
- **What**:
    - Kotlin version has been updated to 2.0.0 in all project and sample build files.
        - All 3 samples and `getting-started` snippet have been confirmed to run as expected
    -  Compiler errors and some warnings on inspection have been addressed.
- **How**:
    - Fix compiler **error** for: 'Type argument can't be inferred with `eq`'
    - Fix all compiler **warnings** for:
        - KDocs: Cannot resolve symbol
        - Unused suppressions
        - Redundant `if` statements
        - Remove explicit type arguments
        - `Sealed` sub-object can be converted to `data object`
        - Value of '?' is always null
        - Deprecated: `kotlinOptions` and `newInstance()`
        - Unused parameters
        - Implicit parameter shadowed

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature
- [X] Version bump

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-476](https://youtrack.jetbrains.com/issue/EXPOSED-476/Update-Kotlin-to-2.0.0)