### PR TITLE
feat!: EXPOSED-497 Allow OFFSET without LIMIT in query

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -5,12 +5,13 @@
   This enables the use of the new `Join.delete()` function, which performs a delete operation on a specific table from the join relation.
   The original statement class constructor has also been deprecated in favor of the constructor that accepts `targetsSet`, as well as another
   additional parameter `targetTables` (for specifying which table from the join relation, if applicable, to delete from).
-* The `SizedIterable.limit(n, offset)` is now deprecated in favor of 2 independent methods, `limit()` and `offset()`.
+* `SizedIterable.limit(n, offset)` is now deprecated in favor of 2 independent methods, `limit()` and `offset()`.
   In supporting databases, this allows the generation of an OFFSET clause in the SELECT statement without any LIMIT clause.
-  Any existing implementations of `SizedIterable` will now require implementation of these 2 new members.
+  Any custom implementations of the `SizedIterable` interface with a `limit()` override will now show a warning that the declaration overrides
+  a deprecated member. This override should be split into an implementation of the 2 new members instead.
 
   The original `FunctionProvider.queryLimit()` is also being deprecated in favor of `queryLimitAndOffset()`, which takes a
-  nullable `size` parameter to allow exclusion of the LIMIT clause. The latter deprecation only affects extensions of the
+  nullable `size` parameter to allow exclusion of the LIMIT clause. This latter deprecation only affects extensions of the
   `FunctionProvider` class when creating a custom `VendorDialect` class.
 
 ## 0.54.0

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -5,6 +5,13 @@
   This enables the use of the new `Join.delete()` function, which performs a delete operation on a specific table from the join relation.
   The original statement class constructor has also been deprecated in favor of the constructor that accepts `targetsSet`, as well as another
   additional parameter `targetTables` (for specifying which table from the join relation, if applicable, to delete from).
+* The `SizedIterable.limit(n, offset)` is now deprecated in favor of 2 independent methods, `limit()` and `offset()`.
+  In supporting databases, this allows the generation of an OFFSET clause in the SELECT statement without any LIMIT clause.
+  Any existing implementations of `SizedIterable` will now require implementation of these 2 new members.
+
+  The original `FunctionProvider.queryLimit()` is also being deprecated in favor of `queryLimitAndOffset()`, which takes a
+  nullable `size` parameter to allow exclusion of the LIMIT clause. The latter deprecation only affects extensions of the
+  `FunctionProvider` class when creating a custom `VendorDialect` class.
 
 ## 0.54.0
 

--- a/documentation-website/Writerside/topics/DSL-Querying-data.topic
+++ b/documentation-website/Writerside/topics/DSL-Querying-data.topic
@@ -246,12 +246,16 @@
         </chapter>
     </chapter>
     <chapter title="Limiting result sets" id="limit-result-sets">
-        <p>You can use the <code>limit</code> function to prevent loading large data sets or use it for pagination with second <code>offset</code>
-            parameter.</p>
+        <p>You can use the <code>limit</code> function to prevent loading large data sets or to accomplish pagination by using the <code>offset</code>
+            function.</p>
 
         <code-block lang="kotlin">
             // Take 2 films after the first one.
-            StarWarsFilms.selectAll().where { StarWarsFilms.sequelId eq Actors.sequelId }.limit(2, offset = 1)
+            StarWarsFilms
+                .selectAll()
+                .where { StarWarsFilms.sequelId eq Actors.sequelId }
+                .limit(2)
+                .offset(1)
         </code-block>
     </chapter>
     <chapter title="Joining tables" id="join-tables">

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -135,9 +135,13 @@ public abstract class org/jetbrains/exposed/sql/AbstractQuery : org/jetbrains/ex
 	public abstract fun getSet ()Lorg/jetbrains/exposed/sql/FieldSet;
 	protected final fun getTransaction ()Lorg/jetbrains/exposed/sql/Transaction;
 	public fun iterator ()Ljava/util/Iterator;
