### PR TITLE
EXPOSED-203 Lightweight DAO insert with encryptedVarchar attemtps to …

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -524,7 +524,7 @@ public final class org/jetbrains/exposed/sql/ColumnTypeKt {
 	public static synthetic fun resolveColumnType$default (Lkotlin/reflect/KClass;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/ColumnType;
 }
 
-public final class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/ColumnTransformer {
+public class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/exposed/sql/ColumnType, org/jetbrains/exposed/sql/ColumnTransformer {
 	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)V
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public fun getNullable ()Z

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -281,7 +281,7 @@ fun <Unwrapped, Wrapped>columnTransformer(unwrap: (value: Wrapped) -> Unwrapped,
  * @param Unwrapped The type of the column
  * @param delegate The original column's [IColumnType]
  */
-class ColumnWithTransform<Unwrapped : Any, Wrapped : Any>(
+open class ColumnWithTransform<Unwrapped : Any, Wrapped : Any>(
     val delegate: IColumnType<Unwrapped>,
     private val transformer: ColumnTransformer<Unwrapped, Wrapped>
 ) : ColumnType<Wrapped>(), ColumnTransformer<Unwrapped, Wrapped> by transformer {

--- a/exposed-crypt/api/exposed-crypt.api
+++ b/exposed-crypt/api/exposed-crypt.api
@@ -6,32 +6,20 @@ public final class org/jetbrains/exposed/crypt/Algorithms {
 	public final fun TRIPLE_DES (Ljava/lang/CharSequence;)Lorg/jetbrains/exposed/crypt/Encryptor;
 }
 
-public final class org/jetbrains/exposed/crypt/EncryptedBinaryColumnType : org/jetbrains/exposed/sql/BinaryColumnType {
-	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;I)V
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString ([B)Ljava/lang/String;
-	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun notNullValueToDB ([B)[B
-	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
-	public fun validateValueBeforeUpdate ([B)V
-	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun valueFromDB (Ljava/lang/Object;)[B
+public final class org/jetbrains/exposed/crypt/ByteArrayEncryptionTransformer : org/jetbrains/exposed/sql/ColumnTransformer {
+	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;)V
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap ([B)[B
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap ([B)[B
 }
 
-public final class org/jetbrains/exposed/crypt/EncryptedVarCharColumnType : org/jetbrains/exposed/sql/VarCharColumnType {
+public final class org/jetbrains/exposed/crypt/EncryptedBinaryColumnType : org/jetbrains/exposed/sql/ColumnWithTransform {
 	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;I)V
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/lang/String;)Ljava/lang/String;
-	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun notNullValueToDB (Ljava/lang/String;)Ljava/lang/String;
-	public synthetic fun validateValueBeforeUpdate (Ljava/lang/Object;)V
-	public fun validateValueBeforeUpdate (Ljava/lang/String;)V
-	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/String;
+}
+
+public final class org/jetbrains/exposed/crypt/EncryptedVarCharColumnType : org/jetbrains/exposed/sql/ColumnWithTransform {
+	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;I)V
 }
 
 public final class org/jetbrains/exposed/crypt/Encryptor {
@@ -42,6 +30,14 @@ public final class org/jetbrains/exposed/crypt/Encryptor {
 	public final fun getEncryptFn ()Lkotlin/jvm/functions/Function1;
 	public final fun getMaxColLengthFn ()Lkotlin/jvm/functions/Function1;
 	public final fun maxColLength (I)I
+}
+
+public final class org/jetbrains/exposed/crypt/StringEncryptionTransformer : org/jetbrains/exposed/sql/ColumnTransformer {
+	public fun <init> (Lorg/jetbrains/exposed/crypt/Encryptor;)V
+	public synthetic fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrap (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun wrap (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun wrap (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/crypt/TablesKt {

--- a/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnDaoTests.kt
+++ b/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnDaoTests.kt
@@ -4,8 +4,6 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
-import org.jetbrains.exposed.sql.StdOutSqlLogger
-import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals

--- a/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnDaoTests.kt
+++ b/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnDaoTests.kt
@@ -27,7 +27,6 @@ class EncryptedColumnDaoTests : DatabaseTestsBase() {
     @Test
     fun testEncryptedColumnsWithDao() {
         withTables(TestTable) {
-            addLogger(StdOutSqlLogger)
             val varcharValue = "varchar"
             val binaryValue = "binary".toByteArray()
 

--- a/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnDaoTests.kt
+++ b/exposed-crypt/src/test/kotlin/org/jetbrains/exposed/crypt/EncryptedColumnDaoTests.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.exposed.crypt
+
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.addLogger
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class EncryptedColumnDaoTests : DatabaseTestsBase() {
+    object TestTable : IntIdTable() {
+        val varchar = encryptedVarchar("varchar", 100, Algorithms.AES_256_PBE_GCM("passwd", "12345678"))
+        val binary = encryptedBinary("binary", 100, Algorithms.AES_256_PBE_GCM("passwd", "12345678"))
+    }
+
+    class ETest(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<ETest>(TestTable)
+
+        var varchar by TestTable.varchar
+        var binary by TestTable.binary
+    }
+
+    @Test
+    fun testEncryptedColumnsWithDao() {
+        withTables(TestTable) {
+            addLogger(StdOutSqlLogger)
+            val varcharValue = "varchar"
+            val binaryValue = "binary".toByteArray()
+
+            val entity = ETest.new {
+                varchar = varcharValue
+                binary = binaryValue
+            }
+            assertEquals(varcharValue, entity.varchar)
+            assertEquals(binaryValue, entity.binary)
+
+            TestTable.selectAll().first().let {
+                assertEquals(varcharValue, it[TestTable.varchar])
+                assertEquals(String(binaryValue), String(it[TestTable.binary]))
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

It's the issue similar to [EXPOSED-474](https://youtrack.jetbrains.com/issue/EXPOSED-474) Unexpected value of type when using a ColumnTransformer in a DAO object

The problem is that due to internal implementation of `ResultRow`, it tries to call `valueFromDb` multiple times. As a result, after the first call value is decrypted, and on the second call (with already decrypted value) it fails.

This behavior was already fixed for transformed columns, so it looks reasonable to reuse the new concept here too. So I updated `EncryptedBinaryColumnType` and `EncryptedVarCharColumnType` to use `ColumnWithTransform` under the hood. It also makes code simpler because there is no overriding of `IColumnType` interface methods.


**Detailed description**:
- **What**: Detail what changes have been made in the PR.
- **Why**: Explain the reasons behind the changes. Why were they necessary?
- **How**: Describe how the changes were implemented, including any key aspects of the code modified or new features added.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Related Issues

[EXPOSED-203](https://youtrack.jetbrains.com/issue/EXPOSED-203) Lightweight DAO insert with encryptedVarchar attemtps to decrypt unencrypted input
