### PR TITLE
feat: EXPOSED-498 Handle auto-increment status change on a column

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2489,6 +2489,7 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public final fun getIndices ()Ljava/util/List;
 	public fun getPrimaryKey ()Lorg/jetbrains/exposed/sql/Table$PrimaryKey;
 	public final fun getSchemaName ()Ljava/lang/String;
+	public final fun getSequences ()Ljava/util/List;
 	public fun getTableName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun index (Ljava/lang/String;Z[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
@@ -3817,6 +3818,7 @@ public final class org/jetbrains/exposed/sql/vendors/DatabaseDialect$DefaultImpl
 
 public final class org/jetbrains/exposed/sql/vendors/DatabaseDialectKt {
 	public static final fun getCurrentDialect ()Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;
+	public static final fun inProperCase (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption {
@@ -3993,6 +3995,7 @@ public class org/jetbrains/exposed/sql/vendors/H2Dialect : org/jetbrains/exposed
 	public final fun getDelegatedDialectNameProvider ()Lorg/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider;
 	public fun getFunctionProvider ()Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;
 	public final fun getH2Mode ()Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
+	public final fun getMajorVersion ()Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2MajorVersion;
 	public fun getName ()Ljava/lang/String;
 	public fun getNeedsSequenceToAutoInc ()Z
 	public final fun getOriginalDataTypeProvider ()Lorg/jetbrains/exposed/sql/vendors/DataTypeProvider;
@@ -4029,6 +4032,14 @@ public final class org/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMo
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2CompatibilityMode;
+}
+
+public final class org/jetbrains/exposed/sql/vendors/H2Dialect$H2MajorVersion : java/lang/Enum {
+	public static final field One Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2MajorVersion;
+	public static final field Two Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2MajorVersion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2MajorVersion;
+	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/H2Dialect$H2MajorVersion;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/H2Kt {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3818,7 +3818,6 @@ public final class org/jetbrains/exposed/sql/vendors/DatabaseDialect$DefaultImpl
 
 public final class org/jetbrains/exposed/sql/vendors/DatabaseDialectKt {
 	public static final fun getCurrentDialect ()Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;
-	public static final fun inProperCase (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -326,8 +326,8 @@ object SchemaUtils {
                         columnType.nullable
                     }
                     val incorrectNullability = existingCol.nullable != colNullable
-                    // Exposed doesn't support changing sequences on columns
-                    val incorrectAutoInc = existingCol.autoIncrement != columnType.isAutoInc && col.autoIncColumnType?.autoincSeq == null
+
+                    val incorrectAutoInc = isIncorrectAutoInc(existingCol, col)
 
                     val incorrectDefaults = isIncorrectDefault(dataTypeProvider, existingCol, col)
 
@@ -356,6 +356,15 @@ object SchemaUtils {
         }
 
         return statements
+    }
+
+    private fun isIncorrectAutoInc(columnMetadata: ColumnMetadata, column: Column<*>): Boolean = when {
+        !columnMetadata.autoIncrement && column.columnType.isAutoInc && column.autoIncColumnType?.sequence == null ->
+            true
+        columnMetadata.autoIncrement && column.columnType.isAutoInc && column.autoIncColumnType?.sequence != null ->
+            true
+        columnMetadata.autoIncrement && !column.columnType.isAutoInc -> true
+        else -> false
     }
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -36,7 +36,7 @@ interface DatabaseDialect {
     /** Returns `true` if the dialect supports returning multiple generated keys as a result of an insert operation, `false` otherwise. */
     val supportsMultipleGeneratedKeys: Boolean
 
-    /** Returns`true` if the dialect supports returning generated keys obtained from a sequence. */
+    /** Returns `true` if the dialect supports returning generated keys obtained from a sequence. */
     val supportsSequenceAsGeneratedKeys: Boolean get() = supportsCreateSequence
 
     /** Returns `true` if the dialect supports only returning generated keys that are identity columns. */
@@ -202,5 +202,5 @@ internal val currentDialectIfAvailable: DatabaseDialect?
         null
     }
 
-internal fun String.inProperCase(): String =
+fun String.inProperCase(): String =
     TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this@inProperCase) ?: this

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -202,5 +202,5 @@ internal val currentDialectIfAvailable: DatabaseDialect?
         null
     }
 
-fun String.inProperCase(): String =
+internal fun String.inProperCase(): String =
     TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this@inProperCase) ?: this

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -196,7 +196,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
 
     override fun toString(): String = "H2Dialect[$dialectName, $h2Mode]"
 
-    internal enum class H2MajorVersion {
+    enum class H2MajorVersion {
         One, Two
     }
 
@@ -204,7 +204,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         exactH2Version(TransactionManager.current())
     }
 
-    internal val majorVersion: H2MajorVersion by lazy {
+    val majorVersion: H2MajorVersion by lazy {
         when {
             version.startsWith("1.") -> H2MajorVersion.One
             version.startsWith("2.") -> H2MajorVersion.Two

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -391,31 +391,58 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
-    override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> = listOf(
-        buildString {
-            val tr = TransactionManager.current()
-            append("ALTER TABLE ${tr.identity(column.table)} ")
-            val colName = tr.identity(column)
-            append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
+    override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> {
+        val list = mutableListOf(
+            buildString {
+                val tr = TransactionManager.current()
+                append("ALTER TABLE ${tr.identity(column.table)} ")
+                val colName = tr.identity(column)
 
-            if (columnDiff.nullability) {
-                append(", ALTER COLUMN $colName ")
-                if (column.columnType.nullable) {
-                    append("DROP ")
+                if (columnDiff.autoInc && column.autoIncColumnType != null) {
+                    val sequence = column.autoIncColumnType?.sequence
+                    if (sequence != null) {
+                        append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
+                        append(", ALTER COLUMN $colName DROP DEFAULT")
+                    } else {
+                        val q = if (column.table.tableName.contains('.')) "\"" else ""
+                        val fallbackSeqName = "$q${column.table.tableName.replace("\"", "")}_${column.name}_seq$q"
+                        append("ALTER COLUMN $colName SET DEFAULT nextval('$fallbackSeqName')")
+                    }
                 } else {
-                    append("SET ")
+                    append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
                 }
-                append("NOT NULL")
-            }
-            if (columnDiff.defaults) {
-                column.dbDefaultValue?.let {
-                    append(", ALTER COLUMN $colName SET DEFAULT ${PostgreSQLDataTypeProvider.processForDefaultValue(it)}")
-                } ?: run {
-                    append(",  ALTER COLUMN $colName DROP DEFAULT")
+
+                if (columnDiff.nullability) {
+                    append(", ALTER COLUMN $colName ")
+                    if (column.columnType.nullable) {
+                        append("DROP ")
+                    } else {
+                        append("SET ")
+                    }
+                    append("NOT NULL")
+                }
+                if (columnDiff.defaults) {
+                    column.dbDefaultValue?.let {
+                        append(", ALTER COLUMN $colName SET DEFAULT ${PostgreSQLDataTypeProvider.processForDefaultValue(it)}")
+                    } ?: run {
+                        append(", ALTER COLUMN $colName DROP DEFAULT")
+                    }
                 }
             }
+        )
+        if (columnDiff.autoInc && column.autoIncColumnType != null && column.autoIncColumnType?.sequence == null) {
+            list.add(
+                buildString {
+                    val tr = TransactionManager.current()
+                    val colName = tr.identity(column)
+                    val q = if (column.table.tableName.contains('.')) "\"" else ""
+                    val fallbackSeqName = "$q${column.table.tableName.replace("\"", "")}_${column.name}_seq$q"
+                    append("ALTER SEQUENCE $fallbackSeqName OWNED BY $q${column.table.tableName.replace("\"", "")}.${column.name}$q")
+                }
+            )
         }
-    )
+        return list
+    }
 
     override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -404,9 +404,8 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
                         append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
                         append(", ALTER COLUMN $colName DROP DEFAULT")
                     } else {
-                        val q = if (column.table.tableName.contains('.')) "\"" else ""
-                        val fallbackSeqName = "$q${column.table.tableName.replace("\"", "")}_${column.name}_seq$q"
-                        append("ALTER COLUMN $colName SET DEFAULT nextval('$fallbackSeqName')")
+                        val fallbackSequenceName = fallbackSequenceName(tableName = column.table.tableName, columnName = column.name)
+                        append("ALTER COLUMN $colName SET DEFAULT nextval('$fallbackSequenceName')")
                     }
                 } else {
                     append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
@@ -433,11 +432,9 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
         if (columnDiff.autoInc && column.autoIncColumnType != null && column.autoIncColumnType?.sequence == null) {
             list.add(
                 buildString {
-                    val tr = TransactionManager.current()
-                    val colName = tr.identity(column)
+                    val fallbackSequenceName = fallbackSequenceName(tableName = column.table.tableName, columnName = column.name)
                     val q = if (column.table.tableName.contains('.')) "\"" else ""
-                    val fallbackSeqName = "$q${column.table.tableName.replace("\"", "")}_${column.name}_seq$q"
-                    append("ALTER SEQUENCE $fallbackSeqName OWNED BY $q${column.table.tableName.replace("\"", "")}.${column.name}$q")
+                    append("ALTER SEQUENCE $fallbackSequenceName OWNED BY $q${column.table.tableName.replace("\"", "")}.${column.name}$q")
                 }
             )
         }

