### PR TITLE
fix!: EXPOSED-545 Byte column allows out-of-range values

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -13,9 +13,9 @@
   The original `FunctionProvider.queryLimit()` is also being deprecated in favor of `queryLimitAndOffset()`, which takes a
   nullable `size` parameter to allow exclusion of the LIMIT clause. This latter deprecation only affects extensions of the
   `FunctionProvider` class when creating a custom `VendorDialect` class.
-* In Oracle and H2 Oracle, the `short` column now maps to data type `NUMBER(5)` instead of `SMALLINT` because `SMALLINT` is stored as `NUMBER(38)` in the database and
+* In Oracle, the `short` column now maps to data type `NUMBER(5)` instead of `SMALLINT` because `SMALLINT` is stored as `NUMBER(38)` in the database and
   takes up unnecessary storage.
-  In Oracle, H2 Oracle, and SQLite, using the `short` column in a table now also creates a check constraint to ensure that no out-of-range values are inserted.
+  In Oracle and SQLite, using the `short` column in a table now also creates a check constraint to ensure that no out-of-range values are inserted.
 * In Oracle, the `byte` column now maps to data type `NUMBER(3)` instead of `SMALLINT` because `SMALLINT` is stored as `NUMBER(38)` in the database and
   takes up unnecessary storage.
   In SQL Server, the `byte` column now maps to data type `SMALLINT` instead of `TINYINT` because `TINYINT`

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -16,6 +16,12 @@
 * In Oracle and H2 Oracle, the `short` column now maps to data type `NUMBER(5)` instead of `SMALLINT` because `SMALLINT` is stored as `NUMBER(38)` in the database and
   takes up unnecessary storage.
   In Oracle, H2 Oracle, and SQLite, using the `short` column in a table now also creates a check constraint to ensure that no out-of-range values are inserted.
