### PR TITLE
fix: EXPOSED-513 DROP SEQUENCE fails when there is a dot in the sequence name

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1707,7 +1707,7 @@ fun ColumnSet.targetTables(): List<Table> = when (this) {
     else -> error("No target provided for update")
 }
 
-private fun String.isAlreadyQuoted(): Boolean =
+internal fun String.isAlreadyQuoted(): Boolean =
     listOf("\"", "'", "`").any { quoteString ->
         startsWith(quoteString) && endsWith(quoteString)
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -316,7 +316,14 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         val sequences = mutableListOf<String>()
         TransactionManager.current().exec("SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SEQUENCES") { rs ->
             while (rs.next()) {
-                sequences.add(rs.getString("SEQUENCE_NAME"))
+                val result = rs.getString("SEQUENCE_NAME")
+                val sequenceName = if (h2Mode == H2CompatibilityMode.Oracle) {
+                    val q = if (result.contains('.') && !result.isAlreadyQuoted()) "\"" else ""
+                    "$q$result$q"
+                } else {
+                    result
+                }
+                sequences.add(sequenceName)
             }
         }
         return sequences

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -431,7 +431,10 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
         val sequences = mutableListOf<String>()
         TransactionManager.current().exec("SELECT SEQUENCE_NAME FROM USER_SEQUENCES") { rs ->
             while (rs.next()) {
-                sequences.add(rs.getString("SEQUENCE_NAME"))
+                val result = rs.getString("SEQUENCE_NAME")
+                val q = if (result.contains('.') && !result.isAlreadyQuoted()) "\"" else ""
+                val sequenceName = "$q$result$q"
+                sequences.add(sequenceName)
             }
         }
         return sequences

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -586,7 +586,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
     @Test
     fun explicitFkNameIsExplicit() {
-        withTables(ExplicitTable, NonExplicitTable) {
+        withTables(PlayerTable, ExplicitTable, NonExplicitTable) {
             assertEquals("Explicit_FK_NAME", ExplicitTable.playerId.foreignKey!!.customFkName)
             assertEquals(null, NonExplicitTable.playerId.foreignKey!!.customFkName)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.sql.tests.shared.ddl
 
 import org.jetbrains.exposed.sql.ExperimentalDatabaseMigrationApi
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.exists
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
@@ -13,6 +14,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.PrimaryKeyMetadata
+import org.junit.Before
 import org.junit.Test
 import java.io.File
 import kotlin.properties.Delegates
@@ -20,6 +22,21 @@ import kotlin.test.assertNull
 
 @OptIn(ExperimentalDatabaseMigrationApi::class)
 class DatabaseMigrationTests : DatabaseTestsBase() {
+
+    @Before
+    fun dropAllSequences() {
+        withDb {
+            if (currentDialectTest.supportsCreateSequence) {
+                val allSequences = currentDialectTest.sequences().map { name -> Sequence(name) }.toSet()
+                allSequences.forEach { sequence ->
+                    val dropStatements = sequence.dropStatement()
+                    dropStatements.forEach { statement ->
+                        exec(statement)
+                    }
+                }
+            }
+        }
+    }
 
     @Test
     fun testMigrationScriptDirectoryAndContent() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -520,7 +520,7 @@ class InsertTests : DatabaseTestsBase() {
                 }
             } finally {
                 withDb(db) {
-                    SchemaUtils.drop()
+                    SchemaUtils.drop(testTable)
                 }
             }
         }
@@ -558,7 +558,7 @@ class InsertTests : DatabaseTestsBase() {
                 }
             } finally {
                 withDb(db) {
-                    SchemaUtils.drop()
+                    SchemaUtils.drop(testTable)
                 }
             }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/ViaTest.kt
@@ -189,7 +189,7 @@ class ViaTests : DatabaseTestsBase() {
 
     @Test
     fun testHierarchicalReferences() {
-        withTables(NodeToNodes) {
+        withTables(NodesTable, NodeToNodes) {
             val root = Node.new { name = "root" }
             val child1 = Node.new {
                 name = "child1"
@@ -219,7 +219,7 @@ class ViaTests : DatabaseTestsBase() {
 
     @Test
     fun testWarmUpOnHierarchicalEntities() {
-        withTables(NodeToNodes) {
+        withTables(NodesTable, NodeToNodes) {
             val child1 = Node.new { name = "child1" }
             val child2 = Node.new { name = "child1" }
             val root1 = Node.new {
@@ -273,7 +273,7 @@ class ViaTests : DatabaseTestsBase() {
 
     @Test
     fun testOrderBy() {
-        withTables(NodeToNodes) {
+        withTables(NodesTable, NodeToNodes) {
             val root = NodeOrdered.new { name = "root" }
             listOf("#3", "#0", "#2", "#4", "#1").forEach {
                 NodeOrdered.new {
@@ -291,6 +291,7 @@ class ViaTests : DatabaseTestsBase() {
     object Projects : IntIdTable("projects") {
         val name = varchar("name", 50)
     }
+
     class Project(id: EntityID<Int>) : IntEntity(id) {
         companion object : IntEntityClass<Project>(Projects)
 
@@ -310,6 +311,7 @@ class ViaTests : DatabaseTestsBase() {
             addIdColumn(task)
         }
     }
+
     class ProjectTask(id: EntityID<CompositeID>) : CompositeEntity(id) {
         companion object : CompositeEntityClass<ProjectTask>(ProjectTasks)
 
@@ -319,6 +321,7 @@ class ViaTests : DatabaseTestsBase() {
     object Tasks : IntIdTable("tasks") {
         val title = varchar("title", 64)
     }
+
     class Task(id: EntityID<Int>) : IntEntity(id) {
         companion object : IntEntityClass<Task>(Tasks)
 


### PR DESCRIPTION
**Detailed description**:
- **What**:
When obtaining all sequences from a database, Oracle and H2 Oracle now quote a sequence name if it has a dot .
- **Why**:
When attempting to drop all available sequences in Oracle and H2 Oracle, DROP SEQUENCE fails when there is a dot in the sequence name because the name obtained from the database is not quoted. The error thrown for Oracle states that the sequence is not found in the database. The error thrown for H2 Oracle states that the schema is not found in the database.
- **How**:
In the overridden `sequences()` function in `OracleDialect` and `H2Dialect`, there is now a check to see if the sequence name has a dot, and if it does and it's not already quoted, quotes are added. This way, when the sequence's `identifier` is used to drop it in the sequence's drop statement, it would succeed in finding and dropping the sequence.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [x] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
