### PR TITLE
fix: EXPOSED-547 idParam() registers composite id value with a single placeholder

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -709,8 +709,7 @@ class QueryParameter<T>(
         queryBuilder {
             compositeValue?.let {
                 it.values.entries.appendTo { (column, value) ->
-                    // wrap each composite key value as a QueryParameter and register it
-                    column.wrap(value).toQueryBuilder(this)
+                    registerArgument(column.columnType, value)
                 }
             } ?: registerArgument(sqlType, value)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
@@ -444,20 +444,10 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
                 it[population] = 4
             }
 
-            val query1 = Towns.selectAll().where { Towns.id eq idParam(townAId, Towns.id) }
-            val whereClause1 = query1.prepareSQL(this, prepared = true).substringAfter("WHERE ")
-            assertEquals("(${fullIdentity(Towns.zipCode)} = ?) AND (${fullIdentity(Towns.name)} = ?)", whereClause1)
-            assertEquals(4, query1.single()[Towns.population])
-
-            val query2 = Towns.selectAll().where { idParam(townAId, Towns.id).isNotNull() }
-            val whereClause2 = query2.prepareSQL(this, prepared = true).substringAfter("WHERE ")
-            assertEquals("(${fullIdentity(Towns.zipCode)} IS NOT NULL) AND (${fullIdentity(Towns.name)} IS NOT NULL)", whereClause2)
-            assertEquals(4, query2.single()[Towns.population])
-
-            // this does not make much sense as a use case for idParam, but it is possible with single entity ids
-            val query3 = Towns.select(idParam(townAId, Towns.id))
-            val selectClause1 = query3.prepareSQL(this, prepared = true).substringBefore(" FROM ")
-            assertEquals("SELECT ?, ?", selectClause1)
+            val query = Towns.selectAll().where { Towns.id eq idParam(townAId, Towns.id) }
+            val whereClause = query.prepareSQL(this, prepared = true).substringAfter("WHERE ")
+            assertEquals("(${fullIdentity(Towns.zipCode)} = ?) AND (${fullIdentity(Towns.name)} = ?)", whereClause)
+            assertEquals(4, query.single()[Towns.population])
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -1609,10 +1609,8 @@ class EntityTests : DatabaseTestsBase() {
                 number = "0000111122223333"
                 spendingLimit = 10000u
             }
-            assertEquals(
-                1,
-                CreditCards.select(idParam(creditCard.id, CreditCards.id)).count()
-            )
+            val aliasId = idParam(creditCard.id, CreditCards.id).alias("id1")
+            assertEquals(1, CreditCards.select(aliasId).single()[aliasId])
             assertEquals(
                 10000u,
                 CreditCards.select(CreditCards.spendingLimit)


### PR DESCRIPTION
#### Description

**Summary of the change**:
`idParam()` now registers each value stored in a composite key value.

**Detailed description**:
- **Why**:

Using `idParam()` with a `Column<EntityID<CompositeID>>` only invokes `registerArgument()` once for the entire composite id value, leading to only 1 placeholder '?' being appended to the statement.

- **What**:

`QueryParameter.toQueryBuilder()` now checks whether the value to parameterize is a `CompositeID` and, if so, calls `registerArgument()` for every component value.

Using `idParam()` with equality or null comparison operators is also now possible.

- **How**:

Internal property `compositeValue` has been added to the `QueryParameter` class, both as a flag (to differentiate between other `QueryParameter`) and to store the `CompositeID` instead of always casting first.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-547](https://youtrack.jetbrains.com/issue/EXPOSED-547/idParam-registers-composite-id-value-with-a-single-placeholder)
