### PR TITLE
fix: EXPOSED-588 Foreign key error when table has dot in its name

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Constraints.kt
@@ -112,7 +112,7 @@ data class ForeignKeyConstraint(
     val fkName: String
         get() = tx.db.identifierManager.cutIfNecessaryAndQuote(
             name ?: (
-                "fk_${fromTable.tableNameWithoutSchemeSanitized}_${from.joinToString("_") { it.name }}__" +
+                "fk_${fromTable.tableNameWithoutSchemeSanitized.replace('.', '_')}_${from.joinToString("_") { it.name }}__" +
                     target.joinToString("_") { it.name }
                 )
         ).inProperCase()


### PR DESCRIPTION



#### Description

**Detailed description**:
- **What**:
Modified the way a foreign key name is constructed.
- **Why**:
When creating a child table that has a dot in its name, the foreign key name created by Exposed would include that dot, which causes an error.
- **How**:
 The fix is to replace the dot in the table name with an underscore when constructing the foreign key name.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
