### PR TITLE
fix: EXPOSED-565 Subquery alias with id fails to use correct alias with eq

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -339,7 +339,7 @@ interface ISqlExpressionBuilder {
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
         return if ((this as? Column<*>)?.isEntityIdentifier() == true) {
-            table.mapIdComparison(entityID, ::EqOp)
+            (this as Column<*>).table.mapIdComparison(entityID, ::EqOp)
         } else {
             EqOp(this, wrap(entityID))
         }
@@ -382,7 +382,7 @@ interface ISqlExpressionBuilder {
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
         return if ((this as? Column<*>)?.isEntityIdentifier() == true) {
-            table.mapIdComparison(entityID, ::NeqOp)
+            (this as Column<*>).table.mapIdComparison(entityID, ::NeqOp)
         } else {
             NeqOp(this, wrap(entityID))
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -339,7 +339,7 @@ interface ISqlExpressionBuilder {
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
         return if ((this as? Column<*>)?.isEntityIdentifier() == true) {
-            (this as Column<*>).table.mapIdComparison(entityID, ::EqOp)
+            this.table.mapIdComparison(entityID, ::EqOp)
         } else {
             EqOp(this, wrap(entityID))
         }
@@ -382,7 +382,7 @@ interface ISqlExpressionBuilder {
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
         val entityID = EntityID(t, table)
         return if ((this as? Column<*>)?.isEntityIdentifier() == true) {
-            (this as Column<*>).table.mapIdComparison(entityID, ::NeqOp)
+            this.table.mapIdComparison(entityID, ::NeqOp)
         } else {
             NeqOp(this, wrap(entityID))
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/AliasesTests.kt
@@ -255,6 +255,11 @@ class AliasesTests : DatabaseTestsBase() {
                 counter[tester.id].isNotNull() and (counter[tester.id] eq t1)
             }.single()
             assertEquals(99, result2[counter[tester.amount]])
+
+            val result3 = counter.selectAll().where {
+                (counter[tester.id] eq t1.value) or (counter[tester.id] neq 123)
+            }.single()
+            assertEquals(99, result3[counter[tester.amount]])
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
@@ -425,10 +425,15 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
 
             val smallCity = Towns.alias("small_city")
 
-            val result = smallCity.selectAll().where {
+            val result1 = smallCity.selectAll().where {
                 smallCity[Towns.id].isNotNull() and (smallCity[Towns.id] eq townAId)
             }.single()
-            assertNull(result[smallCity[Towns.population]])
+            assertNull(result1[smallCity[Towns.population]])
+
+            val result2 = smallCity.select(smallCity[Towns.name]).where {
+                smallCity[Towns.id] eq townAId.value
+            }.single()
+            assertEquals(townAValue[Towns.name], result2[smallCity[Towns.name]])
         }
     }
 


### PR DESCRIPTION
#### Description

**Summary of the change**:
The aliased `id` column from a subquery now generates the correct aliased table identifier when used in an equality comparison with an unwrapped right-hand side value.

**Detailed description**:
- **Why**:
    - In PR #2189  , a fix was implemented for the use of aliased tables with comparison operators that rely on `mapIdComparison()` and `mapIdOperator()`. The added tests only covered cases when the right-hand side of the operators was a wrapped `EntityID` value. Unwrapped values use operators that first need to wrap them as an `EntityID` instance, for which reason the invoking expression's table is found as an `IdTable`. The latter was then incorrectly being used to call `mapIdComparison()`, meaning that the column identifier used in SQL generation was the delegate non-aliased identifier.

- **How**:
    - Equality operators that accept an unwrapped value on the right-hand side now have `mapIdComparison()` called directly on the invoking column's table, not the delegate `IdTable` used to create a wrapping `EntityID` instance.
    - Updated tests from previous fix to cover this case.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-565](https://youtrack.jetbrains.com/issue/EXPOSED-565/Aliases-where-statement-with-EntityId-is-not-working-anymore), [EXPOSED-568](https://youtrack.jetbrains.com/issue/EXPOSED-568/Subquery-alias-with-id-column-fails-to-use-correct-alias-with-eq), [EXPOSED-472](https://youtrack.jetbrains.com/issue/EXPOSED-472/Getting-an-error-with-Aliases-columns-when-using-the-isNull-expression)