### PR TITLE
docs: EXPOSED-572 Add code sample for 'auto-fill columns on entity change﻿'

### DIFF
--- a/documentation-website/Writerside/snippets/exposed-dao/build.gradle.kts
+++ b/documentation-website/Writerside/snippets/exposed-dao/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.exposed.core)
     implementation(libs.exposed.jdbc)
     implementation(libs.exposed.dao)
+    implementation(libs.exposed.kotlin.datetime)
     implementation("com.h2database:h2:2.2.224")
 }
 

--- a/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/BaseEntity.kt
+++ b/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/BaseEntity.kt
@@ -1,0 +1,11 @@
+package org.example.entities
+
+import kotlinx.datetime.LocalDateTime
+import org.example.tables.BaseTable
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.id.EntityID
+
+abstract class BaseEntity(id: EntityID<Int>, table: BaseTable) : IntEntity(id) {
+    val created: LocalDateTime by table.created
+    var modified: LocalDateTime? by table.modified
+}

--- a/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/BaseEntityClass.kt
+++ b/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/BaseEntityClass.kt
@@ -1,0 +1,43 @@
+package org.example.entities
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.example.tables.BaseTable
+import org.jetbrains.exposed.dao.*
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.exposedLogger
+
+abstract class BaseEntityClass<out E : BaseEntity>(
+    table: BaseTable
+) : IntEntityClass<E>(table) {
+    init {
+        EntityHook.subscribe { change ->
+            val changedEntity = change.toEntity(this)
+            when (val type = change.changeType) {
+                EntityChangeType.Updated -> {
+                    val now = nowUTC()
+                    changedEntity?.let {
+                        if (it.writeValues[table.modified as Column<Any?>] == null) {
+                            it.modified = now
+                        }
+                    }
+                    logChange(changedEntity, type, now)
+                }
+                else -> logChange(changedEntity, type)
+            }
+        }
+    }
+
+    private fun nowUTC() = Clock.System.now().toLocalDateTime(TimeZone.UTC)
+
+    private fun logChange(entity: E?, type: EntityChangeType, dateTime: LocalDateTime? = null) {
+        entity?.let {
+            val entityClassName = this::class.java.enclosingClass.simpleName
+            exposedLogger.info(
+                "$entityClassName(${it.id}) ${type.name.lowercase()} at ${dateTime ?: nowUTC()}"
+            )
+        }
+    }
+}

--- a/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/tables/BaseTable.kt
+++ b/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/tables/BaseTable.kt
@@ -1,0 +1,13 @@
+package org.example.tables
+
+import kotlinx.datetime.LocalDateTime
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.kotlin.datetime.CurrentDateTime
+import org.jetbrains.exposed.sql.kotlin.datetime.datetime
+
+abstract class BaseTable(name: String = "") : IntIdTable(name) {
+    val created: Column<LocalDateTime> = datetime("created")
+        .defaultExpression(CurrentDateTime)
+    val modified: Column<LocalDateTime?> = datetime("updated").nullable()
+}

--- a/documentation-website/Writerside/snippets/gradle/libs.versions.toml
+++ b/documentation-website/Writerside/snippets/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
 exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
 
 [plugins]
 jvm = { id = "org.jetbrains.kotlin.jvm", version = "1.9.22" }

--- a/documentation-website/Writerside/topics/DAO-CRUD-Operations.topic
+++ b/documentation-website/Writerside/topics/DAO-CRUD-Operations.topic
@@ -155,8 +155,32 @@
         <code-block lang="kotlin" src="exposed-dao/src/main/kotlin/org/example/examples/ReadExamples.kt" include-symbol="readComputedField"/>
     </chapter>
 
-    <chapter title="Auto-fill created and updated columns on entity change" id="auto-fill-created-and-updated-columns-on-entity-change">
-        <p>See example by @PaulMuriithi <a href="https://github.com/PaulMuriithi/ExposedDatesAutoFill/blob/master/src/main/kotlin/app/Models.kt">here</a>.</p>
+    <chapter title="Auto-fill columns on entity change" id="auto-fill-columns-on-entity-change">
+        <p>Suppose that all table objects need to have at minimum two columns for storing the date and time when
+            a record is created and modified. A <code>BaseTable</code> from which all these objects inherit could be implemented,
+            along with an associated <code>BaseEntity</code>:</p>
+        <tabs>
+            <tab id="abstract-base-table" title="BaseTable">
+                <code-block lang="kotlin" src="exposed-dao/src/main/kotlin/org/example/tables/BaseTable.kt"/>
+            </tab>
+            <tab id="abstract-base-entity" title="BaseEntity">
+                <code-block lang="kotlin" src="exposed-dao/src/main/kotlin/org/example/entities/BaseEntity.kt"/>
+            </tab>
+        </tabs>
+        <p>Whenever a new entity is instantiated, the <code>created</code> column will be filled with the database default
+            defined by <code>CurrentDateTime</code>.</p>
+        <p>A DAO interceptor, <code>EntityHook</code>, can then be subscribed to in order to fill the <code>modified</code> column whenever
+            an existing entity is later updated:</p>
+        <code-block lang="kotlin" src="exposed-dao/src/main/kotlin/org/example/entities/BaseEntityClass.kt"/>
+        <p>In the example above, other than logging the change, an action is only performed when <code>EntityChangeType.Updated</code>
+            is detected. Other actions could be detected for when an entity is <code>Created</code> or <code>Removed</code>.</p>
+        <p><code>Entity.writeValues</code> represents the column-value mapping for an entity instance before being flushed to
+            the database. Checking for a stored value first ensures that filling the <code>modified</code> column does not
+            trigger the interceptor itself.</p>
+        <tip>
+            For more details about using statement interceptors, see
+            <a href="Transactions.md" anchor="statement-interceptors">DSL Statement Interceptors</a>.
+        </tip>
     </chapter>
 
 </topic>

