### PR TITLE
fix: EXPOSED-541

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -64,8 +64,15 @@ open class UpsertStatement<Key : Any>(
         val whereArgs = QueryBuilder(true).apply {
             where?.toQueryBuilder(this)
         }.args
+        val updateArgs = updateValues.takeIf { it.isNotEmpty() }?.map {
+            Pair(
+                it.key.columnType as IColumnType<*>,
+                it.value
+            )
+        } ?: emptyList()
+
         return super.arguments().map {
-            it + whereArgs
+            it + updateArgs + whereArgs
         }
     }
 
@@ -129,6 +136,7 @@ sealed interface UpsertBuilder {
                 H2Dialect.H2CompatibilityMode.MariaDB, H2Dialect.H2CompatibilityMode.MySQL -> MysqlFunctionProvider.INSTANCE
                 else -> H2FunctionProvider
             }
+
             else -> dialect.functionProvider
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -289,8 +289,9 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
             }
 
             +" DO UPDATE SET "
-            onUpdate.appendTo { (columnToUpdate, updateExpression) ->
-                append("${transaction.identity(columnToUpdate)}=$updateExpression")
+            onUpdate.appendTo(this) { (columnToUpdate, updateExpression) ->
+                append("${transaction.identity(columnToUpdate)}=")
+                registerArgument(columnToUpdate, updateExpression)
             }
 
             where?.let {


### PR DESCRIPTION
#### Description

**Summary of the change**:  In PostgreSQL's implementation of upsert, the update do not directly invoke the toString() method

[Can be reproduced here](https://github.com/langbiantianya/testExposed/tree/bug)

```
2024-09-11 10:37:09.379 [main] WARN  Exposed - Transaction attempt #2 failed: org.postgresql.util.PSQLException: ERROR: syntax error at or near "["
  位置：143. Statement(s): INSERT INTO test_upsert_table ("name", "number", age, tags) VALUES (?, ?, ?, ?) ON CONFLICT ("name", "number") DO UPDATE SET age=13, tags=[量子, 虚数]
org.jetbrains.exposed.exceptions.ExposedSQLException: org.postgresql.util.PSQLException: ERROR: syntax error at or near "["
```

**Detailed description**:
- **What**: upsert when the set value is array , bulider sql err in postgresql，
- **Why**: In PostgreSQL, the update value for upsert invokes the toString() method during the construction of SQL statements.
- **How**: Instead of directly calling the toString() method, employ a method consistent with the update method to construct the SQL query
---

#### Type of Change

Please mark the relevant options with an "X":
- [ x ] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ x ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