--- a/exposed-migration/src/main/kotlin/MigrationUtils.kt
+++ b/exposed-migration/src/main/kotlin/MigrationUtils.kt
@@ -10,11 +10,11 @@ import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.exists
 import org.jetbrains.exposed.sql.exposedLogger
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
-import org.jetbrains.exposed.sql.vendors.inProperCase
 import java.io.File
 
 object MigrationUtils {
@@ -293,3 +293,6 @@ object MigrationUtils {
         }
     }
 }
+
+internal fun String.inProperCase(): String =
+    TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this@inProperCase) ?: this

--- a/exposed-migration/src/main/kotlin/MigrationUtils.kt
+++ b/exposed-migration/src/main/kotlin/MigrationUtils.kt
@@ -6,12 +6,15 @@ import org.jetbrains.exposed.sql.SchemaUtils.checkExcessiveIndices
 import org.jetbrains.exposed.sql.SchemaUtils.checkMappingConsistence
 import org.jetbrains.exposed.sql.SchemaUtils.createStatements
 import org.jetbrains.exposed.sql.SchemaUtils.statementsRequiredToActualizeScheme
+import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.exists
 import org.jetbrains.exposed.sql.exposedLogger
+import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
+import org.jetbrains.exposed.sql.vendors.inProperCase
 import java.io.File
 
 object MigrationUtils {
@@ -69,6 +72,9 @@ object MigrationUtils {
         val createStatements = logTimeSpent("Preparing create tables statements", withLogs) {
             createStatements(tables = tablesToCreate.toTypedArray())
         }
+        val createSequencesStatements = logTimeSpent("Preparing create sequences statements", withLogs) {
+            checkMissingSequences(tables = tables, withLogs).flatMap { it.createStatement() }
+        }
         val alterStatements = logTimeSpent("Preparing alter table statements", withLogs) {
             addMissingColumnsStatements(tables = tablesToAlter.toTypedArray(), withLogs)
         }
@@ -80,7 +86,7 @@ object MigrationUtils {
             ).filter { it !in (createStatements + alterStatements) }
         }
 
-        val allStatements = createStatements + alterStatements + modifyTablesStatements
+        val allStatements = createStatements + createSequencesStatements + alterStatements + modifyTablesStatements
         return allStatements
     }
 
