### PR TITLE
chore: EXPOSED-633 Weak ArrayColumnType.delegate from ColumnType to IColumnType

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -201,9 +201,9 @@ public final class org/jetbrains/exposed/sql/AndOp : org/jetbrains/exposed/sql/C
 public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exposed/sql/ColumnType {
 	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/util/List;I)V
-	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/ColumnType;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/ColumnType;
+	public fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/util/List;I)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/IColumnType;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDelegate ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public final fun getDelegateType ()Ljava/lang/String;
 	public final fun getDimensions ()I
 	public final fun getMaximumCardinality ()Ljava/util/List;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -1242,7 +1242,7 @@ class CustomEnumerationColumnType<T : Enum<T>>(
  * **Note:** The maximum cardinality is considered for each dimension, but it is ignored by the PostgreSQL database.
  */
 class ArrayColumnType<T, R : List<Any?>>(
-    val delegate: ColumnType<T & Any>,
+    val delegate: IColumnType<T & Any>,
     val maximumCardinality: List<Int>? = null,
     val dimensions: Int = 1
 ) : ColumnType<R>() {


### PR DESCRIPTION
#### Description

Small change that makes requirements of `ArrayColumnType` to `delegate` weaker

---

#### Related Issues

[EXPOSED-633](https://youtrack.jetbrains.com/issue/EXPOSED-633) Weak ArrayColumnType.delegate from ColumnType to IColumnType
