### PR TITLE
fix: EXPOSED-472 Alias IdTable fails with isNull and eq ops

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
@@ -147,7 +147,7 @@ open class CompositeIdTable(name: String = "") : IdTable<CompositeID>(name) {
     @Suppress("UNCHECKED_CAST")
     override fun mapIdComparison(
         toCompare: Any?,
-        operator: (Column<*>, Expression<*>) -> Op<Boolean>
+        booleanOperator: (Column<*>, Expression<*>) -> Op<Boolean>
     ): Op<Boolean> {
         (toCompare as? EntityID<CompositeID>) ?: error("toCompare must be an EntityID<CompositeID> value")
         return idColumns.map { column ->
@@ -156,11 +156,11 @@ open class CompositeIdTable(name: String = "") : IdTable<CompositeID>(name) {
             } else {
                 error("Comparison CompositeID is missing a key mapping for ${column.name}")
             }
-            operator(column, column.wrap(otherValue.value as? EntityID<*> ?: otherValue))
+            booleanOperator(column, column.wrap(otherValue.value as? EntityID<*> ?: otherValue))
         }.compoundAnd()
     }
 
     override fun mapIdOperator(
-        operator: (Column<*>) -> Op<Boolean>
-    ): Op<Boolean> = idColumns.map { operator(it) }.compoundAnd()
+        booleanOperator: (Column<*>) -> Op<Boolean>
+    ): Op<Boolean> = idColumns.map { booleanOperator(it) }.compoundAnd()
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/IdTable.kt
@@ -56,26 +56,6 @@ abstract class IdTable<T : Comparable<T>>(name: String = "") : Table(name) {
     }
 
     internal fun <S : Comparable<S>> addIdColumnInternal(newColumn: Column<EntityID<S>>) { addIdColumn(newColumn) }
-
-    /**
-     * Returns a boolean operator comparing each of this table's [idColumns] to its corresponding
-     * value in [toCompare], using the specified SQL [operator].
-     *
-     * @throws IllegalStateException If [toCompare] is either not a matching id type or it does not contain a key for
-     * each component column.
-     */
-    internal open fun mapIdComparison(
-        toCompare: Any?,
-        operator: (Column<*>, Expression<*>) -> Op<Boolean>
-    ): Op<Boolean> {
-        val singleId = idColumns.single()
-        return operator(singleId, singleId.wrap(toCompare))
-    }
-
-    /** Returns a boolean operator with each of this table's [idColumns] using the specified SQL [operator]. */
-    internal open fun mapIdOperator(
-        operator: (Column<*>) -> Op<Boolean>
-    ): Op<Boolean> = operator(idColumns.single())
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -1,5 +1,10 @@
 package org.jetbrains.exposed.sql
 
