### PR TITLE
chore: Update hint about the breaking changes in Entity transform API

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -77,6 +77,32 @@ TestTable.upsert(
   exception handler wrapping the inner transaction, and any inner commits will not be saved. In version 0.55.0, this change will be reduced
   so that only inner transactions that throw an `SQLException` from the database will trigger such a rollback.
 
+## 0.53.0
+
+* DAO Entity Transformation Changes
+  * **Parameter Renaming**: `transform()` and `memoizedTransform()` now use `wrap` and `unwrap` instead of `toColumn` and `toReal`.
+    ```kotlin
+    // Old:
+    var name by EmployeeTable.name.transform(toColumn = { it.uppercase() }, toReal = { it.lowercase() })
+    // New:
+    var name by EmployeeTable.name.transform(wrap = { it.uppercase() }, unwrap = { it.lowercase() })
+    ```
+  * **Class Renaming**: `ColumnWithTransform` is now `EntityFieldWithTransform`, consolidating properties into a single `transformer`.
+    ```kotlin
+    EntityFieldWithTransform(column, object : ColumnTransformer<String, Int> {
+            override fun unwrap(value: Int): String = value.toString()
+            override fun wrap(value: String): Int = value.toInt()
+        })
+    ``` 
+  * Entity transformation via DAO is deprecated and should be replaced with DSL transformation.
+    ```kotlin
+    val tester = object : Table() {
+            val value = integer("value")
+                .transform(wrap = { ... }, unwrap = { ... })
+        }
+    ```
+    
+
 ## 0.51.0
 
 * The `exposed-spring-boot-starter` module no longer provides the entire [spring-boot-starter-data-jdbc](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jdbc) module.

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -741,7 +741,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
             "DAOs transform() is deprecated and will be removed in future releases. " +
             "Please use the transform function from the DSL layer. " +
             "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
-            "if a use-case cannot be sufficiently covered by the DSL transform().",
+            "if a use-case cannot be sufficiently covered by the DSL transform(). " +
+            "With version 0.53.0 Entity transformation got several breaking changes. " +
+            "Check related PR (https://github.com/JetBrains/Exposed/pull/2143) for more details.",
         ReplaceWith(
             "object : Table() { val c = column().transform(transformer) }"
         )
@@ -764,7 +766,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
             "DAOs transform() is deprecated and will be removed in future releases. " +
             "Please use the transform function from the DSL layer. " +
             "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
-            "if a use-case cannot be sufficiently covered by the DSL transform().",
+            "if a use-case cannot be sufficiently covered by the DSL transform(). " +
+            "With version 0.53.0 Entity transformation got several breaking changes. " +
+            "Check related PR (https://github.com/JetBrains/Exposed/pull/2143) for more details.",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )
@@ -787,7 +791,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
             "DAOs transform() is deprecated and will be removed in future releases. " +
             "Please use the transform function from the DSL layer. " +
             "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
-            "if a use-case cannot be sufficiently covered by the DSL transform().",
+            "if a use-case cannot be sufficiently covered by the DSL transform(). " +
+            "With version 0.53.0 Entity transformation got several breaking changes. " +
+            "Check related PR (https://github.com/JetBrains/Exposed/pull/2143) for more details.",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )
@@ -812,7 +818,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
             "Please use the transform function from the DSL layer. " +
             "Memoization will not be a part of column transformation API anymore. " +
             "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
-            "if a use-case cannot be sufficiently covered by the DSL transform().",
+            "if a use-case cannot be sufficiently covered by the DSL transform(). " +
+            "With version 0.53.0 Entity transformation got several breaking changes. " +
+            "Check related PR (https://github.com/JetBrains/Exposed/pull/2143) for more details.",
         ReplaceWith(
             "object : Table() { val c = column().transform(transformer) }"
         )
@@ -837,7 +845,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
             "Please use the transform function from the DSL layer. " +
             "Memoization will not be a part of column transformation API anymore. " +
             "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
-            "if a use-case cannot be sufficiently covered by the DSL transform().",
+            "if a use-case cannot be sufficiently covered by the DSL transform(). " +
+            "With version 0.53.0 Entity transformation got several breaking changes. " +
+            "Check related PR (https://github.com/JetBrains/Exposed/pull/2143) for more details.",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )
@@ -862,7 +872,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
             "Please use the transform function from the DSL layer. " +
             "Memoization will not be a part of column transformation API anymore. " +
             "Please log a request on YouTrack (https://youtrack.jetbrains.com/newIssue?project=EXPOSED) " +
-            "if a use-case cannot be sufficiently covered by the DSL transform().",
+            "if a use-case cannot be sufficiently covered by the DSL transform(). " +
+            "With version 0.53.0 Entity transformation got several breaking changes. " +
+            "Check related PR (https://github.com/JetBrains/Exposed/pull/2143) for more details.",
         ReplaceWith(
             "object : Table() { val c = column().transform(wrap, unwrap) }"
         )


### PR DESCRIPTION
#### Description

Update the breaking changes log and deprecation messages for entity transformation api. 

With introducing DSL transformation API the Entity one was updated with breaking changes, but these changes were not documented. 

---

#### Type of Change

- [X] Documentation update