--- a/documentation-website/Writerside/topics/DAO-CRUD-Operations.topic
+++ b/documentation-website/Writerside/topics/DAO-CRUD-Operations.topic
@@ -156,9 +156,10 @@
     </chapter>
 
     <chapter title="Auto-fill columns on entity change" id="auto-fill-columns-on-entity-change">
-        <p>Suppose that all table objects need to have at minimum two columns for storing the date and time when
-            a record is created and modified. A <code>BaseTable</code> from which all these objects inherit could be implemented,
-            along with an associated <code>BaseEntity</code>:</p>
+        <p>Suppose that you need all your table objects to have at minimum two columns for storing the date and time when
+            a record is created and modified. You could define a <code>BaseTable</code> to automatically handle registering
+            these columns to any table that extends this abstract class. An abstract <code>BaseEntity</code> could also be
+            defined to automatically associate fields to the relevant columns:</p>
         <tabs>
             <tab id="abstract-base-table" title="BaseTable">
                 <code-block lang="kotlin" src="exposed-dao/src/main/kotlin/org/example/tables/BaseTable.kt"/>
@@ -167,16 +168,37 @@
                 <code-block lang="kotlin" src="exposed-dao/src/main/kotlin/org/example/entities/BaseEntity.kt"/>
             </tab>
         </tabs>
-        <p>Whenever a new entity is instantiated, the <code>created</code> column will be filled with the database default
-            defined by <code>CurrentDateTime</code>.</p>
-        <p>A DAO interceptor, <code>EntityHook</code>, can then be subscribed to in order to fill the <code>modified</code> column whenever
-            an existing entity is later updated:</p>
+        <p>Whenever a new entity is instantiated, the <code>created</code> column will be filled with the database default defined by
+            <a href="https://jetbrains.github.io/Exposed/api/exposed-kotlin-datetime/org.jetbrains.exposed.sql.kotlin.datetime/-current-date-time/index.html">
+                <code>CurrentDateTime</code>
+            </a>, while the <code>modified</code> column will be filled with a null value.</p>
+        <p>An entity lifecycle interceptor,
+            <a href="https://jetbrains.github.io/Exposed/api/exposed-dao/org.jetbrains.exposed.dao/-entity-hook/index.html">
+                <code>EntityHook</code>
+            </a>, can then be subscribed to in order to automatically populate the <code>modified</code> field whenever an
+            existing entity is later updated:</p>
         <code-block lang="kotlin" src="exposed-dao/src/main/kotlin/org/example/entities/BaseEntityClass.kt"/>
-        <p>In the example above, other than logging the change, an action is only performed when <code>EntityChangeType.Updated</code>
-            is detected. Other actions could be detected for when an entity is <code>Created</code> or <code>Removed</code>.</p>
-        <p><code>Entity.writeValues</code> represents the column-value mapping for an entity instance before being flushed to
-            the database. Checking for a stored value first ensures that filling the <code>modified</code> column does not
-            trigger the interceptor itself.</p>
+        <p>The example above invokes <code>EntityHook.subscribe()</code> in an abstract <code>BaseEntityClass</code> that
+            can be used as a companion object for any <code>BaseEntity</code> implementation, but the interceptor could be
+            subscribed to (and unsubscribed from) on the transaction level as well.</p>
+        <p>The subscription only performs an action when a record is updated (detected by <code>EntityChangeType.Updated</code>).</p>
+        <tip>
+            Other actions could be detected for when an entity is created (<code>EntityChangeType.Created</code>) or
+            removed (<code>EntityChangeType.Removed</code>).
+        </tip>
+        <p>
+            When an update occurs, the <code>modified</code> column is populated with the current UTC time
+            using the <code>nowUTC()</code> method. However, the update only happens if the <code>modified</code> field
+            has not already been set. This is checked by using <code>Entity.writeValues</code>, which holds the column-value
+            mappings for an entity instance before being flushed to the database. Performing this check ensures that filling
+            the <code>modified</code> column does not trigger the interceptor itself.
+        </p>
+        <p>
+            Additionally, every change (creation, update, or deletion) is logged using the
+            <a href="https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.sql/exposed-logger.html?query=val%20exposedLogger:%20Logger">
+                <code>exposedLogger</code>
+            </a>.
+        </p>
         <tip>
             For more details about using statement interceptors, see
             <a href="Transactions.md" anchor="statement-interceptors">DSL Statement Interceptors</a>.


### PR DESCRIPTION
#### Description

**Summary of the change**:
Replace external sample link in DAO subsection (how to auto-fill columns on entity change) with inline sample block.

**Detailed description**:
- **What**:
    - Refactor original sample to use updated api and to not allow auto-fill to trigger continuous self-updates
    - Add dependency on kotlin-datetime module to snippets directory
    - Add refactored abstract classes to snippets directory
    - Edit DAO subsection to use refactored code & link to existing section on DSL interceptors

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-572]()