### PR TITLE
feat: EXPOSED-486 Support REPLACE INTO ... SELECT clause

### DIFF
--- a/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DSL.md
@@ -616,15 +616,15 @@ PostgresSQL [here](https://jdbc.postgresql.org/documentation/logging/).
 
 ## Insert From Select
 
-If you want to use `INSERT INTO ... SELECT ` SQL clause try Exposed analog `Table.insert(Query)`.
+If you want to use the `INSERT INTO ... SELECT ` SQL clause try the function `Table.insert(Query)`:
 
 ```kotlin
 val substring = users.name.substring(1, 2)
 cities.insert(users.select(substring).orderBy(users.id).limit(2))
 ```
 
-By default it will try to insert into all non auto-increment `Table` columns in order they defined in Table instance. If you want to specify columns or change the
-order, provide list of columns as second parameter:
+By default, it will try to insert into all non auto-increment `Table` columns in the order they are defined in the `Table` instance. If you want to specify columns or change the
+order, provide a list of columns as the second parameter:
 
 ```kotlin
 val userCount = users.selectAll().count()
@@ -766,6 +766,29 @@ The values specified in the statement block will be used for the insert statemen
 In the example above, if the original row was inserted with a user-defined <code>rating</code>, then <code>replace()</code> was executed with a block that omitted the <code>rating</code> column, 
 the newly inserted row would store the default rating value. This is because the old row was completely deleted first.
 </note>
+
+The `REPLACE INTO ... SELECT ` SQL clause can be used by instead providing a query to `replace()`:
+
+```kotlin
+val allRowsWithLowRating: Query = StarWarsFilms.selectAll().where {
+    StarWarsFilms.rating less 5.0
+}
+StarWarsFilms.replace(allRowsWithLowRating)
+```
+
+By default, it will try to insert into all non auto-increment `Table` columns in the order they are defined in the `Table` instance.
+If the columns need to be specified or the order should be changed, provide a list of columns as the second parameter:
+
+```kotlin
+val oneYearLater = StarWarsFilms.releaseYear.plus(1)
+val allRowsWithNewYear: Query = StarWarsFilms.select(
+    oneYearLater, StarWarsFilms.sequelId, StarWarsFilms.director, StarWarsFilms.name
+)
+StarWarsFilms.replace(
+    allRowsWithNewYear,
+    columns = listOf(StarWarsFilms.releaseYear, StarWarsFilms.sequelId, StarWarsFilms.director, StarWarsFilms.name)
+)
+```
 
 ## Column transformation
 

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1817,6 +1817,8 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static final fun mergeFrom (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/statements/MergeTableStatement;
 	public static synthetic fun mergeFrom$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/statements/MergeTableStatement;
 	public static final fun replace (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/ReplaceStatement;
+	public static final fun replace (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;)Ljava/lang/Integer;
+	public static synthetic fun replace$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;ILjava/lang/Object;)Ljava/lang/Integer;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun select (Lorg/jetbrains/exposed/sql/Query;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
@@ -3210,6 +3212,11 @@ public final class org/jetbrains/exposed/sql/statements/MergeStatement$ClauseCon
 
 public class org/jetbrains/exposed/sql/statements/MergeTableStatement : org/jetbrains/exposed/sql/statements/MergeStatement {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Op;)V
+	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
+}
+
+public class org/jetbrains/exposed/sql/statements/ReplaceSelectStatement : org/jetbrains/exposed/sql/statements/InsertSelectStatement {
+	public fun <init> (Ljava/util/List;Lorg/jetbrains/exposed/sql/AbstractQuery;)V
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -210,7 +210,7 @@ class AutoIncColumnType<T>(
 val IColumnType<*>.isAutoInc: Boolean
     get() = this is AutoIncColumnType || (this is EntityIDColumnType<*> && idColumn.columnType.isAutoInc)
 
-/** Returns the name of the auto-increment sequence of this column. */
+/** Returns this column's type cast as [AutoIncColumnType] or `null` if the cast fails. */
 val Column<*>.autoIncColumnType: AutoIncColumnType<*>?
     get() = (columnType as? AutoIncColumnType)
         ?: (columnType as? EntityIDColumnType<*>)?.idColumn?.columnType as? AutoIncColumnType

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/SequencesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/SequencesTests.kt
@@ -63,19 +63,10 @@ class SequencesTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `testInsertWithCustomSequence`() {
-        val customSequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
+    fun testInsertWithCustomSequence() {
         val tester = object : Table("tester") {
-            val id = integer("id").autoIncrement(customSequence)
-            var name = varchar("name", 25)
+            val id = integer("id").autoIncrement(myseq)
+            val name = varchar("name", 25)
 
             override val primaryKey = PrimaryKey(id, name)
         }
@@ -83,22 +74,22 @@ class SequencesTests : DatabaseTestsBase() {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
                     SchemaUtils.create(tester)
-                    assertTrue(customSequence.exists())
+                    assertTrue(myseq.exists())
 
                     var testerId = tester.insert {
                         it[name] = "Hichem"
                     } get tester.id
 
-                    assertEquals(customSequence.startWith, testerId.toLong())
+                    assertEquals(myseq.startWith, testerId.toLong())
 
                     testerId = tester.insert {
                         it[name] = "Andrey"
                     } get tester.id
 
-                    assertEquals(customSequence.startWith!! + customSequence.incrementBy!!, testerId.toLong())
+                    assertEquals(myseq.startWith!! + myseq.incrementBy!!, testerId.toLong())
                 } finally {
                     SchemaUtils.drop(tester)
-                    assertFalse(customSequence.exists())
+                    assertFalse(myseq.exists())
                 }
             }
         }
@@ -131,19 +122,10 @@ class SequencesTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun `testInsertInIdTableWithCustomSequence`() {
-        val customSequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
+    fun testInsertInIdTableWithCustomSequence() {
         val tester = object : IdTable<Long>("tester") {
-            override val id = long("id").autoIncrement(customSequence).entityId()
-            var name = varchar("name", 25)
+            override val id = long("id").autoIncrement(myseq).entityId()
+            val name = varchar("name", 25)
 
             override val primaryKey = PrimaryKey(id, name)
         }
@@ -151,22 +133,22 @@ class SequencesTests : DatabaseTestsBase() {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
                     SchemaUtils.create(tester)
-                    assertTrue(customSequence.exists())
+                    assertTrue(myseq.exists())
 
                     var testerId = tester.insert {
                         it[name] = "Hichem"
                     } get tester.id
 
-                    assertEquals(customSequence.startWith, testerId.value)
+                    assertEquals(myseq.startWith, testerId.value)
 
                     testerId = tester.insert {
                         it[name] = "Andrey"
                     } get tester.id
 
-                    assertEquals(customSequence.startWith!! + customSequence.incrementBy!!, testerId.value)
+                    assertEquals(myseq.startWith!! + myseq.incrementBy!!, testerId.value)
                 } finally {
                     SchemaUtils.drop(tester)
-                    assertFalse(customSequence.exists())
+                    assertFalse(myseq.exists())
                 }
             }
         }
@@ -239,17 +221,8 @@ class SequencesTests : DatabaseTestsBase() {
 
     @Test
     fun testExistingSequencesForAutoIncrementWithCustomSequence() {
-        val customSequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
         val tableWithExplicitSequenceName = object : IdTable<Long>() {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(customSequence).entityId()
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(myseq).entityId()
         }
 
         withDb {
@@ -260,7 +233,7 @@ class SequencesTests : DatabaseTestsBase() {
                     val sequences = currentDialectTest.sequences()
 
                     assertTrue(sequences.isNotEmpty())
-                    assertTrue(sequences.any { it == customSequence.name.inProperCase() })
+                    assertTrue(sequences.any { it == myseq.name.inProperCase() })
                 } finally {
                     SchemaUtils.drop(tableWithExplicitSequenceName)
                 }
@@ -340,18 +313,18 @@ class SequencesTests : DatabaseTestsBase() {
 
     private object Developer : Table() {
         val id = integer("id")
-        var name = varchar("name", 25)
+        val name = varchar("name", 25)
 
         override val primaryKey = PrimaryKey(id, name)
     }
 
     private object DeveloperWithLongId : LongIdTable() {
-        var name = varchar("name", 25)
+        val name = varchar("name", 25)
     }
 
     private object DeveloperWithAutoIncrementBySequence : IdTable<Long>() {
         override val id: Column<EntityID<Long>> = long("id").autoIncrement("id_seq").entityId()
-        var name = varchar("name", 25)
+        val name = varchar("name", 25)
     }
 
     private val myseq = Sequence(


### PR DESCRIPTION
#### Description

**Summary of the change**:
Adds an overload for `replace()` that accepts a query as an argument, in the same way that `insert()` can accept a query instead of column-value assignments.

**Detailed description**:
- **Why**:
It is already possible to generate SQL like INSERT INTO ... SELECT using `insert()` with a query parameter and REPLACE INTO ... VALUES is already supported by `replace()`. But it is not possible to generate REPLACE INTO ... SELECT without customizing the statement classes.
- **What**:
It is now possible to generate this statement out of the box.
- **How**:
    - Adds a new class `ReplaceSelectStatement` that extends `InsertSelectStatement`.
    - Adds a new function `Table.replace(query)`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature
- [X] Documentation update

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [X] H2 (MySQL-related only)
- [X] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-486](https://youtrack.jetbrains.com/issue/EXPOSED-486/Support-REPLACE-INTO-...-SELECT-clause)