### PR TITLE
fix: EXPOSED-495 Unable to create new Entity when server-side default valu…

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -70,7 +70,9 @@ open class InsertStatement<Key : Any>(
             if (firstAutoIncColumn != null || returnedColumns.isNotEmpty()) {
                 while (rs?.next() == true) {
                     try {
-                        val returnedValues = returnedColumns.associateTo(mutableMapOf()) { it.first to rs.getObject(it.second) }
+                        val returnedValues = returnedColumns.associateTo(mutableMapOf()) {
+                            it.first to it.first.columnType.readObject(rs, it.second)
+                        }
                         if (returnedValues.isEmpty() && firstAutoIncColumn != null) {
                             returnedValues[firstAutoIncColumn] = rs.getObject(1)
                         }

--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/sql/jodatime/DateColumnType.kt
@@ -265,6 +265,7 @@ class DateTimeWithTimeZoneColumnType : ColumnType<DateTime>(), IDateColumnType {
     }
 
     override fun valueFromDB(value: Any): DateTime = when (value) {
+        is DateTime -> value
         is OffsetDateTime -> DateTime.parse(value.toString())
         is ZonedDateTime -> DateTime.parse(value.toOffsetDateTime().toString())
         is String -> {


### PR DESCRIPTION
#### Description

The root of the problem was in the `JavaOffsetDateTimeColumnType`, it was receiving instance of `java.sql.Timestamp` which is not supposed to be there. It was happening because jdbc driver was returning `java.sql.Timestamp` from `resultSet.getObject(index)` for that column.

It was working for `select` queries because there the value is read via `columnType.readObject(resultSet, index)` what leads to the `rs.getObject(index, OffsetDateTime::class.java)` call. With this PR `insert` statement does the same thing, what should make results of `insert` statement closer to the results of `select` statement.

**Detailed description**:
- **What**: Detail what changes have been made in the PR.
- **Why**: Explain the reasons behind the changes. Why were they necessary?
- **How**: Describe how the changes were implemented, including any key aspects of the code modified or new features added.

---

#### Type of Change

- [X] Bug fix

Affected databases:
- [X] Mysql8
- [X] Postgres
- [X] H2

---

#### Related Issues

[EXPOSED-495](https://youtrack.jetbrains.com/issue/EXPOSED-495) Unable to create new Entity when server-side default value is used for a Column of type OffsetDateTime (TIMESTAMP WITH TIME ZONE)