### PR TITLE
feat!: EXPOSED-577 Allow Entity and EntityID parameters to not be Comparable

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -11,6 +11,9 @@
 * `ArrayColumnType` now supports multidimensional arrays and includes an additional generic parameter.
   If it was previously used for one-dimensional arrays with the parameter `T` like `ArrayColumnType<T>`,
   it should now be defined as `ArrayColumnType<T, List<T>>`. For instance, `ArrayColumnType<Int>` should now be `ArrayColumnType<Int, List<Int>>`.
+* `EntityID` and `CompositeID` no longer implement `Comparable` themselves, to allow their wrapped identity values to be of a type that is not
+  necessarily `Comparable`. Any use of an entity's `id` with Kotlin comparison operators or `compareTo()` will now require that the wrapped
+  value be used directly: `entity1.id < entity2.id` will need to become `entity1.id.value < entity2.id.value`.
 
 ## 0.55.0
 * The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -12,8 +12,13 @@
   If it was previously used for one-dimensional arrays with the parameter `T` like `ArrayColumnType<T>`,
   it should now be defined as `ArrayColumnType<T, List<T>>`. For instance, `ArrayColumnType<Int>` should now be `ArrayColumnType<Int, List<Int>>`.
 * `EntityID` and `CompositeID` no longer implement `Comparable` themselves, to allow their wrapped identity values to be of a type that is not
-  necessarily `Comparable`. Any use of an entity's `id` with Kotlin comparison operators or `compareTo()` will now require that the wrapped
-  value be used directly: `entity1.id < entity2.id` will need to become `entity1.id.value < entity2.id.value`.
+  necessarily `Comparable`, like `kotlin.uuid.Uuid`.
+
+  Any use of an entity's `id` with Kotlin comparison operators or `compareTo()` will now require that the wrapped value be used directly:
+  `entity1.id < entity2.id` will need to become `entity1.id.value < entity2.id.value`. Any use of an entity's `id` with an Exposed function
+  that is also type restricted to `Comparable` (for example, `avg()`) will also require defining a new function. In this event, please
+  also leave a comment on [YouTrack](https://youtrack.jetbrains.com/issue/EXPOSED-577) with a use case so the original function signature
+  can be potentially reassessed.
 
 ## 0.55.0
 * The `DeleteStatement` property `table` is now deprecated in favor of `targetsSet`, which holds a `ColumnSet` that may be a `Table` or `Join`.

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -4,11 +4,11 @@ public final class org/jetbrains/exposed/dao/id/CompositeID : java/lang/Comparab
 	public fun compareTo (Lorg/jetbrains/exposed/dao/id/CompositeID;)I
 	public final fun contains (Lorg/jetbrains/exposed/sql/Column;)Z
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun get (Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/Comparable;
+	public final fun get (Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/Object;
 	public fun hashCode ()I
 	public final fun setWithEntityID (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/dao/id/EntityID;)V
-	public final fun setWithEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)V
-	public final fun setWithNullableEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)V
+	public final fun setWithEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)V
+	public final fun setWithNullableEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -24,13 +24,13 @@ public class org/jetbrains/exposed/dao/id/CompositeIdTable : org/jetbrains/expos
 }
 
 public class org/jetbrains/exposed/dao/id/EntityID : java/lang/Comparable {
-	public fun <init> (Ljava/lang/Comparable;Lorg/jetbrains/exposed/dao/id/IdTable;)V
-	protected fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Comparable;)V
+	public fun <init> (Ljava/lang/Object;Lorg/jetbrains/exposed/dao/id/IdTable;)V
+	protected fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Object;)V
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo (Lorg/jetbrains/exposed/dao/id/EntityID;)I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTable ()Lorg/jetbrains/exposed/dao/id/IdTable;
-	public final fun getValue ()Ljava/lang/Comparable;
+	public final fun getValue ()Ljava/lang/Object;
 	public final fun get_value ()Ljava/lang/Object;
 	public fun hashCode ()I
 	protected fun invokeOnNoValue ()V
