### PR TITLE
feat!: EXPOSED-359 Add support for multidimensional arrays

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -8,6 +8,10 @@
 * In Oracle and H2 Oracle, the `uinteger()` column now maps to data type `NUMBER(10)` instead of `NUMBER(13)`.
 * In Oracle and H2 Oracle, the `integer()` column now maps to data type `NUMBER(10)` and `INTEGER` respectively, instead of `NUMBER(12)`.
   In Oracle and SQLite, using the integer column in a table now also creates a CHECK constraint to ensure that no out-of-range values are inserted.
+* `ArrayColumnType` supports multidimensional arrays now and has one more generic parameter.
+  If the was used directly for one dimensional arrays with parameter `T` like `ArrayColumnType<T>`, now it should 
+  be defined as `ArrayColumnType<T, List<T>>`, for example `ArrayColumnType<Int>` -> `ArrayColumnType<Int, List<Int>>`
+  
 
 ## 0.55.0
 * The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -8,10 +8,9 @@
 * In Oracle and H2 Oracle, the `uinteger()` column now maps to data type `NUMBER(10)` instead of `NUMBER(13)`.
 * In Oracle and H2 Oracle, the `integer()` column now maps to data type `NUMBER(10)` and `INTEGER` respectively, instead of `NUMBER(12)`.
   In Oracle and SQLite, using the integer column in a table now also creates a CHECK constraint to ensure that no out-of-range values are inserted.
-* `ArrayColumnType` supports multidimensional arrays now and has one more generic parameter.
-  If the was used directly for one dimensional arrays with parameter `T` like `ArrayColumnType<T>`, now it should 
-  be defined as `ArrayColumnType<T, List<T>>`, for example `ArrayColumnType<Int>` -> `ArrayColumnType<Int, List<Int>>`
-  
+* `ArrayColumnType` now supports multidimensional arrays and includes an additional generic parameter.
+  If it was previously used for one-dimensional arrays with the parameter `T` like `ArrayColumnType<T>`,
+  it should now be defined as `ArrayColumnType<T, List<T>>`. For instance, `ArrayColumnType<Int>` should now be `ArrayColumnType<Int, List<Int>>`.
 
 ## 0.55.0
 * The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.

--- a/documentation-website/Writerside/topics/Data-Types.topic
+++ b/documentation-website/Writerside/topics/Data-Types.topic
@@ -325,6 +325,40 @@
             </code-block>
         </chapter>
     </chapter>
+    <chapter title="How to use Multi-Dimensional Array types" id="how-to-use-multi-dimensional-array-types">
+        <p>PostgreSQL database supports the explicit ARRAY data type, which includes support for multi-dimensional arrays.</p>
+        <p>Exposed supports columns defined as multi-dimensional arrays, with the stored contents being any
+            out-of-the-box or custom data type.
+            If the contents are of a type with a supported <code>ColumnType</code> in the <code>exposed-core</code>
+            module, the column can be simply defined with that type:</p>
+
+        <code-block lang="kotlin">
+            object Teams : Table("teams") {
+            val memberIds = multi2Array<UUID>("member_ids")
+            val memberNames = multi3Array<String>("member_names")
+            val budgets = multi2Array<Double>("budgets")
+            }
+        </code-block>
+        <p>If more control is needed over the base content type, or if the latter is user-defined or from a non-core
+            module, the explicit type should be provided to the function:</p>
+
+        <code-block lang="kotlin">
+            object Teams : Table("teams") {
+            val memberIds = multi2Array<UUID>("member_ids")
+            val memberNames = multi3Array<String>("member_names", VarCharColumnType(colLength = 32))
+            }
+        </code-block>
+
+        <p>A multi-dimensional array column accepts inserts and retrieves stored array contents as a Kotlin nested <code>List</code>:</p>
+
+        <code-block lang="kotlin">
+            Teams.insert {
+                it[memberIds] = List(5) { List(5) { UUID.randomUUID() } }
+                it[memberNames] = List(3) { List(3) { List(3) { i -> "Member ${'A' + i}" } } }
+                it[budgets] = listOf(listOf(9999.0, 8888.0))
+            }
+        </code-block>
+    </chapter>
     <chapter title="Custom Data Types" id="custom-data-types">
         <p>If a database-specific data type is not immediately supported by Exposed, any existing and open column type
             class can be extended or

--- a/documentation-website/Writerside/topics/Data-Types.topic
+++ b/documentation-website/Writerside/topics/Data-Types.topic
@@ -334,9 +334,9 @@
 
         <code-block lang="kotlin">
             object Teams : Table("teams") {
-            val memberIds = multi2Array<UUID>("member_ids")
-            val memberNames = multi3Array<String>("member_names")
-            val budgets = multi2Array<Double>("budgets")
+            val memberIds = array2<UUID>("member_ids")
+            val memberNames = array3<String>("member_names")
+            val budgets = array2<Double>("budgets")
             }
         </code-block>
         <p>If more control is needed over the base content type, or if the latter is user-defined or from a non-core
@@ -344,8 +344,8 @@
 
         <code-block lang="kotlin">
             object Teams : Table("teams") {
-            val memberIds = multi2Array<UUID>("member_ids")
-            val memberNames = multi3Array<String>("member_names", VarCharColumnType(colLength = 32))
+            val memberIds = array2<UUID>("member_ids")
+            val memberNames = array3<String>("member_names", VarCharColumnType(colLength = 32))
             }
         </code-block>
 

--- a/documentation-website/Writerside/topics/Data-Types.topic
+++ b/documentation-website/Writerside/topics/Data-Types.topic
@@ -252,31 +252,52 @@
         </chapter>
     </chapter>
     <chapter title="How to use Array types" id="how-to-use-array-types">
-        <p>PostgreSQL and H2 databases support the explicit ARRAY data type.</p>
-        <p>Exposed currently only supports columns defined as one-dimensional arrays, with the stored contents being any
-            out-of-the-box or custom data type.
-            If the contents are of a type with a supported <code>ColumnType</code> in the <code>exposed-core</code>
-            module, the column can be simply defined with that type:</p>
+        <p>PostgreSQL and H2 databases support the explicit ARRAY data type,
+            with multi-dimensional arrays being supported by PostgreSQL.</p>
+
+        <p>Exposed allows defining columns as arrays, with the stored contents being any out-of-the-box or custom data type.
+            If the contents are of a type with a supported <code>ColumnType</code> in the <code>exposed-core</code> module,
+            the column can be simply defined with that type:</p>
 
         <code-block lang="kotlin">
             object Teams : Table(&quot;teams&quot;) {
+                // Single-dimensional arrays
                 val memberIds = array&lt;UUID&gt;(&quot;member_ids&quot;)
                 val memberNames = array&lt;String&gt;(&quot;member_names&quot;)
                 val budgets = array&lt;Double&gt;(&quot;budgets&quot;)
+
+                // Multi-dimensional arrays
+                val nestedMemberIds = array&lt;UUID, List&lt;List&lt;UUID&gt;&gt;&gt;(
+                    &quot;nested_member_ids&quot;, dimensions = 2
+                )
+                val hierarchicalMemberNames = array&lt;String, List&lt;List&lt;List&lt;String&gt;&gt;&gt;&gt;(
+                    &quot;hierarchical_member_names&quot;, dimensions = 3
+                )
             }
         </code-block>
