### PR TITLE
fix: EXPOSED-562 Any caught exception from inner transaction triggers full rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Breaking changes:
 * feat!: EXPOSED-476 Update Kotlin to 2.0.0 by @bog-walk in https://github.com/JetBrains/Exposed/pull/2188
 * refactor!: Move `statementsRequiredForDatabaseMigration` function from `SchemaUtils` to `MigrationUtils` by @joc-a in https://github.com/JetBrains/Exposed/pull/2195
 * feat!: EXPOSED-436 Allow using insert values on update with upsert() by @bog-walk in https://github.com/JetBrains/Exposed/pull/2172
-* fix: EXPOSED-439 Outer transaction commits rows from failed inner transaction by @bog-walk in https://github.com/JetBrains/Exposed/pull/2186
+* fix!: EXPOSED-439 Outer transaction commits rows from failed inner transaction by @bog-walk in https://github.com/JetBrains/Exposed/pull/2186
 
 Deprecations:
 * deprecate: Raise deprecation levels of API elements by @bog-walk in https://github.com/JetBrains/Exposed/pull/2208

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Breaking changes:
 * feat!: EXPOSED-476 Update Kotlin to 2.0.0 by @bog-walk in https://github.com/JetBrains/Exposed/pull/2188
 * refactor!: Move `statementsRequiredForDatabaseMigration` function from `SchemaUtils` to `MigrationUtils` by @joc-a in https://github.com/JetBrains/Exposed/pull/2195
 * feat!: EXPOSED-436 Allow using insert values on update with upsert() by @bog-walk in https://github.com/JetBrains/Exposed/pull/2172
+* fix: EXPOSED-439 Outer transaction commits rows from failed inner transaction by @bog-walk in https://github.com/JetBrains/Exposed/pull/2186
 
 Deprecations:
 * deprecate: Raise deprecation levels of API elements by @bog-walk in https://github.com/JetBrains/Exposed/pull/2208
@@ -25,7 +26,6 @@ Features:
 * feat: EXPOSED-486 Support REPLACE INTO ... SELECT clause by @bog-walk in https://github.com/JetBrains/Exposed/pull/2199
 
 Bug fixes:
-* fix: EXPOSED-439 Outer transaction commits rows from failed inner transaction by @bog-walk in https://github.com/JetBrains/Exposed/pull/2186
 * fix: EXPOSED-464 `CurrentTimestampWithTimeZone` expression does not work as a default by @joc-a in https://github.com/JetBrains/Exposed/pull/2180
 * fix: EXPOSED-474 Unexpected value of type when using a ColumnTransfor… by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2191
 * fix: EXPOSED-472 Alias IdTable fails with isNull and eq ops by @bog-walk in https://github.com/JetBrains/Exposed/pull/2189

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -65,10 +65,13 @@ TestTable.upsert(
 }
 ```
 * The function `statementsRequiredForDatabaseMigration` has been moved from `SchemaUtils` to `MigrationUtils` in the `exposed-migration` module.
-* An inner transaction (with `useNestedTransactions = false`) that throws any exception will rollback any commits since the last savepoint.
+* A nested transaction (with `useNestedTransactions = true`) that throws any exception will now rollback any commits since the last savepoint.
+  This ensures that the nested transaction is properly configured to act in the exact same way as a top-level transaction or `inTopLevelTransaction()`.
+
+  An inner transaction (with `useNestedTransactions = false`) that throws any exception will also rollback any commits since the last savepoint.
   This ensures that any exception propagated from the inner transaction to the outer transaction will not be swallowed if caught by some
   exception handler wrapping the inner transaction, and any inner commits will not be saved. In version 0.55.0, this change will be reduced
-  so that only inner transactions that throw an `SQLException` from the database will trigger a rollback.
+  so that only inner transactions that throw an `SQLException` from the database will trigger such a rollback.
 
 ## 0.51.0
 

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -65,6 +65,10 @@ TestTable.upsert(
 }
 ```
 * The function `statementsRequiredForDatabaseMigration` has been moved from `SchemaUtils` to `MigrationUtils` in the `exposed-migration` module.
+* An inner transaction (with `useNestedTransactions = false`) that throws any exception will rollback any commits since the last savepoint.
+  This ensures that any exception propagated from the inner transaction to the outer transaction will not be swallowed if caught by some
+  exception handler wrapping the inner transaction, and any inner commits will not be saved. In version 0.55.0, this change will be reduced
+  so that only inner transactions that throw an `SQLException` from the database will trigger a rollback.
 
 ## 0.51.0
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -269,6 +269,17 @@ fun <T> transaction(
                 )
             }
             throw cause
+        } catch (cause: Throwable) {
+            if (outer.db.useNestedTransactions) {
+                val currentStatement = transaction.currentStatement
+                transaction.rollbackLoggingException {
+                    exposedLogger.warn(
+                        "Transaction rollback failed: ${it.message}. Statement: $currentStatement",
+                        it
+                    )
+                }
+            }
+            throw cause
         } finally {
             TransactionManager.resetCurrent(outerManager)
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -260,7 +260,7 @@ fun <T> transaction(
                     transaction.commit()
                 }
             }
