### PR TITLE
fix: EXPOSED-501 Column.transform() ignores custom setParameter() logic

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -533,6 +533,7 @@ public class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/expos
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun setNullable (Z)V
+	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public fun unwrap (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun unwrapRecursive (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -324,6 +324,10 @@ open class ColumnWithTransform<Unwrapped : Any, Wrapped : Any>(
     }
 
     override var nullable = delegate.nullable
+
+    override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
+        return delegate.setParameter(stmt, index, value)
+    }
 }
 
 // Numeric columns

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/sql/json/JsonColumnTests.kt
@@ -406,4 +406,23 @@ class JsonColumnTests : DatabaseTestsBase() {
             assertEquals(newData2, newResult?.get(tester.jsonColumn))
         }
     }
+
+    @Test
+    fun testJsonWithTransformer() {
+        val tester = object : Table("tester") {
+            val numbers: Column<DoubleArray> = json<IntArray>("numbers", Json.Default).transform(
+                wrap = { DoubleArray(it.size) { i -> 1.0 * it[i] } },
+                unwrap = { IntArray(it.size) { i -> it[i].toInt() } }
+            )
+        }
+
+        withTables(tester) {
+            val data = doubleArrayOf(1.0, 2.0, 3.0)
+            tester.insert {
+                it[numbers] = data
+            }
+
+            assertContentEquals(data, tester.selectAll().single()[tester.numbers])
+        }
+    }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**:
Adds an override for `setParameter()` to `ColumnWithTransform` class.

**Detailed description**:
- **Why**:

Any column type that relies on logic in `setParameter()` to succeed when preparing a statement will fail if `transform()` is used to convert it to `ColumnWithTransform`. This happens because the delegate's implementation is being ignored by the wrapping class.

This behavior can be seen if a custom column type is created that relies on some conversion in `setParameter()`; for example, needing to use `PGobject` when setting the parameter type with PostgreSQL.
Or, as shown in the test, using `json().transform()`.

The same operations that succeed with a standard `json()` will fail with `json().transform()`, throwing something like:
```
org.postgresql.util.PSQLException: ERROR: column "numbers" is of type json but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.
```

This would also fail on H2 because `encodeToByteArray()` is not being reached inside `setParameter()`.

- **How**:

Adding `ColumnWithTransform.setParameter()` that uses delegate's function ensures that it is invoked.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues
[EXPOSED-501](https://youtrack.jetbrains.com/issue/EXPOSED-501/Column.transform-ignores-custom-setParameter-logic)