### PR TITLE
feat: EXPOSED-628 Add comment position for optimizer hints after SELECT

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1949,6 +1949,7 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 }
 
 public final class org/jetbrains/exposed/sql/Query$CommentPosition : java/lang/Enum {
+	public static final field AFTER_SELECT Lorg/jetbrains/exposed/sql/Query$CommentPosition;
 	public static final field BACK Lorg/jetbrains/exposed/sql/Query$CommentPosition;
 	public static final field FRONT Lorg/jetbrains/exposed/sql/Query$CommentPosition;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -215,6 +215,10 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
 
             append("SELECT ")
 
+            comments[CommentPosition.AFTER_SELECT]?.let { comment ->
+                append("/*$comment*/ ")
+            }
+
             if (count) {
                 append("COUNT(*)")
             } else {
@@ -327,7 +331,8 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * Appends an SQL comment, with [content] wrapped by `/* */`, at the specified [CommentPosition] in this `SELECT` query.
      *
      * Adding some comments may be useful for tracking, embedding metadata, or for special instructions, like using
-     * `/*FORCE_MASTER*/` for some cloud databases to force the statement to run in the master database.
+     * `/*FORCE_MASTER*/` for some cloud databases to force the statement to run in the master database
+     * or using optimizer hints.
      *
      * @throws IllegalStateException If a comment has already been appended at the specified [position]. An existing
      * comment can be removed or altered by [adjustComments].
@@ -481,6 +486,9 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     enum class CommentPosition {
         /** The start of the query, before the keyword `SELECT`. */
         FRONT,
+
+        /** Immediately following the keyword `SELECT`. */
+        AFTER_SELECT,
 
         /** The end of the query, after all clauses. */
         BACK


### PR DESCRIPTION
#### Description

**Summary of the change**:
Allow a query comment to be appended to immediately after the SELECT keyword, in addition to either before or after the query entirely.

**Detailed description**:
- **Why**: Requested in PR #2088 . This position is useful for constructs like [MySQL optimizer hints](https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html).
- **How**:
    - Add new constant `AFTER_SELECT` to enum `CommentPosition`
    - Update `Query.prepareSQL()` to append comment in new position

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Affected databases:
- [X] All - _technically, but test example only uses MySQL optimizer hints_

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-628](https://youtrack.jetbrains.com/issue/EXPOSED-628/Add-comment-position-for-optimizer-hints-after-SELECT)