### PR TITLE
fix!: EXPOSED-536 Short column allows out-of-range values

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -13,6 +13,9 @@
   The original `FunctionProvider.queryLimit()` is also being deprecated in favor of `queryLimitAndOffset()`, which takes a
   nullable `size` parameter to allow exclusion of the LIMIT clause. This latter deprecation only affects extensions of the
   `FunctionProvider` class when creating a custom `VendorDialect` class.
+* In Oracle and H2 Oracle, the `short` column now maps to data type `NUMBER(5)` instead of `SMALLINT` because `SMALLINT` is stored as `NUMBER(38)` in the database and
+  takes up unnecessary storage.
+  In Oracle, H2 Oracle, and SQLite, using the `short` column in a table now also creates a check constraint to ensure that no out-of-range values are inserted.
 
 ## 0.54.0
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -15,6 +15,7 @@ import java.util.*
 internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun byteType(): String = "SMALLINT"
     override fun ubyteType(): String = "NUMBER(4)"
+    override fun shortType(): String = "NUMBER(5)"
     override fun ushortType(): String = "NUMBER(6)"
     override fun integerType(): String = "NUMBER(12)"
     override fun integerAutoincType(): String = "NUMBER(12)"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
@@ -1,0 +1,42 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
+import org.junit.Test
+
+class NumericColumnTypesTests : DatabaseTestsBase() {
+    @Test
+    fun testShortAcceptsOnlyAllowedRange() {
+        val testTable = object : Table("test_table") {
+            val short = short("short")
+        }
+
+        withTables(testTable) { testDb ->
+            val columnName = testTable.short.nameInDatabaseCase()
+            val ddlEnding = when (testDb) {
+                TestDB.SQLITE, in TestDB.ALL_ORACLE_LIKE -> "CHECK ($columnName BETWEEN ${Short.MIN_VALUE} and ${Short.MAX_VALUE}))"
+                else -> "($columnName ${testTable.short.columnType} NOT NULL)"
+            }
+            assertTrue(testTable.ddl.single().endsWith(ddlEnding, ignoreCase = true))
+
+            testTable.insert { it[short] = Short.MIN_VALUE }
+            testTable.insert { it[short] = Short.MAX_VALUE }
+            assertEquals(2, testTable.select(testTable.short).count())
+
+            val tableName = testTable.nameInDatabaseCase()
+            assertFailAndRollback(message = "Out-of-range error (or CHECK constraint violation for SQLite & Oracle)") {
+                val outOfRangeValue = Short.MIN_VALUE - 1
+                exec("INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)")
+            }
+            assertFailAndRollback(message = "Out-of-range error (or CHECK constraint violation for SQLite & Oracle)") {
+                val outOfRangeValue = Short.MAX_VALUE + 1
+                exec("INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

- **What**:
fix: EXPOSED-536 Short column allows out-of-range values
- **Why**:
For SQLite and Oracle, inserting an out-of-range value using raw SQL with `exec` would work even though it shouldn't.
- **How**:
Short stores values between -32768 and 32767. For Oracle, Short data type was changed from SMALLINT to NUMBER(5) because SMALLINT is stored as NUMBER(38) in the database and takes up unnecessary storage. Another reason for this change is that this is a precursor to the column type change detection feature for migration, where it will be useful to have the column type be more specific than NUMBER(38).
A check constraint was added (that applies only to SQLite, Oracle and H2_Oracle) to ensure that no out-of-range values are stored.
---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [x] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
