### PR TITLE
fix: EXPOSED-492 Eq/Neq op with partial CompositeID unwrapped value fails

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -337,7 +337,7 @@ interface ISqlExpressionBuilder {
         @Suppress("UNCHECKED_CAST")
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
-        return if (table is CompositeIdTable) table.mapIdComparison(entityID, ::EqOp) else EqOp(this, wrap(entityID))
+        return if (columnType.isEntityIdentifier()) table.mapIdComparison(entityID, ::EqOp) else EqOp(this, wrap(entityID))
     }
 
     /** Checks if this [EntityID] expression is equal to some [other] expression. */
@@ -375,7 +375,7 @@ interface ISqlExpressionBuilder {
         @Suppress("UNCHECKED_CAST")
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
-        return if (table is CompositeIdTable) table.mapIdComparison(entityID, ::NeqOp) else NeqOp(this, wrap(entityID))
+        return if (columnType.isEntityIdentifier()) table.mapIdComparison(entityID, ::NeqOp) else NeqOp(this, wrap(entityID))
     }
 
     /** Checks if this [EntityID] expression is not equal to some [other] expression. */


### PR DESCRIPTION
#### Description

**Summary of the change**:
`eq()` and `neq()` extensions on `EntityID` columns no longer incorrectly assume that their passed parameter value must be a `CompositeID` if the table is a `CompositeIdTable`. The parameter value could also be a single component column value.

**Detailed description**:
- **Why**:
Attempting to select or delete from a `CompositeIdTable`, when using a condition involving an `EntityID` column on the left side and a non-entity id value (and non-`CompositeID`) on the right side, results in a cast exception.
`mapIdComparison()` is being invoked simply because of the table type, which ignores the possibility that a condition could involve only a single composite key column.

- **What**: 
`mapIdComparison` is now only called if the invoking column is actually the `id` column (whether a single or composite key id).

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-492](https://youtrack.jetbrains.com/issue/EXPOSED-492/Selecting-or-deleting-on-part-of-composite-key-fails)