-        } catch (cause: Throwable) {
+        } catch (cause: SQLException) {
             val currentStatement = transaction.currentStatement
             transaction.rollbackLoggingException {
                 exposedLogger.warn(

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
@@ -94,7 +94,8 @@ class RollbackTransactionTest : DatabaseTestsBase() {
             assertEquals(0, RollbackTable.selectAll().count())
         }
 
-        // non-db exception propagates from inner to outer without rollback and is handled when caught
+        // non-db exception propagates from inner to outer without rollback and is handled, if caught.
+        // if not caught & exception propagates all the way to outer tx, full rollback occurs (as always).
         transaction {
             val outerTxId = this.id
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/RollbackTransactionTest.kt
@@ -1,12 +1,18 @@
 package org.jetbrains.exposed.sql.tests.shared
 
+import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.transactions.transactionManager
+import org.junit.Assume
 import org.junit.Test
+import java.sql.SQLException
+import kotlin.test.assertContains
+import kotlin.test.fail
 
 class RollbackTransactionTest : DatabaseTestsBase() {
 
@@ -52,6 +58,66 @@ class RollbackTransactionTest : DatabaseTestsBase() {
             assertEquals(0L, RollbackTable.selectAll().where { RollbackTable.value eq "before-dummy" }.count())
             assertEquals(0L, RollbackTable.selectAll().where { RollbackTable.value eq "inner-dummy" }.count())
             assertEquals(0L, RollbackTable.selectAll().where { RollbackTable.value eq "after-dummy" }.count())
+        }
+    }
+
+    @Test
+    fun testRollbackWithoutSavepointsTriggeredByExceptions() {
+        Assume.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+        TestDB.H2_V2.connect()
+
+        transaction {
+            SchemaUtils.create(RollbackTable)
+        }
+
+        // database exception triggers rollback from inner to outer tx
+        transaction {
+            val fakeSQLString = "BROKEN_SQL_THAT_CAUSES_EXCEPTION"
+            val outerTxId = this.id
+
+            RollbackTable.insert { it[value] = "City A" }
+            assertEquals(1, RollbackTable.selectAll().count())
+
+            try {
+                transaction {
+                    val innerTxId = this.id
+                    assertEquals(outerTxId, innerTxId)
+
+                    RollbackTable.insert { it[value] = "City B" }
+                    exec("$fakeSQLString()")
+                }
+                fail("Should have thrown an exception")
+            } catch (cause: SQLException) {
+                assertContains(cause.toString(), fakeSQLString)
+            }
+
+            assertEquals(0, RollbackTable.selectAll().count())
+        }
+
+        // non-db exception propagates from inner to outer without rollback and is handled when caught
+        transaction {
+            val outerTxId = this.id
+
+            RollbackTable.insert { it[value] = "City A" }
+            assertEquals(1, RollbackTable.selectAll().count())
+
+            try {
+                transaction(db) {
+                    val innerTxId = this.id
+                    assertEquals(outerTxId, innerTxId)
+
+                    RollbackTable.insert { it[value] = "City B" }
+                    error("Failure")
+                }
+            } catch (cause: IllegalStateException) {
+                assertContains(cause.toString(), "Failure")
+            }
+
+            assertEquals(2, RollbackTable.selectAll().count())
+        }
+
+        transaction {
+            SchemaUtils.drop(RollbackTable)
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**:
Nested transaction that throws any exception will continue to trigger a rollback, but inner transaction that throws will only trigger a rollback if the exception is a database SQL exception. Otherwise the latter will be propagated up to the outer transaction, which will handle it in the way that exceptions have always been handled.

**Detailed description**:
- **Why**:

Following PR #2186 , any inner transaction (`useNestedTransaction = false`) that failed, for whatever reason, would trigger a rollback of all commits from the inner to the outer transaction savepoint.
This caused a regression for users that have client-side operations that may throw from inside an inner transaction. These exceptions would usually be caught and handled by try-catch logic wrapping the inner transaction, without rollback of any database operations.

- **What**:
    - Breaking changes and Changelog file have been retroactively updated to ensure any other users bumping versions are aware of the change in behavior in 0.54.0.
    -  Inner transaction exception handling now only triggers rollback if an `SQLException` is caught.
    - Any other caught exception only maintains the behavior of the original fix if the inner transaction is actually a nested (a pseudo-top-level transaction via `useNestedTransaction = true`).
    - Added unit tests for both nested and inner transactions, throwing both database and Kotlin exceptions.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Regression fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-562](https://youtrack.jetbrains.com/issue/EXPOSED-562/Any-exception-thrown-by-inner-transaction-triggers-full-rollback), [EXPOSED-439](https://youtrack.jetbrains.com/issue/EXPOSED-439/Unexpected-behaviour-with-transactions-after-throwing-an-exception)