+	public fun limit (I)Lorg/jetbrains/exposed/sql/AbstractQuery;
+	public synthetic fun limit (I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun limit (IJ)Lorg/jetbrains/exposed/sql/AbstractQuery;
 	public synthetic fun limit (IJ)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun notForUpdate ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public fun offset (J)Lorg/jetbrains/exposed/sql/AbstractQuery;
+	public synthetic fun offset (J)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun orderBy (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/SortOrder;)Lorg/jetbrains/exposed/sql/AbstractQuery;
 	public fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/AbstractQuery;
 	public synthetic fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/SizedIterable;
@@ -820,9 +824,11 @@ public final class org/jetbrains/exposed/sql/EmptySizedIterable : java/util/Iter
 	public fun forUpdate (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun hasNext ()Z
 	public fun iterator ()Ljava/util/Iterator;
+	public fun limit (I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun limit (IJ)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun next ()Ljava/lang/Object;
 	public fun notForUpdate ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public fun offset (J)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun remove ()V
 }
@@ -1494,8 +1500,10 @@ public final class org/jetbrains/exposed/sql/LazySizedCollection : org/jetbrains
 	public final fun getWrapper ()Ljava/util/List;
 	public final fun isLoaded ()Z
 	public fun iterator ()Ljava/util/Iterator;
+	public fun limit (I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun limit (IJ)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun notForUpdate ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public fun offset (J)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
@@ -2189,8 +2197,10 @@ public final class org/jetbrains/exposed/sql/SizedCollection : org/jetbrains/exp
 	public fun forUpdate (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun getDelegate ()Ljava/util/Collection;
 	public fun iterator ()Ljava/util/Iterator;
+	public fun limit (I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun limit (IJ)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun notForUpdate ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public fun offset (J)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
@@ -2199,8 +2209,10 @@ public abstract interface class org/jetbrains/exposed/sql/SizedIterable : java/l
 	public abstract fun count ()J
 	public abstract fun empty ()Z
 	public abstract fun forUpdate (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public abstract fun limit (I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public abstract fun limit (IJ)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public abstract fun notForUpdate ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public abstract fun offset (J)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public abstract fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
@@ -3958,6 +3970,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/FunctionProvider {
 	public fun month (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun nextVal (Lorg/jetbrains/exposed/sql/Sequence;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun queryLimit (IJZ)Ljava/lang/String;
+	public fun queryLimitAndOffset (Ljava/lang/Integer;JZ)Ljava/lang/String;
 	public fun random (Ljava/lang/Integer;)Ljava/lang/String;
 	public fun regexp (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;ZLorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun replace (Lorg/jetbrains/exposed/sql/Table;Ljava/util/List;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1514,7 +1514,9 @@ public abstract interface class org/jetbrains/exposed/sql/LazySizedIterable : or
 
 public final class org/jetbrains/exposed/sql/LazySizedIterable$DefaultImpls {
 	public static fun forUpdate (Lorg/jetbrains/exposed/sql/LazySizedIterable;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public static fun limit (Lorg/jetbrains/exposed/sql/LazySizedIterable;I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public static fun notForUpdate (Lorg/jetbrains/exposed/sql/LazySizedIterable;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public static fun offset (Lorg/jetbrains/exposed/sql/LazySizedIterable;J)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
 public final class org/jetbrains/exposed/sql/Lead : org/jetbrains/exposed/sql/WindowFunction {
@@ -2219,8 +2221,9 @@ public abstract interface class org/jetbrains/exposed/sql/SizedIterable : java/l
 public final class org/jetbrains/exposed/sql/SizedIterable$DefaultImpls {
 	public static fun forUpdate (Lorg/jetbrains/exposed/sql/SizedIterable;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public static synthetic fun forUpdate$default (Lorg/jetbrains/exposed/sql/SizedIterable;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public static synthetic fun limit$default (Lorg/jetbrains/exposed/sql/SizedIterable;IJILjava/lang/Object;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public static fun limit (Lorg/jetbrains/exposed/sql/SizedIterable;I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public static fun notForUpdate (Lorg/jetbrains/exposed/sql/SizedIterable;)Lorg/jetbrains/exposed/sql/SizedIterable;
+	public static fun offset (Lorg/jetbrains/exposed/sql/SizedIterable;J)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
 public final class org/jetbrains/exposed/sql/Slf4jSqlDebugLogger : org/jetbrains/exposed/sql/SqlLogger {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
@@ -56,11 +56,21 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
     /** Modifies this query to retrieve only distinct results if [value] is set to `true`. */
     abstract fun withDistinct(value: Boolean = true): T
 
-    /** Modifies this query to return only [n] results, starting after the specified [offset]. **/
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("limit(n).offset(offset)"),
+        DeprecationLevel.WARNING
+    )
     override fun limit(n: Int, offset: Long): T = apply {
         limit = n
         this.offset = offset
     } as T
+
+    /** Modifies this query to return only [count] results. **/
+    override fun limit(count: Int): T = apply { limit = count } as T
+
+    /** Modifies this query to return only results starting after the specified [start]. **/
+    override fun offset(start: Long): T = apply { offset = start } as T
 
     /** Modifies this query to sort results by the specified [column], according to the provided [order]. **/
     fun orderBy(column: Expression<*>, order: SortOrder = SortOrder.ASC): T = orderBy(column to order)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
@@ -9,13 +9,13 @@ interface SizedIterable<out T> : Iterable<T> {
         ReplaceWith("limit(n).offset(offset)"),
         DeprecationLevel.WARNING
     )
-    fun limit(n: Int, offset: Long = 0): SizedIterable<T>
+    fun limit(n: Int, offset: Long): SizedIterable<T>
 
     /** Returns a new [SizedIterable] containing only [count] elements. */
-    fun limit(count: Int): SizedIterable<T>
+    fun limit(count: Int): SizedIterable<T> = limit(count, 0)
 
     /** Returns a new [SizedIterable] containing only elements starting from the specified [start]. */
-    fun offset(start: Long): SizedIterable<T>
+    fun offset(start: Long): SizedIterable<T> = limit(Int.MAX_VALUE, start)
 
     /** Returns the number of elements stored. */
     fun count(): Long

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
@@ -4,8 +4,18 @@ import org.jetbrains.exposed.sql.vendors.ForUpdateOption
 
 /** Represents the iterable elements of a database result. */
 interface SizedIterable<out T> : Iterable<T> {
-    /** Returns a new [SizedIterable] containing only [n] elements, starting from the specified [offset]. */
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("limit(n).offset(offset)"),
+        DeprecationLevel.WARNING
+    )
     fun limit(n: Int, offset: Long = 0): SizedIterable<T>
+
+    /** Returns a new [SizedIterable] containing only [count] elements. */
+    fun limit(count: Int): SizedIterable<T>
+
+    /** Returns a new [SizedIterable] containing only elements starting from the specified [start]. */
+    fun offset(start: Long): SizedIterable<T>
 
     /** Returns the number of elements stored. */
     fun count(): Long
@@ -40,7 +50,16 @@ fun <T> emptySized(): SizedIterable<T> = EmptySizedIterable()
 class EmptySizedIterable<out T> : SizedIterable<T>, Iterator<T> {
     override fun count(): Long = 0
 
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("limit(n).offset(offset)"),
+        DeprecationLevel.WARNING
+    )
     override fun limit(n: Int, offset: Long): SizedIterable<T> = this
+
+    override fun limit(count: Int): SizedIterable<T> = this
+
+    override fun offset(start: Long): SizedIterable<T> = this
 
     override fun empty(): Boolean = true
 
@@ -60,12 +79,24 @@ class EmptySizedIterable<out T> : SizedIterable<T>, Iterator<T> {
 /** Represents a [SizedIterable] that defers to the specified [delegate] collection. */
 class SizedCollection<out T>(val delegate: Collection<T>) : SizedIterable<T> {
     constructor(vararg values: T) : this(values.toList())
+
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("limit(n).offset(offset)"),
+        DeprecationLevel.WARNING
+    )
     override fun limit(n: Int, offset: Long): SizedIterable<T> {
         return if (offset >= Int.MAX_VALUE) {
             EmptySizedIterable()
         } else {
             SizedCollection(delegate.drop(offset.toInt()).take(n))
         }
+    }
+    override fun limit(count: Int): SizedIterable<T> = SizedCollection(delegate.take(count))
+    override fun offset(start: Long): SizedIterable<T> = if (start >= Int.MAX_VALUE) {
+        EmptySizedIterable()
+    } else {
+        SizedCollection(delegate.drop(start.toInt()))
     }
 
     override operator fun iterator() = delegate.iterator()
@@ -92,7 +123,14 @@ class LazySizedCollection<out T>(_delegate: SizedIterable<T>) : SizedIterable<T>
             return _wrapper!!
         }
 
-    override fun limit(n: Int, offset: Long): SizedIterable<T> = LazySizedCollection(delegate.limit(n, offset))
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("limit(n).offset(offset)"),
+        DeprecationLevel.WARNING
+    )
+    override fun limit(n: Int, offset: Long): SizedIterable<T> = LazySizedCollection(delegate.limit(n).offset(offset))
+    override fun limit(count: Int): SizedIterable<T> = LazySizedCollection(delegate.limit(count))
+    override fun offset(start: Long): SizedIterable<T> = LazySizedCollection(delegate.offset(start))
     override operator fun iterator() = wrapper.iterator()
     override fun count(): Long = _wrapper?.size?.toLong() ?: countInternal()
     override fun empty() = _wrapper?.isEmpty() ?: emptyInternal()
@@ -154,7 +192,15 @@ infix fun <T, R> SizedIterable<T>.mapLazy(f: (T) -> R): SizedIterable<R> {
     val source = this
     return object : LazySizedIterable<R> {
         override var loadedResult: List<R>? = null
-        override fun limit(n: Int, offset: Long): SizedIterable<R> = source.copy().limit(n, offset).mapLazy(f)
+
+        @Deprecated(
+            "This function will be removed in future releases.",
+            ReplaceWith("limit(n).offset(offset)"),
+            DeprecationLevel.WARNING
+        )
+        override fun limit(n: Int, offset: Long): SizedIterable<R> = source.copy().limit(n).offset(offset).mapLazy(f)
+        override fun limit(count: Int): SizedIterable<R> = source.copy().limit(count).mapLazy(f)
+        override fun offset(start: Long): SizedIterable<R> = source.copy().offset(start).mapLazy(f)
         override fun forUpdate(option: ForUpdateOption): SizedIterable<R> = source.copy().forUpdate(option).mapLazy(f)
         override fun notForUpdate(): SizedIterable<R> = source.copy().notForUpdate().mapLazy(f)
         override fun count(): Long = source.count()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -206,9 +206,9 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
                     }
                 }
 
-                limit?.let {
+                if (limit != null || offset > 0) {
                     append(" ")
-                    append(currentDialect.functionProvider.queryLimit(it, offset, orderByExpressions.isNotEmpty()))
+                    append(currentDialect.functionProvider.queryLimitAndOffset(limit, offset, orderByExpressions.isNotEmpty()))
                 }
             }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SetOperations.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SetOperations.kt
@@ -98,9 +98,9 @@ sealed class SetOperation(
                 }
             }
 
-            limit?.let {
+            if (limit != null || offset > 0) {
                 append(" ")
-                append(currentDialect.functionProvider.queryLimit(it, offset, true))
+                append(currentDialect.functionProvider.queryLimitAndOffset(limit, offset, true))
             }
 
             if (count) append(") subquery")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -815,12 +815,22 @@ abstract class FunctionProvider {
      * @param offset The number of rows to skip.
      * @param alreadyOrdered Whether the query is already ordered or not.
      */
-    open fun queryLimit(size: Int, offset: Long, alreadyOrdered: Boolean): String = buildString {
-        append("LIMIT $size")
+    open fun queryLimitAndOffset(size: Int?, offset: Long, alreadyOrdered: Boolean): String = buildString {
+        size?.let {
+            append("LIMIT $size")
+        }
         if (offset > 0) {
-            append(" OFFSET $offset")
+            size?.also { append(" ") }
+            append("OFFSET $offset")
         }
     }
+
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("queryLimitAndOffset(size, offset, alreadyOrdered)"),
+        DeprecationLevel.WARNING
+    )
+    open fun queryLimit(size: Int, offset: Long, alreadyOrdered: Boolean): String = queryLimitAndOffset(size, offset, alreadyOrdered)
 
     /**
      * Returns the SQL command that obtains information about a statement execution plan.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -316,6 +316,15 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
     override fun <T> time(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("SUBSTRING_INDEX(", expr, ", ' ', -1)")
     }
+
+    override fun queryLimitAndOffset(size: Int?, offset: Long, alreadyOrdered: Boolean): String {
+        if (size == null && offset > 0) {
+            TransactionManager.current().throwUnsupportedException(
+                "${currentDialect.name} doesn't support OFFSET clause without LIMIT"
+            )
+        }
+        return super.queryLimitAndOffset(size, offset, alreadyOrdered)
+    }
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -335,8 +335,14 @@ internal object OracleFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun queryLimit(size: Int, offset: Long, alreadyOrdered: Boolean): String {
-        return (if (offset > 0) " OFFSET $offset ROWS" else "") + " FETCH FIRST $size ROWS ONLY"
+    override fun queryLimitAndOffset(size: Int?, offset: Long, alreadyOrdered: Boolean): String = buildString {
+        if (offset > 0) {
+            append("OFFSET $offset ROWS")
+        }
+        size?.let {
+            if (offset > 0) append(" ")
+            append("FETCH FIRST $size ROWS ONLY")
+        }
     }
 
     override fun explain(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -283,8 +283,14 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun queryLimit(size: Int, offset: Long, alreadyOrdered: Boolean): String {
-        return (if (alreadyOrdered) "" else " ORDER BY(SELECT NULL)") + " OFFSET $offset ROWS FETCH NEXT $size ROWS ONLY"
+    override fun queryLimitAndOffset(size: Int?, offset: Long, alreadyOrdered: Boolean): String = buildString {
+        if (!alreadyOrdered) {
+            append("ORDER BY(SELECT NULL) ")
+        }
+        append("OFFSET $offset ROWS")
+        size?.let {
+            append(" FETCH NEXT $size ROWS ONLY")
+        }
     }
 
     override fun explain(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -23,6 +23,7 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }
 
+@Suppress("TooManyFunctions")
 internal object SQLiteFunctionProvider : FunctionProvider() {
     override fun <T : String?> charLength(expr: Expression<T>, queryBuilder: QueryBuilder) = queryBuilder {
         append("LENGTH(", expr, ")")
@@ -257,6 +258,13 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
             transaction.throwUnsupportedException("SQLite doesn't support LIMIT in DELETE clause.")
         }
         return super.delete(ignore, table, where, limit, transaction)
+    }
+
+    override fun queryLimitAndOffset(size: Int?, offset: Long, alreadyOrdered: Boolean): String {
+        if (size == null && offset > 0) {
+            TransactionManager.current().throwUnsupportedException("SQLite doesn't support OFFSET clause without LIMIT")
+        }
+        return super.queryLimitAndOffset(size, offset, alreadyOrdered)
     }
 
     override fun explain(

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -354,8 +354,10 @@ public final class org/jetbrains/exposed/dao/View : org/jetbrains/exposed/sql/Si
 	public final fun getOp ()Lorg/jetbrains/exposed/sql/Op;
 	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun iterator ()Ljava/util/Iterator;
+	public fun limit (I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun limit (IJ)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun notForUpdate ()Lorg/jetbrains/exposed/sql/SizedIterable;
+	public fun offset (J)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun orderBy ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
@@ -15,7 +15,14 @@ import kotlin.reflect.KProperty
  * @param factory The [EntityClass] to use when searching for matching entities.
  */
 class View<out Target : Entity<*>> (val op: Op<Boolean>, val factory: EntityClass<*, Target>) : SizedIterable<Target> {
-    override fun limit(n: Int, offset: Long): SizedIterable<Target> = factory.find(op).limit(n, offset)
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("limit(n).offset(offset)"),
+        DeprecationLevel.WARNING
+    )
+    override fun limit(n: Int, offset: Long): SizedIterable<Target> = factory.find(op).limit(n).offset(offset)
+    override fun limit(count: Int): SizedIterable<Target> = factory.find(op).limit(count)
+    override fun offset(start: Long): SizedIterable<Target> = factory.find(op).offset(start)
     override fun count(): Long = factory.find(op).count()
     override fun empty(): Boolean = factory.find(op).empty()
     override fun forUpdate(option: ForUpdateOption): SizedIterable<Target> = factory.find(op).forUpdate(option)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UnionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UnionTests.kt
@@ -33,7 +33,7 @@ class UnionTests : DatabaseTestsBase() {
         withCitiesAndUsers(exclude = listOf(TestDB.SQLSERVER)) { _, users, _ ->
             val andreyQuery = users.selectAll().where { users.id eq "andrey" }
             val sergeyQuery = users.selectAll().where { users.id.eq("sergey") }
-            andreyQuery.union(sergeyQuery).limit(1, 1).map { it[users.id] }.apply {
+            andreyQuery.union(sergeyQuery).limit(1).offset(1).map { it[users.id] }.apply {
                 assertEquals(1, size)
                 assertEquals("sergey", single())
             }


### PR DESCRIPTION
#### Description

**Summary of the change**:
This makes it possible to generate SELECT query with OFFSET clause that does not require a LIMIT clause.

**Detailed description**:
- **Why**:

The ability to add OFFSET clause is only available through `SizedIterable.limit()`, forcing some value to also be passed for a LIMIT clause even though most databases support the former without the latter. Using `Int.MAX_VALUE` may not always be sufficient.

- **What**: 

It is now possible to append either a LIMIT or an OFFSET clause or both, using DSL or DAO, by chaining `SizedIterable.limit().offset()` as needed.

- **How**:
    - `SizedIterable.limit(n, offset)` is deprecated and default argument for parameter is removed to avoid conflict with below.
    - `SizedIterable` interface has 2 new methods: `limit(count)` and `offset(start)`. They both have default implementations so that any custom implementations of the interface do not break. Only a warning will be raised that there is an override of a deprecated member. This allows time to migrate before deprecation level is bumped and brings a full breaking change.
    - All internal implementations of `SizedIterable` have had the deprecations propagated and new members implemented.
    - `FunctionProvider.queryLimit()` is also deprecated and `queryLimitAndOffset()` is added to accept a nullable `size` parameter in the event `limit()` isn't called.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [X] Oracle
- [X] Postgres
- [X] SqlServer
- [X] H2
- [ ] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-497]()