+
         <p>If more control is needed over the base content type, or if the latter is user-defined or from a non-core
             module, the explicit type should be provided to the function:</p>
 
         <code-block lang="kotlin">
             object Teams : Table(&quot;teams&quot;) {
-                val memberIds = array&lt;UUID&gt;(&quot;member_ids&quot;)
+                // Single-dimensional arrays
                 val memberNames = array&lt;String&gt;(&quot;member_names&quot;, VarCharColumnType(colLength = 32))
                 val deadlines = array&lt;LocalDate&gt;(&quot;deadlines&quot;, KotlinLocalDateColumnType()).nullable()
-                val budgets = array&lt;Double&gt;(&quot;budgets&quot;)
                 val expenses = array&lt;Double?&gt;(&quot;expenses&quot;, DoubleColumnType()).default(emptyList())
+
+                // Multi-dimensional arrays
+                val nestedMemberIds = array&lt;UUID, List&lt;List&lt;UUID&gt;&gt;&gt;(
+                    &quot;nested_member_ids&quot;, dimensions = 2
+                )
+                val hierarchicalMemberNames = array&lt;String, List&lt;List&lt;List&lt;String&gt;&gt;&gt;&gt;(
+                    &quot;hierarchical_member_names&quot;,
+                    VarCharColumnType(colLength = 32),
+                    dimensions = 3
+                )
             }
         </code-block>
+
         <p>This will prevent an exception being thrown if Exposed cannot find an associated column mapping for the
             defined type.
             Null array contents are allowed, and the explicit column type should be provided for these columns as
@@ -285,55 +306,18 @@
 
         <code-block lang="kotlin">
             Teams.insert {
+                // Single-dimensional arrays
                 it[memberIds] = List(5) { UUID.randomUUID() }
                 it[memberNames] = List(5) { i -&gt; &quot;Member ${'A' + i}&quot; }
                 it[budgets] = listOf(9999.0)
+
+                // Multi-dimensional arrays
+                it[nestedMemberIds] = List(5) { List(5) { UUID.randomUUID() } }
+                it[hierarchicalMemberNames] = List(3) { List(3) { List(3) {
+                        i -> "Member ${'A' + i}"
+                } } }
             }
         </code-block>
-        <chapter title="Multi-dimensional arrays" id="how-to-use-multi-dimensional-array-types">
-            <p>PostgreSQL database supports the explicit ARRAY data type, which includes support for multi-dimensional arrays.</p>
-            <p>Exposed supports columns defined as multi-dimensional arrays, with the stored contents being any
-                out-of-the-box or custom data type.
-                If the contents are of a type with a supported <code>ColumnType</code> in the <code>exposed-core</code>
-                module, the column can be simply defined with that type:</p>
-
-            <code-block lang="kotlin">
-                object Teams : Table("teams") {
-                    val nestedMemberIds = array&lt;UUID, List&lt;List&lt;UUID&gt;&gt;&gt;(
-                        "nested_member_ids", dimensions = 2
-                    )
-                    val hierarchicalMemberNames = array&lt;String, List&lt;List&lt;List&lt;String&gt;&gt;&gt;&gt;(
-                        "member_names", dimensions = 3
-                    )
-                }
-            </code-block>
-            <p>If more control is needed over the base content type, or if the latter is user-defined or from a non-core
-                module, the explicit type should be provided to the function:</p>
-
-            <code-block lang="kotlin">
-                object Teams : Table("teams") {
-                    val nestedMemberIds = array&lt;UUID, List&lt;List&lt;UUID&gt;&gt;&gt;(
-                        "nested_member_ids", dimensions = 2
-                    )
-                    val hierarchicalMemberNames = array&lt;String, List&lt;List&lt;List&lt;String&gt;&gt;&gt;&gt;(
-                        "hierarchical_member_names",
-                        VarCharColumnType(colLength = 32),
-                        dimensions = 3
-                    )
-                }
-            </code-block>
-
-            <p>A multi-dimensional array column accepts inserts and retrieves stored array contents as a Kotlin nested <code>List</code>:</p>
-
-            <code-block lang="kotlin">
-                Teams.insert {
-                    it[nestedMemberIds] = List(5) { List(5) { UUID.randomUUID() } }
-                    it[hierarchicalMemberNames] = List(3) { List(3) { List(3) {
-                            i -> "Member ${'A' + i}"
-                    } } }
-                }
-            </code-block>
-        </chapter>
         <chapter title="Array Functions" id="array-functions">
             <p>A single element in a stored array can be accessed using the index reference <code>get()</code> operator:
             </p>

--- a/documentation-website/Writerside/topics/Data-Types.topic
+++ b/documentation-website/Writerside/topics/Data-Types.topic
@@ -290,6 +290,50 @@
                 it[budgets] = listOf(9999.0)
             }
         </code-block>
+        <chapter title="Multi-dimensional arrays" id="how-to-use-multi-dimensional-array-types">
+            <p>PostgreSQL database supports the explicit ARRAY data type, which includes support for multi-dimensional arrays.</p>
+            <p>Exposed supports columns defined as multi-dimensional arrays, with the stored contents being any
+                out-of-the-box or custom data type.
+                If the contents are of a type with a supported <code>ColumnType</code> in the <code>exposed-core</code>
+                module, the column can be simply defined with that type:</p>
+
+            <code-block lang="kotlin">
+                object Teams : Table("teams") {
+                    val nestedMemberIds = array&lt;UUID, List&lt;List&lt;UUID&gt;&gt;&gt;(
+                        "nested_member_ids", dimensions = 2
+                    )
+                    val hierarchicalMemberNames = array&lt;String, List&lt;List&lt;List&lt;String&gt;&gt;&gt;&gt;(
+                        "member_names", dimensions = 3
+                    )
+                }
+            </code-block>
+            <p>If more control is needed over the base content type, or if the latter is user-defined or from a non-core
+                module, the explicit type should be provided to the function:</p>
+
+            <code-block lang="kotlin">
+                object Teams : Table("teams") {
+                    val nestedMemberIds = array&lt;UUID, List&lt;List&lt;UUID&gt;&gt;&gt;(
+                        "nested_member_ids", dimensions = 2
+                    )
+                    val hierarchicalMemberNames = array&lt;String, List&lt;List&lt;List&lt;String&gt;&gt;&gt;&gt;(
+                        "hierarchical_member_names",
+                        VarCharColumnType(colLength = 32),
+                        dimensions = 3
+                    )
+                }
+            </code-block>
+
+            <p>A multi-dimensional array column accepts inserts and retrieves stored array contents as a Kotlin nested <code>List</code>:</p>
+
+            <code-block lang="kotlin">
+                Teams.insert {
+                    it[nestedMemberIds] = List(5) { List(5) { UUID.randomUUID() } }
+                    it[hierarchicalMemberNames] = List(3) { List(3) { List(3) {
+                            i -> "Member ${'A' + i}"
+                    } } }
+                }
+            </code-block>
+        </chapter>
         <chapter title="Array Functions" id="array-functions">
             <p>A single element in a stored array can be accessed using the index reference <code>get()</code> operator:
             </p>
