### PR TITLE
feat: EXPOSED-560 Support DISTINCT ON from Postgres

### DIFF
--- a/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
+++ b/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
@@ -171,9 +171,26 @@
 
             <code-block lang="kotlin">
                 val directors =
-                    StarWarsFilms.select(StarWarsFilms.director).where { StarWarsFilms.sequelId less 5 }.withDistinct()
+                    StarWarsFilms.select(StarWarsFilms.director)
+                        .where { StarWarsFilms.sequelId less 5 }.withDistinct()
                         .map {
                             it[StarWarsFilms.director]
+                        }
+            </code-block>
+
+            <p>Some SQL dialects, such as PostgreSQL and H2, also support the <code>DISTINCT ON</code> clause.
+                You can use this clause with the <code>withDistinctOn()</code> function:</p>
+
+            <code-block lang="kotlin">
+                val directors =
+                    StarWarsFilms.select(StarWarsFilms.director, StarWarsFilms.name)
+                        .withDistinctOn(StarWarsFilms.director)
+                        .orderBy(
+                            StarWarsFilms.director to SortOrder.ASC,
+                            StarWarsFilms.name to SortOrder.ASC
+                        )
+                        .map {
+                            it[StarWarsFilms.name]
                         }
             </code-block>
         </chapter>

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1905,6 +1905,7 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 	public synthetic fun forUpdate (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun getComments ()Ljava/util/Map;
 	public final fun getDistinct ()Z
+	public final fun getDistinctOn ()Ljava/util/List;
 	public final fun getGroupedByColumns ()Ljava/util/List;
 	public final fun getHaving ()Lorg/jetbrains/exposed/sql/Op;
 	protected fun getQueryToExecute ()Lorg/jetbrains/exposed/sql/statements/Statement;
@@ -1918,11 +1919,14 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 	public synthetic fun notForUpdate ()Lorg/jetbrains/exposed/sql/SizedIterable;
 	public fun prepareSQL (Lorg/jetbrains/exposed/sql/QueryBuilder;)Ljava/lang/String;
 	protected final fun setDistinct (Z)V
+	protected final fun setDistinctOn (Ljava/util/List;)V
 	public fun setSet (Lorg/jetbrains/exposed/sql/FieldSet;)V
 	public final fun where (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun where (Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
 	public synthetic fun withDistinct (Z)Lorg/jetbrains/exposed/sql/AbstractQuery;
 	public fun withDistinct (Z)Lorg/jetbrains/exposed/sql/Query;
+	public final fun withDistinctOn ([Lkotlin/Pair;)Lorg/jetbrains/exposed/sql/Query;
+	public final fun withDistinctOn ([Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/sql/Query;
 }
 
 public final class org/jetbrains/exposed/sql/Query$CommentPosition : java/lang/Enum {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -69,6 +69,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     override fun copyTo(other: Query) {
         super.copyTo(other)
         other.distinct = distinct
+        other.distinctOn = distinctOn
         other.groupedByColumns = groupedByColumns.toMutableList()
         other.having = having
         other.forUpdate = forUpdate
@@ -86,6 +87,9 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     }
 
     override fun withDistinct(value: Boolean): Query = apply {
+        if (value) {
+            require(distinctOn == null) { "DISTINCT cannot be used with the DISTINCT ON modifier. Only one of them should be applied." }
+        }
         distinct = value
     }
 
@@ -99,6 +103,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * @return The current `Query` instance with the `DISTINCT ON` clause applied.
      */
     fun withDistinctOn(vararg columns: Column<*>): Query = apply {
+        require(!distinct) { "DISTINCT ON cannot be used with the DISTINCT modifier. Only one of them should be applied." }
         distinctOn = (distinctOn ?: emptyList()) + columns
     }
 
@@ -113,6 +118,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * @return The current `Query` instance with the `DISTINCT ON` clause and reordering applied.
      */
     fun withDistinctOn(vararg columns: Pair<Column<*>, SortOrder>): Query = apply {
+        require(!distinct) { "DISTINCT ON cannot be used with the DISTINCT modifier. Only one of them should be applied." }
         @Suppress("SpreadOperator")
         withDistinctOn(*columns.map { it.first }.toTypedArray())
         return orderBy(*columns)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -213,7 +213,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
                     append("DISTINCT ")
                 }
                 distinctOn?.let { columns ->
-                    columns.appendTo(prefix = "DISTINCT ON (", postfix = ")") { +"${it.table.tableName}.${it.name}" }
+                    columns.appendTo(prefix = "DISTINCT ON (", postfix = ") ") { +"${it.table.tableName}.${it.name}" }
                 }
                 set.realFields.appendTo { +it }
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DistinctOnTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DistinctOnTests.kt
@@ -1,0 +1,57 @@
+package org.jetbrains.exposed.sql.tests.shared.dml
+
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.batchInsert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
+import org.junit.Test
+
+class DistinctOnTests : DatabaseTestsBase() {
+    @Test
+    fun testDistinctOn() {
+        val tester = object : IntIdTable("distinct_function_test") {
+            val value1 = integer("value1")
+            val value2 = integer("value2")
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES - TestDB.ALL_H2, tester) {
+            tester.batchInsert(
+                listOf(
+                    listOf(1, 1), listOf(1, 2), listOf(1, 2),
+                    listOf(2, 1), listOf(2, 2), listOf(2, 2),
+                    listOf(4, 4), listOf(4, 4), listOf(4, 4),
+                )
+            ) {
+                this[tester.value1] = it[0]
+                this[tester.value2] = it[1]
+            }
+
+            val distinctValue1 = tester.selectAll()
+                .withDistinctOn(tester.value1)
+                .orderBy(tester.value1 to SortOrder.ASC, tester.value2 to SortOrder.ASC)
+                .map { it[tester.value1] to it[tester.value2] }
+            assertEqualLists(listOf(1 to 1, 2 to 1, 4 to 4), distinctValue1)
+
+            val distinctValue2 = tester.selectAll()
+                .withDistinctOn(tester.value2)
+                .orderBy(tester.value2 to SortOrder.ASC, tester.value1 to SortOrder.ASC)
+                .map { it[tester.value1] to it[tester.value2] }
+            assertEqualLists(listOf(1 to 1, 1 to 2, 4 to 4), distinctValue2)
+
+            val distinctBoth = tester.selectAll()
+                .withDistinctOn(tester.value1, tester.value2)
+                .orderBy(tester.value1 to SortOrder.ASC, tester.value2 to SortOrder.ASC)
+                .map { it[tester.value1] to it[tester.value2] }
+            assertEqualLists(listOf(1 to 1, 1 to 2, 2 to 1, 2 to 2, 4 to 4), distinctBoth)
+
+            val distinctSequential = tester.selectAll()
+                .withDistinctOn(tester.value1 to SortOrder.ASC)
+                .withDistinctOn(tester.value2 to SortOrder.ASC)
+                .map { it[tester.value1] to it[tester.value2] }
+            assertEqualLists(distinctBoth, distinctSequential)
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Added support for `DISTINCT ON` clauses in the `Query` class, enabling retrieval of distinct rows based on specified columns for SQL SELECT statements. 

**Detailed description**:
- **What**: Introduced new methods `withDistinctOn(Column<*>, vararg Column<*>)` and `withDistinctOn(Pair<Column<*>, SortOrder>, vararg Pair<Column<*>, SortOrder>)` in the `Query` class to allow the use of `DISTINCT ON` clauses. These methods enable distinct rows selection based on the specified columns and optionally ordered by specified sort orders.
- **Why**: We had several requests for that feature from GitHub and Slack
- **How**: The changes were implemented by:
  - Adding two new methods to the `Query` class to set the `distinctOn` property.
  - Adjusting the `prepareSQL` method to include the `DISTINCT ON` clause when `distinctOn` is set.

---

# Type of Change

- [x] New feature

Affected databases:
- [x] Postgres
- [x] H2

---

#### Related Issues

[EXPOSED-560](https://youtrack.jetbrains.com/issue/EXPOSED-560) Support DISTINCT ON from Postgres
[#500](https://github.com/JetBrains/Exposed/issues/500)
