### PR TITLE
fix: EXPOSED-583 alias from inner query missing from outer select

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1441,6 +1441,7 @@ public final class org/jetbrains/exposed/sql/Join : org/jetbrains/exposed/sql/Co
 	public fun describe (Lorg/jetbrains/exposed/sql/Transaction;Lorg/jetbrains/exposed/sql/QueryBuilder;)V
 	public fun fullJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public fun getColumns ()Ljava/util/List;
+	public fun getFields ()Ljava/util/List;
 	public final fun getTable ()Lorg/jetbrains/exposed/sql/ColumnSet;
 	public fun innerJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public fun join (Lorg/jetbrains/exposed/sql/ColumnSet;Lorg/jetbrains/exposed/sql/JoinType;Lorg/jetbrains/exposed/sql/Expression;Lorg/jetbrains/exposed/sql/Expression;ZLkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Join;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Alias.kt
@@ -123,15 +123,23 @@ class ExpressionAlias<T>(val delegate: Expression<T>, val alias: String) : Expre
     /** Returns an [Expression] containing only the string representation of this [alias]. */
     fun aliasOnlyExpression(): Expression<T> {
         return if (delegate is ExpressionWithColumnType<T>) {
-            object : Function<T>(delegate.columnType) {
+            object : AliasOnlyExpression<T>, Function<T>(delegate.columnType) {
+                override val origin: ExpressionAlias<T> = this@ExpressionAlias
+
                 override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append(alias) }
             }
         } else {
-            object : Expression<T>() {
+            object : AliasOnlyExpression<T>, Expression<T>() {
+                override val origin: ExpressionAlias<T> = this@ExpressionAlias
+
                 override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder { append(alias) }
             }
         }
     }
+}
+
+internal interface AliasOnlyExpression<T> {
+    val origin: ExpressionAlias<T>
 }
 
 /** Represents a temporary SQL identifier, [alias], for a [query]. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -247,18 +247,9 @@ class Join(
         ) { it.joinPart.columns }
 
     override val fields: List<Expression<*>>
-        get() = joinParts.flatMapTo(
-            table.fields.toMutableList()
-        ) {
-            when {
-                it.joinPart is QueryAlias ->
-                    it.joinPart.fields.map { field ->
-                        when (field) {
-                            is AliasOnlyExpression<*> ->
-                                field.alias("${it.joinPart.alias}.${field.origin.alias}").aliasOnlyExpression()
-                            else -> field
-                        }
-                    }
+        get() = joinParts.flatMapTo(table.fields.toMutableList()) {
+            when (it.joinPart) {
+                is QueryAlias -> it.joinPart.aliasedFields
                 else -> it.joinPart.fields
             }
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -246,6 +246,23 @@ class Join(
             table.columns.toMutableList()
         ) { it.joinPart.columns }
 
+    override val fields: List<Expression<*>>
+        get() = joinParts.flatMapTo(
+            table.fields.toMutableList()
+        ) {
+            when {
+                it.joinPart is QueryAlias ->
+                    it.joinPart.fields.map { field ->
+                        when (field) {
+                            is AliasOnlyExpression<*> ->
+                                field.alias("${it.joinPart.alias}.${field.origin.alias}").aliasOnlyExpression()
+                            else -> field
+                        }
+                    }
+                else -> it.joinPart.fields
+            }
+        }
+
     internal val joinParts: MutableList<JoinPart> = mutableListOf()
 
     constructor(


### PR DESCRIPTION
#### Description

In the case when select query has joined subquery (by `QueryAlias`) and that subquery has selected aliases (by `ExpressionAlias`) the `selectAll()` for the whole query would ignore that internal aliases.

**Detailed description**:
- **What**: PR adds to select fields with pattern `${subQueryAlias}.${ExpressionAlias}`, it allows to get all the results from the query.
- **Why**: It happens because in moment of join to evaluate `fields` parameter only the values from `columns` parameter from `joinPart` is taken, but not all the `fields.
- **How**: Even if we take all the `fields` from subquery, it would not solve the problem, because these `fields` will not have (in the case of alias) connection to the `QueryAlias`. And what's worser it's not possible to differentiate them from other expressions, because they have not type of `ExpressionAlias` because they were created with `ExpressionAlias::aliasOnlyExpression()` method, that returns just `Expression`/`Function` object.

With this fix I added new interface `AliasOnlyExpression` to mark the expressions that were returned by `ExpressionAlias::aliasOnlyExpression()`. It allows to check for these expression in the moment of join.

But this solution does not work with aliases inside sub-sub-queries, it will generate wrong identifiers with multiple dots inside (like `subquery.subsubquery.alias`). I created another issue to think about that problem: [EXPOSED-605](https://youtrack.jetbrains.com/issue/EXPOSED-605) selectAll() can not select aliases from sub-sub-queries probably a bigger refactoring is required.

 ---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

---

#### Related Issues

[EXPOSED-583](https://youtrack.jetbrains.com/issue/EXPOSED-583) alias from inner query missing from outer select