@@ -300,6 +344,14 @@
                     .select(firstMember)
                     .where { Teams.expenses[1] greater Teams.budgets[1] }
             </code-block>
+
+            <p>This also applies to multidimensional arrays:</p>
+            <code-block lang="kotlin">
+                Teams
+                    .selectAll()
+                    .where { Teams.hierarchicalMemberNames[1][1] eq "Mr. Smith" }
+            </code-block>
+
             <note>
                 Both PostgreSQL and H2 use a one-based indexing convention, so the first element is retrieved by using
                 index 1.
@@ -309,6 +361,11 @@
 
             <code-block lang="kotlin">
                 Teams.select(Teams.deadlines.slice(1, 3))
+            </code-block>
+
+            <p>In the case of multidimensional arrays, the <code>slice()</code> calls can be nested:</p>
+            <code-block lang="kotlin">
+                Teams.select(Teams.hierarchicalMemberNames.slice(1, 2).slice(3, 4))
             </code-block>
             <p>Both arguments for these bounds are optional if using PostgreSQL.</p>
             <p>An array column can also be used as an argument for the <code>ANY</code> and <code>ALL</code> SQL
@@ -324,40 +381,6 @@
                     .where { stringParam(&quot;Member A&quot;) eq anyFrom(Teams.memberNames.slice(1, 4)) }
             </code-block>
         </chapter>
-    </chapter>
-    <chapter title="How to use Multi-Dimensional Array types" id="how-to-use-multi-dimensional-array-types">
-        <p>PostgreSQL database supports the explicit ARRAY data type, which includes support for multi-dimensional arrays.</p>
-        <p>Exposed supports columns defined as multi-dimensional arrays, with the stored contents being any
-            out-of-the-box or custom data type.
-            If the contents are of a type with a supported <code>ColumnType</code> in the <code>exposed-core</code>
-            module, the column can be simply defined with that type:</p>
-
-        <code-block lang="kotlin">
-            object Teams : Table("teams") {
-            val memberIds = array2<UUID>("member_ids")
-            val memberNames = array3<String>("member_names")
-            val budgets = array2<Double>("budgets")
-            }
-        </code-block>
-        <p>If more control is needed over the base content type, or if the latter is user-defined or from a non-core
-            module, the explicit type should be provided to the function:</p>
-
-        <code-block lang="kotlin">
-            object Teams : Table("teams") {
-            val memberIds = array2<UUID>("member_ids")
-            val memberNames = array3<String>("member_names", VarCharColumnType(colLength = 32))
-            }
-        </code-block>
-
-        <p>A multi-dimensional array column accepts inserts and retrieves stored array contents as a Kotlin nested <code>List</code>:</p>
-
-        <code-block lang="kotlin">
-            Teams.insert {
-                it[memberIds] = List(5) { List(5) { UUID.randomUUID() } }
-                it[memberNames] = List(3) { List(3) { List(3) { i -> "Member ${'A' + i}" } } }
-                it[budgets] = listOf(listOf(9999.0, 8888.0))
-            }
-        </code-block>
     </chapter>
     <chapter title="Custom Data Types" id="custom-data-types">
         <p>If a database-specific data type is not immediately supported by Exposed, any existing and open column type

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1632,6 +1632,24 @@ public final class org/jetbrains/exposed/sql/ModOp : org/jetbrains/exposed/sql/E
 public final class org/jetbrains/exposed/sql/ModOp$Companion {
 }
 
