### PR TITLE
feat!: EXPOSED-514 Support DELETE from tables in join

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,12 @@
 # Breaking Changes
 
+## 0.55.0
+* The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.
+  This enables the use of the new `Join.delete()` function, which performs a delete operation on a specific table from the join relation.
+  The original statement class constructor has also been deprecated in favor of the constructor that accepts `targetsSet`, as well as another
+  additional parameter `targetTables` (for specifying which table from the join relation, if applicable, to delete from). The latter defaults
+  to an empty list if not defined.
+
 ## 0.54.0
 
 * All objects that are part of the sealed class `ForUpdateOption` are now converted to `data object`.

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -4,8 +4,7 @@
 * The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.
   This enables the use of the new `Join.delete()` function, which performs a delete operation on a specific table from the join relation.
   The original statement class constructor has also been deprecated in favor of the constructor that accepts `targetsSet`, as well as another
-  additional parameter `targetTables` (for specifying which table from the join relation, if applicable, to delete from). The latter defaults
-  to an empty list if not defined.
+  additional parameter `targetTables` (for specifying which table from the join relation, if applicable, to delete from).
 
 ## 0.54.0
 

--- a/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
+++ b/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
@@ -245,6 +245,18 @@
                 StarWarsFilms.deleteAll { StarWarsFilms.sequelId eq 8 }
             </code-block>
         </chapter>
