### PR TITLE
test: Use `withTables` instead of invoking `SchemaUtils.create` wherever possible

### DIFF
--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -387,16 +387,10 @@ class DefaultsTest : DatabaseTestsBase() {
             val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp)
         }
 
-        withDb {
-            try {
-                SchemaUtils.create(foo)
+        withTables(foo) {
+            val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
 
-                val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
-
-                assertTrue(actual.isEmpty())
-            } finally {
-                SchemaUtils.drop(foo)
-            }
+            assertTrue(actual.isEmpty())
         }
     }
 

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -454,71 +454,65 @@ class JavaTimeTests : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withDb(excludeSettings = timestampWithTimeZoneUnsupportedDB + TestDB.ALL_H2_V1) { testDb ->
-            try {
-                // UTC time zone
-                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
-                assertEquals("UTC", ZoneId.systemDefault().id)
+        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB + TestDB.ALL_H2_V1, testTable) { testDb ->
+            // UTC time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+            assertEquals("UTC", ZoneId.systemDefault().id)
 
-                SchemaUtils.create(testTable)
-
-                val now = OffsetDateTime.parse("2023-05-04T05:04:01.123123123+00:00")
-                val nowId = testTable.insertAndGetId {
-                    it[timestampWithTimeZone] = now
-                }
-
-                assertEquals(
-                    now.toLocalDate(),
-                    testTable.select(testTable.timestampWithTimeZone.date()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.date()]
-                )
-
-                val expectedTime =
-                    when (testDb) {
-                        TestDB.SQLITE -> OffsetDateTime.parse("2023-05-04T05:04:01.123+00:00")
-                        TestDB.MYSQL_V8, TestDB.SQLSERVER,
-                        in TestDB.ALL_ORACLE_LIKE,
-                        in TestDB.ALL_POSTGRES_LIKE -> OffsetDateTime.parse("2023-05-04T05:04:01.123123+00:00")
-                        else -> now
-                    }.toLocalTime()
-                assertEquals(
-                    expectedTime,
-                    testTable.select(testTable.timestampWithTimeZone.time()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.time()]
-                )
-
-                assertEquals(
-                    now.month.value,
-                    testTable.select(testTable.timestampWithTimeZone.month()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.month()]
-                )
-
-                assertEquals(
-                    now.dayOfMonth,
-                    testTable.select(testTable.timestampWithTimeZone.day()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.day()]
-                )
-
-                assertEquals(
-                    now.hour,
-                    testTable.select(testTable.timestampWithTimeZone.hour()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.hour()]
-                )
-
-                assertEquals(
-                    now.minute,
-                    testTable.select(testTable.timestampWithTimeZone.minute()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.minute()]
-                )
-
-                assertEquals(
-                    now.second,
-                    testTable.select(testTable.timestampWithTimeZone.second()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.second()]
-                )
-            } finally {
-                SchemaUtils.drop(testTable)
+            val now = OffsetDateTime.parse("2023-05-04T05:04:01.123123123+00:00")
+            val nowId = testTable.insertAndGetId {
+                it[timestampWithTimeZone] = now
             }
+
+            assertEquals(
+                now.toLocalDate(),
+                testTable.select(testTable.timestampWithTimeZone.date()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.date()]
+            )
+
+            val expectedTime =
+                when (testDb) {
+                    TestDB.SQLITE -> OffsetDateTime.parse("2023-05-04T05:04:01.123+00:00")
+                    TestDB.MYSQL_V8, TestDB.SQLSERVER,
+                    in TestDB.ALL_ORACLE_LIKE,
+                    in TestDB.ALL_POSTGRES_LIKE -> OffsetDateTime.parse("2023-05-04T05:04:01.123123+00:00")
+                    else -> now
+                }.toLocalTime()
+            assertEquals(
+                expectedTime,
+                testTable.select(testTable.timestampWithTimeZone.time()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.time()]
+            )
+
+            assertEquals(
+                now.month.value,
+                testTable.select(testTable.timestampWithTimeZone.month()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.month()]
+            )
+
+            assertEquals(
+                now.dayOfMonth,
+                testTable.select(testTable.timestampWithTimeZone.day()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.day()]
+            )
+
+            assertEquals(
+                now.hour,
+                testTable.select(testTable.timestampWithTimeZone.hour()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.hour()]
+            )
+
+            assertEquals(
+                now.minute,
+                testTable.select(testTable.timestampWithTimeZone.minute()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.minute()]
+            )
+
+            assertEquals(
+                now.second,
+                testTable.select(testTable.timestampWithTimeZone.second()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.second()]
+            )
         }
     }
 

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/JodaTimeTests.kt
@@ -364,8 +364,6 @@ class JodaTimeTests : DatabaseTestsBase() {
             DateTimeZone.setDefault(DateTimeZone.UTC)
             assertEquals("UTC", DateTimeZone.getDefault().id)
 
-            SchemaUtils.create(testTable)
-
             val now = DateTime.parse("2023-05-04T05:04:01.123123123+00:00")
             val nowId = testTable.insertAndGetId {
                 it[timestampWithTimeZone] = now

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -390,16 +390,10 @@ class DefaultsTest : DatabaseTestsBase() {
             val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp)
         }
 
-        withDb {
-            try {
-                SchemaUtils.create(foo)
+        withTables(foo) {
+            val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
 
-                val actual = SchemaUtils.statementsRequiredToActualizeScheme(foo)
-
-                assertTrue(actual.isEmpty())
-            } finally {
-                SchemaUtils.drop(foo)
-            }
+            assertTrue(actual.isEmpty())
         }
     }
 
@@ -568,15 +562,9 @@ class DefaultsTest : DatabaseTestsBase() {
         // SQLite does not support ALTER TABLE on a column that has a default value
         // MariaDB does not support TIMESTAMP WITH TIME ZONE column type
         val unsupportedDatabases = TestDB.ALL_MARIADB + TestDB.SQLITE + TestDB.MYSQL_V5
-        withDb(excludeSettings = unsupportedDatabases) {
-            try {
-                SchemaUtils.drop(tester)
-                SchemaUtils.create(tester)
-                val statements = SchemaUtils.addMissingColumnsStatements(tester)
-                assertEquals(0, statements.size)
-            } finally {
-                SchemaUtils.drop(tester)
-            }
+        withTables(excludeSettings = unsupportedDatabases, tester) {
+            val statements = SchemaUtils.addMissingColumnsStatements(tester)
+            assertEquals(0, statements.size)
         }
     }
 

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -451,77 +451,71 @@ class KotlinTimeTests : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withDb(excludeSettings = timestampWithTimeZoneUnsupportedDB + TestDB.ALL_H2_V1) { testDb ->
-            try {
-                // UTC time zone
-                java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
-                assertEquals("UTC", ZoneId.systemDefault().id)
+        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB + TestDB.ALL_H2_V1, testTable) { testDb ->
+            // UTC time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
+            assertEquals("UTC", ZoneId.systemDefault().id)
 
-                SchemaUtils.create(testTable)
-
-                val now = OffsetDateTime.parse("2023-05-04T05:04:01.123123123+00:00")
-                val nowId = testTable.insertAndGetId {
-                    it[testTable.timestampWithTimeZone] = now
-                }
-
-                assertEquals(
-                    now.toLocalDate().toKotlinLocalDate(),
-                    testTable.select(testTable.timestampWithTimeZone.date()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.date()]
-                )
-
-                val expectedTime =
-                    when (testDb) {
-                        TestDB.SQLITE -> OffsetDateTime.parse("2023-05-04T05:04:01.123+00:00")
-                        TestDB.MYSQL_V8, TestDB.SQLSERVER,
-                        in TestDB.ALL_ORACLE_LIKE,
-                        in TestDB.ALL_POSTGRES_LIKE -> OffsetDateTime.parse("2023-05-04T05:04:01.123123+00:00")
-                        else -> now
-                    }.toLocalTime().toKotlinLocalTime()
-                assertEquals(
-                    expectedTime,
-                    testTable.select(testTable.timestampWithTimeZone.time()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.time()]
-                )
-
-                assertEquals(
-                    now.year,
-                    testTable.select(testTable.timestampWithTimeZone.year()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.year()]
-                )
-
-                assertEquals(
-                    now.month.value,
-                    testTable.select(testTable.timestampWithTimeZone.month()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.month()]
-                )
-
-                assertEquals(
-                    now.dayOfMonth,
-                    testTable.select(testTable.timestampWithTimeZone.day()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.day()]
-                )
-
-                assertEquals(
-                    now.hour,
-                    testTable.select(testTable.timestampWithTimeZone.hour()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.hour()]
-                )
-
-                assertEquals(
-                    now.minute,
-                    testTable.select(testTable.timestampWithTimeZone.minute()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.minute()]
-                )
-
-                assertEquals(
-                    now.second,
-                    testTable.select(testTable.timestampWithTimeZone.second()).where { testTable.id eq nowId }
-                        .single()[testTable.timestampWithTimeZone.second()]
-                )
-            } finally {
-                SchemaUtils.drop(testTable)
+            val now = OffsetDateTime.parse("2023-05-04T05:04:01.123123123+00:00")
+            val nowId = testTable.insertAndGetId {
+                it[testTable.timestampWithTimeZone] = now
             }
+
+            assertEquals(
+                now.toLocalDate().toKotlinLocalDate(),
+                testTable.select(testTable.timestampWithTimeZone.date()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.date()]
+            )
+
+            val expectedTime =
+                when (testDb) {
+                    TestDB.SQLITE -> OffsetDateTime.parse("2023-05-04T05:04:01.123+00:00")
+                    TestDB.MYSQL_V8, TestDB.SQLSERVER,
+                    in TestDB.ALL_ORACLE_LIKE,
+                    in TestDB.ALL_POSTGRES_LIKE -> OffsetDateTime.parse("2023-05-04T05:04:01.123123+00:00")
+                    else -> now
+                }.toLocalTime().toKotlinLocalTime()
+            assertEquals(
+                expectedTime,
+                testTable.select(testTable.timestampWithTimeZone.time()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.time()]
+            )
+
+            assertEquals(
+                now.year,
+                testTable.select(testTable.timestampWithTimeZone.year()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.year()]
+            )
+
+            assertEquals(
+                now.month.value,
+                testTable.select(testTable.timestampWithTimeZone.month()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.month()]
+            )
+
+            assertEquals(
+                now.dayOfMonth,
+                testTable.select(testTable.timestampWithTimeZone.day()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.day()]
+            )
+
+            assertEquals(
+                now.hour,
+                testTable.select(testTable.timestampWithTimeZone.hour()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.hour()]
+            )
+
+            assertEquals(
+                now.minute,
+                testTable.select(testTable.timestampWithTimeZone.minute()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.minute()]
+            )
+
+            assertEquals(
+                now.second,
+                testTable.select(testTable.timestampWithTimeZone.second()).where { testTable.id eq nowId }
+                    .single()[testTable.timestampWithTimeZone.second()]
+            )
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
@@ -38,31 +38,25 @@ class H2Tests : DatabaseTestsBase() {
 
     @Test
     fun insertInH2() {
-        withDb(listOf(TestDB.H2_V2_MYSQL, TestDB.H2_V2)) {
-            SchemaUtils.create(Testing)
+        withTables(TestDB.ALL - listOf(TestDB.H2_V2_MYSQL, TestDB.H2_V2), Testing) {
             Testing.insert {
                 it[id] = 1
                 it[string] = "one"
             }
 
             assertEquals("one", Testing.selectAll().where { Testing.id.eq(1) }.single()[Testing.string])
-
-            SchemaUtils.drop(Testing)
         }
     }
 
     @Test
     fun replaceAsInsertInH2() {
-        withDb(listOf(TestDB.H2_V2_MYSQL, TestDB.H2_V2_MARIADB)) {
-            SchemaUtils.create(Testing)
+        withTables(TestDB.ALL - listOf(TestDB.H2_V2_MYSQL, TestDB.H2_V2_MARIADB), Testing) {
             Testing.replace {
                 it[id] = 1
                 it[string] = "one"
             }
 
             assertEquals("one", Testing.selectAll().where { Testing.id.eq(1) }.single()[Testing.string])
-
-            SchemaUtils.drop(Testing)
         }
     }
 
@@ -120,20 +114,14 @@ class H2Tests : DatabaseTestsBase() {
             val number = short("number")
         }
 
-        withDb(TestDB.ALL_H2) {
-            try {
-                SchemaUtils.create(testTable)
-
-                testTable.batchInsert(listOf<Short>(2, 4, 6, 8, 10)) { n ->
-                    this[testTable.number] = n
-                }
-
-                val average = testTable.number.avg()
-                val result = testTable.select(average).single()[average]
-                assertEquals("6.00".toBigDecimal(), result)
-            } finally {
-                SchemaUtils.drop(testTable)
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_H2, testTable) {
+            testTable.batchInsert(listOf<Short>(2, 4, 6, 8, 10)) { n ->
+                this[testTable.number] = n
             }
+
+            val average = testTable.number.avg()
+            val result = testTable.select(average).single()[average]
+            assertEquals("6.00".toBigDecimal(), result)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ConnectionTests.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.sql.tests.shared
 
 import org.jetbrains.exposed.dao.id.LongIdTable
-import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.vendors.ColumnMetadata
@@ -19,9 +18,7 @@ class ConnectionTests : DatabaseTestsBase() {
 
     @Test
     fun testGettingColumnMetadata() {
-        withDb(TestDB.H2_V2) {
-            SchemaUtils.create(People)
-
+        withTables(excludeSettings = TestDB.ALL - TestDB.H2_V2, People) {
             val columnMetadata = connection.metadata {
                 requireNotNull(columns(People)[People])
             }.toSet()
@@ -40,8 +37,6 @@ class ConnectionTests : DatabaseTestsBase() {
                 )
             }
             assertEquals(expected, columnMetadata)
-
-            SchemaUtils.drop(People)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -827,37 +827,31 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             val province = char("province", 2)
         }
 
+        val taxValue = 123.456.toBigDecimal()
+        val addressValue = "A".repeat(16)
+        val zipValue = "BB".toByteArray()
+        val provinceValue = "CC"
+
         // SQLite doesn't support alter table with add column, so it doesn't generate alter statements
-        withDb(excludeSettings = listOf(TestDB.SQLITE)) {
-            val taxValue = 123.456.toBigDecimal()
-            val addressValue = "A".repeat(16)
-            val zipValue = "BB".toByteArray()
-            val provinceValue = "CC"
-
-            try {
-                SchemaUtils.create(originalTable)
-
-                expectException<IllegalArgumentException> {
-                    originalTable.insert {
-                        it[tax] = taxValue
-                        it[address] = addressValue
-                        it[zip] = zipValue
-                        it[province] = provinceValue
-                    }
-                }
-
-                val alterStatements = SchemaUtils.statementsRequiredToActualizeScheme(newTable)
-                assertEquals(4, alterStatements.size)
-                alterStatements.forEach { exec(it) }
-
-                newTable.insert {
+        withTables(excludeSettings = listOf(TestDB.SQLITE), originalTable) {
+            expectException<IllegalArgumentException> {
+                originalTable.insert {
                     it[tax] = taxValue
                     it[address] = addressValue
                     it[zip] = zipValue
                     it[province] = provinceValue
                 }
-            } finally {
-                SchemaUtils.drop(originalTable)
+            }
+
+            val alterStatements = SchemaUtils.statementsRequiredToActualizeScheme(newTable)
+            assertEquals(4, alterStatements.size)
+            alterStatements.forEach { exec(it) }
+
+            newTable.insert {
+                it[tax] = taxValue
+                it[address] = addressValue
+                it[zip] = zipValue
+                it[province] = provinceValue
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/BooleanColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/BooleanColumnTypeTests.kt
@@ -58,24 +58,18 @@ class BooleanColumnTypeTests : DatabaseTestsBase() {
                 .default(false)
         }
 
-        withDb {
-            try {
-                SchemaUtils.create(tester)
-
-                tester.insert {
-                    it[charBooleanColumn] = true
-                }
-
-                assertEquals(
-                    1,
-                    tester.select(tester.charBooleanColumn)
-                        .where { tester.charBooleanColumn eq true }
-                        .andWhere { tester.charBooleanColumnWithDefault eq false }
-                        .count()
-                )
-            } finally {
-                SchemaUtils.drop(tester)
+        withTables(tester) {
+            tester.insert {
+                it[charBooleanColumn] = true
             }
+
+            assertEquals(
+                1,
+                tester.select(tester.charBooleanColumn)
+                    .where { tester.charBooleanColumn eq true }
+                    .andWhere { tester.charBooleanColumnWithDefault eq false }
+                    .count()
+            )
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/CharColumnType.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/CharColumnType.kt
@@ -42,22 +42,16 @@ class CharColumnType : DatabaseTestsBase() {
         // H2 only allows collation for the entire database using SET COLLATION
         // Oracle only allows collation if MAX_STRING_SIZE=EXTENDED, which can only be set in upgrade mode
         // Oracle -> https://docs.oracle.com/en/database/oracle/oracle-database/12.2/refrn/MAX_STRING_SIZE.html#
-        withDb(excludeSettings = TestDB.ALL_H2 + TestDB.ORACLE) {
-            try {
-                SchemaUtils.create(tester)
-
-                val letters = listOf("a", "A", "b", "B")
-                tester.batchInsert(letters) { ch ->
-                    this[tester.letter] = ch
-                }
-
-                // one of the purposes of collation is to determine ordering rules of stored character data types
-                val expected = letters.sortedBy { it.single().code } // [A, B, a, b]
-                val actual = tester.selectAll().orderBy(tester.letter).map { it[tester.letter] }
-                assertEqualLists(expected, actual)
-            } finally {
-                SchemaUtils.drop(tester)
+        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.ORACLE, tester) {
+            val letters = listOf("a", "A", "b", "B")
+            tester.batchInsert(letters) { ch ->
+                this[tester.letter] = ch
             }
+
+            // one of the purposes of collation is to determine ordering rules of stored character data types
+            val expected = letters.sortedBy { it.single().code } // [A, B, a, b]
+            val actual = tester.selectAll().orderBy(tester.letter).map { it[tester.letter] }
+            assertEqualLists(expected, actual)
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -297,9 +297,7 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
 
     @Test
     fun testMaxUnsignedTypesInMySql() {
-        withDb(excludeSettings = TestDB.ALL_POSTGRES_LIKE) {
-            SchemaUtils.create(UByteTable, UShortTable, UIntTable, ULongTable)
-
+        withTables(excludeSettings = TestDB.ALL_POSTGRES_LIKE, UByteTable, UShortTable, UIntTable, ULongTable) {
             UByteTable.insert { it[unsignedByte] = UByte.MAX_VALUE }
             assertEquals(UByte.MAX_VALUE, UByteTable.selectAll().single()[UByteTable.unsignedByte])
 
@@ -311,8 +309,6 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
 
             ULongTable.insert { it[unsignedLong] = ULong.MAX_VALUE }
             assertEquals(ULong.MAX_VALUE, ULongTable.selectAll().single()[ULongTable.unsignedLong])
-
-            SchemaUtils.drop(UByteTable, UShortTable, UIntTable, ULongTable)
         }
     }
 
@@ -330,23 +326,17 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
             val unsigned3 = uinteger(col3)
         }
 
-        withDb {
-            try {
-                SchemaUtils.create(tester1, tester2)
-
-                val (byte, short, integer) = Triple(191.toUByte(), 49151.toUShort(), 3_221_225_471u)
-                tester1.insert {
-                    it[unsigned1] = byte
-                    it[unsigned2] = short
-                    it[unsigned3] = integer
-                }
-                tester2.insert {
-                    it[unsigned1] = byte
-                    it[unsigned2] = short
-                    it[unsigned3] = integer
-                }
-            } finally {
-                SchemaUtils.drop(tester1, tester2)
+        withTables(tester1, tester2) {
+            val (byte, short, integer) = Triple(191.toUByte(), 49151.toUShort(), 3_221_225_471u)
+            tester1.insert {
+                it[unsigned1] = byte
+                it[unsigned2] = short
+                it[unsigned3] = integer
+            }
+            tester2.insert {
+                it[unsigned1] = byte
+                it[unsigned2] = short
+                it[unsigned3] = integer
             }
         }
     }


### PR DESCRIPTION
#### Description

**Summary of the change**: While refactoring `DatabaseMigrationTests`, I noticed that there were several other test files where `withTables` could be used to simplify the tests.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Tests refactor

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
