### PR TITLE
fix: EXPOSED-485 ClassCastException when eager loading referrersOn with uuid().references()

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/LongIdTableEntityTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.dao.with
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.exists
-import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
@@ -123,21 +122,26 @@ class LongIdTableEntityTest : DatabaseTestsBase() {
             val cId = LongIdTables.Cities.insertAndGetId {
                 it[name] = "City A"
             }
-            LongIdTables.Towns.insert {
+            val tId = LongIdTables.Towns.insertAndGetId {
                 it[cityId] = cId.value
             }
 
-            // lazy loaded reference
+            // lazy loaded referencedOn
             val town1 = LongIdTables.Town.all().single()
             assertEquals(cId, town1.city.id)
 
-            // eager loaded reference
+            // eager loaded referencedOn
             val town1WithCity = LongIdTables.Town.all().with(LongIdTables.Town::city).single()
             assertEquals(cId, town1WithCity.city.id)
 
+            // lazy loaded referrersOn
             val city1 = LongIdTables.City.all().single()
             val towns = city1.towns
             assertEquals(cId, towns.first().city.id)
+
+            // eager loaded referrersOn
+            val city1WithTowns = LongIdTables.City.all().with(LongIdTables.City::towns).single()
+            assertEquals(tId, city1WithTowns.towns.first().id)
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/UuidTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/UuidTableEntityTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.dao.with
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.exists
-import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.insertAndGetId
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
@@ -170,21 +169,26 @@ class UUIDTableEntityTest : DatabaseTestsBase() {
             val cId = UUIDTables.Cities.insertAndGetId {
                 it[name] = "City A"
             }
-            UUIDTables.Towns.insert {
+            val tId = UUIDTables.Towns.insertAndGetId {
                 it[cityId] = cId.value
             }
 
-            // lazy loaded reference
+            // lazy loaded referencedOn
             val town1 = UUIDTables.Town.all().single()
             assertEquals(cId, town1.city.id)
 
-            // eager loaded reference
+            // eager loaded referencedOn
             val town1WithCity = UUIDTables.Town.all().with(UUIDTables.Town::city).single()
             assertEquals(cId, town1WithCity.city.id)
 
+            // lazy loaded referrersOn
             val city1 = UUIDTables.City.all().single()
             val towns = city1.towns
             assertEquals(cId, towns.first().city.id)
+
+            // eager loaded referrersOn
+            val city1WithTowns = UUIDTables.City.all().with(UUIDTables.City::towns).single()
+            assertEquals(tId, city1WithTowns.towns.first().id)
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**:
The logic for eager loading references defined using `referrersOn` or `backReferencedOn` now takes into account potential type mismatch that is caused when `Column.references()` is used to create a non-entityID child column with an entityID parent column.

**Detailed description**:
- **Why**:
Using `Column.references()` invoked on a `UUIDColumnType` that targets an `EntityIDColumnType<UUID>` causes a ClassCastException when `referrersOn` or `backReferencedOn` are eager loaded, for the same type mismatch as detailed in the previous related issues below.
- **What**:
This extends the previous eager load fix to include `Referrers` and `BackReference` objects in `preloadRelations()`.
- **How**:
The reference query clause is now forced to use the underlying/wrapped type of `EntityIDColumnType` if there is a type mismatch between `refColumn.referree` and `refIds`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-485](https://youtrack.jetbrains.com/issue/EXPOSED-485/ClassCastException-when-eager-loading-referrersOn-with-uuid.references), [EXPOSED-411](https://youtrack.jetbrains.com/issue/EXPOSED-411/ClassCastException-when-uuid.references-is-used-with-referrersOn), [EXPOSED-402](https://youtrack.jetbrains.com/issue/EXPOSED-402/ClassCastException-when-eager-loading-with-uuid.references), [EXPOSED-382](https://youtrack.jetbrains.com/issue/EXPOSED-382/ClassCastException-when-uuid.references-is-used-with-EntityID-column)