+* In Oracle, the `byte` column now maps to data type `NUMBER(3)` instead of `SMALLINT` because `SMALLINT` is stored as `NUMBER(38)` in the database and
+  takes up unnecessary storage.
+  In SQL Server, the `byte` column now maps to data type `SMALLINT` instead of `TINYINT` because `TINYINT`
+  [allows values from 0 to 255](https://learn.microsoft.com/en-us/sql/t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql?view=sql-server-ver16#:~:text=2%20bytes-,tinyint,-0%20to%20255).
+  In SQL Server, SQLite, Oracle, PostgreSQL, and H2 PostgreSQL, using the `byte` column in a table now also creates a check constraint to ensure that no out-of-range
+  values are inserted.
 
 ## 0.54.0
 

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -330,6 +330,8 @@ public final class org/jetbrains/exposed/sql/ByteColumnType : org/jetbrains/expo
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Byte;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueToDB (Ljava/lang/Byte;)Ljava/lang/Object;
+	public synthetic fun valueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/sql/Case {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -348,6 +348,15 @@ class ByteColumnType : ColumnType<Byte>() {
         is String -> value.toByte()
         else -> error("Unexpected value of type Byte: $value of ${value::class.qualifiedName}")
     }
+
+    override fun valueToDB(value: Byte?): Any? {
+        return if (currentDialect is SQLServerDialect) {
+            // Workaround for SQL Server JDBC driver mysterious error for in-range values if there's a CHECK constraint
+            value?.toShort()
+        } else {
+            super.valueToDB(value)
+        }
+    }
 }
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1660,9 +1660,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
                         }
                         is H2Dialect -> {
                             when (dialect.h2Mode) {
-                                H2Dialect.H2CompatibilityMode.Oracle -> checkConstraints.filterNot { (name, _) ->
-                                    name.startsWith("${generatedSignedCheckPrefix}byte")
-                                }
                                 H2Dialect.H2CompatibilityMode.PostgreSQL -> checkConstraints.filterNot { (name, _) ->
                                     name.startsWith("${generatedSignedCheckPrefix}short")
                                 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -13,7 +13,11 @@ import java.util.*
 
 @Suppress("TooManyFunctions")
 internal object OracleDataTypeProvider : DataTypeProvider() {
-    override fun byteType(): String = "SMALLINT"
+    override fun byteType(): String = if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+        "TINYINT"
+    } else {
+        "NUMBER(3)"
+    }
     override fun ubyteType(): String = "NUMBER(4)"
     override fun shortType(): String = "NUMBER(5)"
     override fun ushortType(): String = "NUMBER(6)"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -19,7 +19,11 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
         "NUMBER(3)"
     }
     override fun ubyteType(): String = "NUMBER(4)"
-    override fun shortType(): String = "NUMBER(5)"
+    override fun shortType(): String = if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+        "SMALLINT"
+    } else {
+        "NUMBER(5)"
+    }
     override fun ushortType(): String = "NUMBER(6)"
     override fun integerType(): String = "NUMBER(12)"
     override fun integerAutoincType(): String = "NUMBER(12)"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -11,8 +11,14 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import java.util.*
 
 internal object SQLServerDataTypeProvider : DataTypeProvider() {
+    override fun byteType(): String = if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
+        "TINYINT"
+    } else {
+        "SMALLINT"
+    }
+
     override fun ubyteType(): String {
-        return if ((currentDialect as? H2Dialect)?.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
+        return if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
             "SMALLINT"
         } else {
             "TINYINT"
@@ -32,7 +38,7 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
     override fun uuidToDB(value: UUID): Any = value.toString()
     override fun dateTimeType(): String = "DATETIME2"
     override fun timestampWithTimeZoneType(): String =
-        if ((currentDialect as? H2Dialect)?.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
+        if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
             "TIMESTAMP(9) WITH TIME ZONE"
         } else {
             "DATETIMEOFFSET"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
@@ -19,7 +19,7 @@ class NumericColumnTypesTests : DatabaseTestsBase() {
         withTables(testTable) { testDb ->
             val columnName = testTable.short.nameInDatabaseCase()
             val ddlEnding = when (testDb) {
-                TestDB.SQLITE, in TestDB.ALL_ORACLE_LIKE -> "CHECK ($columnName BETWEEN ${Short.MIN_VALUE} and ${Short.MAX_VALUE}))"
+                TestDB.SQLITE, TestDB.ORACLE -> "CHECK ($columnName BETWEEN ${Short.MIN_VALUE} and ${Short.MAX_VALUE}))"
                 else -> "($columnName ${testTable.short.columnType} NOT NULL)"
             }
             assertTrue(testTable.ddl.single().endsWith(ddlEnding, ignoreCase = true))


### PR DESCRIPTION
#### Description

- **What**:
fix!: EXPOSED-545 Byte column allows out-of-range values
- **Why**:
For SQLite, SQL Server, Oracle, PostgreSQL, and H2 PostgreSQL, inserting an out-of-range value using raw SQL with exec would work even though it shouldn't.
- **How**:
Byte stores values between -128 and 127. For Oracle, Byte data type was changed from SMALLINT to NUMBER(3) because SMALLINT is stored as NUMBER(38) in the database and takes up unnecessary storage. Another reason for this change is that this is a precursor to the column type change detection feature for migration, where it will be useful to have the column type be more specific than NUMBER(38).
A check constraint was added (that applies only to SQL Server, SQLite, Oracle, PostgreSQL, and H2 PostgreSQL) to ensure that no out-of-range values are stored.
For SQL Server, Byte data type was changed from TINYINT to SMALLINT. Using TINYINT is incorrect because it [allows values from 0 to 255](https://learn.microsoft.com/en-us/sql/t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql?view=sql-server-ver16#:~:text=2%20bytes-,tinyint,-0%20to%20255). An additional change was needed for SQL Server because when attempting to insert any value below 0 using Exposed, it fails because of the CHECK constraint even though it shouldn't. When inserting using exec, however, it works as expected. Updating the SQL Server database version in the docker compose file and the SQL Server JDBC driver version did not fix it. The problem is most likely in the way that the driver handles the Byte type, so as a workaround, overriding `valueToDB` in `ByteColumnType` and converting the Byte value to Short solves the issue.
---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [x] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
