### PR TITLE
fix: EXPOSED-623 Offset not applied in COUNT query

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -429,7 +429,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.InsertSelectTests.testInsertSelect02
      */
     override fun count(): Long {
-        return if (distinct || groupedByColumns.isNotEmpty() || limit != null) {
+        return if (distinct || groupedByColumns.isNotEmpty() || limit != null || offset > 0) {
             fun Column<*>.makeAlias() =
                 alias(transaction.db.identifierManager.quoteIfNecessary("${table.tableNameWithoutSchemeSanitized}_$name"))
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DistinctOnTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DistinctOnTests.kt
@@ -87,7 +87,6 @@ class DistinctOnTests : DatabaseTestsBase() {
         }
 
         withTables(excludeSettings = TestDB.ALL - distinctOnSupportedDb, tester) {
-            addLogger(StdOutSqlLogger)
             // Empty list of columns should not cause exception
             tester.insert {
                 it[value] = 1


### PR DESCRIPTION
#### Description

Query method `count()` ignores `offset` parameter if the `limit` parameter is not specified.

Since the PR [#2226 Allow OFFSET without LIMIT](https://github.com/JetBrains/Exposed/pull/2226/files) we can create query without `limit` parameter.

If the `count()` is called on such query the following sql is generated:

```sql
SELECT COUNT(*) FROM <table>
```

but expected query is:

```sql
SELECT COUNT(*) FROM (SELECT <columns> FROM <table> OFFSET 10) subquery
```

PR contains a fix for `count()` function that already has a check `limit != null` to generate the variant with subquery. Now it also checks for `offset > 0`

---

#### Type of Change

- [X] Bug fix

Affected databases:
- [X] Oracle
- [X] Postgres
- [X] SqlServer
- [X] H2

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-623](https://youtrack.jetbrains.com/issue/EXPOSED-623) Offset not applied in COUNT query