+public final class org/jetbrains/exposed/sql/MultiArrayColumnType : org/jetbrains/exposed/sql/ColumnType {
+	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
+	public final fun getDelegateType ()Ljava/lang/String;
+	public final fun getDimensions ()I
+	public final fun getMaximumCardinality ()Ljava/util/List;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Ljava/util/List;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Ljava/util/List;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
+	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
+	public fun sqlType ()Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Ljava/util/List;
+}
+
 public final class org/jetbrains/exposed/sql/NeqOp : org/jetbrains/exposed/sql/ComparisonOp {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)V
 }

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -203,13 +203,12 @@ public final class org/jetbrains/exposed/sql/AndOp : org/jetbrains/exposed/sql/C
 }
 
 public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exposed/sql/ColumnType {
-	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
 	public final fun getDelegateType ()Ljava/lang/String;
-	public final fun getMaximumCardinality ()Ljava/lang/Integer;
-	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueAsDefaultString (Ljava/util/List;)Ljava/lang/String;
+	public final fun getDimensions ()I
+	public final fun getMaximumCardinality ()Ljava/util/List;
 	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString (Ljava/util/List;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -219,8 +218,6 @@ public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exp
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/util/List;
-	public synthetic fun valueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun valueToString (Ljava/util/List;)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/AutoIncColumnType : org/jetbrains/exposed/sql/IColumnType {
@@ -1632,24 +1629,6 @@ public final class org/jetbrains/exposed/sql/ModOp : org/jetbrains/exposed/sql/E
 public final class org/jetbrains/exposed/sql/ModOp$Companion {
 }
 
-public final class org/jetbrains/exposed/sql/MultiArrayColumnType : org/jetbrains/exposed/sql/ColumnType {
-	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
-	public final fun getDelegateType ()Ljava/lang/String;
-	public final fun getDimensions ()I
-	public final fun getMaximumCardinality ()Ljava/util/List;
-	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Ljava/util/List;)Ljava/lang/String;
-	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun notNullValueToDB (Ljava/util/List;)Ljava/lang/Object;
-	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
-	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
-	public fun sqlType ()Ljava/lang/String;
-	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun valueFromDB (Ljava/lang/Object;)Ljava/util/List;
-}
-
 public final class org/jetbrains/exposed/sql/NeqOp : org/jetbrains/exposed/sql/ComparisonOp {
 	public fun <init> (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)V
 }
@@ -2486,6 +2465,8 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun array (Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun array$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun arrayN (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;)Lorg/jetbrains/exposed/sql/Column;
+	public static synthetic fun arrayN$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoGenerate (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoIncrement (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoIncrement (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/Column;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -203,12 +203,16 @@ public final class org/jetbrains/exposed/sql/AndOp : org/jetbrains/exposed/sql/C
 }
 
 public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exposed/sql/ColumnType {
-	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/util/List;I)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
 	public final fun getDelegateType ()Ljava/lang/String;
 	public final fun getDimensions ()I
 	public final fun getMaximumCardinality ()Ljava/util/List;
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Ljava/util/List;)Ljava/lang/String;
 	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString (Ljava/util/List;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
@@ -2464,9 +2468,9 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun array (Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun array (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/util/List;I)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun array$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
-	public final fun arrayN (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;)Lorg/jetbrains/exposed/sql/Column;
-	public static synthetic fun arrayN$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;ILjava/util/List;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
+	public static synthetic fun array$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Lorg/jetbrains/exposed/sql/ColumnType;Ljava/util/List;IILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoGenerate (Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoIncrement (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun autoIncrement (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Sequence;)Lorg/jetbrains/exposed/sql/Column;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -687,53 +687,24 @@ fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(Decimal
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType<T>? = null): LiteralOp<List<T>> {
-    @OptIn(InternalApi::class)
-    return LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class)), value)
-}
+inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType<T>? = null): LiteralOp<List<T>> =
+    arrayNLiteral(value, delegateType, dimensions = 1)
 
 /**
- * Returns the specified 3-dimensional [value] as an array literal, with elements parsed by the [delegateType] if provided.
+ * Returns the specified [value] as an array literal, with elements parsed by the [delegateType] if provided.
  *
- * @param value The 3-dimensional list of elements to be represented as an array literal.
- * @param delegateType An optional parameter which provides an explicit column type to parse the elements. If not provided,
- * the column type will be resolved based on the element type [T].
- * @return A `LiteralOp` representing the 3-dimensional array literal for the specified [value].
- * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
- */
-inline fun <reified T : Any> multi3ArrayLiteral(value: List<List<List<T>>>, delegateType: ColumnType<T>? = null): LiteralOp<List<List<List<T>>>> =
-    multiArrayLiteral(value, dimensions = 3, delegateType)
-
-/**
- * Returns the specified 2-dimensional [value] as an array literal, with elements parsed by the [delegateType] if provided.
- *
- * @param value The 2-dimensional list of elements to be represented as an array literal.
- * @param delegateType An optional parameter which provides an explicit column type to parse the elements. If not provided,
- * the column type will be resolved based on the element type [T].
- * @return A `LiteralOp` representing the 2-dimensional array literal for the specified [value].
- * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
- */
-inline fun <reified T : Any> multi2ArrayLiteral(value: List<List<T>>, delegateType: ColumnType<T>? = null): LiteralOp<List<List<T>>> =
-    multiArrayLiteral(value, dimensions = 2, delegateType)
-
-/**
- * Returns the specified multi-dimensional [value] as an array literal, with elements parsed by the [delegateType] if provided.
- * The number of dimensions is specified by the [dimensions] parameter.
- *
- * **Note:** If [delegateType] is left `null`, the associated column type will be resolved according to the
+ * **Note** If [delegateType] is left `null`, the associated column type will be resolved according to the
  * internal mapping of the element's type in [resolveColumnType].
  *
- * @param value The multi-dimensional list of elements to be represented as an array literal.
- * @param dimensions The number of dimensions of the array. This value should be greater than 1.
- * @param delegateType An optional parameter which provides an explicit column type to parse the elements. If not provided,
- * the column type will be resolved based on the element type [T].
- * @return A `LiteralOp` representing the multi-dimensional array literal for the specified [value].
- * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
+ * **Note:** Because arrays can have varying dimensions, you must specify the type of elements
+ * and the number of dimensions when using array literals.
+ * For example, use `arrayNLiteral<Int, List<List<Int>>>(list, dimensions = 2)`.
+ *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any, R : List<Any>> multiArrayLiteral(value: R, dimensions: Int, delegateType: ColumnType<T>? = null): LiteralOp<R> {
+inline fun <reified T : Any, R : List<Any>> arrayNLiteral(value: R, delegateType: ColumnType<T>? = null, dimensions: Int): LiteralOp<R> {
     @OptIn(InternalApi::class)
-    return LiteralOp(MultiArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions), value)
+    return LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions), value)
 }
 
 // Query Parameters
@@ -820,9 +791,24 @@ fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Express
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType<T>? = null): Expression<List<T>> {
+inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType<T>? = null): Expression<List<T>> =
+    arrayNParam(value, delegateType, dimensions = 1)
+
+/**
+ * Returns the specified [value] as an array query parameter, with elements parsed by the [delegateType] if provided.
+ *
+ * **Note** If [delegateType] is left `null`, the associated column type will be resolved according to the
+ * internal mapping of the element's type in [resolveColumnType].
+ *
+ * **Note:** Because arrays can have varying dimensions, you must specify the type of elements
+ * and the number of dimensions when using array literals.
+ * For example, use `arrayNParam<Int, List<List<Int>>>(list, dimensions = 2)`.
+ *
+ * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
+ */
+inline fun <reified T : Any, R : List<Any>> arrayNParam(value: R, delegateType: ColumnType<T>? = null, dimensions: Int): Expression<R> {
     @OptIn(InternalApi::class)
-    return QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class)))
+    return QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions))
 }
 
 // Misc.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -692,6 +692,50 @@ inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnTy
     return LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class)), value)
 }
 
+/**
+ * Returns the specified 3-dimensional [value] as an array literal, with elements parsed by the [delegateType] if provided.
+ *
+ * @param value The 3-dimensional list of elements to be represented as an array literal.
+ * @param delegateType An optional parameter which provides an explicit column type to parse the elements. If not provided,
+ * the column type will be resolved based on the element type [T].
+ * @return A `LiteralOp` representing the 3-dimensional array literal for the specified [value].
+ * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
+ */
+inline fun <reified T : Any> multi3ArrayLiteral(value: List<List<List<T>>>, delegateType: ColumnType<T>? = null): LiteralOp<List<List<List<T>>>> =
+    multiArrayLiteral(value, dimensions = 3, delegateType)
+
+/**
+ * Returns the specified 2-dimensional [value] as an array literal, with elements parsed by the [delegateType] if provided.
+ *
+ * @param value The 2-dimensional list of elements to be represented as an array literal.
+ * @param delegateType An optional parameter which provides an explicit column type to parse the elements. If not provided,
+ * the column type will be resolved based on the element type [T].
+ * @return A `LiteralOp` representing the 2-dimensional array literal for the specified [value].
+ * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
+ */
+inline fun <reified T : Any> multi2ArrayLiteral(value: List<List<T>>, delegateType: ColumnType<T>? = null): LiteralOp<List<List<T>>> =
+    multiArrayLiteral(value, dimensions = 2, delegateType)
+
+/**
+ * Returns the specified multi-dimensional [value] as an array literal, with elements parsed by the [delegateType] if provided.
+ * The number of dimensions is specified by the [dimensions] parameter.
+ *
+ * **Note:** If [delegateType] is left `null`, the associated column type will be resolved according to the
+ * internal mapping of the element's type in [resolveColumnType].
+ *
+ * @param value The multi-dimensional list of elements to be represented as an array literal.
+ * @param dimensions The number of dimensions of the array. This value should be greater than 1.
+ * @param delegateType An optional parameter which provides an explicit column type to parse the elements. If not provided,
+ * the column type will be resolved based on the element type [T].
+ * @return A `LiteralOp` representing the multi-dimensional array literal for the specified [value].
+ * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
+ * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
+ */
+inline fun <reified T : Any, R : List<Any>> multiArrayLiteral(value: R, dimensions: Int, delegateType: ColumnType<T>? = null): LiteralOp<R> {
+    @OptIn(InternalApi::class)
+    return LiteralOp(MultiArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions), value)
+}
+
 // Query Parameters
 
 /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -688,7 +688,7 @@ fun decimalLiteral(value: BigDecimal): LiteralOp<BigDecimal> = LiteralOp(Decimal
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
 inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnType<T>? = null): LiteralOp<List<T>> =
