### PR TITLE
fix: EXPOSED-467 Decimal type precision and scale not checked by SchemaUtils

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -446,18 +446,20 @@ public final class org/jetbrains/exposed/sql/Column : org/jetbrains/exposed/sql/
 
 public final class org/jetbrains/exposed/sql/ColumnDiff {
 	public static final field Companion Lorg/jetbrains/exposed/sql/ColumnDiff$Companion;
-	public fun <init> (ZZZZ)V
+	public fun <init> (ZZZZZ)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
-	public final fun copy (ZZZZ)Lorg/jetbrains/exposed/sql/ColumnDiff;
-	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/ColumnDiff;ZZZZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/ColumnDiff;
+	public final fun component5 ()Z
+	public final fun copy (ZZZZZ)Lorg/jetbrains/exposed/sql/ColumnDiff;
+	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/ColumnDiff;ZZZZZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/ColumnDiff;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAutoInc ()Z
 	public final fun getCaseSensitiveName ()Z
 	public final fun getDefaults ()Z
 	public final fun getNullability ()Z
+	public final fun getSizeAndScale ()Z
 	public final fun hasDifferences ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3618,20 +3620,22 @@ public final class org/jetbrains/exposed/sql/transactions/experimental/Suspended
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ColumnMetadata {
-	public fun <init> (Ljava/lang/String;IZLjava/lang/Integer;ZLjava/lang/String;)V
+	public fun <init> (Ljava/lang/String;IZLjava/lang/Integer;Ljava/lang/Integer;ZLjava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()I
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/lang/Integer;
-	public final fun component5 ()Z
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;IZLjava/lang/Integer;ZLjava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/ColumnMetadata;
-	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/vendors/ColumnMetadata;Ljava/lang/String;IZLjava/lang/Integer;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/vendors/ColumnMetadata;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;IZLjava/lang/Integer;Ljava/lang/Integer;ZLjava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/ColumnMetadata;
+	public static synthetic fun copy$default (Lorg/jetbrains/exposed/sql/vendors/ColumnMetadata;Ljava/lang/String;IZLjava/lang/Integer;Ljava/lang/Integer;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/vendors/ColumnMetadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAutoIncrement ()Z
 	public final fun getDefaultDbValue ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getNullable ()Z
+	public final fun getScale ()Ljava/lang/Integer;
 	public final fun getSize ()Ljava/lang/Integer;
 	public final fun getType ()I
 	public fun hashCode ()I

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnDiff.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnDiff.kt
@@ -12,6 +12,8 @@ data class ColumnDiff(
     val defaults: Boolean,
     /** Whether the existing column identifier matches and has the correct casing. */
     val caseSensitiveName: Boolean,
+    /** Whether the size and scale of the existing column, if applicable, is correct. */
+    val sizeAndScale: Boolean,
 ) {
     /** Returns `true` if there is a difference between the column definition and the existing column in the database. */
     fun hasDifferences() = this != NoneChanged
@@ -23,6 +25,7 @@ data class ColumnDiff(
             autoInc = false,
             defaults = false,
             caseSensitiveName = false,
+            sizeAndScale = false,
         )
 
         /** A [ColumnDiff] with differences for every matched property. */
@@ -31,6 +34,7 @@ data class ColumnDiff(
             autoInc = true,
             defaults = true,
             caseSensitiveName = true,
+            sizeAndScale = true,
         )
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/ColumnMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/ColumnMetadata.kt
@@ -12,12 +12,14 @@ data class ColumnMetadata(
      * @see java.sql.Types
      */
     val type: Int,
-    /** Whether the column if nullable or not. */
+    /** Whether the column is nullable or not. */
     val nullable: Boolean,
     /** Optional size of the column. */
     val size: Int?,
-    /** Is the column auto increment */
+    /** Optional amount of fractional digits allowed in the column. */
+    val scale: Int?,
+    /** Whether the column is auto-incremented. */
     val autoIncrement: Boolean,
-    /** Default value */
+    /** Default value of the column. */
     val defaultDbValue: String?,
 )

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -167,16 +167,12 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         val defaultDbValue = getString("COLUMN_DEF")?.let { sanitizedDefault(it) }
         val autoIncrement = getString("IS_AUTOINCREMENT") == "YES"
         val type = getInt("DATA_TYPE")
+        val name = getString("COLUMN_NAME")
+        val nullable = getBoolean("NULLABLE")
+        val size = getInt("COLUMN_SIZE").takeIf { it != 0 }
+        val scale = getInt("DECIMAL_DIGITS").takeIf { it != 0 }
 
-        return ColumnMetadata(
-            getString("COLUMN_NAME"),
-            type,
-            getBoolean("NULLABLE"),
-            getInt("COLUMN_SIZE").takeIf { it != 0 },
-            autoIncrement,
-            // Not sure this filters enough but I dont think we ever want to have sequences here
-            defaultDbValue?.takeIf { !autoIncrement },
-        )
+        return ColumnMetadata(name, type, nullable, size, scale, autoIncrement, defaultDbValue?.takeIf { !autoIncrement })
     }
 
     /**

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -27,16 +27,16 @@ class ConnectionTests : DatabaseTestsBase() {
             }.toSet()
             val expected = when ((db.dialect as H2Dialect).isSecondVersion) {
                 false -> setOf(
-                    ColumnMetadata("ID", Types.BIGINT, false, 19, true, null),
-                    ColumnMetadata("FIRSTNAME", Types.VARCHAR, true, 80, false, null),
-                    ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
-                    ColumnMetadata("AGE", Types.INTEGER, false, 10, false, "18"),
+                    ColumnMetadata("ID", Types.BIGINT, false, 19, null, true, null),
+                    ColumnMetadata("FIRSTNAME", Types.VARCHAR, true, 80, null, false, null),
+                    ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, null, false, "Doe"),
+                    ColumnMetadata("AGE", Types.INTEGER, false, 10, null, false, "18"),
                 )
                 true -> setOf(
-                    ColumnMetadata("ID", Types.BIGINT, false, 64, true, null),
-                    ColumnMetadata("FIRSTNAME", Types.VARCHAR, true, 80, false, null),
-                    ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, false, "Doe"),
-                    ColumnMetadata("AGE", Types.INTEGER, false, 32, false, "18"),
+                    ColumnMetadata("ID", Types.BIGINT, false, 64, null, true, null),
+                    ColumnMetadata("FIRSTNAME", Types.VARCHAR, true, 80, null, false, null),
+                    ColumnMetadata("LASTNAME", Types.VARCHAR, false, 42, null, false, "Doe"),
+                    ColumnMetadata("AGE", Types.INTEGER, false, 32, null, false, "18"),
                 )
             }
             assertEquals(expected, columnMetadata)


### PR DESCRIPTION
#### Description

**Summary of the change**:
Defining the same column of type `decimal()`, `binary()`, `varchar()`, or `char()` but with a different size (precision) or scale (for `decimal` only) now correctly triggers an ALTER statement when `SchemaUtils.createMissingTablesAndColumns` is used.

**Detailed description**:
- **Why**:
Currently, if the existing database table has a column of type DECIMAL(?,?), VARCHAR(?), VARBINARY(?), or CHAR(?) and the Exposed table object defines the same column type but with a different size, the `SchemaUtils` functions will not generate any ALTER statements to fix the inconsistency.

- **What**:
`SchemaUtils.createMissingTablesAndColumns` now compares existing- and defined- column size (and scale, if applicable to type) when inspecting the `ColumnDiff`.

- **How**:
    - Extracted column metadata now includes `DECIMAL_DIGITS` label for scale (only non-null for decimal types).
    - Extracted column metadata `COLUMN_SIZE` is now used as part of the `ColumnDiff` comparison

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [X] SqlServer
- [X] H2
- [X] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues

[EXPOSED-467](https://youtrack.jetbrains.com/issue/EXPOSED-467/Decimal-type-precision-and-scale-not-checked-by-SchemaUtils)
