### PR TITLE
feat: EXPOSED-555 Allow read-only suspendable transactions

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3718,10 +3718,10 @@ public final class org/jetbrains/exposed/sql/transactions/TransactionStore : kot
 }
 
 public final class org/jetbrains/exposed/sql/transactions/experimental/SuspendedKt {
-	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun newSuspendedTransaction (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun newSuspendedTransaction$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun suspendedTransactionAsync (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun suspendedTransactionAsync$default (Lkotlin/coroutines/CoroutineContext;Lorg/jetbrains/exposed/sql/Database;Ljava/lang/Integer;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun withSuspendTransaction (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun withSuspendTransaction$default (Lorg/jetbrains/exposed/sql/Transaction;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/experimental/Suspended.kt
@@ -87,7 +87,7 @@ suspend fun <T> Transaction.withSuspendTransaction(
     context: CoroutineContext? = null,
     statement: suspend Transaction.() -> T
 ): T =
-    withTransactionScope(context, this, db = null, transactionIsolation = null) {
+    withTransactionScope(context, this, db = null, transactionIsolation = null, readOnly = null) {
         suspendedTransactionAsyncInternal(false, statement).await()
     }
 
@@ -131,7 +131,7 @@ private suspend fun <T> withTransactionScope(
     currentTransaction: Transaction?,
     db: Database? = null,
     transactionIsolation: Int?,
-    readOnly: Boolean? = null,
+    readOnly: Boolean?,
     body: suspend TransactionScope.() -> T
 ): T {
     val currentScope = coroutineContext[TransactionScope]

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     compileOnly(libs.h2)
     testCompileOnly(libs.sqlite.jdbc)
     testImplementation(libs.logcaptor)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 tasks.withType<Test>().configureEach {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/ConnectionPoolTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/ConnectionPoolTests.kt
@@ -17,10 +17,10 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Assert
+import org.junit.Assert.assertNotNull
 import org.junit.Assume
 import org.junit.Test
 import java.sql.Connection
-import kotlin.test.assertNotNull
 
 class ConnectionPoolTests : LogDbInTestName() {
     private val hikariDataSourcePG by lazy {
@@ -64,24 +64,13 @@ class ConnectionPoolTests : LogDbInTestName() {
     fun testReadOnlyModeWithHikariAndPostgres() {
         Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
 
-        val testTable = object : IntIdTable("HIKARI_TESTER") { }
-
-        fun Transaction.getReadOnlyMode(): Boolean {
-            val mode = exec("SHOW transaction_read_only;") {
-                it.next()
-                it.getBoolean(1)
-            }
-            assertNotNull(mode)
-            return mode
-        }
-
         // read only mode should be set directly by hikari config
         transaction(db = hikariPG) {
             assertTrue(getReadOnlyMode())
 
             // table cannot be created in read-only mode
             expectException<ExposedSQLException> {
-                SchemaUtils.create(testTable)
+                SchemaUtils.create(TestTable)
             }
         }
 
@@ -90,8 +79,8 @@ class ConnectionPoolTests : LogDbInTestName() {
             Assert.assertFalse(getReadOnlyMode())
 
             // table can now be created and dropped
-            SchemaUtils.create(testTable)
-            SchemaUtils.drop(testTable)
+            SchemaUtils.create(TestTable)
+            SchemaUtils.drop(TestTable)
         }
 
         TransactionManager.closeAndUnregister(hikariPG)
@@ -102,15 +91,6 @@ class ConnectionPoolTests : LogDbInTestName() {
         Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
 
         val testTable = object : IntIdTable("HIKARI_TESTER") { }
-
-        fun Transaction.getReadOnlyMode(): Boolean {
-            val mode = exec("SHOW transaction_read_only;") {
-                it.next()
-                it.getBoolean(1)
-            }
-            assertNotNull(mode)
-            return mode
-        }
 
         // read only mode should be set directly by hikari config
         newSuspendedTransaction(db = hikariPG) {
@@ -133,4 +113,15 @@ class ConnectionPoolTests : LogDbInTestName() {
 
         TransactionManager.closeAndUnregister(hikariPG)
     }
+}
+
+private val TestTable = object : IntIdTable("HIKARI_TESTER") { }
+
+private fun Transaction.getReadOnlyMode(): Boolean {
+    val mode = exec("SHOW transaction_read_only;") {
+        it.next()
+        it.getBoolean(1)
+    }
+    assertNotNull(mode)
+    return mode == true
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/ConnectionPoolTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/ConnectionPoolTests.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.sql.tests.postgresql
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
@@ -13,6 +14,7 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.Assert
 import org.junit.Assume
@@ -85,6 +87,43 @@ class ConnectionPoolTests : LogDbInTestName() {
 
         // transaction setting should override hikari config
         transaction(transactionIsolation = Connection.TRANSACTION_SERIALIZABLE, readOnly = false, db = hikariPG) {
+            Assert.assertFalse(getReadOnlyMode())
+
+            // table can now be created and dropped
+            SchemaUtils.create(testTable)
+            SchemaUtils.drop(testTable)
+        }
+
+        TransactionManager.closeAndUnregister(hikariPG)
+    }
+
+    @Test
+    fun testSuspendedReadOnlyModeWithHikariAndPostgres() = runTest {
+        Assume.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
+
+        val testTable = object : IntIdTable("HIKARI_TESTER") { }
+
+        fun Transaction.getReadOnlyMode(): Boolean {
+            val mode = exec("SHOW transaction_read_only;") {
+                it.next()
+                it.getBoolean(1)
+            }
+            assertNotNull(mode)
+            return mode
+        }
+
+        // read only mode should be set directly by hikari config
+        newSuspendedTransaction(db = hikariPG) {
+            assertTrue(getReadOnlyMode())
+
+            // table cannot be created in read-only mode
+            expectException<ExposedSQLException> {
+                SchemaUtils.create(testTable)
+            }
+        }
+
+        // transaction setting should override hikari config
+        newSuspendedTransaction(transactionIsolation = Connection.TRANSACTION_SERIALIZABLE, readOnly = false, db = hikariPG) {
             Assert.assertFalse(getReadOnlyMode())
 
             // table can now be created and dropped

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-form
 
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinCoroutines" }
 kotlinx-coroutines-debug = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-debug", version.ref = "kotlinCoroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 kotlinx-jvm-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime-jvm", version.ref = "kotlinx-datetime" }
 kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Regular transaction management allow callers to configure if new transactions should be read-only. This change adds the same behavior to suspendable transactions.

**Detailed description**:
- **What**: A `readOnly` parameter has been added for `newSuspendTransaction`.
- **Why**: Regular transactions allow `readOnly` to be configured by callers. As per JetBrains Exposed documentation, this behavior is supposed to be the same for regular and suspendable transactions, but the parameter was missing for suspendable transactions.
- **How**: The parameter was added as optional (nullable with the default value set to `null`) to avoid breaking changes as much as possible. It is passed ahead to internal functions in order to create the transaction either as read-only based on caller's configuration or as the original behavior for existing code.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] Mysql5
- [X] Mysql8
- [X] Postgres

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
https://youtrack.jetbrains.com/issue/EXPOSED-555/newSuspendedTransaction-support-for-readOnly
[EXPOSED-243](https://youtrack.jetbrains.com/issue/EXPOSED-243/Cant-set-readOnly-when-using-suspended-transactions)