-    arrayNLiteral(value, delegateType, dimensions = 1)
+    arrayLiteral(value, 1, delegateType)
 
 /**
  * Returns the specified [value] as an array literal, with elements parsed by the [delegateType] if provided.
@@ -698,13 +698,13 @@ inline fun <reified T : Any> arrayLiteral(value: List<T>, delegateType: ColumnTy
  *
  * **Note:** Because arrays can have varying dimensions, you must specify the type of elements
  * and the number of dimensions when using array literals.
- * For example, use `arrayNLiteral<Int, List<List<Int>>>(list, dimensions = 2)`.
+ * For example, use `arrayLiteral<Int, List<List<Int>>>(list, dimensions = 2)`.
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any, R : List<Any>> arrayNLiteral(value: R, delegateType: ColumnType<T>? = null, dimensions: Int): LiteralOp<R> {
+inline fun <reified T : Any, R : List<Any>> arrayLiteral(value: R, dimensions: Int, delegateType: ColumnType<T>? = null): LiteralOp<R> {
     @OptIn(InternalApi::class)
-    return LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions), value)
+    return LiteralOp(ArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions = dimensions), value)
 }
 
 // Query Parameters
@@ -792,7 +792,7 @@ fun blobParam(value: ExposedBlob, useObjectIdentifier: Boolean = false): Express
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
 inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType<T>? = null): Expression<List<T>> =
-    arrayNParam(value, delegateType, dimensions = 1)
+    arrayParam(value, 1, delegateType)
 
 /**
  * Returns the specified [value] as an array query parameter, with elements parsed by the [delegateType] if provided.
@@ -802,13 +802,13 @@ inline fun <reified T : Any> arrayParam(value: List<T>, delegateType: ColumnType
  *
  * **Note:** Because arrays can have varying dimensions, you must specify the type of elements
  * and the number of dimensions when using array literals.
- * For example, use `arrayNParam<Int, List<List<Int>>>(list, dimensions = 2)`.
+ * For example, use `arrayParam<Int, List<List<Int>>>(list, dimensions = 2)`.
  *
  * @throws IllegalStateException If no column type mapping is found and a [delegateType] is not provided.
  */
-inline fun <reified T : Any, R : List<Any>> arrayNParam(value: R, delegateType: ColumnType<T>? = null, dimensions: Int): Expression<R> {
+inline fun <reified T : Any, R : List<Any>> arrayParam(value: R, dimensions: Int, delegateType: ColumnType<T>? = null): Expression<R> {
     @OptIn(InternalApi::class)
-    return QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions))
+    return QueryParameter(value, ArrayColumnType(delegateType ?: resolveColumnType(T::class), dimensions = dimensions))
 }
 
 // Misc.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -199,7 +199,7 @@ fun <E, T : List<E>?> allFrom(expression: Expression<T>): Op<E> = AllAnyFromExpr
  * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArrayGet
  */
 infix operator fun <E, T : List<E>?> ExpressionWithColumnType<T>.get(index: Int): ArrayGet<E, T> =
-    ArrayGet(this, index, (this.columnType as ArrayColumnType<E>).delegate)
+    ArrayGet(this, index, (this.columnType as ArrayColumnType<E, List<E>>).delegate)
 
 /**
  * Returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -198,8 +198,12 @@ fun <E, T : List<E>?> allFrom(expression: Expression<T>): Op<E> = AllAnyFromExpr
  *
  * @sample org.jetbrains.exposed.sql.tests.shared.types.ArrayColumnTypeTests.testSelectUsingArrayGet
  */