@@ -39,12 +39,12 @@ public class org/jetbrains/exposed/dao/id/EntityID : java/lang/Comparable {
 }
 
 public abstract interface class org/jetbrains/exposed/dao/id/EntityIDFactory {
-	public abstract fun createEntityID (Ljava/lang/Comparable;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/id/EntityID;
+	public abstract fun createEntityID (Ljava/lang/Object;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/id/EntityID;
 }
 
 public final class org/jetbrains/exposed/dao/id/EntityIDFunctionProvider {
 	public static final field INSTANCE Lorg/jetbrains/exposed/dao/id/EntityIDFunctionProvider;
-	public final fun createEntityID (Ljava/lang/Comparable;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/id/EntityID;
+	public final fun createEntityID (Ljava/lang/Object;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/id/EntityID;
 }
 
 public abstract class org/jetbrains/exposed/dao/id/IdTable : org/jetbrains/exposed/sql/Table {
@@ -1085,7 +1085,7 @@ public abstract interface class org/jetbrains/exposed/sql/IDateColumnType {
 
 public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder {
 	public abstract fun asLiteral (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
-	public abstract fun between (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Between;
+	public abstract fun between (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public abstract fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public abstract fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/AndBitOp;
 	public abstract fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/AndBitOp;
@@ -1104,9 +1104,9 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun eq (Lorg/jetbrains/exposed/sql/CompositeColumn;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun eq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun eq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Op;
-	public abstract fun eq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun eq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun eq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
+	public abstract fun eqEntityIDValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun eqSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/EqSubQueryOp;
 	public abstract fun firstValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/FirstValue;
 	public abstract fun greater (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/GreaterOp;
@@ -1135,12 +1135,12 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun isDistinctFrom (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public abstract fun isDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public abstract fun isDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
-	public abstract fun isDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
+	public abstract fun isDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public abstract fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public abstract fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public abstract fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public abstract fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
-	public abstract fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
+	public abstract fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public abstract fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun isNullOrEmpty (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
@@ -1174,9 +1174,9 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 	public abstract fun modWithEntityId3 (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;
 	public abstract fun neq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun neq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Op;
-	public abstract fun neq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun neq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun neq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
+	public abstract fun neqEntityIDValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public abstract fun notEqSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/NotEqSubQueryOp;
 	public abstract fun notInList (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public abstract fun notInList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
@@ -1217,7 +1217,7 @@ public abstract interface class org/jetbrains/exposed/sql/ISqlExpressionBuilder 
 
 public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls {
 	public static fun asLiteral (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
-	public static fun between (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Between;
+	public static fun between (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public static fun between (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public static fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/AndBitOp;
 	public static fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/AndBitOp;
@@ -1238,9 +1238,9 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun eq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/CompositeColumn;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun eq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun eq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Op;
-	public static fun eq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun eq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun eq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
+	public static fun eqEntityIDValue (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun eqSubQuery (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/EqSubQueryOp;
 	public static fun firstValue (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/FirstValue;
 	public static fun greater (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/GreaterOp;
@@ -1269,12 +1269,12 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun isDistinctFrom (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public static fun isDistinctFrom (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public static fun isDistinctFrom (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
-	public static fun isDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
+	public static fun isDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public static fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public static fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public static fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public static fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
-	public static fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
+	public static fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public static fun isNotNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun isNull (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun isNullOrEmpty (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
@@ -1310,9 +1310,9 @@ public final class org/jetbrains/exposed/sql/ISqlExpressionBuilder$DefaultImpls 
 	public static fun modWithEntityId3 (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;
 	public static fun neq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun neq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Op;
-	public static fun neq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun neq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun neq (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
+	public static fun neqEntityIDValue (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public static fun notEqSubQuery (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/NotEqSubQueryOp;
 	public static fun notInList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public static fun notInList (Lorg/jetbrains/exposed/sql/ISqlExpressionBuilder;Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
@@ -2270,7 +2270,7 @@ public final class org/jetbrains/exposed/sql/SortOrder : java/lang/Enum {
 public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrains/exposed/sql/ISqlExpressionBuilder {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/SqlExpressionBuilder;
 	public fun asLiteral (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/LiteralOp;
-	public fun between (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Between;
+	public fun between (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public fun between (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Between;
 	public fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/AndBitOp;
 	public fun bitwiseAnd (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/AndBitOp;
@@ -2289,9 +2289,9 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun eq (Lorg/jetbrains/exposed/sql/CompositeColumn;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public fun eq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public fun eq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Op;
-	public fun eq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Op;
 	public fun eq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public fun eq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
+	public fun eqEntityIDValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public fun eqSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/EqSubQueryOp;
 	public fun firstValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/FirstValue;
 	public fun greater (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/GreaterOp;
@@ -2320,12 +2320,12 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun isDistinctFrom (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public fun isDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public fun isDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
-	public fun isDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
+	public fun isDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/IsDistinctFromOp;
 	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
-	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
+	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/IsNotDistinctFromOp;
 	public fun isNotNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public fun isNull (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public fun isNullOrEmpty (Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
@@ -2359,9 +2359,9 @@ public final class org/jetbrains/exposed/sql/SqlExpressionBuilder : org/jetbrain
 	public fun modWithEntityId3 (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;
 	public fun neq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
 	public fun neq (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;)Lorg/jetbrains/exposed/sql/Op;
-	public fun neq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/sql/Op;
 	public fun neq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public fun neq (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Op;
+	public fun neqEntityIDValue (Lorg/jetbrains/exposed/sql/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/sql/Op;
 	public fun notEqSubQuery (Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/AbstractQuery;)Lorg/jetbrains/exposed/sql/NotEqSubQueryOp;
 	public fun notInList (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
 	public fun notInList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/sql/ops/InListOrNotInListBaseOp;
@@ -3416,8 +3416,8 @@ public abstract class org/jetbrains/exposed/sql/statements/UpdateBuilder : org/j
 	public fun set (Lorg/jetbrains/exposed/sql/CompositeColumn;Ljava/lang/Object;)V
 	protected final fun setHasBatchedValues (Z)V
 	public final fun setWithEntityIdExpression (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Expression;)V
-	public final fun setWithEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)V
-	public final fun setWithNullableEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Comparable;)V
+	public final fun setWithEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)V
+	public final fun setWithNullableEntityIdValue (Lorg/jetbrains/exposed/sql/Column;Ljava/lang/Object;)V
 	public fun update (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;)V
 	public fun update (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/Expression;)V
 }

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1,7 +1,5 @@
-public final class org/jetbrains/exposed/dao/id/CompositeID : java/lang/Comparable {
+public final class org/jetbrains/exposed/dao/id/CompositeID {
 	public static final field Companion Lorg/jetbrains/exposed/dao/id/CompositeID$Companion;
-	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public fun compareTo (Lorg/jetbrains/exposed/dao/id/CompositeID;)I
 	public final fun contains (Lorg/jetbrains/exposed/sql/Column;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun get (Lorg/jetbrains/exposed/sql/Column;)Ljava/lang/Object;
@@ -23,11 +21,9 @@ public class org/jetbrains/exposed/dao/id/CompositeIdTable : org/jetbrains/expos
 	public final fun getId ()Lorg/jetbrains/exposed/sql/Column;
 }
 
-public class org/jetbrains/exposed/dao/id/EntityID : java/lang/Comparable {
+public class org/jetbrains/exposed/dao/id/EntityID {
 	public fun <init> (Ljava/lang/Object;Lorg/jetbrains/exposed/dao/id/IdTable;)V
 	protected fun <init> (Lorg/jetbrains/exposed/dao/id/IdTable;Ljava/lang/Object;)V
-	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public fun compareTo (Lorg/jetbrains/exposed/dao/id/EntityID;)I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTable ()Lorg/jetbrains/exposed/dao/id/IdTable;
 	public final fun getValue ()Ljava/lang/Object;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/CompositeID.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/CompositeID.kt
@@ -3,7 +3,7 @@ package org.jetbrains.exposed.dao.id
 import org.jetbrains.exposed.sql.Column
 
 /** Class representing a mapping of each composite primary key column to its stored identity value. */
-class CompositeID private constructor() : Comparable<CompositeID> {
+class CompositeID private constructor() {
     internal val values: MutableMap<Column<*>, Any?> = HashMap()
 
     @Suppress("UNCHECKED_CAST")
@@ -48,22 +48,6 @@ class CompositeID private constructor() : Comparable<CompositeID> {
         if (other !is CompositeID) return false
 
         return values == other.values
-    }
-
-    override fun compareTo(other: CompositeID): Int {
-        val compareSize = compareValues(other.values.size, values.size)
-        if (compareSize != 0) return compareSize
-
-        values.entries.forEach { (column, idValue) ->
-            if (!other.values.containsKey(column)) return -1
-            require(idValue is Comparable<*>) { "This stored identity value must implement Comparable" }
-            val otherValue = other.values[column]
-            require(otherValue is Comparable<*>) { "This stored identity value must implement Comparable" }
-            compareValues(idValue, otherValue).let {
-                if (it != 0) return it
-            }
-        }
-        return 0
     }
 
     companion object {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
@@ -11,7 +11,7 @@ package org.jetbrains.exposed.dao.id
  * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTestsData.YTable
  * @sample org.jetbrains.exposed.sql.tests.shared.dml.InsertTests.testInsertWithPredefinedId
  */
-open class EntityID<T : Any> protected constructor(val table: IdTable<T>, id: T?) : Comparable<EntityID<T>> {
+open class EntityID<T : Any> protected constructor(val table: IdTable<T>, id: T?) {
     constructor(id: T, table: IdTable<T>) : this(table, id)
 
     @Suppress("VariableNaming")
@@ -40,11 +40,5 @@ open class EntityID<T : Any> protected constructor(val table: IdTable<T>, id: T?
         if (other !is EntityID<*>) return false
 
         return other._value == _value && other.table == table
-    }
-
-    override fun compareTo(other: EntityID<T>): Int {
-        require(value is Comparable<*>) { "This stored identity value must implement Comparable" }
-        require(other.value is Comparable<*>) { "The other stored identity value must implement Comparable" }
-        return (value as Comparable<T>).compareTo(other.value)
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/dao/id/EntityID.kt
@@ -11,7 +11,7 @@ package org.jetbrains.exposed.dao.id
  * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTestsData.YTable
  * @sample org.jetbrains.exposed.sql.tests.shared.dml.InsertTests.testInsertWithPredefinedId
  */
-open class EntityID<T : Comparable<T>> protected constructor(val table: IdTable<T>, id: T?) : Comparable<EntityID<T>> {
+open class EntityID<T : Any> protected constructor(val table: IdTable<T>, id: T?) : Comparable<EntityID<T>> {
     constructor(id: T, table: IdTable<T>) : this(table, id)
 
     @Suppress("VariableNaming")
@@ -42,5 +42,9 @@ open class EntityID<T : Comparable<T>> protected constructor(val table: IdTable<
         return other._value == _value && other.table == table
     }
 
-    override fun compareTo(other: EntityID<T>): Int = value.compareTo(other.value)
+    override fun compareTo(other: EntityID<T>): Int {
+        require(value is Comparable<*>) { "This stored identity value must implement Comparable" }
+        require(other.value is Comparable<*>) { "The other stored identity value must implement Comparable" }
+        return (value as Comparable<T>).compareTo(other.value)
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -80,7 +80,7 @@ class Alias<out T : Table>(val delegate: T, val alias: String) : Table() {
             delegateIdColumns.map { column ->
                 val delegateColumn = originalColumn(column)
                 val otherValue = if (delegateColumn in toCompare.value.values) {
-                    toCompare.value[delegateColumn as Column<EntityID<Comparable<Any>>>]
+                    toCompare.value[delegateColumn as Column<EntityID<Any>>]
                 } else {
                     error("Comparison CompositeID is missing a key mapping for ${delegateColumn?.name}")
                 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -235,7 +235,7 @@ internal fun Column<*>.isEntityIdentifier(): Boolean {
 /**
  * Identity column type for storing unique [EntityID] values.
  */
-class EntityIDColumnType<T : Comparable<T>>(
+class EntityIDColumnType<T : Any>(
     /** The underlying wrapped column storing the identity values. */
     val idColumn: Column<T>
 ) : ColumnType<EntityID<T>>() {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Function.kt
@@ -167,7 +167,7 @@ class Locate<T : String?>(val expr: Expression<T>, val substring: String) : Func
 /**
  * Represents an SQL function that returns the minimum value of [expr] across all non-null input values, or `null` if there are no non-null values.
  */
-class Min<T : Comparable<T>, in S : T?>(
+class Min<T : Any, in S : T?>(
     /** Returns the expression from which the minimum value is obtained. */
     val expr: Expression<in S>,
     columnType: IColumnType<T>
@@ -182,7 +182,7 @@ class Min<T : Comparable<T>, in S : T?>(
 /**
  * Represents an SQL function that returns the maximum value of [expr] across all non-null input values, or `null` if there are no non-null values.
  */
-class Max<T : Comparable<T>, in S : T?>(
+class Max<T : Any, in S : T?>(
     /** Returns the expression from which the maximum value is obtained. */
     val expr: Expression<in S>,
     columnType: IColumnType<T>

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Op.kt
@@ -732,7 +732,7 @@ class QueryParameter<T>(
 }
 
 /** Returns the specified [value] as a query parameter with the same type as [column]. */
-fun <T : Comparable<T>> idParam(value: EntityID<T>, column: Column<EntityID<T>>): Expression<EntityID<T>> =
+fun <T : Any> idParam(value: EntityID<T>, column: Column<EntityID<T>>): Expression<EntityID<T>> =
     QueryParameter(value, column.columnType)
 
 /** Returns the specified [value] as a boolean query parameter. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -213,7 +213,7 @@ fun <T : Table> T.insert(body: T.(InsertStatement<Number>) -> Unit): InsertState
  * @return The generated ID for the new row.
  * @sample org.jetbrains.exposed.sql.tests.shared.dml.InsertTests.testGeneratedKey04
  */
-fun <Key : Comparable<Key>, T : IdTable<Key>> T.insertAndGetId(body: T.(InsertStatement<EntityID<Key>>) -> Unit): EntityID<Key> =
+fun <Key : Any, T : IdTable<Key>> T.insertAndGetId(body: T.(InsertStatement<EntityID<Key>>) -> Unit): EntityID<Key> =
     InsertStatement<EntityID<Key>>(this, false).run {
         body(this)
         execute(TransactionManager.current())
@@ -381,7 +381,7 @@ fun <T : Table> T.insertIgnore(body: T.(UpdateBuilder<*>) -> Unit): InsertStatem
  * @return The generated ID for the new row, or `null` if none was retrieved after statement execution.
  * @sample org.jetbrains.exposed.sql.tests.shared.dml.InsertTests.testInsertIgnoreAndGetId01
  */
-fun <Key : Comparable<Key>, T : IdTable<Key>> T.insertIgnoreAndGetId(body: T.(UpdateBuilder<*>) -> Unit): EntityID<Key>? =
+fun <Key : Any, T : IdTable<Key>> T.insertIgnoreAndGetId(body: T.(UpdateBuilder<*>) -> Unit): EntityID<Key>? =
     InsertStatement<EntityID<Key>>(this, isIgnore = true).run {
         body(this)
         when (execute(TransactionManager.current())) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ResultRow.kt
@@ -32,7 +32,7 @@ class ResultRow(
             column?.isEntityIdentifier() == true && column.table is CompositeIdTable -> {
                 val resultID = CompositeID {
                     column.table.idColumns.forEach { column ->
-                        it[column as Column<EntityID<Comparable<Any>>>] = getInternal(column, checkNullability = true).value
+                        it[column as Column<EntityID<Any>>] = getInternal(column, checkNullability = true).value
                     }
                 }
                 EntityID(resultID, column.table) as T

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -336,7 +336,8 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this [EntityID] expression is equal to some [t] value. */
-    infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.eq(t: V): Op<Boolean> {
+    @JvmName("eqEntityIDValue")
+    infix fun <T : Any, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.eq(t: V): Op<Boolean> {
         if (t == null) return isNull()
 
         @Suppress("UNCHECKED_CAST")
@@ -350,7 +351,7 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this [EntityID] expression is equal to some [other] expression. */
-    infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.eq(
+    infix fun <T : Any, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.eq(
         other: Expression<V>
     ): Op<Boolean> = when (other as Expression<*>) {
         is Op.NULL -> isNull()
@@ -358,7 +359,7 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.eq(
+    infix fun <T : Any, V : T?, E : EntityID<T>?> Expression<V>.eq(
         other: ExpressionWithColumnType<E>
     ): Op<Boolean> = other eq this
 
@@ -380,7 +381,8 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this [EntityID] expression is not equal to some [t] value. */
-    infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.neq(t: V): Op<Boolean> {
+    @JvmName("neqEntityIDValue")
+    infix fun <T : Any, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.neq(t: V): Op<Boolean> {
         if (t == null) return isNotNull()
         @Suppress("UNCHECKED_CAST")
         val table = (columnType as EntityIDColumnType<*>).idColumn.table as IdTable<T>
@@ -393,7 +395,7 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this [EntityID] expression is not equal to some [other] expression. */
-    infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.neq(
+    infix fun <T : Any, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.neq(
         other: Expression<V>
     ): Op<Boolean> = when (other as Expression<*>) {
         is Op.NULL -> isNotNull()
@@ -401,7 +403,7 @@ interface ISqlExpressionBuilder {
     }
 
     /** Checks if this expression is not equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.neq(
+    infix fun <T : Any, V : T?, E : EntityID<T>?> Expression<V>.neq(
         other: ExpressionWithColumnType<E>
     ): Op<Boolean> = other neq this
 
@@ -507,7 +509,7 @@ interface ISqlExpressionBuilder {
     fun <T, S : T?> ExpressionWithColumnType<in S>.between(from: T, to: T): Between = Between(this, wrap(from), wrap(to))
 
     /** Returns `true` if this [EntityID] expression is between the values [from] and [to], `false` otherwise. */
-    fun <T : Comparable<T>, E : EntityID<T>?> Column<E>.between(from: T, to: T): Between =
+    fun <T : Any, E : EntityID<T>?> Column<E>.between(from: T, to: T): Between =
         Between(this, wrap(EntityID(from, this.idTable())), wrap(EntityID(to, this.idTable())))
 
     /** Returns `true` if this expression is null, `false` otherwise. */
@@ -542,16 +544,16 @@ interface ISqlExpressionBuilder {
 
     /** Checks if this expression is equal to some [t] value, with `null` treated as a comparable value */
     @JvmName("isNotDistinctFromEntityID")
-    infix fun <T : Comparable<T>> Column<EntityID<T>>.isNotDistinctFrom(t: T): IsNotDistinctFromOp =
+    infix fun <T : Any> Column<EntityID<T>>.isNotDistinctFrom(t: T): IsNotDistinctFromOp =
         IsNotDistinctFromOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is equal to some [other] expression */
-    infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isNotDistinctFrom(
+    infix fun <T : Any, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isNotDistinctFrom(
         other: Expression<in V>
     ): IsNotDistinctFromOp = IsNotDistinctFromOp(this, other)
 
     /** Checks if this expression is equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<V>.isNotDistinctFrom(
+    infix fun <T : Any, V : T?, E : EntityID<T>?> Expression<V>.isNotDistinctFrom(
         other: ExpressionWithColumnType<E>
     ): IsNotDistinctFromOp = IsNotDistinctFromOp(this, other)
 
@@ -564,16 +566,16 @@ interface ISqlExpressionBuilder {
 
     /** Checks if this expression is not equal to some [t] value, with `null` treated as a comparable value */
     @JvmName("isDistinctFromEntityID")
-    infix fun <T : Comparable<T>> Column<EntityID<T>>.isDistinctFrom(t: T): IsDistinctFromOp =
+    infix fun <T : Any> Column<EntityID<T>>.isDistinctFrom(t: T): IsDistinctFromOp =
         IsDistinctFromOp(this, wrap(EntityID(t, this.idTable())))
 
     /** Checks if this [EntityID] expression is not equal to some [other] expression */
-    infix fun <T : Comparable<T>, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isDistinctFrom(
+    infix fun <T : Any, E : EntityID<T>?, V : T?> ExpressionWithColumnType<E>.isDistinctFrom(
         other: Expression<in V>
     ): IsDistinctFromOp = IsDistinctFromOp(this, other)
 
     /** Checks if this expression is not equal to some [other] [EntityID] expression. */
-    infix fun <T : Comparable<T>, V : T?, E : EntityID<T>?> Expression<in V>.isDistinctFrom(
+    infix fun <T : Any, V : T?, E : EntityID<T>?> Expression<in V>.isDistinctFrom(
         other: ExpressionWithColumnType<E>
     ): IsDistinctFromOp = IsDistinctFromOp(this, other)
 
@@ -927,7 +929,7 @@ interface ISqlExpressionBuilder {
     infix fun List<Column<*>>.inList(list: Iterable<CompositeID>): InListOrNotInListBaseOp<List<*>> {
         val componentList = list.map { id ->
             List(this.size) { i ->
-                val component = id[this[i] as Column<Comparable<Any>>]
+                val component = id[this[i] as Column<Any>]
                 component.takeIf { this[i].columnType is EntityIDColumnType<*> } ?: (component as EntityID<*>).value
             }
         }
@@ -941,7 +943,7 @@ interface ISqlExpressionBuilder {
      */
     @Suppress("UNCHECKED_CAST")
     @JvmName("inListIds")
-    infix fun <T : Comparable<T>, ID : EntityID<T>?> Column<ID>.inList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
+    infix fun <T : Any, ID : EntityID<T>?> Column<ID>.inList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return SingleValueInListOp(this, list.map { EntityIDFunctionProvider.createEntityID(it, idTable) }, isInList = true)
     }
@@ -1007,7 +1009,7 @@ interface ISqlExpressionBuilder {
     infix fun List<Column<*>>.notInList(list: Iterable<CompositeID>): InListOrNotInListBaseOp<List<*>> {
         val componentList = list.map { id ->
             List(this.size) { i ->
-                val component = id[this[i] as Column<Comparable<Any>>]
+                val component = id[this[i] as Column<Any>]
                 component.takeIf { this[i].columnType is EntityIDColumnType<*> } ?: (component as EntityID<*>).value
             }
         }
@@ -1021,7 +1023,7 @@ interface ISqlExpressionBuilder {
      */
     @Suppress("UNCHECKED_CAST")
     @JvmName("notInListIds")
-    infix fun <T : Comparable<T>, ID : EntityID<T>?> Column<ID>.notInList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
+    infix fun <T : Any, ID : EntityID<T>?> Column<ID>.notInList(list: Iterable<T>): InListOrNotInListBaseOp<EntityID<T>?> {
         val idTable = (columnType as EntityIDColumnType<T>).idColumn.table as IdTable<T>
         return SingleValueInListOp(this, list.map { EntityIDFunctionProvider.createEntityID(it, idTable) }, isInList = false)
     }
@@ -1073,7 +1075,7 @@ interface ISqlExpressionBuilder {
     fun ExpressionWithColumnType<Int>.intToDecimal(): NoOpConversion<Int, BigDecimal> =
         NoOpConversion(this, DecimalColumnType(precision = 15, scale = 0))
 
-    private fun <T : Comparable<T>, E : EntityID<T>> Column<out E?>.idTable(): IdTable<T> =
+    private fun <T : Any, E : EntityID<T>> Column<out E?>.idTable(): IdTable<T> =
         when (val table = this.foreignKey?.targetTable ?: this.table) {
             is Alias<*> -> table.delegate
             else -> table

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SQLExpressionBuilder.kt
@@ -66,10 +66,10 @@ fun <T : String?> Expression<T>.locate(substring: String): Locate<T> = Locate(th
 // General-Purpose Aggregate Functions
 
 /** Returns the minimum value of this expression across all non-null input values, or `null` if there are no non-null values. */
-fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.min(): Min<T, S> = Min<T, S>(this, this.columnType as IColumnType<T>)
+fun <T : Any, S : T?> ExpressionWithColumnType<in S>.min(): Min<T, S> = Min<T, S>(this, this.columnType as IColumnType<T>)
 
 /** Returns the maximum value of this expression across all non-null input values, or `null` if there are no non-null values. */
-fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<in S>.max(): Max<T, S> = Max<T, S>(this, this.columnType as IColumnType<T>)
+fun <T : Any, S : T?> ExpressionWithColumnType<in S>.max(): Max<T, S> = Max<T, S>(this, this.columnType as IColumnType<T>)
 
 /** Returns the average (arithmetic mean) value of this expression across all non-null input values, or `null` if there are no non-null values. */
 fun <T : Comparable<T>, S : T?> ExpressionWithColumnType<S>.avg(scale: Int = 2): Avg<T, S> = Avg<T, S>(this, scale)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -1005,15 +1005,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     fun <N : Any> Column<N>.autoIncrement(sequence: Sequence): Column<N> =
         cloneWithAutoInc(sequence).also { replaceColumn(this, it) }
 
-    /**
-     * Make @receiver column an auto-increment column to generate its values in a database.
-     * **Note:** Only integer and long columns are supported (signed and unsigned types).
-     * Some databases, like PostgreSQL, support auto-increment via sequences.
-     * In this case a name should be provided using the [idSeqName] param and Exposed will create a sequence.
-     * If a sequence already exists in the database just use its name in [idSeqName].
-     *
-     * @param idSeqName an optional parameter to provide a sequence name
-     */
+    @Deprecated(
+        message = "This function will be removed in future releases.",
+        replaceWith = ReplaceWith("autoIncrement(idSeqName)"),
+        level = DeprecationLevel.WARNING
+    )
     fun <N : Any> Column<EntityID<N>>.autoinc(idSeqName: String? = null): Column<EntityID<N>> =
         cloneWithAutoInc(idSeqName).also { replaceColumn(this, it) }
 
@@ -1069,7 +1065,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param ref A column from another table which will be used as a "parent".
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.JoinTests.testJoin04
      */
-    infix fun <T : Comparable<T>, S : T, C : Column<S>> C.references(ref: Column<T>): C = references(
+    infix fun <T : Any, S : T, C : Column<S>> C.references(ref: Column<T>): C = references(
         ref,
         null,
         null,
@@ -1089,7 +1085,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param fkName Optional foreign key constraint name.
      * @sample org.jetbrains.exposed.sql.tests.sqlite.ForeignKeyConstraintTests.testUpdateAndDeleteRulesReadCorrectlyWhenSpecifiedInChildTable
      */
-    fun <T : Comparable<T>, S : T, C : Column<S>> C.references(
+    fun <T : Any, S : T, C : Column<S>> C.references(
         ref: Column<T>,
         onDelete: ReferenceOption? = null,
         onUpdate: ReferenceOption? = null,
@@ -1147,7 +1143,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param fkName Optional foreign key constraint name.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Orders
      */
-    fun <T : Comparable<T>> reference(
+    fun <T : Any> reference(
         name: String,
         refColumn: Column<T>,
         onDelete: ReferenceOption? = null,
@@ -1230,7 +1226,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param fkName Optional foreign key constraint name.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Posts
      */
-    fun <T : Comparable<T>> optReference(
+    fun <T : Any> optReference(
         name: String,
         refColumn: Column<T>,
         onDelete: ReferenceOption? = null,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -645,7 +645,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /** Converts the @receiver column to an [EntityID] column. */
     @Suppress("UNCHECKED_CAST")
-    fun <T : Comparable<T>> Column<T>.entityId(): Column<EntityID<T>> {
+    fun <T : Any> Column<T>.entityId(): Column<EntityID<T>> {
         val newColumn = Column<EntityID<T>>(table, name, EntityIDColumnType(this)).also {
             it.defaultValueFun = defaultValueFun?.let { { EntityIDFunctionProvider.createEntityID(it(), table as IdTable<T>) } }
             it.dbDefaultValue = dbDefaultValue?.let { default -> default as Expression<EntityID<T>> }
@@ -656,7 +656,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     }
 
     /** Creates an [EntityID] column, with the specified [name], for storing the same objects as the specified [originalColumn]. */
-    fun <ID : Comparable<ID>> entityId(name: String, originalColumn: Column<ID>): Column<EntityID<ID>> {
+    fun <ID : Any> entityId(name: String, originalColumn: Column<ID>): Column<EntityID<ID>> {
         val columnTypeCopy = originalColumn.columnType.cloneAsBaseType()
         val answer = Column<EntityID<ID>>(
             this,
@@ -669,7 +669,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 
     /** Creates an [EntityID] column, with the specified [name], for storing the identifier of the specified [table]. */
     @Suppress("UNCHECKED_CAST")
-    fun <ID : Comparable<ID>> entityId(name: String, table: IdTable<ID>): Column<EntityID<ID>> {
+    fun <ID : Any> entityId(name: String, table: IdTable<ID>): Column<EntityID<ID>> {
         val originalColumn = (table.id.columnType as EntityIDColumnType<*>).idColumn as Column<ID>
         return entityId(name, originalColumn)
     }
@@ -1014,7 +1014,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      *
      * @param idSeqName an optional parameter to provide a sequence name
      */
-    fun <N : Comparable<N>> Column<EntityID<N>>.autoinc(idSeqName: String? = null): Column<EntityID<N>> =
+    fun <N : Any> Column<EntityID<N>>.autoinc(idSeqName: String? = null): Column<EntityID<N>> =
         cloneWithAutoInc(idSeqName).also { replaceColumn(this, it) }
 
     /** Sets the default value for this column in the database side. */
@@ -1118,7 +1118,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @sample org.jetbrains.exposed.sql.tests.shared.ddl.CreateMissingTablesAndColumnsTests.ExplicitTable
      */
     @JvmName("referencesById")
-    fun <T : Comparable<T>, S : T, C : Column<S>> C.references(
+    fun <T : Any, S : T, C : Column<S>> C.references(
         ref: Column<EntityID<T>>,
         onDelete: ReferenceOption? = null,
         onUpdate: ReferenceOption? = null,
@@ -1179,7 +1179,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      */
     @Suppress("UNCHECKED_CAST")
     @JvmName("referenceByIdColumn")
-    fun <T : Comparable<T>, E : EntityID<T>> reference(
+    fun <T : Any, E : EntityID<T>> reference(
         name: String,
         refColumn: Column<E>,
         onDelete: ReferenceOption? = null,
@@ -1204,7 +1204,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param fkName Optional foreign key constraint name.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Schools
      */
-    fun <T : Comparable<T>> reference(
+    fun <T : Any> reference(
         name: String,
         foreign: IdTable<T>,
         onDelete: ReferenceOption? = null,
@@ -1251,7 +1251,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Posts
      */
     @JvmName("optReferenceByIdColumn")
-    fun <T : Comparable<T>, E : EntityID<T>> optReference(
+    fun <T : Any, E : EntityID<T>> optReference(
         name: String,
         refColumn: Column<E>,
         onDelete: ReferenceOption? = null,
@@ -1272,7 +1272,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * @param fkName Optional foreign key constraint name.
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Schools
      */
-    fun <T : Comparable<T>> optReference(
+    fun <T : Any> optReference(
         name: String,
         foreign: IdTable<T>,
         onDelete: ReferenceOption? = null,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpdateBuilder.kt
@@ -40,7 +40,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
 
     @Suppress("UNCHECKED_CAST")
     @JvmName("setWithEntityIdValue")
-    operator fun <S : Comparable<S>> set(column: Column<EntityID<S>>, value: S) {
+    operator fun <S : Any> set(column: Column<EntityID<S>>, value: S) {
         if (value is CompositeID) {
             value.setComponentValues()
         } else {
@@ -52,7 +52,7 @@ abstract class UpdateBuilder<out T>(type: StatementType, targets: List<Table>) :
 
     @Suppress("UNCHECKED_CAST")
     @JvmName("setWithNullableEntityIdValue")
-    operator fun <S : Comparable<S>> set(column: Column<EntityID<S>?>, value: S?) {
+    operator fun <S : Any> set(column: Column<EntityID<S>?>, value: S?) {
         require(column.columnType.nullable || value != null) {
             "Trying to set null to not nullable column $column"
         }

--- a/exposed-dao/api/exposed-dao.api
+++ b/exposed-dao/api/exposed-dao.api
@@ -8,12 +8,12 @@ public abstract class org/jetbrains/exposed/dao/CompositeEntityClass : org/jetbr
 }
 
 public final class org/jetbrains/exposed/dao/DaoEntityID : org/jetbrains/exposed/dao/id/EntityID {
-	public fun <init> (Ljava/lang/Comparable;Lorg/jetbrains/exposed/dao/id/IdTable;)V
+	public fun <init> (Ljava/lang/Object;Lorg/jetbrains/exposed/dao/id/IdTable;)V
 }
 
 public final class org/jetbrains/exposed/dao/DaoEntityIDFactory : org/jetbrains/exposed/dao/id/EntityIDFactory {
 	public fun <init> ()V
-	public fun createEntityID (Ljava/lang/Comparable;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/id/EntityID;
+	public fun createEntityID (Ljava/lang/Object;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/id/EntityID;
 }
 
 public class org/jetbrains/exposed/dao/Entity {
@@ -123,14 +123,14 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	protected fun createInstance (Lorg/jetbrains/exposed/dao/id/EntityID;Lorg/jetbrains/exposed/sql/ResultRow;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun find (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun find (Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public final fun findById (Ljava/lang/Comparable;)Lorg/jetbrains/exposed/dao/Entity;
+	public final fun findById (Ljava/lang/Object;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun findById (Lorg/jetbrains/exposed/dao/id/EntityID;)Lorg/jetbrains/exposed/dao/Entity;
-	public final fun findByIdAndUpdate (Ljava/lang/Comparable;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
+	public final fun findByIdAndUpdate (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun findSingleByAndUpdate (Lorg/jetbrains/exposed/sql/Op;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun findWithCacheCondition (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
 	public fun forEntityIds (Ljava/util/List;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public final fun forIds (Ljava/util/List;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public final fun get (Ljava/lang/Comparable;)Lorg/jetbrains/exposed/dao/Entity;
+	public final fun get (Ljava/lang/Object;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun get (Lorg/jetbrains/exposed/dao/id/EntityID;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun getDependsOnColumns ()Ljava/util/List;
 	public fun getDependsOnTables ()Lorg/jetbrains/exposed/sql/ColumnSet;
@@ -139,7 +139,7 @@ public abstract class org/jetbrains/exposed/dao/EntityClass {
 	public final fun memoizedTransform (Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
 	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
 	public final fun memoizedTransform (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnTransformer;)Lorg/jetbrains/exposed/dao/EntityFieldWithTransform;
-	public fun new (Ljava/lang/Comparable;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
+	public fun new (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public fun new (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/dao/Entity;
 	public final fun optionalBackReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/dao/id/IdTable;)Lorg/jetbrains/exposed/dao/OptionalBackReference;
 	public final fun optionalBackReferencedOn (Lorg/jetbrains/exposed/dao/EntityClass;Lorg/jetbrains/exposed/sql/Column;)Lorg/jetbrains/exposed/dao/OptionalBackReference;

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityID.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityID.kt
@@ -8,7 +8,7 @@ import org.jetbrains.exposed.sql.transactions.TransactionManager
  * Class representing a wrapper for a stored identity value of type [T], which is managed and cached
  * by an [EntityClass] using a data access object pattern.
  */
-class DaoEntityID<T : Comparable<T>>(id: T?, table: IdTable<T>) : EntityID<T>(table, id) {
+class DaoEntityID<T : Any>(id: T?, table: IdTable<T>) : EntityID<T>(table, id) {
     override fun invokeOnNoValue() {
         TransactionManager.current().entityCache.flushInserts(table)
     }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityIDFactory.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/DaoEntityIDFactory.kt
@@ -9,7 +9,7 @@ import org.jetbrains.exposed.dao.id.IdTable
  * [EntityClass] instances using a data access object pattern.
  */
 class DaoEntityIDFactory : EntityIDFactory {
-    override fun <T : Comparable<T>> createEntityID(value: T, table: IdTable<T>): EntityID<T> {
+    override fun <T : Any> createEntityID(value: T, table: IdTable<T>): EntityID<T> {
         return DaoEntityID(value, table)
     }
 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -52,7 +52,7 @@ open class EntityFieldWithTransform<Unwrapped, Wrapped>(
  *
  * @param id The unique stored identity value for the mapped record.
  */
-open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
+open class Entity<ID : Any>(val id: EntityID<ID>) {
     /** The associated [EntityClass] that manages this [Entity] instance. */
     var klass: EntityClass<ID, Entity<ID>> by Delegates.notNull()
         internal set
@@ -120,7 +120,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
     }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <REF : Comparable<REF>, RID : Comparable<RID>, T : Entity<RID>> Reference<REF, RID, T>.getValue(
+    operator fun <REF : Any, RID : Any, T : Entity<RID>> Reference<REF, RID, T>.getValue(
         o: Entity<ID>,
         desc: KProperty<*>
     ): T {
@@ -154,7 +154,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
                             reference.referee!!.getValue(this, desc) == refValue
                         } else {
                             allReferences.all {
-                                it.value.getValue(this, desc) == (refValue as CompositeID)[it.key as Column<EntityID<Comparable<Any>>>]
+                                it.value.getValue(this, desc) == (refValue as CompositeID)[it.key as Column<EntityID<Any>>]
                             }
                         }
                     }) {
@@ -167,7 +167,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
         }
     }
 
-    operator fun <REF : Comparable<REF>, RID : Comparable<RID>, T : Entity<RID>> Reference<REF, RID, T>.setValue(
+    operator fun <REF : Any, RID : Any, T : Entity<RID>> Reference<REF, RID, T>.setValue(
         o: Entity<ID>,
         desc: KProperty<*>,
         value: T
@@ -182,7 +182,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
     }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <REF : Comparable<REF>, RID : Comparable<RID>, T : Entity<RID>> OptionalReference<REF, RID, T>.getValue(
+    operator fun <REF : Any, RID : Any, T : Entity<RID>> OptionalReference<REF, RID, T>.getValue(
         o: Entity<ID>,
         desc: KProperty<*>
     ): T? {
@@ -216,7 +216,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
                             reference.referee!!.getValue(this, desc) == refValue
                         } else {
                             allReferences.all {
-                                it.value.getValue(this, desc) == (refValue as CompositeID)[it.key as Column<EntityID<Comparable<Any>>>]
+                                it.value.getValue(this, desc) == (refValue as CompositeID)[it.key as Column<EntityID<Any>>]
                             }
                         }
                     }) {
@@ -230,7 +230,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
     }
 
     @Suppress("UNCHECKED_CAST")
-    operator fun <REF : Comparable<REF>, RID : Comparable<RID>, T : Entity<RID>> OptionalReference<REF, RID, T>.setValue(
+    operator fun <REF : Any, RID : Any, T : Entity<RID>> OptionalReference<REF, RID, T>.setValue(
         o: Entity<ID>,
         desc: KProperty<*>,
         value: T?
@@ -324,7 +324,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityHookTestData.City
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityHookTestData.UsersToCities
      */
-    infix fun <TID : Comparable<TID>, Target : Entity<TID>> EntityClass<TID, Target>.via(
+    infix fun <TID : Any, Target : Entity<TID>> EntityClass<TID, Target>.via(
         table: Table
     ): InnerTableLink<ID, Entity<ID>, TID, Target> =
         InnerTableLink(table, this@Entity.id.table, this@via)
@@ -341,7 +341,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.ViaTests.Node
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.ViaTests.NodeToNodes
      */
-    fun <TID : Comparable<TID>, Target : Entity<TID>> EntityClass<TID, Target>.via(
+    fun <TID : Any, Target : Entity<TID>> EntityClass<TID, Target>.via(
         sourceColumn: Column<EntityID<ID>>,
         targetColumn: Column<EntityID<TID>>
     ) = InnerTableLink(sourceColumn.table, this@Entity.id.table, this@via, sourceColumn, targetColumn)
@@ -433,7 +433,7 @@ open class Entity<ID : Comparable<ID>>(val id: EntityID<ID>) {
     internal fun writeIdColumnValue(table: IdTable<*>, value: EntityID<*>) {
         (value._value as? CompositeID)?.let { id ->
             table.idColumns.forEach { column ->
-                id[column as Column<EntityID<Comparable<Any>>>]?.let {
+                id[column as Column<EntityID<Any>>]?.let {
                     writeValues[column as Column<Any?>] = it
                 }
             }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityCache.kt
@@ -87,7 +87,7 @@ class EntityCache(private val transaction: Transaction) {
      *
      * @return The entity that has this wrapped id value, or `null` if no entity was found.
      */
-    fun <ID : Comparable<ID>, T : Entity<ID>> find(f: EntityClass<ID, T>, id: EntityID<ID>): T? =
+    fun <ID : Any, T : Entity<ID>> find(f: EntityClass<ID, T>, id: EntityID<ID>): T? =
         getMap(f)[id.value] as T?
             ?: inserts[f.table]?.firstOrNull { it.id == id } as? T
             ?: initializingEntities.firstOrNull { it.klass == f && it.id == id } as? T
@@ -97,10 +97,10 @@ class EntityCache(private val transaction: Transaction) {
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityCacheTests.testPerTransactionEntityCacheLimit
      */
-    fun <ID : Comparable<ID>, T : Entity<ID>> findAll(f: EntityClass<ID, T>): Collection<T> = getMap(f).values as Collection<T>
+    fun <ID : Any, T : Entity<ID>> findAll(f: EntityClass<ID, T>): Collection<T> = getMap(f).values as Collection<T>
 
     /** Stores the specified [Entity] in this [EntityCache] using its associated [EntityClass] as the key. */
-    fun <ID : Comparable<ID>, T : Entity<ID>> store(f: EntityClass<ID, T>, o: T) {
+    fun <ID : Any, T : Entity<ID>> store(f: EntityClass<ID, T>, o: T) {
         getMap(f)[o.id.value] = o
     }
 
@@ -114,7 +114,7 @@ class EntityCache(private val transaction: Transaction) {
     }
 
     /** Removes the specified [Entity] from this [EntityCache] using its associated [table] as the key. */
-    fun <ID : Comparable<ID>, T : Entity<ID>> remove(table: IdTable<ID>, o: T) {
+    fun <ID : Any, T : Entity<ID>> remove(table: IdTable<ID>, o: T) {
         getMap(table).remove(o.id.value)
     }
 
@@ -132,12 +132,12 @@ class EntityCache(private val transaction: Transaction) {
     internal fun isEntityInInitializationState(entity: Entity<*>) = entity in initializingEntities
 
     /** Stores the specified [Entity] in this [EntityCache] as scheduled to be inserted into the database. */
-    fun <ID : Comparable<ID>, T : Entity<ID>> scheduleInsert(f: EntityClass<ID, T>, o: T) {
+    fun <ID : Any, T : Entity<ID>> scheduleInsert(f: EntityClass<ID, T>, o: T) {
         inserts.getOrPut(f.table) { LinkedIdentityHashSet() }.add(o as Entity<*>)
     }
 
     /** Stores the specified [Entity] in this [EntityCache] as scheduled to be updated in the database. */
-    fun <ID : Comparable<ID>, T : Entity<ID>> scheduleUpdate(f: EntityClass<ID, T>, o: T) {
+    fun <ID : Any, T : Entity<ID>> scheduleUpdate(f: EntityClass<ID, T>, o: T) {
         updates.getOrPut(f.table) { LinkedIdentityHashSet() }.add(o as Entity<*>)
     }
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -27,7 +27,7 @@ import kotlin.sequences.Sequence
  * be used to determine the primary constructor of the associated entity class on first access (which can be slower).
  */
 @Suppress("UNCHECKED_CAST", "UnnecessaryAbstractClass", "TooManyFunctions")
-abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
+abstract class EntityClass<ID : Any, out T : Entity<ID>>(
     val table: IdTable<ID>,
     entityType: Class<T>? = null,
     entityCtor: ((EntityID<ID>) -> T)? = null,
@@ -420,7 +420,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Children
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Child
      */
-    infix fun <REF : Comparable<REF>> referencedOn(column: Column<REF>) = registerRefRule(column) { Reference(column, this) }
+    infix fun <REF : Any> referencedOn(column: Column<REF>) = registerRefRule(column) { Reference(column, this) }
 
     /**
      * Registers a reference as a field of the child entity class, which returns a parent object of this `EntityClass`.
@@ -432,9 +432,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Authors
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Author
      */
-    infix fun referencedOn(table: IdTable<*>): Reference<Comparable<Any>, ID, T> {
+    infix fun referencedOn(table: IdTable<*>): Reference<Any, ID, T> {
         val tableFK = getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>>
+        val delegate = tableFK.from.first() as Column<Any>
         return registerRefRule(delegate) { Reference(delegate, this, tableFK.references) }
     }
 
@@ -449,7 +449,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Posts
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Post
      */
-    infix fun <REF : Comparable<REF>> optionalReferencedOn(column: Column<REF?>) = registerRefRule(column) { OptionalReference(column, this) }
+    infix fun <REF : Any> optionalReferencedOn(column: Column<REF?>) = registerRefRule(column) { OptionalReference(column, this) }
 
     /**
      * Registers an optional reference as a field of the child entity class, which returns a parent object of
@@ -462,9 +462,9 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Offices
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Office
      */
-    infix fun optionalReferencedOn(table: IdTable<*>): OptionalReference<Comparable<Any>, ID, T> {
+    infix fun optionalReferencedOn(table: IdTable<*>): OptionalReference<Any, ID, T> {
         val tableFK = getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>?>
+        val delegate = tableFK.from.first() as Column<Any?>
         return registerRefRule(delegate) { OptionalReference(delegate, this, tableFK.references) }
     }
 
@@ -478,7 +478,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTestsData.XTable
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTestsData.BEntity
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.backReferencedOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.backReferencedOn(
         column: Column<REF>
     ): ReadOnlyProperty<Entity<ID>, Target> = registerRefRule(column) { BackReference(column, this) }
 
@@ -493,7 +493,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTestsData.BEntity
      */
     @JvmName("backReferencedOnOpt")
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.backReferencedOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.backReferencedOn(
         column: Column<REF?>
     ): ReadOnlyProperty<Entity<ID>, Target> = registerRefRule(column) { BackReference(column, this) }
 
@@ -508,11 +508,11 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Reviews
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Review
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>> EntityClass<TargetID, Target>.backReferencedOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>> EntityClass<TargetID, Target>.backReferencedOn(
         table: IdTable<*>
     ): ReadOnlyProperty<Entity<ID>, Target> {
         val tableFK = this@EntityClass.getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>?>
+        val delegate = tableFK.from.first() as Column<Any?>
         return registerRefRule(delegate) { BackReference(delegate, this, tableFK.references) }
     }
 
@@ -527,7 +527,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.StudentBios
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.StudentBio
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.optionalBackReferencedOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.optionalBackReferencedOn(
         column: Column<REF>
     ) =
         registerRefRule(column) { OptionalBackReference<TargetID, Target, ID, Entity<ID>, REF>(column as Column<REF?>, this) }
@@ -544,7 +544,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.StudentBio
      */
     @JvmName("optionalBackReferencedOnOpt")
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.optionalBackReferencedOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.optionalBackReferencedOn(
         column: Column<REF?>
     ) =
         registerRefRule(column) { OptionalBackReference<TargetID, Target, ID, Entity<ID>, REF>(column, this) }
@@ -560,11 +560,11 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Offices
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Office
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>> EntityClass<TargetID, Target>.optionalBackReferencedOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>> EntityClass<TargetID, Target>.optionalBackReferencedOn(
         table: IdTable<*>
-    ): OptionalBackReference<TargetID, Target, ID, Entity<ID>, Comparable<Any>> {
+    ): OptionalBackReference<TargetID, Target, ID, Entity<ID>, Any> {
         val tableFK = this@EntityClass.getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>?>
+        val delegate = tableFK.from.first() as Column<Any?>
         return registerRefRule(delegate) { OptionalBackReference(delegate, this, tableFK.references) }
     }
 
@@ -580,7 +580,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityHookTestData.Cities
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityHookTestData.City
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.referrersOn(column: Column<REF>) =
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.referrersOn(column: Column<REF>) =
         registerRefRule(column) { Referrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, true) }
 
     /**
@@ -594,11 +594,11 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Authors
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Author
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>> EntityClass<TargetID, Target>.referrersOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>> EntityClass<TargetID, Target>.referrersOn(
         table: IdTable<*>
-    ): Referrers<ID, Entity<ID>, TargetID, Target, Comparable<Any>> {
+    ): Referrers<ID, Entity<ID>, TargetID, Target, Any> {
         val tableFK = this@EntityClass.getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>>
+        val delegate = tableFK.from.first() as Column<Any>
         return registerRefRule(delegate) { Referrers(delegate, this, true, tableFK.references) }
     }
 
@@ -614,7 +614,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Students
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Student
      */
-    fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.referrersOn(
+    fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.referrersOn(
         column: Column<REF>,
         cache: Boolean
     ) =
@@ -629,12 +629,12 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      *
      * Set [cache] to `true` to also store the loaded entities to a cache.
      */
-    fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>> EntityClass<TargetID, Target>.referrersOn(
+    fun <TargetID : Any, Target : Entity<TargetID>> EntityClass<TargetID, Target>.referrersOn(
         table: IdTable<*>,
         cache: Boolean
-    ): Referrers<ID, Entity<ID>, TargetID, Target, Comparable<Any>> {
+    ): Referrers<ID, Entity<ID>, TargetID, Target, Any> {
         val tableFK = this@EntityClass.getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>>
+        val delegate = tableFK.from.first() as Column<Any>
         return registerRefRule(delegate) { Referrers(delegate, this, cache, tableFK.references) }
     }
 
@@ -651,7 +651,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Posts
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Post
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.optionalReferrersOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.optionalReferrersOn(
         column: Column<REF?>
     ) =
         registerRefRule(column) { OptionalReferrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, true) }
@@ -669,11 +669,11 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Authors
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.CompositeIdTableEntityTest.Author
      */
-    infix fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>> EntityClass<TargetID, Target>.optionalReferrersOn(
+    infix fun <TargetID : Any, Target : Entity<TargetID>> EntityClass<TargetID, Target>.optionalReferrersOn(
         table: IdTable<*>
-    ): OptionalReferrers<ID, Entity<ID>, TargetID, Target, Comparable<Any>> {
+    ): OptionalReferrers<ID, Entity<ID>, TargetID, Target, Any> {
         val tableFK = this@EntityClass.getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>?>
+        val delegate = tableFK.from.first() as Column<Any?>
         return registerRefRule(delegate) { OptionalReferrers(delegate, this, true, tableFK.references) }
     }
 
@@ -690,7 +690,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Detentions
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Detention
      */
-    fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>, REF : Comparable<REF>> EntityClass<TargetID, Target>.optionalReferrersOn(
+    fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> EntityClass<TargetID, Target>.optionalReferrersOn(
         column: Column<REF?>,
         cache: Boolean = false
     ) =
@@ -705,12 +705,12 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      *
      * Set [cache] to `true` to also store the loaded entities to a cache.
      */
-    fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>> EntityClass<TargetID, Target>.optionalReferrersOn(
+    fun <TargetID : Any, Target : Entity<TargetID>> EntityClass<TargetID, Target>.optionalReferrersOn(
         table: IdTable<*>,
         cache: Boolean = false
-    ): OptionalReferrers<ID, Entity<ID>, TargetID, Target, Comparable<Any>> {
+    ): OptionalReferrers<ID, Entity<ID>, TargetID, Target, Any> {
         val tableFK = this@EntityClass.getCompositeForeignKey(table)
-        val delegate = tableFK.from.first() as Column<Comparable<Any>?>
+        val delegate = tableFK.from.first() as Column<Any?>
         return registerRefRule(delegate) { OptionalReferrers(delegate, this, cache, tableFK.references) }
     }
 
@@ -721,7 +721,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * @throws IllegalStateException If [table] does not have a defined composite foreign key that matches the
      * primary key defined on the table associated with this `EntityClass`.
      */
-    private fun <TargetID : Comparable<TargetID>, Target : Entity<TargetID>> EntityClass<TargetID, Target>.getCompositeForeignKey(
+    private fun <TargetID : Any, Target : Entity<TargetID>> EntityClass<TargetID, Target>.getCompositeForeignKey(
         table: IdTable<*>
     ): ForeignKeyConstraint = table.foreignKeys.firstOrNull {
         it.target == this.table.idColumns
@@ -922,7 +922,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
         if (refColumn.columnType is EntityIDColumnType<*>) {
             refColumn as Column<EntityID<*>>
             distinctRefIds as List<EntityID<ID>>
-            val toLoad = distinctRefIds.filter {
+            val toLoad: List<EntityID<ID>> = distinctRefIds.filter {
                 cache.referrers[refColumn]?.containsKey(it)?.not() ?: true
             }
             if (toLoad.isNotEmpty()) {
@@ -1038,7 +1038,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     }
 
     @Suppress("ComplexMethod")
-    internal fun <SID : Comparable<SID>> warmUpLinkedReferences(
+    internal fun <SID : Any> warmUpLinkedReferences(
         references: List<EntityID<SID>>,
         sourceRefColumn: Column<EntityID<SID>>,
         targetRefColumn: Column<EntityID<ID>>,
@@ -1107,7 +1107,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
      * loading multiple times (per each reference row) and will require less memory/bandwidth for "heavy" entities
      * (with a lot of columns and/or columns that store large data sizes).
      */
-    fun <SID : Comparable<SID>> warmUpLinkedReferences(
+    fun <SID : Any> warmUpLinkedReferences(
         references: List<EntityID<SID>>,
         linkTable: Table,
         forUpdate: Boolean? = null,
@@ -1126,7 +1126,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
     /**
      * Returns whether the [entityClass] type is equivalent to or a superclass of this [EntityClass] instance's [klass].
      */
-    fun <ID : Comparable<ID>, T : Entity<ID>> isAssignableTo(entityClass: EntityClass<ID, T>) = entityClass.klass.isAssignableFrom(klass)
+    fun <ID : Any, T : Entity<ID>> isAssignableTo(entityClass: EntityClass<ID, T>) = entityClass.klass.isAssignableFrom(klass)
 }
 
 /**
@@ -1142,7 +1142,7 @@ abstract class EntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
  * @sample org.jetbrains.exposed.sql.tests.shared.entities.ImmutableEntityTest.Schema.Organization
  * @sample org.jetbrains.exposed.sql.tests.shared.entities.ImmutableEntityTest.EOrganization
  */
-abstract class ImmutableEntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
+abstract class ImmutableEntityClass<ID : Any, out T : Entity<ID>>(
     table: IdTable<ID>,
     entityType: Class<T>? = null,
     ctor: ((EntityID<ID>) -> T)? = null
@@ -1183,7 +1183,7 @@ abstract class ImmutableEntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
  * @sample org.jetbrains.exposed.sql.tests.shared.entities.ImmutableEntityTest.Schema.Organization
  * @sample org.jetbrains.exposed.sql.tests.shared.entities.ImmutableEntityTest.ECachedOrganization
  */
-abstract class ImmutableCachedEntityClass<ID : Comparable<ID>, out T : Entity<ID>>(
+abstract class ImmutableCachedEntityClass<ID : Any, out T : Entity<ID>>(
     table: IdTable<ID>,
     entityType: Class<T>? = null,
     ctor: ((EntityID<ID>) -> T)? = null

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transactionScope
-import java.util.*
+import java.util.Deque
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.ConcurrentLinkedQueue
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityHook.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transactionScope
-import java.util.Deque
+import java.util.*
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -36,7 +36,7 @@ data class EntityChange(
  * Returns the actual [Entity] instance associated with [this][EntityChange] event,
  * or `null` if the entity is not found.
  */
-fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(): T? =
+fun <ID : Any, T : Entity<ID>> EntityChange.toEntity(): T? =
     (entityClass as EntityClass<ID, T>).findById(entityId as EntityID<ID>)
 
 /**
@@ -44,7 +44,7 @@ fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(): T? =
  * or `null` if either its [EntityClass] type is neither equivalent to nor a subclass of [klass],
  * or if the entity is not found.
  */
-fun <ID : Comparable<ID>, T : Entity<ID>> EntityChange.toEntity(klass: EntityClass<ID, T>): T? {
+fun <ID : Any, T : Entity<ID>> EntityChange.toEntity(klass: EntityClass<ID, T>): T? {
     if (!entityClass.isAssignableTo(klass)) return null
     return toEntity<ID, T>()
 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/InnerTableLink.kt
@@ -22,7 +22,7 @@ import kotlin.reflect.KProperty
  * this will be inferred from the provided intermediate [table] columns.
  */
 @Suppress("UNCHECKED_CAST")
-class InnerTableLink<SID : Comparable<SID>, Source : Entity<SID>, ID : Comparable<ID>, Target : Entity<ID>>(
+class InnerTableLink<SID : Any, Source : Entity<SID>, ID : Any, Target : Entity<ID>>(
     val table: Table,
     sourceTable: IdTable<SID>,
     val target: EntityClass<ID, Target>,

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ColumnWithTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ColumnWithTransformTest.kt
@@ -224,9 +224,7 @@ class ColumnWithTransformTest : DatabaseTestsBase() {
         }
     }
 
-    data class CustomId(val id: UUID) : Comparable<CustomId> {
-        override fun compareTo(other: CustomId): Int = id.compareTo(other.id)
-    }
+    private data class CustomId(val id: UUID)
 
     @Test
     fun testTransformIdColumn() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/CompositeIdTableEntityTest.kt
@@ -733,7 +733,7 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
         return EntityID(
             CompositeID {
                 referenceColumns.forEach { (child, parent) ->
-                    it[parent as Column<EntityID<Comparable<Any>>>] = this.readValues[child] as Comparable<Any>
+                    it[parent as Column<EntityID<Any>>] = this.readValues[child] as Any
                 }
             },
             table

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/OrderedReferenceTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/OrderedReferenceTest.kt
@@ -101,14 +101,14 @@ class OrderedReferenceTest : DatabaseTestsBase() {
             fun assertRatingsOrdered(current: UserRatingMultiColumn, prev: UserRatingMultiColumn) {
                 assertTrue(current.value <= prev.value)
                 if (current.value == prev.value) {
-                    assertTrue(current.id <= prev.id)
+                    assertTrue(current.id.value <= prev.id.value)
                 }
             }
 
             fun assertNullableRatingsOrdered(current: UserNullableRatingMultiColumn, prev: UserNullableRatingMultiColumn) {
                 assertTrue(current.value <= prev.value)
                 if (current.value == prev.value) {
-                    assertTrue(current.id <= prev.id)
+                    assertTrue(current.id.value <= prev.id.value)
                 }
             }
 
@@ -140,7 +140,7 @@ class OrderedReferenceTest : DatabaseTestsBase() {
             fun assertRatingsOrdered(current: UserRatingChainedColumn, prev: UserRatingChainedColumn) {
                 assertTrue(current.value <= prev.value)
                 if (current.value == prev.value) {
-                    assertTrue(current.id <= prev.id)
+                    assertTrue(current.id.value <= prev.id.value)
                 }
             }
 


### PR DESCRIPTION
#### Description

**Summary of the change**:
All `Entity` related objects and functions are no longer restricted to type-parameter `Comparable`.

**Detailed description**:
- **Why**:
Introduction of [Kotlin 2.0](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.uuid/-uuid/) brought `kotlin.uuid.Uuid`, which does not implement `Comparable` interface, and many requests to allow its usage with `IdTable`. Loosening these type restrictions will allow users to easily implement their own `UuidColumnType` and `IdTable<Uuid>`, at least until the new type is no longer `@ExperimentalUuidApi` and built-in Exposed api options are made available.

- **How**:
    - Any entity related function type-parameter restriction `T : Comparable<T>` has been replaced with `T : Any`.
    - `Min` and `Max` class operators are also no longer restricted to `Comparable` types, so that `max()` and `min()` can be called on `id`. This was done because some tests presented this use case.
    -  Reference functions are also no longer restricted to `Comparable` to allow use of these functions with `id` columns.
    - `EntityID` and `CompositeID` are no longer `Comparable`, since their wrapped values are no longer restricted to this. This means that any use of these directly with comparison operators, or any variant of sort or `compareTo()`, will no longer compile:
 ```kt
// will no longer work:
entity1.id >= entity2.id

// must be replaced with:
entity1.id.value >= entity2.id.value
// and will only compile if the values are actually comparable
```
---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-577](https://youtrack.jetbrains.com/issue/EXPOSED-577)