### PR TITLE
fix: EXPOSED-602 Column name that includes table name is aliased with upserts

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -724,7 +724,7 @@ abstract class FunctionProvider {
                 append("T.${transaction.identity(columnToUpdate)}=")
                 when (updateExpression) {
                     is QueryParameter<*>, !is Expression<*> -> registerArgument(columnToUpdate.columnType, updateExpression)
-                    else -> append(updateExpression.toString().replace(tableIdentifier, "T"))
+                    else -> append(updateExpression.toString().replace("$tableIdentifier.", "T."))
                 }
             }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpsertTests.kt
@@ -749,6 +749,24 @@ class UpsertTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testUpsertWhenColumnNameIncludesTableName() {
+        val tester = object : Table("my_table") {
+            val myTableId = integer("my_table_id")
+            val myTableValue = varchar("my_table_value", 100)
+            override val primaryKey = PrimaryKey(myTableId)
+        }
+
+        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
+            tester.upsert {
+                it[myTableId] = 1
+                it[myTableValue] = "Hello"
+            }
+
+            assertEquals("Hello", tester.selectAll().single()[tester.myTableValue])
+        }
+    }
+
     private object AutoIncTable : Table("auto_inc_table") {
         val id = integer("id").autoIncrement()
         val name = varchar("name", 64)


### PR DESCRIPTION
#### Description

**Summary of the change**:
Allows valid MERGE syntax to be generated again when using `upsert()` with update columns that include the table name in their name.

**Detailed description**:
- **Why**: PR #2172 changed the way update values that copy insert values are processed internally. Since then (version 0.54.0), any update-insert value is parsed like a regular expression. For dialects that use MERGE, this means the value is automatically aliased with virtual S alias and any potential presence of the table name in the update expression is also aliased with origin T. This leads to invalid identifier syntax if the expression holds a column name that itself includes the table name.

- **What**: String replacement now only happens if the table name is located in a prefix identifier position, before '.'

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Oracle
- [X] SqlServer
- [X] H2

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-602](https://youtrack.jetbrains.com/issue/EXPOSED-602)