@@ -92,7 +98,8 @@ object MigrationUtils {
         return checkMissingIndices(tables = tables, withLogs).flatMap { it.createStatement() } +
             checkUnmappedIndices(tables = tables, withLogs).flatMap { it.dropStatement() } +
             checkExcessiveForeignKeyConstraints(tables = tables, withLogs).flatMap { it.dropStatement() } +
-            checkExcessiveIndices(tables = tables, withLogs).flatMap { it.dropStatement() }
+            checkExcessiveIndices(tables = tables, withLogs).flatMap { it.dropStatement() } +
+            checkUnmappedSequences(tables = tables, withLogs).flatMap { it.dropStatement() }
     }
 
     /**
@@ -214,6 +221,65 @@ object MigrationUtils {
             )
         }
         return toDrop.toList()
+    }
+
+    /**
+     * Checks all [tables] for any that have sequences that are missing in the database but are defined in the code. If
+     * found, this function also logs the SQL statements that can be used to create these sequences.
+     *
+     * @return List of sequences that are missing and can be created.
+     */
+    private fun checkMissingSequences(vararg tables: Table, withLogs: Boolean): List<Sequence> {
+        if (!currentDialect.supportsCreateSequence) {
+            return emptyList()
+        }
+
+        fun Collection<Sequence>.log(mainMessage: String) {
+            if (withLogs && isNotEmpty()) {
+                exposedLogger.warn(joinToString(prefix = "$mainMessage\n\t\t", separator = "\n\t\t"))
+            }
+        }
+
+        val existingSequencesNames: Set<String> = currentDialect.sequences().toSet()
+
+        val missingSequences = mutableSetOf<Sequence>()
+
+        val mappedSequences: Set<Sequence> = tables.flatMap { table -> table.sequences }.toSet()
+
+        missingSequences.addAll(mappedSequences.filterNot { it.identifier.inProperCase() in existingSequencesNames })
+
+        missingSequences.log("Sequences missed from database (will be created):")
+        return missingSequences.toList()
+    }
+
+    /**
+     * Checks all [tables] for any that have sequences that exist in the database but are not mapped in the code. If
+     * found, this function also logs the SQL statements that can be used to drop these sequences.
+     *
+     * @return List of sequences that are unmapped and can be dropped.
+     */
+    private fun checkUnmappedSequences(vararg tables: Table, withLogs: Boolean): List<Sequence> {
+        if (!currentDialect.supportsCreateSequence || (currentDialect as? H2Dialect)?.majorVersion == H2Dialect.H2MajorVersion.One) {
+            return emptyList()
+        }
+
+        fun Collection<Sequence>.log(mainMessage: String) {
+            if (withLogs && isNotEmpty()) {
+                exposedLogger.warn(joinToString(prefix = "$mainMessage\n\t\t", separator = "\n\t\t"))
+            }
+        }
+
+        val existingSequencesNames: Set<String> = currentDialect.sequences().toSet()
+
+        val unmappedSequences = mutableSetOf<Sequence>()
+
+        val mappedSequencesNames: Set<String> = tables.flatMap { table -> table.sequences.map { it.identifier.inProperCase() } }.toSet()
+
+        unmappedSequences.addAll(existingSequencesNames.subtract(mappedSequencesNames).map { Sequence(it) })
+
+        unmappedSequences.log("Sequences exist in database and not mapped in code:")
+
+        return unmappedSequences.toList()
     }
 
     private inline fun <R> logTimeSpent(message: String, withLogs: Boolean, block: () -> R): R {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -271,13 +271,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddAutoIncrementToExistingColumn() {
-        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").entityId()
-        }
-        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
-        }
-
         withTables(excludeSettings = listOf(TestDB.SQLITE), tableWithoutAutoIncrement) { testDb ->
             assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false).size)
 
@@ -310,14 +303,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddAutoIncrementWithSequenceNameToExistingColumn() {
-        val sequenceName = "custom_sequence"
-        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").entityId()
-        }
-        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
-        }
-
         withTables(excludeSettings = listOf(TestDB.SQLITE), tableWithoutAutoIncrement) {
             assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false).size)
 
