### PR TITLE
feat: EXPOSED-487 Add ability to pass custom sequence to auto-increment column

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -221,11 +221,13 @@ public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exp
 
 public final class org/jetbrains/exposed/sql/AutoIncColumnType : org/jetbrains/exposed/sql/IColumnType {
 	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Lorg/jetbrains/exposed/sql/Sequence;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAutoincSeq ()Ljava/lang/String;
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
 	public final fun getNextValExpression ()Lorg/jetbrains/exposed/sql/NextVal;
 	public fun getNullable ()Z
+	public final fun getSequence ()Lorg/jetbrains/exposed/sql/Sequence;
 	public fun hashCode ()I
 	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
@@ -2132,6 +2134,7 @@ public final class org/jetbrains/exposed/sql/Sequence {
 	public final fun getIncrementBy ()Ljava/lang/Long;
 	public final fun getMaxValue ()Ljava/lang/Long;
 	public final fun getMinValue ()Ljava/lang/Long;
+	public final fun getName ()Ljava/lang/String;
 	public final fun getStartWith ()Ljava/lang/Long;
 }
 
@@ -2424,6 +2427,7 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public static synthetic fun array$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoGenerate (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoIncrement (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun autoIncrement (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun autoIncrement$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoinc (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun autoinc$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -109,12 +109,12 @@ object SchemaUtils {
     }
 
     private fun tableDdlWithoutExistingSequence(table: Table): List<String> {
-        val existingAutoIncSeq = table.autoIncColumn?.autoIncColumnType?.autoincSeq
-            ?.takeIf { currentDialect.sequenceExists(Sequence(it)) }
+        val existingAutoIncSeq = table.autoIncColumn?.autoIncColumnType?.sequence
+            ?.takeIf { currentDialect.sequenceExists(it) }
 
         return table.ddl.filter { statement ->
             if (existingAutoIncSeq != null) {
-                !statement.lowercase().startsWith("create sequence") || !statement.contains(existingAutoIncSeq)
+                !statement.lowercase().startsWith("create sequence") || !statement.contains(existingAutoIncSeq.name)
             } else {
                 true
             }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
@@ -17,7 +17,7 @@ import org.jetbrains.exposed.sql.vendors.currentDialect
  * @param cache Specifies how many sequence numbers are to be pre-allocated and stored in memory for faster access.
  */
 class Sequence(
-    private val name: String,
+    val name: String,
     val startWith: Long? = null,
     val incrementBy: Long? = null,
     val minValue: Long? = null,

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -308,14 +308,7 @@ class CreateTableTests : DatabaseTestsBase() {
         withDb {
             val t = TransactionManager.current()
             val expected = listOfNotNull(
-                child.autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
-                    Sequence(
-                        it,
-                        startWith = 1,
-                        minValue = 1,
-                        maxValue = Long.MAX_VALUE
-                    ).createStatement().single()
-                },
+                child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${t.identity(child)} (" +
                     "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
@@ -389,14 +382,7 @@ class CreateTableTests : DatabaseTestsBase() {
         withDb {
             val t = TransactionManager.current()
             val expected = listOfNotNull(
-                child.autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
-                    Sequence(
-                        it,
-                        startWith = 1,
-                        minValue = 1,
-                        maxValue = Long.MAX_VALUE
-                    ).createStatement().single()
-                },
+                child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${t.identity(child)} (" +
                     "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
@@ -424,14 +410,7 @@ class CreateTableTests : DatabaseTestsBase() {
         withDb {
             val t = TransactionManager.current()
             val expected = listOfNotNull(
-                child.autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
-                    Sequence(
-                        it,
-                        startWith = 1,
-                        minValue = 1,
-                        maxValue = Long.MAX_VALUE
-                    ).createStatement().single()
-                },
+                child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${t.identity(child)} (" +
                     "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
@@ -462,14 +441,7 @@ class CreateTableTests : DatabaseTestsBase() {
         withDb {
             val t = TransactionManager.current()
             val expected = listOfNotNull(
-                child.autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
-                    Sequence(
-                        it,
-                        startWith = 1,
-                        minValue = 1,
-                        maxValue = Long.MAX_VALUE
-                    ).createStatement().single()
-                },
+                child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${t.identity(child)} (" +
                     "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
@@ -507,14 +479,7 @@ class CreateTableTests : DatabaseTestsBase() {
             val t = TransactionManager.current()
             val updateCascadePart = if (testDb != TestDB.ORACLE) " ON UPDATE CASCADE" else ""
             val expected = listOfNotNull(
-                child.autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
-                    Sequence(
-                        it,
-                        startWith = 1,
-                        minValue = 1,
-                        maxValue = Long.MAX_VALUE
-                    ).createStatement().single()
-                },
+                child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${t.identity(child)} (" +
                     "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
@@ -553,14 +518,7 @@ class CreateTableTests : DatabaseTestsBase() {
         withDb {
             val t = TransactionManager.current()
             val expected = listOfNotNull(
-                child.autoIncColumn?.autoIncColumnType?.autoincSeq?.let {
-                    Sequence(
-                        it,
-                        startWith = 1,
-                        minValue = 1,
-                        maxValue = Long.MAX_VALUE
-                    ).createStatement().single()
-                },
+                child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "${t.identity(child)} (" +
                     "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +


### PR DESCRIPTION
#### Description

**Summary of the change**:
Add ability to pass custom sequence to auto-increment column.

**Detailed description**:
- **What**:
Added `autoIncrement` overload function that accepts a sequence of type `org.jetbrains.exposed.sql.Sequence`.
- **Why**:
I noticed that it even though it was possible to create a custom sequence using `SchemaUtils.createSequence(mySequence)` and manually call `mySequence.nextIntVal()` or `mySequence.nextLongVal()` when inserting, it was not possible to simply pass it to an auto-increment column to use internally.
- **How**:
A secondary constructor was added to `AutoIncColumnType` to pass it the custom sequence. A sequence field was also added to `AutoIncColumnType` and this field is now used instead of `autoincSeq` in SchemaUtils.kt where it was used to create/drop a sequence.
---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
