### PR TITLE
feat: EXPOSED-552 Include DROP statements for unmapped columns for migration

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -664,6 +664,7 @@ public final class org/jetbrains/exposed/sql/Database {
 	public final fun getDialect ()Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;
 	public final fun getIdentifierManager ()Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi;
 	public final fun getSupportsAlterTableWithAddColumn ()Z
+	public final fun getSupportsAlterTableWithDropColumn ()Z
 	public final fun getSupportsMultipleResultSets ()Z
 	public final fun getUrl ()Ljava/lang/String;
 	public final fun getUseNestedTransactions ()Z
@@ -3508,6 +3509,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun getIdentifierManager ()Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi;
 	public abstract fun getSchemaNames ()Ljava/util/List;
 	public abstract fun getSupportsAlterTableWithAddColumn ()Z
+	public abstract fun getSupportsAlterTableWithDropColumn ()Z
 	public abstract fun getSupportsMultipleResultSets ()Z
 	public abstract fun getSupportsSelectForUpdate ()Z
 	public abstract fun getTableNames ()Ljava/util/Map;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -69,6 +69,11 @@ class Database private constructor(
         LazyThreadSafetyMode.NONE
     ) { metadata { supportsAlterTableWithAddColumn } }
 
+    /** Whether the database supports ALTER TABLE with a drop column clause. */
+    val supportsAlterTableWithDropColumn by lazy(
+        LazyThreadSafetyMode.NONE
+    ) { metadata { supportsAlterTableWithDropColumn } }
+
     /** Whether the database supports getting multiple result sets from a single execute. */
     val supportsMultipleResultSets by lazy(LazyThreadSafetyMode.NONE) { metadata { supportsMultipleResultSets } }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -30,6 +30,9 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     /** Whether the database supports `ALTER TABLE` with an add column clause. */
     abstract val supportsAlterTableWithAddColumn: Boolean
 
+    /** Whether the database supports `ALTER TABLE` with a drop column clause. */
+    abstract val supportsAlterTableWithDropColumn: Boolean
+
     /** Whether the database supports getting multiple result sets from a single execute. */
     abstract val supportsMultipleResultSets: Boolean
 

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -45,6 +45,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public final fun getMetadata ()Ljava/sql/DatabaseMetaData;
 	public fun getSchemaNames ()Ljava/util/List;
 	public fun getSupportsAlterTableWithAddColumn ()Z
+	public fun getSupportsAlterTableWithDropColumn ()Z
 	public fun getSupportsMultipleResultSets ()Z
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getTableNames ()Ljava/util/Map;

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -50,6 +50,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
     override val defaultIsolationLevel: Int by lazyMetadata { defaultTransactionIsolation }
 
     override val supportsAlterTableWithAddColumn by lazyMetadata { supportsAlterTableWithAddColumn() }
+    override val supportsAlterTableWithDropColumn by lazyMetadata { supportsAlterTableWithDropColumn() }
     override val supportsMultipleResultSets by lazyMetadata { supportsMultipleResultSets() }
     override val supportsSelectForUpdate: Boolean by lazyMetadata { supportsSelectForUpdate() }
 

--- a/exposed-migration/api/exposed-migration.api
+++ b/exposed-migration/api/exposed-migration.api
@@ -1,5 +1,7 @@
 public final class MigrationUtils {
 	public static final field INSTANCE LMigrationUtils;
+	public final fun dropUnmappedColumnsStatements ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;
+	public static synthetic fun dropUnmappedColumnsStatements$default (LMigrationUtils;[Lorg/jetbrains/exposed/sql/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun generateMigrationScript ([Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;Z)Ljava/io/File;
 	public static synthetic fun generateMigrationScript$default (LMigrationUtils;[Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public final fun statementsRequiredForDatabaseMigration ([Lorg/jetbrains/exposed/sql/Table;Z)Ljava/util/List;


### PR DESCRIPTION
#### Description

`MigrationUtils.statementsRequiredForDatabaseMigration` now includes DROP statements for unmapped columns (those that exist in the database but not in the Exposed Kotlin code).

**Detailed description**:
- **Why**:
Necessary for migration.
- **How**:
A new function `dropUnmappedColumnsStatements` was added to `MigrationUtils`. This function returns the SQL statements that drop any columns that exist in the database but are not defined in the Exposed tables. This function is then invoked in `statementsRequiredForDatabaseMigration`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
