### PR TITLE
docs: EXPOSED-515 How to identify composite key columns that use reference()

### DIFF
--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -81,6 +81,23 @@ class Director(id: EntityID<CompositeID>) : CompositeEntity(id) {
     var genre by Directors.genre
 }
 ```
+If any of the key columns have already been marked by `entityId()` in another table, they can still be identified in the
+`CompositeIdTable` using `addIdColumn()`. This might be useful for key columns that reference another `IdTable`:
+```kotlin
+object Guilds : UUIDTable("guilds")
+
+object Directors : CompositeIdTable("directors") {
+    val name = varchar("name", 50).entityId()
+    val guildId = reference("guild_id", Guilds)
+    val genre = enumeration<Genre>("genre")
+    
+    init {
+        addIdColumn(guildId)
+    }
+
+    override val primaryKey = PrimaryKey(name, guildId)
+}
+```
 
 ## Basic CRUD operations
 ### Create
@@ -143,8 +160,8 @@ val directorId = CompositeID {
     it[Directors.guildId] = "..."
 }
 
+// these will both deconstruct in SQL to the 2 component columns
 val director = Director.findById(directorId)
-// this will deconstruct in SQL to both component columns
 val directors = Director.find { Directors.id eq directorId }
 ```
 #### Sort (Order-by)

--- a/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
+++ b/documentation-website/Writerside/topics/Deep-Dive-into-DAO.md
@@ -81,8 +81,7 @@ class Director(id: EntityID<CompositeID>) : CompositeEntity(id) {
     var genre by Directors.genre
 }
 ```
-If any of the key columns have already been marked by `entityId()` in another table, they can still be identified in the
-`CompositeIdTable` using `addIdColumn()`. This might be useful for key columns that reference another `IdTable`:
+<include from="Table-Definition.topic" element-id="add-id-column-tip" />
 ```kotlin
 object Guilds : UUIDTable("guilds")
 

--- a/documentation-website/Writerside/topics/Table-Definition.topic
+++ b/documentation-website/Writerside/topics/Table-Definition.topic
@@ -304,6 +304,28 @@
                     override val primaryKey = PrimaryKey(areaCode, latitude, longitude)
                 }
             </code-block>
+            <p>If any of the component columns are already type <code>Column&lt;EntityID&lt;?&gt;&gt;</code>, for
+                example, because they reference the <code>id</code> of another table, they can still be identified by
+                <code>addIdColumn()</code>:</p>
+            <code-block lang="kotlin">
+                object AreaCodes : IdTable&lt;Int&gt;("area_codes") {
+                    override val id = integer("code").entityId()
+                    override val primaryKey = PrimaryKey(id)
+                }
+
+                object Towns : CompositeIdTable("towns") {
+                    val areaCode = reference("area_code", AreaCodes)
+                    val latitude = decimal("latitude", 9, 6).entityId()
+                    val longitude = decimal("longitude", 9, 6).entityId()
+                    val name = varchar("name", 32)
+
+                    init {
+                        addIdColumn(areaCode)
+                    }
+
+                    override val primaryKey = PrimaryKey(areaCode, latitude, longitude)
+                }
+            </code-block>
             <tip>For more information on <code>CompositeIdTable</code> types, see <a
                     href="Deep-Dive-into-DAO.md#table-types">DAO Table Types</a>.
             </tip>

--- a/documentation-website/Writerside/topics/Table-Definition.topic
+++ b/documentation-website/Writerside/topics/Table-Definition.topic
@@ -304,9 +304,9 @@
                     override val primaryKey = PrimaryKey(areaCode, latitude, longitude)
                 }
             </code-block>
-            <p>If any of the component columns are already type <code>Column&lt;EntityID&lt;?&gt;&gt;</code>, for
-                example, because they reference the <code>id</code> of another table, they can still be identified by
-                <code>addIdColumn()</code>:</p>
+            <p id="add-id-column-tip">If any of the key component columns have already been marked by <code>entityId()</code>
+                in another table, they can still be identified using <code>addIdColumn()</code>. This might be useful for
+                key columns that reference another <code>IdTable</code>:</p>
             <code-block lang="kotlin">
                 object AreaCodes : IdTable&lt;Int&gt;("area_codes") {
                     override val id = integer("code").entityId()


### PR DESCRIPTION
#### Description

**Summary of the change**:
Adds examples of `CompositeIdTable` definition using a key `reference()` column via `addIdColumn()`.

**Detailed description**:
- **Why**:

User presented with a thrown exception because they tried to create a new `CompositeID` using a `CompositeIdTable` definition that called `entityId()` unnecessarily on a reference column:
```kt
object Members : CompositeIdTable("members") {
    // this results in unnecessary Column<EntityID<EntityID<Long>>>
    val user = reference("user", Users).entityId() // Users is IdTable<Long> with id = long("id").entityId()
    val guild = reference("guild", Guilds).entityId() // Guilds is IdTable<Long> with id = long("id").entityId()
    val experience = integer("experience").default(0)

    override val primaryKey = PrimaryKey(user, guild)
}
```
The documentation only mentions calling `entityId()` as the way to define a key component column, when an alternative for this use case exists:
```kt
object Members : CompositeIdTable("members") {
    // this results in correct Column<EntityID<Long>>
    val user = reference("user", Users)
    val guild = reference("guild", Guilds)
    val experience = integer("experience").default(0)

    init {
        addIdColumn(user)
        addIdColumn(guild)
    }

    override val primaryKey = PrimaryKey(user, guild)
}
```

- **What**:
    - Both topics that explain how to define a `CompositeIdTable` have been updated to include:
        - An example of how to mark a key reference column using `addIdColumn()` instead of an extra `entityId()`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-515](https://youtrack.jetbrains.com/issue/EXPOSED-515)