### PR TITLE
fix: EXPOSED-580 MigrationsUtils.statementsRequiredForDatabaseMigration throws an error when a table is passed that does not already exist in the database

### DIFF
--- a/exposed-migration/src/main/kotlin/MigrationUtils.kt
+++ b/exposed-migration/src/main/kotlin/MigrationUtils.kt
@@ -82,7 +82,7 @@ object MigrationUtils {
 
         val modifyTablesStatements = logTimeSpent("Checking mapping consistence", withLogs) {
             mappingConsistenceRequiredStatements(
-                tables = tables,
+                tables = tablesToAlter.toTypedArray(),
                 withLogs
             ).filter { it !in (createStatements + alterStatements) }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -134,6 +134,23 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testCreateStatementsGeneratedForTablesThatDoNotExist() {
+        val tester = object : Table("tester") {
+            val bar = char("bar")
+        }
+
+        withDb {
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+            assertEquals(1, statements.size)
+            assertEquals(
+                "CREATE TABLE ${addIfNotExistsIfSupported()}${tester.nameInDatabaseCase()} " +
+                    "(${"bar".inProperCase()} CHAR NOT NULL)",
+                statements.first()
+            )
+        }
+    }
+
+    @Test
     fun testDropUnmappedColumnsStatementsIdentical() {
         val t1 = object : Table("foo") {
             val col1 = integer("col1")


### PR DESCRIPTION
- **What**:
This PR fixes the bug wherein `MigrationsUtils.statementsRequiredForDatabaseMigration` throws an error when a table is passed that does not already exist in the database.
- **How**:
The problem was in the `existingIndices` function. For some dialects, querying indices for a table that does not exist throws an error. This is fixed in the `statementsRequiredForDatabaseMigration` function by passing only tables that exist when invoking the `mappingConsistenceRequiredStatements` function.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [x] Mysql5
- [ ] Mysql8
- [x] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