@@ -338,13 +323,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddAutoIncrementWithCustomSequenceToExistingColumn() {
-        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").entityId()
-        }
-        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) {
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -452,13 +430,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddCustomSequenceToExistingAutoIncrementColumn() {
-        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
-        }
-        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -497,14 +468,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testDropAutoIncrementWithSequenceNameOnExistingColumn() {
-        val sequenceName = "custom_sequence"
-        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
-        }
-        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -536,14 +499,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testDropSequenceNameOnExistingAutoIncrementColumn() {
-        val sequenceName = "custom_sequence"
-        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
-        }
-        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -596,14 +551,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddCustomSequenceToExistingAutoIncrementColumnWithSequenceName() {
-        val sequenceName = "custom_sequence"
-        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
-        }
-        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -645,13 +592,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testDropAutoIncrementWithCustomSequenceOnExistingColumn() {
-        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
-        }
-        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -683,13 +623,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testDropCustomSequenceOnExistingAutoIncrementColumn() {
-        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
-        }
-        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -742,14 +675,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddSequenceNameToExistingAutoIncrementColumnWithCustomSequence() {
-        val sequenceName = "custom_sequence"
-        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
-        }
-        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
-            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
-        }
-
         withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
             if (currentDialectTest.supportsCreateSequence) {
                 try {
@@ -798,4 +723,22 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
         cycle = true,
         cache = 20
     )
+
+    private val sequenceName = "custom_sequence"
+
+    private val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
+        override val id: Column<EntityID<Long>> = long("id").entityId()
+    }
+
+    private val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
+        override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+    }
+
+    private val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
+        override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
+    }
+
+    private val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
+        override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -1,5 +1,8 @@
 package org.jetbrains.exposed.sql.tests.shared.ddl
 
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ExperimentalDatabaseMigrationApi
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.Sequence
@@ -13,6 +16,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.vendors.MysqlDialect
 import org.jetbrains.exposed.sql.vendors.PrimaryKeyMetadata
 import org.junit.Before
 import org.junit.Test
@@ -57,11 +61,11 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
             try {
                 SchemaUtils.create(noPKTable)
 
-                val script = MigrationUtils.generateMigrationScript(singlePKTable, scriptDirectory = scriptDirectory, scriptName = scriptName)
+                val script = MigrationUtils.generateMigrationScript(singlePKTable, scriptDirectory = scriptDirectory, scriptName = scriptName, withLogs = false)
                 assertTrue(script.exists())
                 assertEquals("src/test/resources/$scriptName.sql", script.path)
 
-                val expectedStatements: List<String> = MigrationUtils.statementsRequiredForDatabaseMigration(singlePKTable)
+                val expectedStatements: List<String> = MigrationUtils.statementsRequiredForDatabaseMigration(singlePKTable, withLogs = false)
                 assertEquals(1, expectedStatements.size)
 
                 val fileStatements: List<String> = script.bufferedReader().readLines().map { it.trimEnd(';') }
@@ -97,15 +101,15 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                 // Create initial script
                 val initialScript = File("$directory/$name.sql")
                 initialScript.createNewFile()
-                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(noPKTable)
+                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(noPKTable, withLogs = false)
                 statements.forEach {
                     initialScript.appendText(it)
                 }
 
                 // Generate script with the same name of initial script
-                val newScript = MigrationUtils.generateMigrationScript(singlePKTable, scriptDirectory = directory, scriptName = name)
+                val newScript = MigrationUtils.generateMigrationScript(singlePKTable, scriptDirectory = directory, scriptName = name, withLogs = false)
 
-                val expectedStatements: List<String> = MigrationUtils.statementsRequiredForDatabaseMigration(singlePKTable)
+                val expectedStatements: List<String> = MigrationUtils.statementsRequiredForDatabaseMigration(singlePKTable, withLogs = false)
                 assertEquals(1, expectedStatements.size)
 
                 val fileStatements: List<String> = newScript.bufferedReader().readLines().map { it.trimEnd(';') }
@@ -123,7 +127,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
     fun testNoTablesPassedWhenGeneratingMigrationScript() {
         withDb {
             expectException<IllegalArgumentException> {
-                MigrationUtils.generateMigrationScript(scriptDirectory = "src/test/resources", scriptName = "V2__Test")
+                MigrationUtils.generateMigrationScript(scriptDirectory = "src/test/resources", scriptName = "V2__Test", withLogs = false)
             }
         }
     }
@@ -148,7 +152,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                 assertNull(primaryKey)
 
                 val expected = "ALTER TABLE ${tableName.inProperCase()} ADD PRIMARY KEY (${noPKTable.bar.nameInDatabaseCase()})"
-                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(singlePKTable)
+                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(singlePKTable, withLogs = false)
                 assertEquals(expected, statements.single())
             } finally {
                 SchemaUtils.drop(noPKTable)
@@ -174,7 +178,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                 }
 
                 SchemaUtils.create(table)