-infix operator fun <E, T : List<E>?> ExpressionWithColumnType<T>.get(index: Int): ArrayGet<E, T> =
-    ArrayGet(this, index, (this.columnType as ArrayColumnType<E, List<E>>).delegate)
+infix operator fun <E, T : List<E>?> ExpressionWithColumnType<T>.get(index: Int): ArrayGet<E, T> {
+    return when (this) {
+        is ArrayGet<*, *> -> ArrayGet(this as Expression<T>, index, this.columnType as IColumnType<E & Any>) as ArrayGet<E, T>
+        else -> ArrayGet(this, index, (this.columnType as ArrayColumnType<E, List<E>>).delegate)
+    }
+}
 
 /**
  * Returns a subarray of elements stored from between [lower] and [upper] bounds (inclusive),

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -221,7 +221,7 @@ object SchemaUtils {
                                 }
                             }
 
-                            column.columnType is ArrayColumnType<*> && dialect is PostgreSQLDialect -> {
+                            column.columnType is ArrayColumnType<*, *> && dialect is PostgreSQLDialect -> {
                                 (value as List<*>)
                                     .takeIf { it.isNotEmpty() }
                                     ?.run {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -955,7 +955,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      *
      * @return A column instance that represents a multi-dimensional list of elements of type [T].
-     * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
      * @throws IllegalStateException If no column type mapping is found.
      */
     inline fun <reified T : Any, R : List<Any>> Table.array(name: String, maximumCardinality: List<Int>? = null, dimensions: Int): Column<R> {
@@ -976,7 +975,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      *
      * @return A column instance that represents a multi-dimensional list of elements of type [E].
-     * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
      * @throws IllegalStateException If no column type mapping is found.
      */
     fun <E, R : List<Any?>> Table.array(name: String, columnType: ColumnType<E & Any>, maximumCardinality: List<Int>? = null, dimensions: Int): Column<R> =

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -922,7 +922,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      */
     fun <E> array(name: String, columnType: ColumnType<E & Any>, maximumCardinality: Int? = null): Column<List<E>> =
-        arrayN<E, List<E>>(name, columnType, dimensions = 1, maximumCardinality = maximumCardinality?.let { listOf(it) })
+        array<E, List<E>>(name, columnType, dimensions = 1, maximumCardinality = maximumCardinality?.let { listOf(it) })
 
     /**
      * Creates an array column, with the specified [name], for storing elements of a `List`.
@@ -940,41 +940,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @throws IllegalStateException If no column type mapping is found.
      */
     inline fun <reified E : Any> array(name: String, maximumCardinality: Int? = null): Column<List<E>> =
-        arrayN<E, List<E>>(name, dimensions = 1, maximumCardinality?.let { listOf(it) })
-
-    /**
-     * Creates a 3-dimensional array column, with the specified [name], for storing elements of a nested `List`.
-     *
-     * **Note:** This column type is only supported by PostgreSQL dialect.
-     *
-     * @param name Name of the column.
-     * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
-     *
-     * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
-     * The whole validation is performed on the client side.
-     *
-     * @return A column instance that represents a 3-dimensional list of elements of type [T].
-     * @throws IllegalStateException If no column type mapping is found.
-     */
-    inline fun <reified T : Any> Table.array3(name: String, maximumCardinality: List<Int>? = null): Column<List<List<List<T>>>> =
-        arrayN<T, List<List<List<T>>>>(name, dimensions = 3, maximumCardinality)
-
-    /**
-     * Creates a 2-dimensional array column, with the specified [name], for storing elements of a nested `List`.
-     *
-     * **Note:** This column type is only supported by PostgreSQL dialect.
-     *
-     * @param name Name of the column.
-     * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
-     *
-     * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
-     * The whole validation is performed on the client side.
-     *
-     * @return A column instance that represents a 2-dimensional list of elements of type [T].
-     * @throws IllegalStateException If no column type mapping is found.
-     */
-    inline fun <reified T : Any> Table.array2(name: String, maximumCardinality: List<Int>? = null): Column<List<List<T>>> =
-        arrayN<T, List<List<T>>>(name, dimensions = 2, maximumCardinality)
+        array<E, List<E>>(name, maximumCardinality?.let { listOf(it) }, dimensions = 1)
 
     /**
      * Creates a multi-dimensional array column, with the specified [name], for storing elements of a nested `List`.
@@ -983,19 +949,18 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * **Note:** This column type is only supported by PostgreSQL dialect.
      *
      * @param name Name of the column.
-     * @param dimensions The number of dimensions of the array.
      * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
+     * @param dimensions The number of dimensions of the array.
      *
      * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
-     * The whole validation is performed on the client side.
      *
      * @return A column instance that represents a multi-dimensional list of elements of type [T].
      * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
      * @throws IllegalStateException If no column type mapping is found.
      */
-    inline fun <reified T : Any, R : List<Any>> Table.arrayN(name: String, dimensions: Int, maximumCardinality: List<Int>? = null): Column<R> {
+    inline fun <reified T : Any, R : List<Any>> Table.array(name: String, maximumCardinality: List<Int>? = null, dimensions: Int): Column<R> {
         @OptIn(InternalApi::class)
-        return arrayN(name, resolveColumnType(T::class), dimensions, maximumCardinality)
+        return array(name, resolveColumnType(T::class), maximumCardinality, dimensions)
     }
 
     /**
@@ -1005,18 +970,17 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * **Note:** This column type is only supported by PostgreSQL dialect.
      *
      * @param name Name of the column.
-     * @param dimensions The number of dimensions of the array.
      * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
+     * @param dimensions The number of dimensions of the array.
      *
      * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
-     * The whole validation is performed on the client side.
      *
      * @return A column instance that represents a multi-dimensional list of elements of type [E].
      * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
      * @throws IllegalStateException If no column type mapping is found.
      */
-    fun <E, R : List<Any?>> Table.arrayN(name: String, columnType: ColumnType<E & Any>, dimensions: Int, maximumCardinality: List<Int>? = null): Column<R> =
-        registerColumn(name, ArrayColumnType(columnType, dimensions, maximumCardinality))
+    fun <E, R : List<Any?>> Table.array(name: String, columnType: ColumnType<E & Any>, maximumCardinality: List<Int>? = null, dimensions: Int): Column<R> =
+        registerColumn(name, ArrayColumnType(columnType, maximumCardinality, dimensions))
 
     // Auto-generated values
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -944,6 +944,65 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         return array(name, resolveColumnType(E::class), maximumCardinality)
     }
 
+    /**
+     * Creates a 3-dimensional array column, with the specified [name], for storing elements of a nested `List`.
+     *
+     * **Note:** This column type is only supported by PostgreSQL dialect.
+     *
+     * @param name Name of the column.
+     * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
+     *
+     * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
+     * The whole validation is performed on the client side.
+     *
+     * @return A column instance that represents a 3-dimensional list of elements of type [T].
+     * @throws IllegalStateException If no column type mapping is found.
+     */
+    inline fun <reified T : Any> Table.multi3Array(name: String, maximumCardinality: List<Int>? = null): Column<List<List<List<T>>>> =
+        multiArray<T, List<List<List<T>>>>(name, dimensions = 3, maximumCardinality)
+
+    /**
+     * Creates a 2-dimensional array column, with the specified [name], for storing elements of a nested `List`.
+     *
+     * **Note:** This column type is only supported by PostgreSQL dialect.
+     *
+     * @param name Name of the column.
+     * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
+     *
+     * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
+     * The whole validation is performed on the client side.
+     *
+     * @return A column instance that represents a 2-dimensional list of elements of type [T].
+     * @throws IllegalStateException If no column type mapping is found.
+     */
+    inline fun <reified T : Any> Table.multi2Array(name: String, maximumCardinality: List<Int>? = null): Column<List<List<T>>> =
+        multiArray<T, List<List<T>>>(name, dimensions = 2, maximumCardinality)
+
+    /**
+     * Creates a multi-dimensional array column, with the specified [name], for storing elements of a nested `List`.
+     * The number of dimensions is specified by the [dimensions] parameter.
+     *
+     * **Note:** This column type is only supported by PostgreSQL dialect.
+     *
+     * @param name Name of the column.
+     * @param dimensions The number of dimensions of the array. This value should be greater than 1.
+     * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
+     *
+     * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
+     * The whole validation is performed on the client side.
+     *
+     * @return A column instance that represents a multi-dimensional list of elements of type [T].
+     * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
+     * @throws IllegalStateException If no column type mapping is found.
+     */
+    inline fun <reified T : Any, R : List<Any>> Table.multiArray(name: String, dimensions: Int, maximumCardinality: List<Int>? = null): Column<R> {
+        if (dimensions <= 1) {
+            error("Dimension $dimensions should be greater than 1")
+        }
+        @OptIn(InternalApi::class)
+        return registerColumn(name, MultiArrayColumnType(resolveColumnType(T::class), dimensions, maximumCardinality))
+    }
+
     // Auto-generated values
 
     /**
@@ -1689,6 +1748,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
                                 H2Dialect.H2CompatibilityMode.PostgreSQL -> checkConstraints.filterNot { (name, _) ->
                                     name.startsWith("${generatedSignedCheckPrefix}short")
                                 }
+
                                 else -> checkConstraints.filterNot { (name, _) ->
                                     name.startsWith(generatedSignedCheckPrefix)
                                 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -922,7 +922,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      */
     fun <E> array(name: String, columnType: ColumnType<E & Any>, maximumCardinality: Int? = null): Column<List<E>> =
-        registerColumn(name, ArrayColumnType(columnType.apply { nullable = true }, maximumCardinality))
+        arrayN<E, List<E>>(name, columnType, dimensions = 1, maximumCardinality = maximumCardinality?.let { listOf(it) })
 
     /**
      * Creates an array column, with the specified [name], for storing elements of a `List`.
@@ -939,10 +939,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
      * @throws IllegalStateException If no column type mapping is found.
      */
-    inline fun <reified E : Any> array(name: String, maximumCardinality: Int? = null): Column<List<E>> {
-        @OptIn(InternalApi::class)
-        return array(name, resolveColumnType(E::class), maximumCardinality)
-    }
+    inline fun <reified E : Any> array(name: String, maximumCardinality: Int? = null): Column<List<E>> =
+        arrayN<E, List<E>>(name, dimensions = 1, maximumCardinality?.let { listOf(it) })
 
     /**
      * Creates a 3-dimensional array column, with the specified [name], for storing elements of a nested `List`.
@@ -958,8 +956,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @return A column instance that represents a 3-dimensional list of elements of type [T].
      * @throws IllegalStateException If no column type mapping is found.
      */
-    inline fun <reified T : Any> Table.multi3Array(name: String, maximumCardinality: List<Int>? = null): Column<List<List<List<T>>>> =
-        multiArray<T, List<List<List<T>>>>(name, dimensions = 3, maximumCardinality)
+    inline fun <reified T : Any> Table.array3(name: String, maximumCardinality: List<Int>? = null): Column<List<List<List<T>>>> =
+        arrayN<T, List<List<List<T>>>>(name, dimensions = 3, maximumCardinality)
 
     /**
      * Creates a 2-dimensional array column, with the specified [name], for storing elements of a nested `List`.
@@ -975,8 +973,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @return A column instance that represents a 2-dimensional list of elements of type [T].
      * @throws IllegalStateException If no column type mapping is found.
      */
-    inline fun <reified T : Any> Table.multi2Array(name: String, maximumCardinality: List<Int>? = null): Column<List<List<T>>> =
-        multiArray<T, List<List<T>>>(name, dimensions = 2, maximumCardinality)
+    inline fun <reified T : Any> Table.array2(name: String, maximumCardinality: List<Int>? = null): Column<List<List<T>>> =
+        arrayN<T, List<List<T>>>(name, dimensions = 2, maximumCardinality)
 
     /**
      * Creates a multi-dimensional array column, with the specified [name], for storing elements of a nested `List`.
@@ -985,7 +983,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * **Note:** This column type is only supported by PostgreSQL dialect.
      *
      * @param name Name of the column.
-     * @param dimensions The number of dimensions of the array. This value should be greater than 1.
+     * @param dimensions The number of dimensions of the array.
      * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
      *
      * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
@@ -995,13 +993,30 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
      * @throws IllegalStateException If no column type mapping is found.
      */
-    inline fun <reified T : Any, R : List<Any>> Table.multiArray(name: String, dimensions: Int, maximumCardinality: List<Int>? = null): Column<R> {
-        if (dimensions <= 1) {
-            error("Dimension $dimensions should be greater than 1")
-        }
+    inline fun <reified T : Any, R : List<Any>> Table.arrayN(name: String, dimensions: Int, maximumCardinality: List<Int>? = null): Column<R> {
         @OptIn(InternalApi::class)
-        return registerColumn(name, MultiArrayColumnType(resolveColumnType(T::class), dimensions, maximumCardinality))
+        return arrayN(name, resolveColumnType(T::class), dimensions, maximumCardinality)
     }
+
+    /**
+     * Creates a multi-dimensional array column, with the specified [name], for storing elements of a nested `List`.
+     * The number of dimensions is specified by the [dimensions] parameter.
+     *
+     * **Note:** This column type is only supported by PostgreSQL dialect.
+     *
+     * @param name Name of the column.
+     * @param dimensions The number of dimensions of the array.
+     * @param maximumCardinality The maximum cardinality (number of allowed elements) for each dimension in the array.
+     *
+     * **Note:** Providing an array size limit when using the PostgreSQL dialect is allowed, but this value will be ignored by the database.
+     * The whole validation is performed on the client side.
+     *
+     * @return A column instance that represents a multi-dimensional list of elements of type [E].
+     * @throws IllegalArgumentException If [dimensions] is less than or equal to 1.
+     * @throws IllegalStateException If no column type mapping is found.
+     */
+    fun <E, R : List<Any?>> Table.arrayN(name: String, columnType: ColumnType<E & Any>, dimensions: Int, maximumCardinality: List<Int>? = null): Column<R> =
+        registerColumn(name, ArrayColumnType(columnType, dimensions, maximumCardinality))
 
     // Auto-generated values
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
@@ -41,6 +41,8 @@ class AllAnyFromSubQueryOp<T>(
  * against an array of values.
  *
  * **Note** This operation is only supported by PostgreSQL and H2 dialects.
+ *
+ * **Note** This operation is supported only for 1 dimensional arrays
  */
 class AllAnyFromArrayOp<T : Any>(
     isAny: Boolean,
@@ -48,7 +50,7 @@ class AllAnyFromArrayOp<T : Any>(
     private val delegateType: ColumnType<T>
 ) : AllAnyFromBaseOp<T, List<T>>(isAny, array) {
     override fun QueryBuilder.registerSubSearchArgument(subSearch: List<T>) {
-        registerArgument(ArrayColumnType(delegateType), subSearch)
+        registerArgument(ArrayColumnType<T, List<T>>(delegateType, dimensions = 1), subSearch)
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ops/AllAnyOps.kt
@@ -50,7 +50,7 @@ class AllAnyFromArrayOp<T : Any>(
     private val delegateType: ColumnType<T>
 ) : AllAnyFromBaseOp<T, List<T>>(isAny, array) {
     override fun QueryBuilder.registerSubSearchArgument(subSearch: List<T>) {
-        registerArgument(ArrayColumnType<T, List<T>>(delegateType, dimensions = 1), subSearch)
+        registerArgument(ArrayColumnType<T, List<T>>(delegateType), subSearch)
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -32,7 +32,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
         e is LiteralOp<*> && e.columnType is BlobColumnType && e.columnType.useObjectIdentifier && (currentDialect as? H2Dialect) == null -> {
             "lo_from_bytea(0, ${super.processForDefaultValue(e)} :: bytea)"
         }
-        e is LiteralOp<*> && e.columnType is ArrayColumnType<*> -> {
+        e is LiteralOp<*> && e.columnType is ArrayColumnType<*, *> -> {
             val processed = super.processForDefaultValue(e)
             processed
                 .takeUnless { it == "ARRAY[]" }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/MultiArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/MultiArrayColumnTypeTests.kt
@@ -1,0 +1,262 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.multi2ArrayLiteral
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.expectException
+import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.sql.upsert
+import org.junit.Test
+import kotlin.test.assertNull
+
+class MultiArrayColumnTypeTests : DatabaseTestsBase() {
+
+    private val multiArrayTypeUnsupportedDb = TestDB.ALL - TestDB.ALL_POSTGRES.toSet()
+
+    @Test
+    fun test2xMultiArray() {
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array")
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val list = listOf(listOf(1, 2, 3), listOf(4, 5, 6), listOf(7, 8, 9))
+            val statement = tester.insert {
+                it[multiArray] = list
+            }
+            assertEqualLists(list.flatten(), statement[tester.multiArray].flatten())
+
+            val value = tester.selectAll().first()[tester.multiArray]
+            assertEqualLists(list.flatten(), value.flatten())
+        }
+    }
+
+    @Test
+    fun test3xMultiArray() {
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi3Array<Int>("multi_array")
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val list = listOf(
+                listOf(listOf(1, 2), listOf(3, 4)),
+                listOf(listOf(5, 6), listOf(7, 8))
+            )
+            tester.insert {
+                it[multiArray] = list
+            }
+
+            val value = tester.selectAll().first()[tester.multiArray]
+            assertEqualLists(list.flatten().flatten(), value.flatten().flatten())
+        }
+    }
+
+    @Test
+    fun test5xMultiArray() {
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multiArray<String, List<List<List<List<List<String>>>>>>("multi_array", 5)
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val list = listOf(listOf(listOf(listOf(listOf("Hallo", "MultiDimensional", "Array")))))
+            tester.insert {
+                it[multiArray] = list
+            }
+
+            val value = tester.selectAll().first()[tester.multiArray]
+            assertEqualLists(
+                list.flatten().flatten().flatten().flatten(),
+                value.flatten().flatten().flatten().flatten()
+            )
+        }
+    }
+
+    @Test
+    fun testMultiArrayDefault() {
+        val default = listOf(listOf(1, 2), listOf(3, 4))
+
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array")
+                .default(default)
+        }
+
+        val testerDatabaseGenerated = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array")
+                .databaseGenerated()
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val statement = testerDatabaseGenerated.insert {}
+            assertEqualLists(default.flatten(), statement[testerDatabaseGenerated.multiArray].flatten())
+
+            val value = testerDatabaseGenerated.selectAll().first()[tester.multiArray]
+            assertEqualLists(default.flatten(), value.flatten())
+        }
+    }
+
+    @Test
+    fun testMultiArrayCardinality() {
+        val list = listOf(listOf(1, 2, 3), listOf(4, 5, 6))
+
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array", maximumCardinality = listOf(2, 2))
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            expectException<IllegalArgumentException> {
+                tester.insert {
+                    it[tester.multiArray] = list
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testMultiArrayWithNullable() {
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array")
+                .nullable()
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val statement = tester.insert {
+                it[multiArray] = null
+            }
+            assertNull(statement[tester.multiArray])
+            assertNull(tester.selectAll().first()[tester.multiArray])
+        }
+    }
+
+    @Test
+    fun testMultiArrayLiteral() {
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array")
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val list = listOf(listOf(1, 2), listOf(3, 4))
+
+            tester.insert {
+                it[multiArray] = multi2ArrayLiteral(list)
+            }
+
+            val value = tester.selectAll().first()[tester.multiArray]
+            assertEqualLists(list.flatten(), value.flatten())
+        }
+    }
+
+    @Test
+    fun testMultiArrayUpdate() {
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array")
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val initialArray = listOf(listOf(1, 2), listOf(3, 4))
+
+            val insertedId = tester.insert {
+                it[multiArray] = initialArray
+            } get tester.id
+
+            var value = tester.selectAll().where { tester.id eq insertedId }.first()[tester.multiArray]
+            assertEqualLists(initialArray.flatten(), value.flatten())
+
+            val updatedArray = listOf(listOf(5, 6), listOf(7, 8))
+
+            // Perform the update
+            tester.update({ tester.id eq insertedId }) {
+                it[multiArray] = updatedArray
+            }
+
+            value = tester.selectAll().where { tester.id eq insertedId }.first()[tester.multiArray]
+            assertEqualLists(updatedArray.flatten(), value.flatten())
+        }
+    }
+
+    @Test
+    fun testMultiArrayUpsert() {
+        val tester = object : IntIdTable("test_table") {
+            val multiArray = multi2Array<Int>("multi_array")
+        }
+
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, tester) {
+            val initialArray = listOf(listOf(1, 2), listOf(3, 4))
+
+            val id = tester.insertAndGetId {
+                it[multiArray] = initialArray
+            }
+
+            var value = tester.selectAll().where { tester.id eq id }.first()[tester.multiArray]
+            assertEqualLists(initialArray.flatten(), value.flatten())
+
+            val updatedArray = listOf(listOf(5, 6), listOf(7, 8))
+
+            tester.upsert(tester.id, onUpdate = { it[tester.multiArray] = updatedArray }) {
+                it[tester.id] = id
+                it[multiArray] = initialArray
+            }
+
+            value = tester.selectAll().where { tester.id eq id }.first()[tester.multiArray]
+            assertEqualLists(updatedArray.flatten(), value.flatten())
+
+            tester.upsert(tester.id) {
+                it[multiArray] = updatedArray
+            }
+
+            assertEquals(2, tester.selectAll().count())
+        }
+    }
+
+    object MultiArrayTable : IntIdTable() {
+        val multiArray = multi2Array<Int>("multi_array")
+    }
+
+    class MultiArrayEntity(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<MultiArrayEntity>(MultiArrayTable)
+
+        var multiArray by MultiArrayTable.multiArray
+    }
+
+    @Test
+    fun testMultiArrayEntityCreate() {
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, MultiArrayTable) {
+            val initialArray = listOf(listOf(1, 2), listOf(3, 4))
+
+            val entity = MultiArrayEntity.new {
+                multiArray = initialArray
+            }
+
+            assertEqualLists(initialArray.flatten(), entity.multiArray.flatten())
+
+            val fetchedList = MultiArrayEntity.findById(entity.id)?.multiArray
+            assertEqualLists(initialArray.flatten(), fetchedList!!.flatten())
+        }
+    }
+
+    @Test
+    fun testMultiArrayEntityUpdate() {
+        withTables(excludeSettings = multiArrayTypeUnsupportedDb, MultiArrayTable) {
+            val initialArray = listOf(listOf(1, 2), listOf(3, 4))
+
+            val entity = MultiArrayEntity.new {
+                multiArray = initialArray
+            }
+
+            val updatedArray = listOf(listOf(5, 6), listOf(7, 8))
+            entity.multiArray = updatedArray
+
+            val fetchedEntity = MultiArrayEntity.findById(entity.id)
+            assertEquals(entity, fetchedEntity)
+            assertEqualLists(updatedArray.flatten(), fetchedEntity!!.multiArray.flatten())
+        }
+    }
+}


### PR DESCRIPTION
#### Description

**Summary of the change**: Added support for multi-dimensional array types in Exposed for PostgreSQL database.

**Detailed description**:
- **What**: This PR adds support for multi-dimensional arrays (Postgres). Corresponding literal and param functions are updated. It also works with `ArrayGet` and `ArraySlice` functions.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] New feature
- [x] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] Postgres

---

#### Related Issues

[EXPOSED-359](https://youtrack.jetbrains.com/issue/EXPOSED-359) Add support for multidimensional arrays
