### PR TITLE
chore!: Change H2 Oracle longType and longAutoincType from NUMBER(19) to BIGINT and add CHECK constraint in Oracle

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -51,6 +51,8 @@
   that is also type restricted to `Comparable` (for example, `avg()`) will also require defining a new function. In this event, please
   also leave a comment on [YouTrack](https://youtrack.jetbrains.com/issue/EXPOSED-577) with a use case so the original function signature
   can be potentially reassessed.
+* In H2 Oracle, the `long()` column now maps to data type `BIGINT` instead of `NUMBER(19)`.
+  In Oracle and SQLite, using the long column in a table now also creates a CHECK constraint to ensure that no out-of-range values are inserted.
 
 ## 0.55.0
 * The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1703,6 +1703,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
                 append("IF NOT EXISTS ")
             }
             append(TransactionManager.current().identity(this@Table))
+
+            // Add CHECK constraint to Long columns in Oracle and SQLite.
+            // It is done here because special handling is necessary based on the dialect.
+            addLongColumnCheckConstraintIfNeeded()
+
             if (columns.isNotEmpty()) {
                 columns.joinTo(this, prefix = " (") { column ->
                     column.descriptionDdl(false)
@@ -1744,7 +1749,8 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
                     }.let {
                         if (currentDialect !is SQLiteDialect && currentDialect !is OracleDialect) {
                             it.filterNot { (name, _) ->
-                                name.startsWith("${generatedSignedCheckPrefix}integer")
+                                name.startsWith("${generatedSignedCheckPrefix}integer") ||
+                                    name.startsWith("${generatedSignedCheckPrefix}long")
                             }
                         } else {
                             it
@@ -1767,6 +1773,34 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         }
 
         return createAutoIncColumnSequence() + createTable + createConstraint
+    }
+
+    private fun addLongColumnCheckConstraintIfNeeded() {
+        if (currentDialect is OracleDialect || currentDialect is SQLiteDialect) {
+            columns.filter { it.columnType is LongColumnType }.forEach { column ->
+                val name = column.name
+                val checkName = "${generatedSignedCheckPrefix}long_$name"
+                if (checkConstraints.none { it.first == checkName }) {
+                    column.check(checkName) {
+                        if (currentDialect is SQLiteDialect) {
+                            fun typeOf(value: String) = object : ExpressionWithColumnType<String>() {
+                                override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("typeof($value)") }
+                                override val columnType: IColumnType<String> = TextColumnType()
+                            }
+
+                            val typeCondition = Expression.build { typeOf(name) eq stringLiteral("integer") }
+                            if (column.columnType.nullable) {
+                                column.isNull() or typeCondition
+                            } else {
+                                typeCondition
+                            }
+                        } else {
+                            it.between(Long.MIN_VALUE, Long.MAX_VALUE)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun createAutoIncColumnSequence(): List<String> {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -758,7 +758,9 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     }
 
     /** Creates a numeric column, with the specified [name], for storing 8-byte integers. */
-    fun long(name: String): Column<Long> = registerColumn(name, LongColumnType())
+    fun long(name: String): Column<Long> = registerColumn(name, LongColumnType()).apply {
+        check("${generatedSignedCheckPrefix}long_${this.unquotedName()}") { it.between(Long.MIN_VALUE, Long.MAX_VALUE) }
+    }
 
     /** Creates a numeric column, with the specified [name], for storing 8-byte unsigned integers.
      *
@@ -1704,10 +1706,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
             }
             append(TransactionManager.current().identity(this@Table))
 
-            // Add CHECK constraint to Long columns in Oracle and SQLite.
-            // It is done here because special handling is necessary based on the dialect.
-            addLongColumnCheckConstraintIfNeeded()
-
             if (columns.isNotEmpty()) {
                 columns.joinTo(this, prefix = " (") { column ->
                     column.descriptionDdl(false)
@@ -1749,8 +1747,15 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
                     }.let {
                         if (currentDialect !is SQLiteDialect && currentDialect !is OracleDialect) {
                             it.filterNot { (name, _) ->
-                                name.startsWith("${generatedSignedCheckPrefix}integer") ||
-                                    name.startsWith("${generatedSignedCheckPrefix}long")
+                                name.startsWith("${generatedSignedCheckPrefix}integer")
+                            }
+                        } else {
+                            it
+                        }
+                    }.let {
+                        if (currentDialect !is OracleDialect) {
+                            it.filterNot { (name, _) ->
+                                name.startsWith("${generatedSignedCheckPrefix}long")
                             }
                         } else {
                             it
@@ -1773,34 +1778,6 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         }
 
         return createAutoIncColumnSequence() + createTable + createConstraint
-    }
-
-    private fun addLongColumnCheckConstraintIfNeeded() {
-        if (currentDialect is OracleDialect || currentDialect is SQLiteDialect) {
-            columns.filter { it.columnType is LongColumnType }.forEach { column ->
-                val name = column.name
-                val checkName = "${generatedSignedCheckPrefix}long_$name"
-                if (checkConstraints.none { it.first == checkName }) {
-                    column.check(checkName) {
-                        if (currentDialect is SQLiteDialect) {
-                            fun typeOf(value: String) = object : ExpressionWithColumnType<String>() {
-                                override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append("typeof($value)") }
-                                override val columnType: IColumnType<String> = TextColumnType()
-                            }
-
-                            val typeCondition = Expression.build { typeOf(name) eq stringLiteral("integer") }
-                            if (column.columnType.nullable) {
-                                column.isNull() or typeCondition
-                            } else {
-                                typeCondition
-                            }
-                        } else {
-                            it.between(Long.MIN_VALUE, Long.MAX_VALUE)
-                        }
-                    }
-                }
-            }
-        }
     }
 
     private fun createAutoIncColumnSequence(): List<String> {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -33,8 +33,12 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun integerAutoincType(): String = integerType()
     override fun uintegerType(): String = "NUMBER(10)"
     override fun uintegerAutoincType(): String = "NUMBER(10)"
-    override fun longType(): String = "NUMBER(19)"
-    override fun longAutoincType(): String = "NUMBER(19)"
+    override fun longType(): String = if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+        "BIGINT"
+    } else {
+        "NUMBER(19)"
+    }
+    override fun longAutoincType(): String = longType()
     override fun ulongType(): String = "NUMBER(20)"
     override fun ulongAutoincType(): String = "NUMBER(20)"
     override fun varcharType(colLength: Int): String = "VARCHAR2($colLength CHAR)"

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -273,8 +273,12 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t9".inProperCase()} $timeType${testTable.t9.constraintNamePart()} ${tLiteral.itOrNull()}, " +
                 "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
-                    TestDB.SQLITE, TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                    TestDB.SQLITE ->
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT chk_t_signed_long_l CHECK (typeof(l) = 'integer')"
+                    TestDB.ORACLE ->
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -274,8 +274,7 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (typeof(l) = 'integer')"
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     TestDB.ORACLE ->
                         ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
                             ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -210,8 +210,12 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
                 "${"t5".inProperCase()} $timeType${testTable.t5.constraintNamePart()} ${tLiteral.itOrNull()}, " +
                 "${"t6".inProperCase()} $timeType${testTable.t6.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
-                    TestDB.SQLITE, TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                    TestDB.SQLITE ->
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT chk_t_signed_long_l CHECK (typeof(l) = 'integer')"
+                    TestDB.ORACLE ->
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeDefaultsTest.kt
@@ -211,8 +211,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
                 "${"t6".inProperCase()} $timeType${testTable.t6.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (typeof(l) = 'integer')"
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     TestDB.ORACLE ->
                         ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
                             ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -272,8 +272,7 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (typeof(l) = 'integer')"
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     TestDB.ORACLE ->
                         ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
                             ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -271,8 +271,12 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t9".inProperCase()} $timeType${testTable.t9.constraintNamePart()} ${tLiteral.itOrNull()}, " +
                 "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
-                    TestDB.SQLITE, TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                    TestDB.SQLITE ->
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT chk_t_signed_long_l CHECK (typeof(l) = 'integer')"
+                    TestDB.ORACLE ->
+                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -322,7 +322,7 @@ class CreateTableTests : DatabaseTestsBase() {
                 fkName = fkName
             )
         }
-        withDb {
+        withDb { testDb ->
             val t = TransactionManager.current()
             val expected = listOfNotNull(
                 child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
@@ -331,6 +331,11 @@ class CreateTableTests : DatabaseTestsBase() {
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.id)})" +
+                    if (testDb == TestDB.ORACLE) {
+                        ", CONSTRAINT chk_child1_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    } else {
+                        ""
+                    } +
                     ")"
             )
             assertEqualCollections(child.ddl, expected)
@@ -348,12 +353,17 @@ class CreateTableTests : DatabaseTestsBase() {
                 onDelete = ReferenceOption.NO_ACTION,
             )
         }
-        withDb {
+        withDb { testDb ->
             val expected = "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(child)} (" +
                 "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                 " CONSTRAINT ${"fk_Child_parent_id__id".inProperCase()}" +
                 " FOREIGN KEY (${this.identity(child.parentId)})" +
                 " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
+                if (testDb == TestDB.ORACLE) {
+                    ", CONSTRAINT chk_Child_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                } else {
+                    ""
+                } +
                 ")"
             assertEquals(child.ddl.last(), expected)
         }
@@ -370,12 +380,17 @@ class CreateTableTests : DatabaseTestsBase() {
                 onDelete = ReferenceOption.NO_ACTION,
             )
         }
-        withDb {
+        withDb { testDb ->
             val expected = "CREATE TABLE " + addIfNotExistsIfSupported() + "${this.identity(child)} (" +
                 "${child.columns.joinToString { it.descriptionDdl(false) }}," +
                 " CONSTRAINT ${"fk_Child2_parent_id__id".inProperCase()}" +
                 " FOREIGN KEY (${this.identity(child.parentId)})" +
                 " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
+                if (testDb == TestDB.ORACLE) {
+                    ", CONSTRAINT chk_Child2_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                } else {
+                    ""
+                } +
                 ")"
             assertEquals(child.ddl.last(), expected)
         }
@@ -396,7 +411,7 @@ class CreateTableTests : DatabaseTestsBase() {
                 fkName = fkName
             )
         }
-        withDb {
+        withDb { testDb ->
             val t = TransactionManager.current()
             val expected = listOfNotNull(
                 child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
@@ -405,6 +420,11 @@ class CreateTableTests : DatabaseTestsBase() {
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.uniqueId)})" +
+                    if (testDb == TestDB.ORACLE) {
+                        ", CONSTRAINT chk_child2_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    } else {
+                        ""
+                    } +
                     ")"
             )
             assertEqualCollections(child.ddl, expected)
@@ -424,7 +444,7 @@ class CreateTableTests : DatabaseTestsBase() {
                 fkName = fkName
             )
         }
-        withDb {
+        withDb { testDb ->
             val t = TransactionManager.current()
             val expected = listOfNotNull(
                 child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
@@ -433,6 +453,11 @@ class CreateTableTests : DatabaseTestsBase() {
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.id)})" +
+                    if (testDb == TestDB.ORACLE) {
+                        ", CONSTRAINT chk_child3_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    } else {
+                        ""
+                    } +
                     ")"
             )
             assertEqualCollections(child.ddl, expected)
@@ -455,7 +480,7 @@ class CreateTableTests : DatabaseTestsBase() {
                 fkName = fkName
             )
         }
-        withDb {
+        withDb { testDb ->
             val t = TransactionManager.current()
             val expected = listOfNotNull(
                 child.autoIncColumn?.autoIncColumnType?.sequence?.createStatement()?.single(),
@@ -464,6 +489,11 @@ class CreateTableTests : DatabaseTestsBase() {
                     " CONSTRAINT ${t.db.identifierManager.cutIfNecessaryAndQuote(fkName).inProperCase()}" +
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.uniqueId)})" +
+                    if (testDb == TestDB.ORACLE) {
+                        ", CONSTRAINT chk_child4_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    } else {
+                        ""
+                    } +
                     ")"
             )
             assertEqualCollections(child.ddl, expected)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
@@ -109,6 +109,37 @@ class NumericColumnTypesTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testLongAcceptsOnlyAllowedRange() {
+        val testTable = object : Table("test_table") {
+            val long = long("long_column")
+        }
+
+        withTables(testTable) { testDb ->
+            val columnName = testTable.long.nameInDatabaseCase()
+            val ddlEnding = when (testDb) {
+                TestDB.SQLITE -> "CHECK (typeof($columnName) = 'integer'))"
+                TestDB.ORACLE -> "CHECK ($columnName BETWEEN ${Long.MIN_VALUE} and ${Long.MAX_VALUE}))"
+                else -> "($columnName ${testTable.long.columnType} NOT NULL)"
+            }
+            assertTrue(testTable.ddl.single().endsWith(ddlEnding, ignoreCase = true))
+
+            testTable.insert { it[long] = Long.MIN_VALUE }
+            testTable.insert { it[long] = Long.MAX_VALUE }
+            assertEquals(2, testTable.select(testTable.long).count())
+
+            val tableName = testTable.nameInDatabaseCase()
+            assertFailAndRollback(message = "Out-of-range error (or CHECK constraint violation for SQLite & Oracle)") {
+                val outOfRangeValue = Long.MIN_VALUE.toBigDecimal() - 1.toBigDecimal()
+                exec("INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)")
+            }
+            assertFailAndRollback(message = "Out-of-range error (or CHECK constraint violation for SQLite & Oracle)") {
+                val outOfRangeValue = Long.MAX_VALUE.toBigDecimal() + 1.toBigDecimal()
+                exec("INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)")
+            }
+        }
+    }
+
+    @Test
     fun testParams() {
         val testTable = object : Table("test_table") {
             val byte = byte("byte_column")


### PR DESCRIPTION
#### Description

**Detailed description**:
- **What**:
The SQL type of H2 Oracle Long type was changed. A CHECK constraint was also added for Oracle.
- **Why**:
1. H2 enforces the range on its own when BIGINT is used.
2. It is a preparation step for making detecting column type change for migration easier

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Improvement

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [x] Oracle
- [ ] Postgres
- [ ] SqlServer
- [x] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