-                val actual = MigrationUtils.statementsRequiredForDatabaseMigration(table)
+                val actual = MigrationUtils.statementsRequiredForDatabaseMigration(table, withLogs = false)
                 assertEqualLists(emptyList(), actual)
             } finally {
                 SchemaUtils.drop(table)
@@ -194,7 +198,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                 SchemaUtils.create(quotedTable)
                 assertTrue(quotedTable.exists())
 
-                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(quotedTable)
+                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(quotedTable, withLogs = false)
                 assertTrue(statements.isEmpty())
             } finally {
                 SchemaUtils.drop(quotedTable)
@@ -227,7 +231,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                 SchemaUtils.create(testTableWithTwoIndices)
                 assertTrue(testTableWithTwoIndices.exists())
 
-                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(testTableWithOneIndex)
+                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(testTableWithOneIndex, withLogs = false)
                 assertEquals(1, statements.size)
             } finally {
                 SchemaUtils.drop(testTableWithTwoIndices)
@@ -257,10 +261,584 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                 SchemaUtils.create(testTableWithIndex)
                 assertTrue(testTableWithIndex.exists())
 
-                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(testTableWithoutIndex)
+                val statements = MigrationUtils.statementsRequiredForDatabaseMigration(testTableWithoutIndex, withLogs = false)
                 assertEquals(1, statements.size)
             } finally {
                 SchemaUtils.drop(testTableWithIndex)
+            }
+        }
+    }
+
+    @Test
+    fun testAddAutoIncrementToExistingColumn() {
+        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").entityId()
+        }
+        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+        }
+
+        withTables(excludeSettings = listOf(TestDB.SQLITE), tableWithoutAutoIncrement) { testDb ->
+            assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false).size)
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrement, withLogs = false)
+            when (testDb) {
+                TestDB.POSTGRESQL, TestDB.POSTGRESQLNG -> {
+                    assertEquals(3, statements.size)
+                    assertEquals("CREATE SEQUENCE IF NOT EXISTS test_table_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807", statements[0])
+                    assertEquals("ALTER TABLE test_table ALTER COLUMN id SET DEFAULT nextval('test_table_id_seq')", statements[1])
+                    assertEquals("ALTER SEQUENCE test_table_id_seq OWNED BY test_table.id", statements[2])
+                }
+                TestDB.SQLSERVER -> {
+                    assertEquals(3, statements.size)
+                    assertEquals("ALTER TABLE test_table ADD NEW_id BIGINT IDENTITY(1,1)", statements[0])
+                    assertEquals("ALTER TABLE test_table DROP COLUMN id", statements[1])
+                    assertEquals("EXEC sp_rename 'test_table.NEW_id', 'id', 'COLUMN'", statements[2])
+                }
+                TestDB.ORACLE, TestDB.H2_V2_ORACLE -> {
+                    assertEquals(1, statements.size)
+                    assertEquals("CREATE SEQUENCE test_table_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807", statements[0])
+                }
+                else -> {
+                    assertEquals(1, statements.size)
+                    val alterColumnWord = if (currentDialectTest is MysqlDialect) "MODIFY" else "ALTER"
+                    assertTrue(statements[0].startsWith("ALTER TABLE test_table $alterColumnWord COLUMN id ", ignoreCase = true))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testAddAutoIncrementWithSequenceNameToExistingColumn() {
+        val sequenceName = "custom_sequence"
+        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").entityId()
+        }
+        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
+        }
+
+        withTables(excludeSettings = listOf(TestDB.SQLITE), tableWithoutAutoIncrement) {
+            assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false).size)
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementSequenceName, withLogs = false)
+            assertEquals(1, statements.size)
+            if (currentDialectTest.supportsCreateSequence) {
+                assertEquals(
+                    "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                        "$sequenceName START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                    statements[0]
+                )
+            } else {
+                val alterColumnWord = if (currentDialectTest is MysqlDialect) "MODIFY" else "ALTER"
+                assertTrue(statements[0].equals("ALTER TABLE TEST_TABLE $alterColumnWord COLUMN ID BIGINT AUTO_INCREMENT NOT NULL", ignoreCase = true))
+            }
+        }
+    }
+
+    @Test
+    fun testAddAutoIncrementWithCustomSequenceToExistingColumn() {
+        val sequence = Sequence(
+            name = "my_sequence",
+            startWith = 4,
+            incrementBy = 2,
+            minValue = 1,
+            maxValue = 100,
+            cycle = true,
+            cache = 20
+        )
+        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").entityId()
+        }
+        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) {
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithoutAutoIncrement)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementCustomSequence, withLogs = false)
+                    assertEquals(1, statements.size)
+                    assertEquals(
+                        "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                            "${sequence.name} START WITH 4 INCREMENT BY 2 MINVALUE 1 MAXVALUE 100 CYCLE CACHE 20",
+                        statements[0]
+                    )
+                } finally {
+                    SchemaUtils.drop(tableWithoutAutoIncrement)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDropAutoIncrementOnExistingColumn() {
+        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").entityId()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.SQLITE), tableWithAutoIncrement) { testDb ->
+            assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrement, withLogs = false).size)
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false)
+            when (testDb) {
+                TestDB.POSTGRESQL, TestDB.POSTGRESQLNG -> {
+                    assertEquals(2, statements.size)
+                    assertEquals("ALTER TABLE test_table ALTER COLUMN id TYPE BIGINT", statements[0])
+                    assertEquals("DROP SEQUENCE IF EXISTS test_table_id_seq", statements[1])
+                }
+                TestDB.ORACLE, TestDB.H2_V2_ORACLE -> {
+                    assertEquals(1, statements.size)
+                    assertTrue(statements[0].equals("DROP SEQUENCE TEST_TABLE_ID_SEQ", ignoreCase = true))
+                }
+                else -> {
+                    assertEquals(1, statements.size)
+                    val alterColumnWord = if (currentDialectTest is MysqlDialect) "MODIFY" else "ALTER"
+                    assertTrue(statements[0].equals("ALTER TABLE test_table $alterColumnWord COLUMN id BIGINT", ignoreCase = true))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testAddSequenceNameToExistingAutoIncrementColumn() {
+        val sequenceName = "custom_sequence"
+        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrement)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrement, withLogs = false).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementSequenceName, withLogs = false)
+                    assertEquals(
+                        "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                            "$sequenceName START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                        statements[0]
+                    )
+                    when (testDb) {
+                        TestDB.POSTGRESQL, TestDB.POSTGRESQLNG -> {
+                            assertEquals(3, statements.size)
+                            assertEquals("ALTER TABLE test_table ALTER COLUMN id TYPE BIGINT, ALTER COLUMN id DROP DEFAULT", statements[1])
+                            assertEquals("DROP SEQUENCE IF EXISTS test_table_id_seq", statements[2])
+                        }
+                        TestDB.ORACLE, TestDB.H2_V2_ORACLE -> {
+                            assertTrue(statements[1].equals("DROP SEQUENCE TEST_TABLE_ID_SEQ", ignoreCase = true))
+                        }
+                        else -> {
+                            val alterColumnWord = if (currentDialectTest is MysqlDialect) "MODIFY" else "ALTER"
+                            assertTrue(statements[1].startsWith("ALTER TABLE test_table $alterColumnWord COLUMN id BIGINT", ignoreCase = true))
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrement)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testAddCustomSequenceToExistingAutoIncrementColumn() {
+        val sequence = Sequence(
+            name = "my_sequence",
+            startWith = 4,
+            incrementBy = 2,
+            minValue = 1,
+            maxValue = 100,
+            cycle = true,
+            cache = 20
+        )
+        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+        }
+        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrement)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrement, withLogs = false).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementCustomSequence, withLogs = false)
+                    assertEquals(
+                        "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                            "${sequence.name} START WITH 4 INCREMENT BY 2 MINVALUE 1 MAXVALUE 100 CYCLE CACHE 20",
+                        statements[0]
+                    )
+                    when (testDb) {
+                        TestDB.POSTGRESQL, TestDB.POSTGRESQLNG -> {
+                            assertEquals(3, statements.size)
+                            assertEquals("ALTER TABLE test_table ALTER COLUMN id TYPE BIGINT, ALTER COLUMN id DROP DEFAULT", statements[1])
+                            assertEquals("DROP SEQUENCE IF EXISTS test_table_id_seq", statements[2])
+                        }
+                        TestDB.ORACLE, TestDB.H2_V2_ORACLE -> {
+                            assertEquals(2, statements.size)
+                            assertTrue(statements[1].equals("DROP SEQUENCE test_table_id_seq", ignoreCase = true))
+                        }
+                        else -> {
+                            assertEquals(2, statements.size)
+                            val alterColumnWord = if (currentDialectTest is MysqlDialect) "MODIFY" else "ALTER"
+                            assertTrue(statements[1].startsWith("ALTER TABLE test_table $alterColumnWord COLUMN id BIGINT", ignoreCase = true))
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrement)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDropAutoIncrementWithSequenceNameOnExistingColumn() {
+        val sequenceName = "custom_sequence"
+        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
+        }
+        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrementSequenceName)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementSequenceName, withLogs = false).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false)
+                    when (testDb) {
+                        TestDB.H2_V1 -> {
+                            assertEquals(0, statements.size)
+                        }
+                        else -> {
+                            assertEquals(1, statements.size)
+                            assertTrue(
+                                statements[0].equals(
+                                    "DROP SEQUENCE${" IF EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} $sequenceName",
+                                    ignoreCase = true
+                                )
+                            )
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrementSequenceName)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDropSequenceNameOnExistingAutoIncrementColumn() {
+        val sequenceName = "custom_sequence"
+        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
+        }
+        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrementSequenceName)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementSequenceName).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrement, withLogs = false)
+                    when (testDb) {
+                        TestDB.POSTGRESQL, TestDB.POSTGRESQLNG -> {
+                            assertEquals(4, statements.size)
+                            assertEquals("CREATE SEQUENCE IF NOT EXISTS test_table_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807", statements[0])
+                            assertEquals("ALTER TABLE test_table ALTER COLUMN id SET DEFAULT nextval('test_table_id_seq')", statements[1])
+                            assertEquals("ALTER SEQUENCE test_table_id_seq OWNED BY test_table.id", statements[2])
+                            assertEquals("DROP SEQUENCE IF EXISTS $sequenceName", statements[3])
+                        }
+                        TestDB.SQLSERVER -> {
+                            assertEquals(4, statements.size)
+                            assertEquals("ALTER TABLE test_table ADD NEW_id BIGINT IDENTITY(1,1)", statements[0])
+                            assertEquals("ALTER TABLE test_table DROP COLUMN id", statements[1])
+                            assertEquals("EXEC sp_rename 'test_table.NEW_id', 'id', 'COLUMN'", statements[2])
+                            assertEquals("DROP SEQUENCE $sequenceName", statements[3])
+                        }
+                        TestDB.ORACLE, TestDB.H2_V2_ORACLE -> {
+                            assertEquals(2, statements.size)
+                            assertEquals("CREATE SEQUENCE test_table_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807", statements[0])
+                            assertTrue(statements[1].equals("DROP SEQUENCE $sequenceName", ignoreCase = true))
+                        }
+                        TestDB.H2_V1 -> {
+                            assertEquals(1, statements.size)
+                            assertEquals("ALTER TABLE TEST_TABLE ALTER COLUMN ID BIGINT AUTO_INCREMENT NOT NULL", statements[0])
+                        }
+                        else -> {
+                            assertEquals(2, statements.size)
+                            assertTrue(statements[0].startsWith("ALTER TABLE TEST_TABLE ALTER COLUMN ID", ignoreCase = true))
+                            assertTrue(
+                                statements[1].equals(
+                                    "DROP SEQUENCE${" IF EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} $sequenceName",
+                                    ignoreCase = true
+                                )
+                            )
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrementSequenceName)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testAddCustomSequenceToExistingAutoIncrementColumnWithSequenceName() {
+        val sequenceName = "custom_sequence"
+        val sequence = Sequence(
+            name = "my_sequence",
+            startWith = 4,
+            incrementBy = 2,
+            minValue = 1,
+            maxValue = 100,
+            cycle = true,
+            cache = 20
+        )
+        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
+        }
+        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrementSequenceName)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementSequenceName, withLogs = false).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementCustomSequence, withLogs = false)
+                    when (testDb) {
+                        TestDB.H2_V1 -> {
+                            assertEquals(1, statements.size)
+                            assertEquals(
+                                "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                                    "${sequence.name} START WITH 4 INCREMENT BY 2 MINVALUE 1 MAXVALUE 100 CYCLE CACHE 20",
+                                statements[0]
+                            )
+                        }
+                        else -> {
+                            assertEquals(2, statements.size)
+                            assertEquals(
+                                "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                                    "${sequence.name} START WITH 4 INCREMENT BY 2 MINVALUE 1 MAXVALUE 100 CYCLE CACHE 20",
+                                statements[0]
+                            )
+                            assertTrue(
+                                statements[1].equals(
+                                    "DROP SEQUENCE${" IF EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} $sequenceName",
+                                    ignoreCase = true
+                                )
+                            )
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrementSequenceName)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDropAutoIncrementWithCustomSequenceOnExistingColumn() {
+        val sequence = Sequence(
+            name = "my_sequence",
+            startWith = 4,
+            incrementBy = 2,
+            minValue = 1,
+            maxValue = 100,
+            cycle = true,
+            cache = 20
+        )
+        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
+        }
+        val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrementCustomSequence)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementCustomSequence, withLogs = false).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false)
+                    when (testDb) {
+                        TestDB.H2_V1 -> {
+                            assertEquals(0, statements.size)
+                        }
+                        else -> {
+                            assertEquals(1, statements.size)
+                            assertTrue(
+                                statements[0].equals(
+                                    "DROP SEQUENCE${" IF EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} ${sequence.name}",
+                                    ignoreCase = true
+                                )
+                            )
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrementCustomSequence)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDropCustomSequenceOnExistingAutoIncrementColumn() {
+        val sequence = Sequence(
+            name = "my_sequence",
+            startWith = 4,
+            incrementBy = 2,
+            minValue = 1,
+            maxValue = 100,
+            cycle = true,
+            cache = 20
+        )
+        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
+        }
+        val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrementCustomSequence)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementCustomSequence).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrement, withLogs = false)
+                    when (testDb) {
+                        TestDB.POSTGRESQL, TestDB.POSTGRESQLNG -> {
+                            assertEquals(4, statements.size)
+                            assertEquals("CREATE SEQUENCE IF NOT EXISTS test_table_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807", statements[0])
+                            assertEquals("ALTER TABLE test_table ALTER COLUMN id SET DEFAULT nextval('test_table_id_seq')", statements[1])
+                            assertEquals("ALTER SEQUENCE test_table_id_seq OWNED BY test_table.id", statements[2])
+                            assertEquals("DROP SEQUENCE IF EXISTS ${sequence.name}", statements[3])
+                        }
+                        TestDB.SQLSERVER -> {
+                            assertEquals(4, statements.size)
+                            assertEquals("ALTER TABLE test_table ADD NEW_id BIGINT IDENTITY(1,1)", statements[0])
+                            assertEquals("ALTER TABLE test_table DROP COLUMN id", statements[1])
+                            assertEquals("EXEC sp_rename 'test_table.NEW_id', 'id', 'COLUMN'", statements[2])
+                            assertEquals("DROP SEQUENCE ${sequence.name}", statements[3])
+                        }
+                        TestDB.ORACLE, TestDB.H2_V2_ORACLE -> {
+                            assertEquals(2, statements.size)
+                            assertEquals("CREATE SEQUENCE test_table_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807", statements[0])
+                            assertTrue(statements[1].equals("DROP SEQUENCE ${sequence.name}", ignoreCase = true))
+                        }
+                        TestDB.H2_V1 -> {
+                            assertEquals(1, statements.size)
+                            assertEquals("ALTER TABLE TEST_TABLE ALTER COLUMN ID BIGINT AUTO_INCREMENT NOT NULL", statements[0])
+                        }
+                        else -> {
+                            assertEquals(2, statements.size)
+                            assertTrue(statements[0].startsWith("ALTER TABLE TEST_TABLE ALTER COLUMN ID", ignoreCase = true))
+                            assertTrue(
+                                statements[1].equals(
+                                    "DROP SEQUENCE${" IF EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} ${sequence.name}",
+                                    ignoreCase = true
+                                )
+                            )
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrementCustomSequence)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testAddSequenceNameToExistingAutoIncrementColumnWithCustomSequence() {
+        val sequenceName = "custom_sequence"
+        val sequence = Sequence(
+            name = "my_sequence",
+            startWith = 4,
+            incrementBy = 2,
+            minValue = 1,
+            maxValue = 100,
+            cycle = true,
+            cache = 20
+        )
+        val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
+        }
+        val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
+            override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
+        }
+
+        withDb(excludeSettings = listOf(TestDB.SQLITE)) { testDb ->
+            if (currentDialectTest.supportsCreateSequence) {
+                try {
+                    SchemaUtils.create(tableWithAutoIncrementCustomSequence)
+
+                    assertEquals(0, MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementCustomSequence).size)
+
+                    val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementSequenceName, withLogs = false)
+                    when (testDb) {
+                        TestDB.H2_V1 -> {
+                            assertEquals(1, statements.size)
+                            assertEquals(
+                                "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                                    "$sequenceName START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                                statements[0]
+                            )
+                        }
+                        else -> {
+                            assertEquals(2, statements.size)
+                            assertEquals(
+                                "CREATE SEQUENCE${" IF NOT EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} " +
+                                    "$sequenceName START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                                statements[0]
+                            )
+                            assertTrue(
+                                statements[1].equals(
+                                    "DROP SEQUENCE${" IF EXISTS".takeIf { currentDialectTest.supportsIfNotExists } ?: ""} ${sequence.name}",
+                                    ignoreCase = true
+                                )
+                            )
+                        }
+                    }
+                } finally {
+                    SchemaUtils.drop(tableWithAutoIncrementCustomSequence)
+                }
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -338,15 +338,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddAutoIncrementWithCustomSequenceToExistingColumn() {
-        val sequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
         val tableWithoutAutoIncrement = object : IdTable<Long>("test_table") {
             override val id: Column<EntityID<Long>> = long("id").entityId()
         }
@@ -461,15 +452,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testAddCustomSequenceToExistingAutoIncrementColumn() {
-        val sequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
         val tableWithAutoIncrement = object : IdTable<Long>("test_table") {
             override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
         }
@@ -615,15 +597,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
     @Test
     fun testAddCustomSequenceToExistingAutoIncrementColumnWithSequenceName() {
         val sequenceName = "custom_sequence"
-        val sequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
         val tableWithAutoIncrementSequenceName = object : IdTable<Long>("test_table") {
             override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequenceName).entityId()
         }
@@ -672,15 +645,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testDropAutoIncrementWithCustomSequenceOnExistingColumn() {
-        val sequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
         val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
             override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
         }
@@ -719,15 +683,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
     @Test
     fun testDropCustomSequenceOnExistingAutoIncrementColumn() {
-        val sequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
         val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
             override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
         }
@@ -788,15 +743,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
     @Test
     fun testAddSequenceNameToExistingAutoIncrementColumnWithCustomSequence() {
         val sequenceName = "custom_sequence"
-        val sequence = Sequence(
-            name = "my_sequence",
-            startWith = 4,
-            incrementBy = 2,
-            minValue = 1,
-            maxValue = 100,
-            cycle = true,
-            cache = 20
-        )
         val tableWithAutoIncrementCustomSequence = object : IdTable<Long>("test_table") {
             override val id: Column<EntityID<Long>> = long("id").autoIncrement(sequence).entityId()
         }
@@ -842,4 +788,14 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
             }
         }
     }
