### PR TITLE
fix: EXPOSED-558 Entity cache for upsertReturning statements results in stale return values

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityLifecycleInterceptor.kt
@@ -33,8 +33,16 @@ class EntityLifecycleInterceptor : GlobalStatementInterceptor {
 
     @Suppress("ComplexMethod")
     override fun beforeExecution(transaction: Transaction, context: StatementContext) {
-        when (val statement = context.statement) {
+        beforeExecution(transaction = transaction, context = context, childStatement = null)
+    }
+
+    private fun beforeExecution(transaction: Transaction, context: StatementContext, childStatement: Statement<*>?) {
+        when (val statement = childStatement ?: context.statement) {
             is Query -> transaction.flushEntities(statement)
+
+            is ReturningStatement -> {
+                beforeExecution(transaction = transaction, context = context, childStatement = statement.mainStatement)
+            }
 
             is DeleteStatement -> {
                 transaction.flushCache()


### PR DESCRIPTION
#### Description

**Summary of the change**:
`EntityLifecycleInterceptor.beforeExecution()` now includes a branch to handle entity cache flushes for `ReturnStatement.mainStatement`.

**Detailed description**:
- **Why**:

We were noticing weird issues where DAOs returned using upsertReturning had stale values.
We pinned it down to the EntityLifecycleInterceptor not correctly handling ReturningStatement upsertStatement cache evictions.
The test I’ve added validates this and will fail without my changes.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-558](https://youtrack.jetbrains.com/issue/EXPOSED-558/ReturnStatements-dont-trigger-entity-cache-flush-before-execution) ReturnStatements don't trigger entity cache flush before execution
