### PR TITLE
fix: EXPOSED-527 BUG: mergeFrom(...) using a query with const-condition do…

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3178,6 +3178,7 @@ public class org/jetbrains/exposed/sql/statements/InsertStatement : org/jetbrain
 
 public class org/jetbrains/exposed/sql/statements/MergeSelectStatement : org/jetbrains/exposed/sql/statements/MergeStatement {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/QueryAlias;Lorg/jetbrains/exposed/sql/Op;)V
+	public fun arguments ()Ljava/lang/Iterable;
 	public final fun getOn ()Lorg/jetbrains/exposed/sql/Op;
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/Transaction;Z)Ljava/lang/String;
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/MergeStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/MergeStatement.kt
@@ -153,6 +153,14 @@ open class MergeSelectStatement(
     private val selectQuery: QueryAlias,
     val on: Op<Boolean>
 ) : MergeStatement(dest) {
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> {
+        val queryArguments = selectQuery.query.arguments().firstOrNull() ?: emptyList()
+        val mergeStatementArguments = super.arguments().firstOrNull() ?: emptyList()
+        return listOf(
+            queryArguments + mergeStatementArguments
+        )
+    }
+
     override fun prepareSQL(transaction: Transaction, prepared: Boolean): String {
         return transaction.db.dialect.functionProvider.mergeSelect(table, selectQuery, transaction, clauses, on, prepared)
     }


### PR DESCRIPTION
#### Description

`mergeFrom()` command with subquery source were losing `args` from that subquery. The fix adds these arguments to the arguments of merge command.

---

#### Type of Change
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

---

#### Related Issues
