### PR TITLE
build: Bump org.jetbrains.kotlinx:kotlinx-serialization-json from 1.6.3 to 1.7.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ detekt = "1.23.6" # When upgrading, also upgrade in detekt.yml and add correspon
 binary-compatibility-validator = "0.16.3"
 docker-compose = "0.17.5"
 kotlinCoroutines = "1.8.1"
-kotlinxSerialization = "1.6.3"
+kotlinxSerialization = "1.7.1"
 
 slf4j = "2.0.9"
 log4j2 = "2.23.1"


### PR DESCRIPTION
#### Description

**Summary of the change**:
Bump version of kotlinx-serialization-json to 1.7.1.

**Detailed description**:
- **Why**:
Dependabot bump in PR #2117 originally [failed to compile](https://exposed.teamcity.com/buildConfiguration/Exposed_Build/6040?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true) because this version requires at least Kotlin 2.0.0-RC1.
Kotlin version has now been updated to 2.0.0 in PR #2188 .

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Dependency version bump

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-476](https://youtrack.jetbrains.com/issue/EXPOSED-476/Update-Kotlin-to-2.0.0)