### PR TITLE
build(deps): EXPOSED-587 Bump com.oracle.database.jdbc:ojdbc8 from 12.2.0.1 to 19.24.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,7 +110,7 @@ subprojects {
         colima = true
         dialects("ORACLE")
         dependencies {
-            dependency(rootProject.libs.oracle12)
+            dependency(rootProject.libs.oracle19)
         }
     }
 

--- a/buildScripts/docker/docker-compose-oracle.yml
+++ b/buildScripts/docker/docker-compose-oracle.yml
@@ -2,7 +2,7 @@ services:
     oracle:
         container_name: oracleDB
         restart: always
-        image: gvenzl/oracle-xe:18-slim-faststart
+        image: gvenzl/oracle-xe:21-slim-faststart
         ports:
             - "3003:1521"
         environment:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ mariaDB_v2 = "2.7.9"
 mariaDB_v3 = "3.3.1"
 mysql51 = "5.1.49"
 mysql80 = "8.0.33"
-oracle12 = "12.2.0.1"
+oracle19 = "19.24.0.0"
 postgre = "42.7.4"
 postgreNG = "0.8.9"
 sqlite3 = "3.46.1.3"
@@ -77,7 +77,7 @@ postgre = { group = "org.postgresql", name = "postgresql", version.ref = "postgr
 sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqlite3" }
 maria-db2 = { group = "org.mariadb.jdbc", name = "mariadb-java-client", version.ref = "mariaDB_v2" }
 maria-db3 = { group = "org.mariadb.jdbc", name = "mariadb-java-client", version.ref = "mariaDB_v3" }
-oracle12 = { group = "com.oracle.database.jdbc", name = "ojdbc8", version.ref = "oracle12" }
+oracle19 = { group = "com.oracle.database.jdbc", name = "ojdbc8", version.ref = "oracle19" }
 mssql = { group = "com.microsoft.sqlserver", name = "mssql-jdbc", version.ref = "sqlserver" }
 
 logcaptor = { group = "io.github.hakky54", name = "logcaptor", version.ref = "logcaptor" }


### PR DESCRIPTION
#### Description

**Summary of the change**:
Bump Oracle JDBC driver, as well as docker image for testing.

**Note** [Oracle 19c LTS](https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html) could ideally be used, but [available express edition images](https://hub.docker.com/r/gvenzl/oracle-xe) do not include 19c, so the image version was bumped to 21c.

**Detailed description**:
- **Why**:
    - Implementation of R2DBC support with Oracle requires some changes to test configuration: Oracle database and jdbc version 18+, as well as JDK11+. **Note** If R2DBC is tested using `exposed-tests`, the latter will require other module dependencies also bumping JDK version later.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Dependency bump

Affected databases:
- [X] Oracle

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOED-587](https://youtrack.jetbrains.com/issue/EXPOSED-587/Bump-com.oracle.database.jdbcojdbc8-version-to-18)