### PR TITLE
fix: EXPOSED-474 Unexpected value of type when using a ColumnTransfor…

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -531,6 +531,7 @@ public final class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains
 	public fun setNullable (Z)V
 	public fun sqlType ()Ljava/lang/String;
 	public fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun unwrapRecursive (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -285,6 +285,14 @@ class ColumnWithTransform<Unwrapped : Any, Wrapped : Any>(
     val delegate: IColumnType<Unwrapped>,
     private val transformer: ColumnTransformer<Unwrapped, Wrapped>
 ) : ColumnType<Wrapped>(), ColumnTransformer<Unwrapped, Wrapped> by transformer {
+    fun unwrapRecursive(value: Wrapped): Any {
+        return if (delegate is ColumnWithTransform<*, *>) {
+            (delegate as ColumnWithTransform<Any, Unwrapped>).unwrapRecursive(unwrap(value))
+        } else {
+            unwrap(value)
+        }
+    }
+
     override fun sqlType() = delegate.sqlType()
 
     override fun valueFromDB(value: Any): Wrapped? {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -125,10 +125,11 @@ open class InsertStatement<Key : Any>(
             }
             pairs.forEach { (col, value) ->
                 if (value != DefaultValueMarker) {
+                    val unwrappedValue = value?.let { (col.columnType as? ColumnWithTransform<Any, Any>)?.unwrapRecursive(it) } ?: value
                     if (isColumnValuePreferredFromResultSet(col, value)) {
-                        map.getOrPut(col) { value }
+                        map.getOrPut(col) { unwrappedValue }
                     } else {
-                        map[col] = value
+                        map[col] = unwrappedValue
                     }
                 }
             }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -410,7 +410,12 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
         // move write values to read values
         if (_readValues != null) {
             for ((c, v) in writeValues) {
-                _readValues!![c] = v
+                val unwrappedValue = if (v != null && c.columnType is ColumnWithTransform<*, *>) {
+                    (c.columnType as ColumnWithTransform<Any, Any>).unwrapRecursive(v)
+                } else {
+                    v
+                }
+                _readValues!![c] = unwrappedValue
             }
             if (klass.dependsOnColumns.any { it.table == klass.table && !_readValues!!.hasValue(it) }) {
                 _readValues = null


### PR DESCRIPTION
#### Description

An interesting issue with the new column conversion feature was found.

Transformed value actually cannot be read from the insert statement directly and via DAO entity.

The reason is that statements and entities work via `ResultRow` that has mappting of expressions to the values. And `ResultRow` works in the way that it accepts as values both user values and db values. It works because internally `ResultRow` calls `ColumnType::valueFromDB()` for all the values, and `ColumnType`s should convert the values into correct kotlin types.

And the column types are implemented in the way that if they receive already valid value, they just return it. For example `IntegerColumnType` in this context looks like this:

```kotlin
override fun valueFromDB(value: Any): Int = when (value) {
    is Int -> value
    is Number -> value.toInt()
    is String -> value.toInt()
    else -> error("Unexpected value of type Int: $value of ${value::class.qualifiedName}")
}
```

So it was not a problem to recall `valueFromDB` several times for the value.

But with introduced transforms this logic breaks, because every try to call `valueFromDB` method leads to the transformation process.

So the flow was looking like:

- `statement = table.insert { it[field] = CustomData() } ` // insert value, so `ResultRow` will contain `CustomData` object
- `statement[field]` fails, because it tries to call `expression.columnType.valueFromDB(raw)` internally, where `raw` is `CustomData` object. It leads to class cast exception.

### Solution

At the current I found a way to unwrap (recursively for chained transforms) the values before setting them to `ResultRow`. It will allow keeping only original column type values inside `ResultRow` as before. 

Alternatively, I tried two other options.

1) Store in the `ResultRow` only really `raw` values (the values produced by `ColumnType::valueToDB` method). But it causes other problems, the main reason, as I understand, is that the values which we put to the database and the values we get back from the database are not always of the same data types, and not all column types are ready for it. And potentially it adds lots of unnecessary conversions.

2) Store in the `ResultRow` only wrapped values, so no conversion is necessary. It can be an interesting solution, but it would require much more refactoring (as I can see now, but not sure), because many places of creating `ResultRow` should be extended. The positive side here is that the user will get the `ResultRow` object with final data, and no extra conversion magic would be applied on reading the data. I have a feeling that I will face many obstacles in this way, so I didn't invest more time here, but if you see that it's a good way in general, I could try to do a separate refactoring.
---

#### Type of Change

- [x] Bug fix


Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

---

#### Related Issues

[EXPOSED-474](https://youtrack.jetbrains.com/issue/EXPOSED-474) Unexpected value of type when using a ColumnTransformer in a DAO object
