### PR TITLE
fix: EXPOSED-481 Bug with batch-flushing of CompositeID entities

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
@@ -16,7 +16,6 @@ import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
-import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Test
 import java.sql.Connection
 import java.util.*
@@ -433,7 +432,6 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
                 val town = Town[id]
                 town.population = 2000
-                // triggers batch update statement on composite ID table
             }
             inTopLevelTransaction(Connection.TRANSACTION_SERIALIZABLE) {
                 val town = Town[id]


### PR DESCRIPTION
#### Description

We recently decided to adopt the new CompositeID-based Entities/Tables, and might have stumbled upon a bug.

Concisely put, it looks like it doesn't entirely work when CompositeID-entities are being batch-flushed (as at the end of a transaction). Here is an example stack trace when testing towards Postgres:

```
Can't infer the SQL type to use for an instance of org.jetbrains.exposed.dao.id.CompositeID. Use setObject() with an explicit Types value to specify the type to use.
org.postgresql.util.PSQLException: Can't infer the SQL type to use for an instance of org.jetbrains.exposed.dao.id.CompositeID. Use setObject() with an explicit Types value to specify the type to use.
	at org.postgresql.jdbc.PgPreparedStatement.setObject(PgPreparedStatement.java:1076)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcPreparedStatementImpl.set(JdbcPreparedStatementImpl.kt:69)
	at org.jetbrains.exposed.sql.IColumnType$DefaultImpls.setParameter(ColumnType.kt:90)
	at org.jetbrains.exposed.sql.ColumnType.setParameter(ColumnType.kt:115)
	at org.jetbrains.exposed.sql.statements.api.PreparedStatementApi$DefaultImpls.fillParameters(PreparedStatementApi.kt:24)
	at org.jetbrains.exposed.sql.statements.jdbc.JdbcPreparedStatementImpl.fillParameters(JdbcPreparedStatementImpl.kt:22)
	at org.jetbrains.exposed.sql.statements.Statement.executeIn$exposed_core(Statement.kt:86)
	at org.jetbrains.exposed.sql.Transaction.exec(Transaction.kt:292)
	at org.jetbrains.exposed.sql.Transaction.exec(Transaction.kt:269)
	at org.jetbrains.exposed.sql.statements.Statement.execute(Statement.kt:59)
	at org.jetbrains.exposed.dao.EntityBatchUpdate.execute(EntityBatchUpdate.kt:56)
	at org.jetbrains.exposed.dao.EntityCache.updateEntities$lambda$12(EntityCache.kt:170)
	at org.jetbrains.exposed.dao.EntityLifecycleInterceptorKt.executeAsPartOfEntityLifecycle(EntityLifecycleInterceptor.kt:18)
	at org.jetbrains.exposed.dao.EntityCache.updateEntities(EntityCache.kt:169)
	at org.jetbrains.exposed.dao.EntityCache.flush(EntityCache.kt:196)
	at org.jetbrains.exposed.dao.EntityCache.flush(EntityCache.kt:152)
	at org.jetbrains.exposed.dao.EntityCacheKt.flushCache(EntityCache.kt:331)
	at org.jetbrains.exposed.dao.EntityLifecycleInterceptor.beforeCommit(EntityLifecycleInterceptor.kt:90)
	at org.jetbrains.exposed.sql.Transaction.commit(Transaction.kt:168)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$run(ThreadLocalTransactionManager.kt:335)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$lambda$10(ThreadLocalTransactionManager.kt:381)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:389)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction(ThreadLocalTransactionManager.kt:380)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$default(ThreadLocalTransactionManager.kt:312)
	at org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.testFlushingUpdatedEntity$lambda$51(CompositeIdTableEntityTest.kt:433)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withTables$lambda$3(DatabaseTestsBase.kt:110)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withDb$lambda$1(DatabaseTestsBase.kt:76)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$run(ThreadLocalTransactionManager.kt:334)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$lambda$10(ThreadLocalTransactionManager.kt:381)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:389)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction(ThreadLocalTransactionManager.kt:380)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction$lambda$4(ThreadLocalTransactionManager.kt:289)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:389)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction(ThreadLocalTransactionManager.kt:249)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction$default(ThreadLocalTransactionManager.kt:244)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withDb(DatabaseTestsBase.kt:72)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withTables(DatabaseTestsBase.kt:102)
	at org.jetbrains.exposed.sql.tests.DatabaseTestsBase.withTables(DatabaseTestsBase.kt:154)
	at org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.testFlushingUpdatedEntity(CompositeIdTableEntityTest.kt:422)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:60)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
```

We have narrowed it down to possibly `BatchUpdateStatement` missing updates to handle the new CompositeID case, because its `arguments()` and `prepareSQL` (at least) produce values that don't respect the nature of composite IDs:
- `prepareSQL` creates a query referencing a column named `composite_id` (which I noticed is a "placeholder column" created inside `CompositeIdTable`)
- `arguments` produces raw `CompositeID` values, which probably should be split up into its underlying columns

I have attached a failing test inside the existing `CompositeIdTableEntityTest` that reproduces the error using the existing table and entity definitions.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
https://youtrack.jetbrains.com/issue/EXPOSED-481/Possible-bug-when-batch-flushing-CompositeEntity