+        <chapter id="join-delete">
+            <title>Join <code>delete</code></title>
+            <p>To delete records from a table in a join relation, use the <code>delete</code> function with a
+                <code>Join</code> as its receiver. Provide the specific table from which records should be deleted as
+                the argument to the parameter <code>targetTable</code>.
+            </p>
+            <code-block lang="kotlin">
+                val join = StarWarsFilms innerJoin Actors
+                join.delete(Actors) { Actors.sequelId greater 2 }
+            </code-block>
+            <tip>For more information on creating and using a <code>Join</code>, see <a href="DSL-Querying-data.topic#join-tables">Joining Tables</a>.</tip>
+        </chapter>
 
     </chapter>
     <chapter title="Insert Or Update" id="insert-or-update">

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1800,6 +1800,8 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static synthetic fun batchUpsert$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Iterable;[Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function2;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun batchUpsert$default (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;[Lorg/jetbrains/exposed/sql/Column;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun batchUpsert$default (Lorg/jetbrains/exposed/sql/Table;Lkotlin/sequences/Sequence;[Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function2;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun delete (Lorg/jetbrains/exposed/sql/Join;Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Table;ZLjava/lang/Integer;Lkotlin/jvm/functions/Function1;)I
+	public static synthetic fun delete$default (Lorg/jetbrains/exposed/sql/Join;Lorg/jetbrains/exposed/sql/Table;[Lorg/jetbrains/exposed/sql/Table;ZLjava/lang/Integer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)I
 	public static final fun deleteAll (Lorg/jetbrains/exposed/sql/Table;)I
 	public static final fun deleteIgnoreWhere (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/jvm/functions/Function2;)I
 	public static synthetic fun deleteIgnoreWhere$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/Integer;Ljava/lang/Long;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)I
@@ -3082,14 +3084,17 @@ public class org/jetbrains/exposed/sql/statements/BatchUpsertStatement : org/jet
 
 public class org/jetbrains/exposed/sql/statements/DeleteStatement : org/jetbrains/exposed/sql/statements/Statement {
 	public static final field Companion Lorg/jetbrains/exposed/sql/statements/DeleteStatement$Companion;
+	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnSet;Lorg/jetbrains/exposed/sql/Op;ZLjava/lang/Integer;Ljava/lang/Long;Ljava/util/List;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnSet;Lorg/jetbrains/exposed/sql/Op;ZLjava/lang/Integer;Ljava/lang/Long;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Op;ZLjava/lang/Integer;Ljava/lang/Long;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Op;ZLjava/lang/Integer;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun arguments ()Ljava/lang/Iterable;
 	public fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/Integer;
 	public synthetic fun executeInternal (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/Object;
 	public final fun getLimit ()Ljava/lang/Integer;
 	public final fun getOffset ()Ljava/lang/Long;
 	public final fun getTable ()Lorg/jetbrains/exposed/sql/Table;
+	public final fun getTargetTables ()Ljava/util/List;
+	public final fun getTargetsSet ()Lorg/jetbrains/exposed/sql/ColumnSet;
 	public final fun getWhere ()Lorg/jetbrains/exposed/sql/Op;
 	public final fun isIgnore ()Z
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
@@ -3923,6 +3928,8 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$
 
 public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	public fun <init> ()V
+	protected final fun appendJoinPart (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Join;Lorg/jetbrains/exposed/sql/Transaction;Z)V
+	public static synthetic fun appendJoinPart$default (Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Join;Lorg/jetbrains/exposed/sql/Transaction;ZILjava/lang/Object;)V
 	protected final fun appendJoinPartForUpdateClause (Lorg/jetbrains/exposed/sql/QueryBuilder;Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Join;Lorg/jetbrains/exposed/sql/Transaction;)V
 	protected fun appendOptionsToExplain (Ljava/lang/StringBuilder;Ljava/lang/String;)V
 	public fun arraySlice (Lorg/jetbrains/exposed/sql/Expression;Ljava/lang/Integer;Ljava/lang/Integer;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
@@ -3931,6 +3938,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	public fun concat (Ljava/lang/String;Lorg/jetbrains/exposed/sql/QueryBuilder;[Lorg/jetbrains/exposed/sql/Expression;)V
 	public fun date (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun day (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
+	public fun delete (ZLorg/jetbrains/exposed/sql/Join;Ljava/util/List;Lorg/jetbrains/exposed/sql/Op;Ljava/lang/Integer;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun delete (ZLorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/Integer;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun explain (ZLjava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Transaction;)Ljava/lang/String;
 	public fun getDEFAULT_VALUE_EXPRESSION ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
@@ -1,38 +1,80 @@
 package org.jetbrains.exposed.sql.statements
 
-import org.jetbrains.exposed.sql.IColumnType
-import org.jetbrains.exposed.sql.Op
-import org.jetbrains.exposed.sql.QueryBuilder
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.exceptions.throwUnsupportedException
+import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.sql.vendors.H2Dialect.H2CompatibilityMode
+import org.jetbrains.exposed.sql.vendors.H2FunctionProvider
+import org.jetbrains.exposed.sql.vendors.h2Mode
 
 /**
  * Represents the SQL statement that deletes one or more rows of a table.
  *
- * @param table Table to delete rows from.
+ * @param targetsSet Column set to delete rows from. This may be a [Table] or a [Join] instance.
  * @param where Condition that determines which rows to delete.
  * @param isIgnore Whether to ignore errors or not.
  * **Note** [isIgnore] is not supported by all vendors. Please check the documentation.
  * @param limit Maximum number of rows to delete.
  * @param offset The number of rows to skip.
+ * @param targetTables List of specific tables from [targetsSet] to delete rows from.
  */
 open class DeleteStatement(
-    val table: Table,
+    val targetsSet: ColumnSet,
     val where: Op<Boolean>? = null,
     val isIgnore: Boolean = false,
     val limit: Int? = null,
-    val offset: Long? = null
-) : Statement<Int>(StatementType.DELETE, listOf(table)) {
+    val offset: Long? = null,
+    val targetTables: List<Table> = emptyList(),
+) : Statement<Int>(StatementType.DELETE, targetsSet.targetTables()) {
+    @Deprecated(
+        "This constructor will be removed in future releases.",
+        ReplaceWith("DeleteStatement(targetsSet = table, where, isIgnore, limit, offset, emptyList())"),
+        DeprecationLevel.WARNING
+    )
+    constructor(
+        table: Table,
+        where: Op<Boolean>?,
+        isIgnore: Boolean,
+        limit: Int?,
+        offset: Long?
+    ) : this(table, where, isIgnore, limit, offset, emptyList())
+
+    @Deprecated(
+        "This property will be removed in future releases and replaced with a property that stores a `ColumnSet`," +
+            "which may be a `Table` or a `Join`. To access the table(s) to which the columns belong, use `ColumnSet.targetTables()`",
+        ReplaceWith("targetsSet"),
+        DeprecationLevel.WARNING
+    )
+    val table: Table = targets.first()
 
     override fun PreparedStatementApi.executeInternal(transaction: Transaction): Int {
         return executeUpdate()
     }
 
-    override fun prepareSQL(transaction: Transaction, prepared: Boolean): String =
-        transaction.db.dialect.functionProvider.delete(isIgnore, table, where?.let { QueryBuilder(prepared).append(it).toString() }, limit, transaction)
+    override fun prepareSQL(transaction: Transaction, prepared: Boolean): String {
+        val dialect = transaction.db.dialect
+        return when (targetsSet) {
+            is Table -> dialect.functionProvider.delete(
+                isIgnore, targetsSet, where?.let { QueryBuilder(prepared).append(it).toString() }, limit, transaction
+            )
+            is Join -> {
+                val functionProvider = when (dialect.h2Mode) {
+                    H2CompatibilityMode.PostgreSQL, H2CompatibilityMode.Oracle, H2CompatibilityMode.SQLServer -> H2FunctionProvider
+                    else -> dialect.functionProvider
+                }
+                functionProvider.delete(isIgnore, targetsSet, targetTables, where, limit, transaction)
+            }
+            else -> transaction.throwUnsupportedException("DELETE with ${targetsSet::class.simpleName} is unsupported")
+        }
+    }
 
     override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = QueryBuilder(true).run {
+        if (targetsSet is Join) {
+            targetsSet.joinParts.forEach {
+                (it.joinPart as? QueryAlias)?.query?.prepareSQL(this)
+                it.additionalConstraint?.invoke(SqlExpressionBuilder)?.toQueryBuilder(this)
+            }
+        }
         where?.toQueryBuilder(this)
         listOf(args)
     }
@@ -44,7 +86,7 @@ open class DeleteStatement(
          * @return Count of deleted rows.
          */
         fun where(transaction: Transaction, table: Table, op: Op<Boolean>, isIgnore: Boolean = false, limit: Int? = null, offset: Long? = null): Int =
-            DeleteStatement(table, op, isIgnore, limit, offset).execute(transaction) ?: 0
+            DeleteStatement(targetsSet = table, op, isIgnore, limit, offset).execute(transaction) ?: 0
 
         /**
          * Creates a [DeleteStatement] that deletes all rows in [table].

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -74,6 +74,7 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
     override fun hexToDb(hexString: String): String = "0x$hexString"
 }
 
+@Suppress("TooManyFunctions")
 internal object SQLServerFunctionProvider : FunctionProvider() {
     override fun nextVal(seq: Sequence, builder: QueryBuilder) = builder {
         append("NEXT VALUE FOR ", seq.identifier)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.statements.MergeStatement
 import org.jetbrains.exposed.sql.statements.MergeStatement.ClauseAction.DELETE
 import org.jetbrains.exposed.sql.statements.MergeStatement.ClauseAction.INSERT
 import org.jetbrains.exposed.sql.statements.MergeStatement.ClauseAction.UPDATE
+import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.util.*
 
@@ -202,9 +203,7 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         val tableToUpdate = columnsAndValues.map { it.first.table }.distinct().singleOrNull()
             ?: transaction.throwUnsupportedException("SQLServer supports a join updates with a single table columns to update.")
 
-        if (targets.joinParts.any { it.joinType != JoinType.INNER }) {
-            exposedLogger.warn("All tables in UPDATE statement will be joined with inner join")
-        }
+        targets.checkJoinTypes(StatementType.UPDATE)
         if (limit != null) {
             +"UPDATE TOP($limit)"
         } else {
@@ -243,6 +242,44 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
     override fun delete(ignore: Boolean, table: Table, where: String?, limit: Int?, transaction: Transaction): String {
         val def = super.delete(ignore, table, where, null, transaction)
         return if (limit != null) def.replaceFirst("DELETE", "DELETE TOP($limit)") else def
+    }
+
+    override fun delete(
+        ignore: Boolean,
+        targets: Join,
+        targetTables: List<Table>,
+        where: Op<Boolean>?,
+        limit: Int?,
+        transaction: Transaction
+    ): String {
+        if (ignore) {
+            transaction.throwUnsupportedException("SQL Server doesn't support IGNORE in DELETE from join relation")
+        }
+        val tableToDelete = targetTables.singleOrNull()
+            ?: transaction.throwUnsupportedException(
+                "SQL Server doesn't support DELETE from join relation with multiple tables to delete from"
+            )
+        targets.checkJoinTypes(StatementType.DELETE)
+
+        return with(QueryBuilder(true)) {
+            +"DELETE "
+            limit?.let {
+                +"TOP($it) "
+            }
+            +"FROM "
+            if (tableToDelete is Alias<*>) {
+                +tableToDelete.alias
+            } else {
+                tableToDelete.describe(transaction, this)
+            }
+            +" FROM "
+            appendJoinPart(tableToDelete, targets, transaction, filterTargetTable = false)
+            where?.let {
+                +" AND "
+                +it
+            }
+            toString()
+        }
     }
 
     override fun queryLimit(size: Int, offset: Long, alreadyOrdered: Boolean): String {

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
@@ -38,7 +38,7 @@ class EntityLifecycleInterceptor : GlobalStatementInterceptor {
 
             is DeleteStatement -> {
                 transaction.flushCache()
-                transaction.entityCache.removeTablesReferrers(listOf(statement.table), false)
+                transaction.entityCache.removeTablesReferrers(statement.targetsSet.targetTables(), false)
                 if (!isExecutedWithinEntityLifecycle) {
                     statement.targets.filterIsInstance<IdTable<*>>().forEach {
                         transaction.entityCache.data[it]?.clear()


### PR DESCRIPTION
#### Description

**Summary of the change**:
Adds `Join.delete()` to Queries.kt.

**Detailed description**:
- **Why**:

It is already possible to perform an UPDATE of a table from a join relation using `Join.update()`.
But it is not possible to perform the DELETE equivalent.

- **What**:

```kt
val join = Users innerJoin UserData
// update all records in UserData table
join.update {
    it[UserData.comment] = Users.name
    it[UserData.value] = 123
}
// delete first 3 records in UserData table that have specified value
join.delete(UserData, limit = 3) { UserData.value eq 123 }
```

- **How**:
    - `DeleteStatement` property `table: Table` is replaced with the common super class `targetsSet: ColumnSet`, so that it can accept either a `Table` or a `Join`. This follows the same pattern for [UpdateStatement](https://github.com/JetBrains/Exposed/blob/main/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateStatement.kt#L21). 
    - `DeleteStatement` constructor takes another additional parameter `targetTables` to store which table(s) from the join relation to delete rows from.
        - The 2 above changes will show as a deprecation warning for any custom class extension or direct instantiation of the statement. Replacing `table` with `targetsSet` may be breaking because it now returns a `ColumnSet`, which requires either a cast or a call to `.targetTables().single()` to return the same table type.
    - Database-specific SQL building has been added to `FunctionProvider`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [X] SqlServer
- [X] H2

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-514](https://youtrack.jetbrains.com/issue/EXPOSED-514/Support-DELETE-from-tables-in-join)
