### PR TITLE
EXPOSED-414 Docs Search: Add Algolia parameters to Writerside config

### DIFF
--- a/documentation-website/Writerside/cfg/buildprofiles.xml
+++ b/documentation-website/Writerside/cfg/buildprofiles.xml
@@ -4,6 +4,9 @@
 
     <variables>
         <product-web-url>https://jetbrains.github.io/Exposed/home.html</product-web-url>
+        <algolia-id>MMA5Z3JT91</algolia-id>
+        <algolia-index>prod_exposed</algolia-index>
+        <algolia-api-key>119a138f76e4c043bcbb9f0c16119094</algolia-api-key>
     </variables>
     <build-profile instance="hi">
         <variables>


### PR DESCRIPTION
Add Algolia configuration for the search feature in Exposed Docs, as defined in [WH-5391](https://youtrack.jetbrains.com/issue/WH-5391).

Docs Ref: [EXPOSED-414](https://youtrack.jetbrains.com/issue/EXPOSED-414)
