### PR TITLE
fix: EXPOSED-629 aliased array throws java.lang.ClassCastException: o…

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -1292,8 +1292,9 @@ class ArrayColumnType<T, R : List<Any?>>(
 
     @Suppress("UNCHECKED_CAST")
     override fun valueFromDB(value: Any): R? {
-        return when {
-            value is Array<*> -> recursiveValueFromDB(value, dimensions) as R?
+        return when (value) {
+            is Array<*> -> recursiveValueFromDB(value, dimensions) as R?
+            is java.sql.Array -> recursiveValueFromDB(value.array, dimensions) as R?
             else -> value as R?
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/ArrayColumnTypeTests.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
+import org.jetbrains.exposed.sql.tests.shared.assertEqualLists
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.tests.shared.expectException
@@ -336,6 +337,25 @@ class ArrayColumnTypeTests : DatabaseTestsBase() {
             assertNotNull(result)
             assertEquals(testByteArraysList[0][0], result[0][0])
             assertEquals(testByteArraysList[1].toUByteString(), result[1].toUByteString())
+        }
+    }
+
+    @Test
+    fun testAliasedArray() {
+        val tester = object : IntIdTable("test_aliased_array") {
+            val value = array<Int>("value")
+        }
+
+        val value = listOf(1, 2, 3)
+
+        withTables(excludeSettings = arrayTypeUnsupportedDb, tester) {
+            tester.insert {
+                it[tester.value] = value
+            }
+
+            val alias = tester.value.alias("testTable_indexes")
+
+            assertEqualLists(value, tester.select(alias).first()[tester.value])
         }
     }
 


### PR DESCRIPTION
Here is the fix for `ArrayColumnType` that was not handling `java.sql.Array` that also could be received from the database.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Postgres
- [X] H2

---

#### Related Issues

[EXPOSED-629](https://youtrack.jetbrains.com/issue/EXPOSED-629) aliased array throws java.lang.ClassCastException: org.postgresql.jdbc.PgArray cannot be cast to java.util.List
[EXPOSED-634](https://youtrack.jetbrains.com/issue/EXPOSED-634) Column transform broken for array columns
