### PR TITLE
fix!: EXPOSED-569 groupConcat uses wrong SQLite syntax & ignores DISTINCT in Oracle & SQL Server

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,9 @@
 # Breaking Changes
 
+## 0.56.0
+* If the `distinct` parameter of `groupConcat()` is set to `true`, when using Oracle or SQL Server, this will now fail early with an
+  `UnsupportedByDialectException`. Previously, the setting would be ignored and SQL function generation would not include a `DISTINCT` clause.
+
 ## 0.55.0
 * The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.
   This enables the use of the new `Join.delete()` function, which performs a delete operation on a specific table from the join relation.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -113,7 +113,8 @@ class Concat(
 }
 
 /**
- * Represents an SQL function that concatenates the text representation of all non-null input values of each group from [expr], separated by [separator]
+ * Represents an SQL function that concatenates the text representation of all non-null input values of each group
+ * from [expr], separated by [separator].
  */
 class GroupConcat<T : String?>(
     /** Returns grouped expression being concatenated. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -113,8 +113,7 @@ class Concat(
 }
 
 /**
- * Represents an SQL function that concatenates the text representation of all non-null input values of each group
- * from [expr], separated by [separator].
+ * Represents an SQL function that concatenates the text representation of all non-null input values of each group from [expr], separated by [separator]
  */
 class GroupConcat<T : String?>(
     /** Returns grouped expression being concatenated. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -29,9 +29,9 @@ fun <T : String?> Expression<T>.upperCase(): UpperCase<T> = UpperCase(this)
 /**
  * Concatenates all non-null input values of each group from [this] string expression, separated by [separator].
  *
- * When [distinct] is set to `true`, duplicate values will be eliminated.
- * [orderBy] can be used to sort values in the concatenated string.
- *
+ * @param separator The separator to use between concatenated values. If left `null`, the database default will be used.
+ * @param distinct If set to `true`, duplicate values will be eliminated.
+ * @param orderBy If specified, values will be sorted in the concatenated string.
  * @sample org.jetbrains.exposed.sql.tests.shared.dml.GroupByTests.testGroupConcat
  */
 fun <T : String?> Expression<T>.groupConcat(
@@ -43,9 +43,9 @@ fun <T : String?> Expression<T>.groupConcat(
 /**
  * Concatenates all non-null input values of each group from [this] string expression, separated by [separator].
  *
- * When [distinct] is set to `true`, duplicate values will be eliminated.
- * [orderBy] can be used to sort values in the concatenated string by one or more expressions.
- *
+ * @param separator The separator to use between concatenated values. If left `null`, the database default will be used.
+ * @param distinct If set to `true`, duplicate values will be eliminated.
+ * @param orderBy If specified, values will be sorted in the concatenated string.
  * @sample org.jetbrains.exposed.sql.tests.shared.dml.GroupByTests.testGroupConcat
  */
 fun <T : String?> Expression<T>.groupConcat(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -121,7 +121,7 @@ internal object OracleFunctionProvider : FunctionProvider() {
         queryBuilder: QueryBuilder
     ): Unit = queryBuilder {
         val tr = TransactionManager.current()
-        if (expr.distinct) tr.throwUnsupportedException("Oracle doesn't support DISTINCT in STRING_AGG")
+        if (expr.distinct) tr.throwUnsupportedException("Oracle doesn't support DISTINCT in LISTAGG")
         if (expr.orderBy.size > 1) {
             tr.throwUnsupportedException("Oracle supports only single column in ORDER BY clause in LISTAGG")
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -95,8 +95,9 @@ internal object SQLServerFunctionProvider : FunctionProvider() {
     override fun <T : String?> groupConcat(expr: GroupConcat<T>, queryBuilder: QueryBuilder) {
         val tr = TransactionManager.current()
         return when {
-            expr.separator == null -> tr.throwUnsupportedException("SQLServer requires explicit separator in STRING_AGG.")
-            expr.orderBy.size > 1 -> tr.throwUnsupportedException("SQLServer supports only single column in ORDER BY clause in STRING_AGG.")
+            expr.separator == null -> tr.throwUnsupportedException("SQL Server requires explicit separator in STRING_AGG")
+            expr.distinct -> tr.throwUnsupportedException("SQL Server doesn't support DISTINCT in STRING_AGG")
+            expr.orderBy.size > 1 -> tr.throwUnsupportedException("SQL Server supports only single column in ORDER BY clause in STRING_AGG")
             else -> queryBuilder {
                 append("STRING_AGG(")
                 append(expr.expr)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -46,11 +46,22 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
     }
 
     override fun <T : String?> groupConcat(expr: GroupConcat<T>, queryBuilder: QueryBuilder) {
-        val tr = TransactionManager.current()
-        return when {
-            expr.orderBy.isNotEmpty() -> tr.throwUnsupportedException("SQLite doesn't support ORDER BY in GROUP_CONCAT function.")
-            expr.distinct -> tr.throwUnsupportedException("SQLite doesn't support DISTINCT in GROUP_CONCAT function.")
-            else -> super.groupConcat(expr, queryBuilder) // .replace(" SEPARATOR ", ", ")
+        if (expr.distinct) {
+            TransactionManager.current().throwUnsupportedException("SQLite doesn't support DISTINCT in GROUP_CONCAT function")
+        }
+        queryBuilder {
+            +"GROUP_CONCAT("
+            +expr.expr
+            expr.separator?.let {
+                +", '$it'"
+            }
+            if (expr.orderBy.isNotEmpty()) {
+                +" ORDER BY "
+                expr.orderBy.appendTo { (expression, sortOrder) ->
+                    currentDialect.dataTypeProvider.precessOrderByClause(this, expression, sortOrder)
+                }
+            }
+            +")"
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLiteDialect.kt
@@ -56,8 +56,7 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
                 +", '$it'"
             }
             if (expr.orderBy.isNotEmpty()) {
-                +" ORDER BY "
-                expr.orderBy.appendTo { (expression, sortOrder) ->
+                expr.orderBy.appendTo(prefix = " ORDER BY ") { (expression, sortOrder) ->
                     currentDialect.dataTypeProvider.precessOrderByClause(this, expression, sortOrder)
                 }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/GroupByTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/GroupByTests.kt
@@ -3,7 +3,6 @@ package org.jetbrains.exposed.sql.tests.shared.dml
 import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
-import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.vendors.*
@@ -158,7 +157,7 @@ class GroupByTests : DatabaseTestsBase() {
 
     @Test
     fun testGroupConcat() {
-        withCitiesAndUsers(exclude = listOf(TestDB.SQLITE)) { cities, users, _ ->
+        withCitiesAndUsers { cities, users, _ ->
             fun <T : String?> GroupConcat<T>.checkExcept(vararg dialects: VendorDialect.DialectNameProvider, assert: (Map<String, String?>) -> Unit) {
                 try {
                     val result = cities.leftJoin(users)
@@ -179,15 +178,17 @@ class GroupByTests : DatabaseTestsBase() {
                 }
             }
 
-            users.name.groupConcat().checkExcept(PostgreSQLDialect, PostgreSQLNGDialect, SQLServerDialect, OracleDialect) {
+            // separator must be specified by PostgreSQL and SQL Server
+            users.name.groupConcat().checkExcept(PostgreSQLDialect, PostgreSQLNGDialect, SQLServerDialect) {
                 assertEquals(3, it.size)
             }
 
-            users.name.groupConcat(separator = ", ").checkExcept(OracleDialect) {
+            users.name.groupConcat(separator = ", ").checkExcept {
                 assertEquals(3, it.size)
                 assertEquals("Andrey", it["St. Petersburg"])
                 when (currentDialectTest) {
-                    is MariaDBDialect -> assertEquals(true, it["Munich"] in listOf("Sergey, Eugene", "Eugene, Sergey"))
+                    // return order is arbitrary if no ORDER BY is specified
+                    is MariaDBDialect, is SQLiteDialect -> assertTrue(it["Munich"] in listOf("Sergey, Eugene", "Eugene, Sergey"))
                     is MysqlDialect, is SQLServerDialect -> assertEquals("Eugene, Sergey", it["Munich"])
                     else -> assertEquals("Sergey, Eugene", it["Munich"])
                 }
@@ -195,13 +196,12 @@ class GroupByTests : DatabaseTestsBase() {
                 assertNull(it["Prague"])
             }
 
-            users.name.groupConcat(separator = " | ", distinct = true).checkExcept(OracleDialect) {
+            users.name.groupConcat(separator = " | ", distinct = true).checkExcept(OracleDialect, SQLiteDialect, SQLServerDialect) {
                 assertEquals(3, it.size)
                 assertEquals("Andrey", it["St. Petersburg"])
                 when (currentDialectTest) {
                     is MariaDBDialect -> assertEquals(true, it["Munich"] in listOf("Sergey | Eugene", "Eugene | Sergey"))
-                    is MysqlDialect, is SQLServerDialect, is PostgreSQLDialect ->
-                        assertEquals("Eugene | Sergey", it["Munich"])
+                    is MysqlDialect, is PostgreSQLDialect -> assertEquals("Eugene | Sergey", it["Munich"])
                     is H2Dialect -> {
                         if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
                             assertEquals("Sergey | Eugene", it["Munich"])


### PR DESCRIPTION
#### Description

**Summary of the change**:
`groupConcat()` no longer generates wrong SQL syntax for SQLite and no longer ignores unsupported parameters for Oracle and SQL Server.

**Detailed description**:
- **Why**:

It was observed by a user that SQLite uses the wrong syntax for a separator in its `GROUP_CONCAT` funtion. They were also attempting to use the ORDER BY clause, which Exposed prevents because the database used to not support it. ORDER BY with aggregate functions has been supported since [version 3.44.0](https://www.sqlite.org/changes.html).

While adjusting the tests to no longer exclude, it was confirmed that SQL Server doesn't actually support DISTINCT in the function. Exposed was ignoring this value if set to `true` and not including it in SQL, whereas the usual behavior is to fail early.

Oracle was doing the same thing for DISTINCT. But it was also, for some reason, preventing `groupConcat()` from being used unless an argument for `orderBy` was provided. ORDER BY is supposed to be optional with `LISTAGG` function.

- **How**:
    - [**SQLite**] Uses correct `(expr, '?')` syntax instead of `(expr, SEPARATOR '?')`. Allows arguments to be passed to `orderBy` for syntax `(expr, '?' ORDER BY col)`.
    - [**SQL Server**] Throws `UnsupportedByDialectException` if `dialect` is set to `true`.
    - [**Oracle**] Allows function to be called without passing argument to `orderBy`. Throws `UnsupportedByDialectException` if `dialect` is set to `true`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] SQLite
- [X] SQL Server
- [X] Oracle

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-569](https://youtrack.jetbrains.com/issue/EXPOSED-569/SQLite-groupConcat-uses-wrong-separator-syntax-restricts-ORDER-BY-clause)