### PR TITLE
deprecate: Raise deprecation levels of API property setters

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -24,7 +24,7 @@ class Database private constructor(
 ) {
     /** Whether nested transaction blocks are configured to act like top-level transactions. */
     var useNestedTransactions: Boolean = config.useNestedTransactions
-        @Deprecated("Use DatabaseConfig to define the useNestedTransactions")
+        @Deprecated("Use DatabaseConfig to define the useNestedTransactions", level = DeprecationLevel.ERROR)
         @TestOnly
         set
 
@@ -79,7 +79,7 @@ class Database private constructor(
     var defaultFetchSize: Int? = config.defaultFetchSize
         private set
 
-    @Deprecated("Use DatabaseConfig to define the defaultFetchSize")
+    @Deprecated("Use DatabaseConfig to define the defaultFetchSize", level = DeprecationLevel.ERROR)
     @TestOnly
     fun defaultFetchSize(size: Int): Database {
         defaultFetchSize = size

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -76,7 +76,7 @@ class ThreadLocalTransactionManager(
             return field
         }
 
-        @Deprecated("Use DatabaseConfig to define the defaultIsolationLevel")
+        @Deprecated("Use DatabaseConfig to define the defaultIsolationLevel", level = DeprecationLevel.ERROR)
         @TestOnly
         set
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
@@ -29,7 +29,7 @@ class NestedTransactionsTest : DatabaseTestsBase() {
             assertTrue(DMLTestsData.Cities.selectAll().empty())
 
             DMLTestsData.Cities.insert {
-                it[DMLTestsData.Cities.name] = "city1"
+                it[name] = "city1"
             }
 
             assertEquals(1L, DMLTestsData.Cities.selectAll().count())
@@ -38,13 +38,13 @@ class NestedTransactionsTest : DatabaseTestsBase() {
 
             transaction {
                 DMLTestsData.Cities.insert {
-                    it[DMLTestsData.Cities.name] = "city2"
+                    it[name] = "city2"
                 }
                 assertEqualLists(listOf("city1", "city2"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
 
                 transaction {
                     DMLTestsData.Cities.insert {
-                        it[DMLTestsData.Cities.name] = "city3"
+                        it[name] = "city3"
                     }
                     assertEqualLists(listOf("city1", "city2", "city3"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
                 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/NestedTransactionsTest.kt
@@ -25,41 +25,36 @@ class NestedTransactionsTest : DatabaseTestsBase() {
 
     @Test
     fun testNestedTransactions() {
-        withTables(DMLTestsData.Cities) {
-            try {
-                db.useNestedTransactions = true
-                assertTrue(DMLTestsData.Cities.selectAll().empty())
+        withTables(DMLTestsData.Cities, configure = { useNestedTransactions = true }) {
+            assertTrue(DMLTestsData.Cities.selectAll().empty())
 
+            DMLTestsData.Cities.insert {
+                it[DMLTestsData.Cities.name] = "city1"
+            }
+
+            assertEquals(1L, DMLTestsData.Cities.selectAll().count())
+
+            assertEqualLists(listOf("city1"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+
+            transaction {
                 DMLTestsData.Cities.insert {
-                    it[DMLTestsData.Cities.name] = "city1"
+                    it[DMLTestsData.Cities.name] = "city2"
                 }
-
-                assertEquals(1L, DMLTestsData.Cities.selectAll().count())
-
-                assertEqualLists(listOf("city1"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+                assertEqualLists(listOf("city1", "city2"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
 
                 transaction {
                     DMLTestsData.Cities.insert {
-                        it[DMLTestsData.Cities.name] = "city2"
+                        it[DMLTestsData.Cities.name] = "city3"
                     }
-                    assertEqualLists(listOf("city1", "city2"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
-
-                    transaction {
-                        DMLTestsData.Cities.insert {
-                            it[DMLTestsData.Cities.name] = "city3"
-                        }
-                        assertEqualLists(listOf("city1", "city2", "city3"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
-                    }
-
                     assertEqualLists(listOf("city1", "city2", "city3"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
-
-                    rollback()
                 }
 
-                assertEqualLists(listOf("city1"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
-            } finally {
-                db.useNestedTransactions = false
+                assertEqualLists(listOf("city1", "city2", "city3"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+
+                rollback()
             }
+
+            assertEqualLists(listOf("city1"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
@@ -15,14 +15,14 @@ class RollbackTransactionTest : DatabaseTestsBase() {
         withTables(RollbackTable) {
             inTopLevelTransaction(db.transactionManager.defaultIsolationLevel) {
                 maxAttempts = 1
-                RollbackTable.insert { it[RollbackTable.value] = "before-dummy" }
+                RollbackTable.insert { it[value] = "before-dummy" }
                 transaction {
                     assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "before-dummy" }.count())
-                    RollbackTable.insert { it[RollbackTable.value] = "inner-dummy" }
+                    RollbackTable.insert { it[value] = "inner-dummy" }
                 }
                 assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "before-dummy" }.count())
                 assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "inner-dummy" }.count())
-                RollbackTable.insert { it[RollbackTable.value] = "after-dummy" }
+                RollbackTable.insert { it[value] = "after-dummy" }
                 assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "after-dummy" }.count())
                 rollback()
             }
@@ -37,15 +37,15 @@ class RollbackTransactionTest : DatabaseTestsBase() {
         withTables(RollbackTable, configure = { useNestedTransactions = true }) {
             inTopLevelTransaction(db.transactionManager.defaultIsolationLevel) {
                 maxAttempts = 1
-                RollbackTable.insert { it[RollbackTable.value] = "before-dummy" }
+                RollbackTable.insert { it[value] = "before-dummy" }
                 transaction {
                     assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "before-dummy" }.count())
-                    RollbackTable.insert { it[RollbackTable.value] = "inner-dummy" }
+                    RollbackTable.insert { it[value] = "inner-dummy" }
                     rollback()
                 }
                 assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "before-dummy" }.count())
                 assertEquals(0L, RollbackTable.selectAll().where { RollbackTable.value eq "inner-dummy" }.count())
-                RollbackTable.insert { it[RollbackTable.value] = "after-dummy" }
+                RollbackTable.insert { it[value] = "after-dummy" }
                 assertEquals(1L, RollbackTable.selectAll().where { RollbackTable.value eq "after-dummy" }.count())
                 rollback()
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
@@ -412,9 +412,7 @@ class UpsertTests : DatabaseTestsBase() {
             val losses = integer("losses")
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
-            db.useNestedTransactions = true
-
+        withTables(excludeSettings = TestDB.ALL_H2_V1, tester, configure = { useNestedTransactions = true }) {
             val itemA = "Item A"
             tester.upsert {
                 it[item] = itemA
@@ -456,8 +454,6 @@ class UpsertTests : DatabaseTestsBase() {
             assertEquals(insertCode, updateCode)
             assertEquals(insertGains, updateGains)
             assertNotEquals(insertLosses, updateLosses)
-
-            db.useNestedTransactions = false
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ForeignIdEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ForeignIdEntityTest.kt
@@ -42,9 +42,7 @@ class ForeignIdEntityTest : DatabaseTestsBase() {
     @Test
     fun foreignIdEntityUpdate() {
         // reproducer for https://github.com/JetBrains/Exposed/issues/880
-        withTables(Schema.Projects, Schema.ProjectConfigs) {
-            db.useNestedTransactions = true
-
+        withTables(Schema.Projects, Schema.ProjectConfigs, configure = { useNestedTransactions = true }) {
             transaction {
                 val projectId = Project.new { name = "Space" }.id.value
                 ProjectConfig.new(projectId) { setting = true }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ImmutableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ImmutableEntityTest.kt
@@ -38,10 +38,9 @@ class ImmutableEntityTest : DatabaseTestsBase() {
         val etag by Schema.Organization.etag
     }
 
-    @Test fun immutableEntityReadAfterUpdate() {
-        withTables(Schema.Organization) {
-            db.useNestedTransactions = true
-
+    @Test
+    fun immutableEntityReadAfterUpdate() {
+        withTables(Schema.Organization, configure = { useNestedTransactions = true }) {
             transaction {
                 Schema.Organization.insert {
                     it[name] = "JetBrains"
@@ -59,10 +58,9 @@ class ImmutableEntityTest : DatabaseTestsBase() {
         }
     }
 
-    @Test fun immutableEntityCacheInvalidation() {
-        withTables(Schema.Organization) {
-            db.useNestedTransactions = true
-
+    @Test
+    fun immutableEntityCacheInvalidation() {
+        withTables(Schema.Organization, configure = { useNestedTransactions = true }) {
             transaction {
                 Schema.Organization.insert {
                     it[name] = "JetBrains"


### PR DESCRIPTION
#### Description

**Summary of the change**: Raise the deprecation levels of property setters that were deprecated after `DatabaseConfig` was implemented. The deprecation level has remained untouched because they were being used for testing purposes.

**Detailed description**:
- **What**:

The following elements have been deprecated since around [0.35.1](https://github.com/JetBrains/Exposed/commit/32323e35bab9c1bdd95eb7d78eda2f221e91678f) ->

**Raise from WARNING to ERROR:**

- `Database.useNestedTransactions`
- `Database.defaultFetchSize`
- `ThreadLocalTransactionManager.defaultIsolationLevel`

- **Why**: [Test refactoring]
For the last remaining property used in tests, the only current alternative to setting the deprecated property would be to either store a configured `Database.connect()` instance in a variable or use `TestDB.connect { setter }`. Both then require using new transaction blocks and manually creating and dropping tables, which becomes tedious if multiple tables and dialects are being tested.

- **How**:
`DatabaseTestsBase` methods, `withDb()`, `withTables()`, and `withSchemas()`, now have a parameter that accepts a configuration builder, which is more easily passed to the call to `connect()`.
Some logic has been added to base `withDb()` to make sure that any database that stays registered for the entire test suite only retains the set configuration for that single call. 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bump deprecation levels

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues
