### PR TITLE
fix: EXPOSED-373 Close ResultSet before closing Statement to suppress Agroal leak warning

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
@@ -103,7 +103,9 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
             set(value) {
                 field = value
                 if (!field) {
-                    rs.statement?.close()
+                    val statement = rs.statement
+                    rs.close()
+                    statement?.close()
                     transaction.openResultSetsCount--
                 }
             }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ExplainQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ExplainQuery.kt
@@ -43,7 +43,9 @@ open class ExplainQuery(
             set(value) {
                 field = value
                 if (!field) {
-                    rs.statement?.close()
+                    val statement = rs.statement
+                    rs.close()
+                    statement?.close()
                     transaction.openResultSetsCount--
                 }
             }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -199,6 +199,7 @@ open class InsertStatement<Key : Any>(
         return inserted.apply {
             insertedCount = this
             resultedValues = processResults(rs, this)
+            rs?.close()
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReturningStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReturningStatement.kt
@@ -45,7 +45,9 @@ open class ReturningStatement(
             set(value) {
                 field = value
                 if (!field) {
-                    rs.statement?.close()
+                    val statement = rs.statement
+                    rs.close()
+                    statement?.close()
                     transaction.openResultSetsCount--
                 }
             }


### PR DESCRIPTION
#### Description

**Summary of the change**: 

Close ResultSet before closing Statement. Motivation is to suppress "JDBC resource leaked" warning when used with agroal.

**Detailed description**:
[Agroal](https://agroal.github.io/docs.html), a popular `javax.sql.DataSource` implementation as used by [Quarkus](https://quarkus.io/) and others, issues a ["leak report"](https://github.com/agroal/agroal/blob/3cde889cd9c90cfed00ba494ebde9689e4837fb9/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java#L112-L114) before automatically closing tracked ResultSets and Statements. If a Statement is closed before related ResultSets are closed it will trigger a leak report - [ref](https://github.com/agroal/agroal/blob/3cde889cd9c90cfed00ba494ebde9689e4837fb9/agroal-pool/src/main/java/io/agroal/pool/wrapper/StatementWrapper.java#L70-L86).

ex.
```
2024-09-21 11:14:47,325 WARN  [io.agr.pool] (executor-thread-1) Datasource '<default>': JDBC resources leaked: 4 ResultSet(s) and 0 Statement(s)
```

This warning occurs on every query with results and can cause developers concern - [ref](https://kotlinlang.slack.com/archives/C0CG7E0A1/p1712756657120689?thread_ts=1712680200.410719&cid=C0CG7E0A1).

The following is a trace of the "leaked" ResultSet being accounted.
```
addLeakedResultSets:804, ConnectionWrapper (io.agroal.pool.wrapper)
closeTrackedResultSets:72, StatementWrapper (io.agroal.pool.wrapper)
close:84, StatementWrapper (io.agroal.pool.wrapper)
close:72, PreparedStatementWrapper (io.agroal.pool.wrapper)
setHasNext:96, AbstractQuery$ResultIterator (org.jetbrains.exposed.sql)
next:111, AbstractQuery$ResultIterator (org.jetbrains.exposed.sql)
next:91, AbstractQuery$ResultIterator (org.jetbrains.exposed.sql)
next:170, IterableExKt$mapLazy$1$iterator$2 (org.jetbrains.exposed.sql)
firstOrNull:279, CollectionsKt___CollectionsKt (kotlin.collections)
findById:95, EntityClass (org.jetbrains.exposed.dao)
findById:57, EntityClass (org.jetbrains.exposed.dao)
...
```

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-373](https://youtrack.jetbrains.com/issue/EXPOSED-373/ResultSet-not-closing-properly-when-using-with-Quarkus-Agroal)