### PR TITLE
chore: Remove docker yml files warning -> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

### DIFF
--- a/buildScripts/docker/docker-compose-mariadb.yml
+++ b/buildScripts/docker/docker-compose-mariadb.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     mariadb:
         image: mariadb

--- a/buildScripts/docker/docker-compose-mysql5.yml
+++ b/buildScripts/docker/docker-compose-mysql5.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
     mysql5:
         platform: linux/x86_64

--- a/buildScripts/docker/docker-compose-mysql8.yml
+++ b/buildScripts/docker/docker-compose-mysql8.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     mysql8:
         image: mysql:8.0

--- a/buildScripts/docker/docker-compose-oracle.yml
+++ b/buildScripts/docker/docker-compose-oracle.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     oracle:
         container_name: oracleDB

--- a/buildScripts/docker/docker-compose-postgres.yml
+++ b/buildScripts/docker/docker-compose-postgres.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     postgres:
         image: postgres

--- a/buildScripts/docker/docker-compose-sqlserver.yml
+++ b/buildScripts/docker/docker-compose-sqlserver.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     sqlserver:
         container_name: SQLServer


### PR DESCRIPTION
#### Description

- **What**:
The `version` bit has been removed from all docker yml files.
- **Why**:
Because of this warning:
> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
