### PR TITLE
fix: EXPOSED-496 reference() idColumn equality check with referree's id is insufficient

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -61,7 +61,7 @@ class Alias<out T : Table>(val delegate: T, val alias: String) : Table() {
     @Suppress("UNCHECKED_CAST")
     operator fun <T : Any?> get(original: Column<T>): Column<T> {
         // CompositeIdTable id is not a typical database-registered column
-        val delegateColumn = if (delegate is CompositeIdTable && original.columnType.isEntityIdentifier()) {
+        val delegateColumn = if (delegate is CompositeIdTable && original.isEntityIdentifier()) {
             delegate.id
         } else {
             delegate.columns.find { it == original }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -221,8 +221,12 @@ internal fun IColumnType<*>.rawSqlType(): IColumnType<*> = when {
     else -> this
 }
 
-internal fun IColumnType<*>.isEntityIdentifier(): Boolean {
-    return this is EntityIDColumnType<*> && (idColumn.table as IdTable<*>).id == idColumn
+/** Returns whether this column is registered to an [IdTable] and is that table's `id` column. */
+internal fun Column<*>.isEntityIdentifier(): Boolean {
+    if (columnType !is EntityIDColumnType<*>) return false
+
+    val tableToCheck = ((table as? Alias<*>)?.delegate ?: table) as? IdTable<*>
+    return tableToCheck?.id == columnType.idColumn
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
@@ -29,7 +29,7 @@ class ResultRow(
     operator fun <T> get(expression: Expression<T>): T {
         val column = expression as? Column<*>
         return when {
-            column?.columnType?.isEntityIdentifier() == true && column.table is CompositeIdTable -> {
+            column?.isEntityIdentifier() == true && column.table is CompositeIdTable -> {
                 val resultID = CompositeID {
                     column.table.idColumns.forEach { column ->
                         it[column as Column<EntityID<Comparable<Any>>>] = getInternal(column, checkNullability = true).value

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -312,7 +312,7 @@ interface ISqlExpressionBuilder {
     @LowPriorityInOverloadResolution
     infix fun <T> ExpressionWithColumnType<T>.eq(t: T): Op<Boolean> = when {
         t == null -> isNull()
-        columnType.isEntityIdentifier() -> (this as Column<*>).table.mapIdComparison(t, ::EqOp)
+        (this as? Column<*>)?.isEntityIdentifier() == true -> table.mapIdComparison(t, ::EqOp)
         else -> EqOp(this, wrap(t))
     }
 
@@ -337,7 +337,11 @@ interface ISqlExpressionBuilder {
         @Suppress("UNCHECKED_CAST")
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
-        return if (columnType.isEntityIdentifier()) table.mapIdComparison(entityID, ::EqOp) else EqOp(this, wrap(entityID))
+        return if ((this as? Column<*>)?.isEntityIdentifier() == true) {
+            table.mapIdComparison(entityID, ::EqOp)
+        } else {
+            EqOp(this, wrap(entityID))
+        }
     }
 
     /** Checks if this [EntityID] expression is equal to some [other] expression. */
@@ -359,7 +363,7 @@ interface ISqlExpressionBuilder {
     @LowPriorityInOverloadResolution
     infix fun <T> ExpressionWithColumnType<T>.neq(other: T): Op<Boolean> = when {
         other == null -> isNotNull()
-        columnType.isEntityIdentifier() -> (this as Column<*>).table.mapIdComparison(other, ::NeqOp)
+        (this as? Column<*>)?.isEntityIdentifier() == true -> table.mapIdComparison(other, ::NeqOp)
         else -> NeqOp(this, wrap(other))
     }
 
@@ -375,7 +379,11 @@ interface ISqlExpressionBuilder {
         @Suppress("UNCHECKED_CAST")
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
-        return if (columnType.isEntityIdentifier()) table.mapIdComparison(entityID, ::NeqOp) else NeqOp(this, wrap(entityID))
+        return if ((this as? Column<*>)?.isEntityIdentifier() == true) {
+            table.mapIdComparison(entityID, ::NeqOp)
+        } else {
+            NeqOp(this, wrap(entityID))
+        }
     }
 
     /** Checks if this [EntityID] expression is not equal to some [other] expression. */
@@ -497,21 +505,21 @@ interface ISqlExpressionBuilder {
         Between(this, wrap(EntityID(from, this.idTable())), wrap(EntityID(to, this.idTable())))
 
     /** Returns `true` if this expression is null, `false` otherwise. */
-    fun <T> Expression<T>.isNull() = if (this is Column<*> && columnType.isEntityIdentifier()) {
+    fun <T> Expression<T>.isNull() = if (this is Column<*> && isEntityIdentifier()) {
         table.mapIdOperator(::IsNullOp)
     } else {
         IsNullOp(this)
     }
 
     /** Returns `true` if this string expression is null or empty, `false` otherwise. */
-    fun <T : String?> Expression<T>.isNullOrEmpty() = if (this is Column<*> && columnType.isEntityIdentifier()) {
+    fun <T : String?> Expression<T>.isNullOrEmpty() = if (this is Column<*> && isEntityIdentifier()) {
         table.mapIdOperator(::IsNullOp)
     } else {
         IsNullOp(this)
     }.or { this@isNullOrEmpty.charLength() eq 0 }
 
     /** Returns `true` if this expression is not null, `false` otherwise. */
-    fun <T> Expression<T>.isNotNull() = if (this is Column<*> && columnType.isEntityIdentifier()) {
+    fun <T> Expression<T>.isNotNull() = if (this is Column<*> && isEntityIdentifier()) {
         table.mapIdOperator(::IsNotNullOp)
     } else {
         IsNotNullOp(this)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -47,7 +47,7 @@ interface FieldSet {
             fields.forEach {
                 when {
                     it is CompositeColumn<*> -> unrolled.addAll(it.getRealColumns())
-                    (it as? Column<*>)?.columnType?.isEntityIdentifier() == true && it.table is CompositeIdTable -> {
+                    (it as? Column<*>)?.isEntityIdentifier() == true && it.table is CompositeIdTable -> {
                         unrolled.addAll(it.table.idColumns)
                     }
                     else -> unrolled.add(it)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -30,7 +30,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
             "Trying to set null to not nullable column $column"
         }
 
-        if (column.columnType.isEntityIdentifier() && (value as EntityID<*>).value is CompositeID) {
+        if (column.isEntityIdentifier() && (value as EntityID<*>).value is CompositeID) {
             (value.value as CompositeID).setComponentValues()
         } else {
             column.columnType.validateValueBeforeUpdate(value)


### PR DESCRIPTION
#### Description

**Summary of the change**:
Internal `isEntityIdentifier()` now takes a `Column` as its receiver instead of `ColumnType`.

**Detailed description**:
- **Why**:

`isEntityIdentifier()` is used to determine whether a compound operator should be used on a table's `idColumns` and its logic was dependent on an equality comparison between the receiver column type and the table's `id`.

But when `Table.reference()` is called it creates a new column using the parent's `id` column as the `idColumn`, so the table used in the comparison is equivalent. Column equality also [no longer relies on column type](https://github.com/JetBrains/Exposed/pull/2151/files#diff-8455a7e11eea94f34ecde2b3dd5eb0dc60bc7725bc190707dc792ad1d23051c2), and is solely based on table name and column name.

So if the parent's `id` column has an identical name to the child's `reference()` column, a false positive occurs. This leads to the child's `id` being incorrectly used in the compound operator.

- **How**:

The receiver of `isEntityIdentifier()` is now `Column`, to ensure that it is the child's table that is being accessed for equality comparison with the invoking `idColumn`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-496](https://youtrack.jetbrains.com/issue/EXPOSED-496/reference-idColumn-equality-check-with-referrees-id-is-insufficient)