+import org.jetbrains.exposed.dao.id.CompositeID
+import org.jetbrains.exposed.dao.id.CompositeIdTable
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.wrap
 import org.jetbrains.exposed.sql.vendors.OracleDialect
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialectIfAvailable
@@ -54,9 +59,54 @@ class Alias<out T : Table>(val delegate: T, val alias: String) : Table() {
     override fun hashCode(): Int = tableNameWithAlias.hashCode()
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <T : Any?> get(original: Column<T>): Column<T> =
-        delegate.columns.find { it == original }?.let { it.clone() as? Column<T> }
+    operator fun <T : Any?> get(original: Column<T>): Column<T> {
+        // CompositeIdTable id is not a typical database-registered column
+        val delegateColumn = if (delegate is CompositeIdTable && original.columnType.isEntityIdentifier()) {
+            delegate.id
+        } else {
+            delegate.columns.find { it == original }
+        }
+        return delegateColumn?.let { it.clone() as? Column<T> }
             ?: error("Column not found in original table")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun mapIdComparison(
+        toCompare: Any?,
+        operator: (Column<*>, Expression<*>) -> Op<Boolean>,
+    ): Op<Boolean> {
+        return when (delegate) {
+            is CompositeIdTable -> {
+                (toCompare as? EntityID<CompositeID>) ?: error("toCompare must be an EntityID<CompositeID> value")
+                return delegateIdColumns.map { column ->
+                    val delegateColumn = originalColumn(column)
+                    val otherValue = if (delegateColumn in toCompare.value.values) {
+                        toCompare.value[delegateColumn as Column<EntityID<Comparable<Any>>>]
+                    } else {
+                        error("Comparison CompositeID is missing a key mapping for ${delegateColumn?.name}")
+                    }
+                    operator(column, column.wrap(otherValue.value as? EntityID<*> ?: otherValue))
+                }.compoundAnd()
+            }
+            is IdTable<*> -> {
+                val singleId = delegateIdColumns.single()
+                operator(singleId, singleId.wrap(toCompare))
+            }
+            else -> error("idColumns for mapping are only available from IdTable instances")
+        }
+    }
+
+    override fun mapIdOperator(
+        operator: (Column<*>) -> Op<Boolean>
+    ): Op<Boolean> {
+        require(delegate is IdTable<*>) { "idColumns for mapping are only available from IdTable instances" }
+        return delegateIdColumns.map { operator(it) }.compoundAnd()
+    }
+
+    private val delegateIdColumns: List<Column<*>> = columns
+        .takeIf { delegate is IdTable<*> }
+        ?.filter { originalColumn(it) in (delegate as IdTable<*>).idColumns }
+        .orEmpty()
 }
 
 /** Represents a temporary SQL identifier, [alias], for a [delegate] expression. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -505,7 +505,7 @@ interface ISqlExpressionBuilder {
 
     /** Returns `true` if this string expression is null or empty, `false` otherwise. */
     fun <T : String?> Expression<T>.isNullOrEmpty() = if (this is Column<*> && columnType.isEntityIdentifier()) {
-        (table as IdTable<*>).mapIdOperator(::IsNullOp)
+        table.mapIdOperator(::IsNullOp)
     } else {
         IsNullOp(this)
     }.or { this@isNullOrEmpty.charLength() eq 0 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -312,10 +312,7 @@ interface ISqlExpressionBuilder {
     @LowPriorityInOverloadResolution
     infix fun <T> ExpressionWithColumnType<T>.eq(t: T): Op<Boolean> = when {
         t == null -> isNull()
-        columnType.isEntityIdentifier() -> {
-            val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<*>
-            table.mapIdComparison(t, ::EqOp)
-        }
+        columnType.isEntityIdentifier() -> (this as Column<*>).table.mapIdComparison(t, ::EqOp)
         else -> EqOp(this, wrap(t))
     }
 
@@ -362,10 +359,7 @@ interface ISqlExpressionBuilder {
     @LowPriorityInOverloadResolution
     infix fun <T> ExpressionWithColumnType<T>.neq(other: T): Op<Boolean> = when {
         other == null -> isNotNull()
-        columnType.isEntityIdentifier() -> {
-            val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<*>
-            table.mapIdComparison(other, ::NeqOp)
-        }
+        columnType.isEntityIdentifier() -> (this as Column<*>).table.mapIdComparison(other, ::NeqOp)
         else -> NeqOp(this, wrap(other))
     }
 
@@ -504,7 +498,7 @@ interface ISqlExpressionBuilder {
 
     /** Returns `true` if this expression is null, `false` otherwise. */
     fun <T> Expression<T>.isNull() = if (this is Column<*> && columnType.isEntityIdentifier()) {
-        (table as IdTable<*>).mapIdOperator(::IsNullOp)
+        table.mapIdOperator(::IsNullOp)
     } else {
         IsNullOp(this)
     }
@@ -518,7 +512,7 @@ interface ISqlExpressionBuilder {
 
     /** Returns `true` if this expression is not null, `false` otherwise. */
     fun <T> Expression<T>.isNotNull() = if (this is Column<*> && columnType.isEntityIdentifier()) {
-        (table as IdTable<*>).mapIdOperator(::IsNotNullOp)
+        table.mapIdOperator(::IsNotNullOp)
     } else {
         IsNotNullOp(this)
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -644,26 +644,26 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /**
      * Returns a boolean operator comparing each of an IdTable's `idColumns` to its corresponding
-     * value in [toCompare], using the specified SQL [operator].
+     * value in [toCompare], using the specified SQL [booleanOperator].
      *
      * @throws IllegalStateException If this is not an [IdTable], or if [toCompare] is either not
      * a matching id type or it does not contain a key for each component column.
      */
     internal open fun mapIdComparison(
         toCompare: Any?,
-        operator: (Column<*>, Expression<*>) -> Op<Boolean>
+        booleanOperator: (Column<*>, Expression<*>) -> Op<Boolean>
     ): Op<Boolean> {
         require(this is IdTable<*>) { "idColumns for mapping are only available from IdTable instances" }
         val singleId = idColumns.single()
-        return operator(singleId, singleId.wrap(toCompare))
+        return booleanOperator(singleId, singleId.wrap(toCompare))
     }
 
-    /** Returns a boolean operator with each of an IdTable's `idColumns` using the specified SQL [operator]. */
+    /** Returns a boolean operator with each of an IdTable's `idColumns` using the specified SQL [booleanOperator]. */
     internal open fun mapIdOperator(
-        operator: (Column<*>) -> Op<Boolean>
+        booleanOperator: (Column<*>) -> Op<Boolean>
     ): Op<Boolean> {
         require(this is IdTable<*>) { "idColumns for mapping are only available from IdTable instances" }
-        return operator(idColumns.single())
+        return booleanOperator(idColumns.single())
     }
 
     // Numeric columns

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.exceptions.DuplicateColumnException
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.wrap
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
@@ -639,6 +640,30 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <ID : Comparable<ID>> entityId(name: String, table: IdTable<ID>): Column<EntityID<ID>> {
         val originalColumn = (table.id.columnType as EntityIDColumnType<*>).idColumn as Column<ID>
         return entityId(name, originalColumn)
+    }
+
+    /**
+     * Returns a boolean operator comparing each of an IdTable's `idColumns` to its corresponding
+     * value in [toCompare], using the specified SQL [operator].
+     *
+     * @throws IllegalStateException If this is not an [IdTable], or if [toCompare] is either not
+     * a matching id type or it does not contain a key for each component column.
+     */
+    internal open fun mapIdComparison(
+        toCompare: Any?,
+        operator: (Column<*>, Expression<*>) -> Op<Boolean>
+    ): Op<Boolean> {
+        require(this is IdTable<*>) { "idColumns for mapping are only available from IdTable instances" }
+        val singleId = idColumns.single()
+        return operator(singleId, singleId.wrap(toCompare))
+    }
+
+    /** Returns a boolean operator with each of an IdTable's `idColumns` using the specified SQL [operator]. */
+    internal open fun mapIdOperator(
+        operator: (Column<*>) -> Op<Boolean>
+    ): Op<Boolean> {
+        require(this is IdTable<*>) { "idColumns for mapping are only available from IdTable instances" }
+        return operator(idColumns.single())
     }
 
     // Numeric columns

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
@@ -399,6 +399,24 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
     }
 
     @Test
+    fun testIsNullAndEqWithAlias() {
+        withTables(Towns) {
+            val townAValue = CompositeID {
+                it[Towns.zipCode] = "1A2 3B4"
+                it[Towns.name] = "Town A"
+            }
+            val townAId = Towns.insertAndGetId { it[id] = townAValue }
+
+            val smallCity = Towns.alias("small_city")
+
+            val result = smallCity.selectAll().where {
+                smallCity[Towns.id].isNotNull() and (smallCity[Towns.id] eq townAId)
+            }.single()
+            assertNull(result[smallCity[Towns.population]])
+        }
+    }
+
+    @Test
     fun testInsertAndSelectReferencedEntities() {
         withTables(excludeSettings = listOf(TestDB.SQLITE), tables = allTables) {
             val publisherA = Publisher.new {


### PR DESCRIPTION
#### Description

**Summary of the change**: Using any aliased `IdTable` with `isNull()` or `eq()` no longer throws a class cast exception.

**Detailed description**:
- **Why**:
The introduction of `CompositeIdTable` (PR #1987 ), and internal functions `mapIdComparison` and `mapIdOperator`, led to a regression. When any `IdTable` is aliased and used with the associated comparison operators, `eq` and `isNull` (and negative variants), the following is thrown: `org.jetbrains.exposed.sql.Alias cannot be cast to org.jetbrains.exposed.dao.id.IdTable`

- **What**:
The `Alias` class now has its own override for these internal functions, so that the aliased `idColumns` of the delegate are used.

- **How**:
    - Both `mapIdComparison` and `mapIdOperator` have been moved a level down to `Table`, so that they can be overridden by `Alias` as well, which is a subclass too.
    - `Alias.get()` operator has also been fixed to allow `CompositeIdTable` to be aliased and still access the delegate `id` column properly.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues

[EXPOSED-472](https://youtrack.jetbrains.com/issue/EXPOSED-472/Getting-an-error-with-Aliases-columns-when-using-the-isNull-expression)