### PR TITLE
fix: EXPOSED-621 IllegalStateException on accessing autoincrement column after insert using Entity

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -204,7 +204,7 @@ class AutoIncColumnType<T>(
         var result = delegate.hashCode()
         result = 31 * result + (_autoincSeq?.hashCode() ?: 0)
         result = 31 * result + fallbackSeqName.hashCode()
-        result = 31 * result + (sequence?.hashCode() ?: 0)
+        result = 31 * result + (_sequence?.hashCode() ?: 0)
         return result
     }
 }


### PR DESCRIPTION
#### Description

- **Why**:
The issue was that the `hashCode()` function was using `sequence` which invokes `autoincSeq` if `_sequence` is null, which then invokes `currentDialect`, and if this is not within a transaction, it will throw an error. This was introduced [here](https://github.com/JetBrains/Exposed/pull/2197).
- **How**:
The fix is to use `_sequence` instead of `sequence` when generating a hashcode.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
