### PR TITLE
fix: EXPOSED-551 [SQL Server] Update from join with limit throws syntax exception

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -24,6 +24,17 @@ internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
         append("LOCATE(\'", substring, "\',", expr, ")")
     }
 
+    override fun update(
+        targets: Join,
+        columnsAndValues: List<Pair<Column<*>, Any?>>,
+        limit: Int?,
+        where: Op<Boolean>?,
+        transaction: Transaction
+    ): String {
+        val sql = super.update(targets, columnsAndValues, null, where, transaction)
+        return if (limit != null) "$sql LIMIT $limit" else sql
+    }
+
     override fun explain(
         analyze: Boolean,
         options: String?,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -212,7 +212,7 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
 
         targets.checkJoinTypes(StatementType.UPDATE)
         if (limit != null) {
-            +"UPDATE TOP($limit)"
+            +"UPDATE TOP($limit) "
         } else {
             +"UPDATE "
         }
@@ -229,7 +229,6 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
             +" AND "
             +it
         }
-        limit?.let { +" LIMIT $it" }
         toString()
     }
 


### PR DESCRIPTION
#### Description

**Summary of the change**:
`Join.update(limit = ?)` now uses correct syntax with SQL Server and fails early for MySQL. These were not caught because there was no test for this operation.

**Detailed description**:
- **Why**:

Attempting to perform an update from a join, with a provided limit, throws a syntax exception for SQL Server:
```
com.microsoft.sqlserver.jdbc.SQLServerException: Incorrect syntax near 'LIMIT'.
```
because generated SQL uses both `TOP` and `LIMIT` clauses, when only `TOP` syntax should be used.

An exception is also thrown for MySQL:
```
java.sql.SQLException: Incorrect usage of UPDATE and LIMIT
```
because `LIMIT` clause is being added even though the database does not support it [for multiple-table syntax](https://dev.mysql.com/doc/refman/8.4/en/update.html). Attempting to do so with this database should instead cause an early failure.

- **What**:
    - SQL Server now uses `TOP` syntax alone if `limit` is not null.
    - MySQL throws `UnsupportedByDialectException` if `limit` is not null.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Mysql5
- [X] Mysql8
- [X] SqlServer

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-551](https://youtrack.jetbrains.com/issue/EXPOSED-551/SQL-Server-Update-from-join-with-limit-throws-syntax-exception)