### PR TITLE
EXPOSED-576 DAO Entity.new() fails if there is column with default va…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,6 +40,7 @@ ij_kotlin_spaces_around_logical_operators = true
 ij_kotlin_spaces_around_equality_operators = true
 ij_any_align_group_field_declarations = false
 ij_java_align_group_field_declarations = false
+ij_kotlin_line_break_after_multiline_when_entry = false
 
 [{.github/**/*.yml, .idea/*.xml}]
 indent_size = 2

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -536,12 +536,13 @@ public class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/expos
 	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)V
 	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public fun getNullable ()Z
+	public final fun getOriginalColumnType ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public final fun getTransformer ()Lorg/jetbrains/exposed/sql/ColumnTransformer;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun setNullable (Z)V
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
-	public final fun unwrapRecursive (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun unwrapRecursive (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 }
@@ -1693,6 +1694,7 @@ public final class org/jetbrains/exposed/sql/Ntile : org/jetbrains/exposed/sql/W
 
 public class org/jetbrains/exposed/sql/NullableColumnWithTransform : org/jetbrains/exposed/sql/ColumnWithTransform {
 	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Lorg/jetbrains/exposed/sql/ColumnTransformer;)V
+	public fun unwrapRecursive (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueToString (Ljava/lang/Object;)Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -316,6 +316,16 @@ open class ColumnWithTransform<Unwrapped, Wrapped>(
     val transformer: ColumnTransformer<Unwrapped, Wrapped>
 ) : ColumnType<Wrapped & Any>() {
 
+    /**
+     * Recursively unwraps the given value by applying the delegate's transformation.
+     *
+     * This method will recursively call unwrap on the inner delegate if the delegate
+     * is also an instance of [ColumnWithTransform]. This is useful for handling nested
+     * transformations.
+     *
+     * @param value The value to unwrap. Could be null.
+     * @return The unwrapped value. Returns the value transformed by the transformer if it's not null.
+     */
     open fun unwrapRecursive(value: Wrapped?): Any? {
         return if (delegate is ColumnWithTransform<*, *>) {
             (delegate as ColumnWithTransform<Any, Unwrapped>).unwrapRecursive(transformer.unwrap(value as Wrapped))
@@ -324,6 +334,15 @@ open class ColumnWithTransform<Unwrapped, Wrapped>(
         }
     }
 
+    /**
+     * Gets the original column type that this column with transformation wraps around.
+     *
+     * This property will recursively unwrap the delegate column type if the delegate
+     * is also an instance of [ColumnWithTransform]. This ensures that you get the
+     * original column type, regardless of the number of nested transformations.
+     *
+     * @return The original column's [IColumnType].
+     */
     val originalColumnType: IColumnType<Any>
         get() = when {
             delegate is ColumnWithTransform<*, *> -> delegate.originalColumnType
@@ -371,6 +390,18 @@ open class NullableColumnWithTransform<Unwrapped, Wrapped>(
     delegate: IColumnType<Unwrapped & Any>,
     transformer: ColumnTransformer<Unwrapped, Wrapped>
 ) : ColumnWithTransform<Unwrapped, Wrapped>(delegate, transformer) {
+    /**
+     * Recursively unwraps the given value by applying the delegate's transformation.
+     *
+     * This method will recursively call unwrap on the inner delegate if the delegate
+     * is also an instance of [ColumnWithTransform]. This is useful for handling nested
+     * transformations. Unlike [ColumnWithTransform.unwrapRecursive], this method allows
+     * transformation involving `null` values.
+     *
+     * @param value The value to unwrap. Could be `null`.
+     * @return The unwrapped value. Returns the value transformed by the transformer, which
+     * could be `null` if the transformer design allows it.
+     */
     override fun unwrapRecursive(value: Wrapped?): Any? {
         return if (delegate is ColumnWithTransform<*, *>) {
             (delegate as ColumnWithTransform<Any, Unwrapped>).unwrapRecursive(transformer.unwrap(value as Wrapped))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
@@ -176,10 +176,8 @@ class ResultRow(
                 columnType is ColumnWithTransform<*, *> -> {
                     (columnType as ColumnWithTransform<Any, Any>).unwrapRecursive(defaultValueFun!!())
                 }
-
                 else -> defaultValueFun!!()
             }
-
             columnType.nullable -> null
             else -> NotInitializedValue
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -1061,6 +1061,8 @@ interface ISqlExpressionBuilder {
     @Suppress("UNCHECKED_CAST", "ComplexMethod")
     fun <T, S : T?> ExpressionWithColumnType<S>.asLiteral(value: T): LiteralOp<T> = when {
         value is ByteArray && columnType is BasicBinaryColumnType -> stringLiteral(value.toString(Charsets.UTF_8))
+        columnType is ColumnWithTransform<*, *> -> (columnType as ColumnWithTransform<Any, Any>)
+            .let { LiteralOp(it.originalColumnType, it.unwrapRecursive(value)) }
         else -> LiteralOp(columnType as IColumnType<T & Any>, value)
     } as LiteralOp<T>
 


### PR DESCRIPTION
### Description

**Summary of the change**:  
This PR fixes an issue with `DAO Entity.new()` when dealing with columns that have default values and transformations. It modifies how the `ResultRow` is populated with default values to ensure that base types are stored rather than transformed values.

**Detailed description**:
- **What**:  
  - Introduced changes to the `ResultRow.createAndFillDefaults()` method to handle default values with transformations more effectively. It now ensures that the unwrapped base types are stored in the `ResultRow`.  
  - Added `originalColumnType` to the `ColumnWithTransform` class to access the base column type

- **How**:  
  - By adjusting how the default values are handled in `ResultRow.createAndFillDefaults()`, it unwraps the transformed values before they are set in the row. The `unwrapRecursive` method ensures that nested transformations are properly unwrapped.

---

### Type of Change

- [x] Bug fix

Affected databases:
- [x] All


---

### Related Issues
[EXPOSED-576](https://youtrack.jetbrains.com/issue/EXPOSED-576) DAO Entity.new() fails if there is column with default value and **transformation**
[EXPOSED-574](https://youtrack.jetbrains.com/issue/EXPOSED-574) NPE when using a nullable ColumnWithTransform with default