+
+    private val sequence = Sequence(
+        name = "my_sequence",
+        startWith = 4,
+        incrementBy = 2,
+        minValue = 1,
+        maxValue = 100,
+        cycle = true,
+        cache = 20
+    )
 }


### PR DESCRIPTION
**Summary of the change**:

The function `MigrationUtils.statementsRequiredForDatabaseMigration` now includes the proper statements to change the type of a column when it detects that the auto-increment status has changed for PostgreSQL and SQL Server, and statements to create/drop the necessary sequences.

**Detailed description**:
- **Why**:

**PostgreSQL**: The generated ALTER COLUMN statement was setting SERIAL as the target column type and that was throwing an error because it is not recognised as a type.

**SQL Server**: The generated ALTER COLUMN statement was setting IDENTITY as the target column type and that was throwing an error because it is not possible to add it to an existing column later on and must be defined that way from the start.

- **How**:

Two functions, `checkMissingSequences` and `checkUnmappedSequences` were added to `MigrationUtils`. For `checkUnmappedSequences`, H2_V1 is excluded because its system sequences do not have predictable naming patterns and it’s impossible to know if an existing sequence in the database is mapped in the Exposed code, so we would get false DROP statements that should not be there.

**PostgreSQL**: The SQL equivalent to setting a column type as SERIAL was used. Check PostgreSQL documentation [here](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL). This means that when changing a column to be auto-incrementing in PostgreSQL, Exposed will generate three SQL statements:
1. One to create a sequence
2. One to set the column's default values to be assigned from a sequence generator
3. One to set the column as the owner of the sequence created in Step 1

**SQL Server**:
The simplest way to solve it is to create a new IDENTITY column and drop the old one. This means that when changing a column to be auto-incrementing in SQL Server, Exposed will generate three SQL statements:
1. One to add a new IDENTITY column named "NEW_columnName"
2. One to drop the old column
3. One to rename the new column to the same name as the old dropped column

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [x] Postgres
- [x] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
