### PR TITLE
docs: EXPOSED-639 Add note about required imports with deleteWhere()

### DIFF
--- a/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
+++ b/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
@@ -238,7 +238,14 @@
         <chapter id="deleteWhere">
             <title><code>deleteWhere</code></title>
             <p>To delete records and return the count of deleted rows, use the <code>deleteWhere</code> function.</p>
+            <p>
+                Any <code>SqlExpressionBuilder</code> comparison operators or extension functions used in the <code>op</code>
+                parameter lambda block will require inclusion of an import statement like <code>import org.jetbrains.exposed.sql.SqlExpressionBuilder.*</code>.
+            </p>
             <code-block lang="kotlin">
+                import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+                import org.jetbrains.exposed.sql.deleteWhere
+
                 StarWarsFilms.deleteWhere { StarWarsFilms.sequelId eq 8 }
             </code-block>
         </chapter>
@@ -250,16 +257,25 @@
             <p>To delete records while ignoring any possible errors that occur during the process, use the
                 <code>deleteIgnoreWhere</code> function. The function will return the count of deleted rows.
             </p>
+            <p>
+                Any <code>SqlExpressionBuilder</code> comparison operators or extension functions used in the <code>op</code>
+                parameter lambda block will require inclusion of an import statement like <code>import org.jetbrains.exposed.sql.SqlExpressionBuilder.*</code>.
+            </p>
             <code-block lang="kotlin">
+                import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+                import org.jetbrains.exposed.sql.deleteIgnoreWhere
+
                 StarWarsFilms.deleteIgnoreWhere { StarWarsFilms.sequelId eq 8 }
             </code-block>
         </chapter>
         <chapter id="deleteAll">
             <title><code>deleteAll</code></title>
-            <p>To deletes all rows in a table and return the count of deleted rows, use the <code>deleteAll</code>
+            <p>To delete all rows in a table and return the count of deleted rows, use the <code>deleteAll</code>
                 function.</p>
             <code-block lang="kotlin">
-                StarWarsFilms.deleteAll { StarWarsFilms.sequelId eq 8 }
+                import org.jetbrains.exposed.sql.deleteAll
+
+                StarWarsFilms.deleteAll()
             </code-block>
         </chapter>
         <chapter id="join-delete">
@@ -269,8 +285,10 @@
                 the argument to the parameter <code>targetTable</code>.
             </p>
             <code-block lang="kotlin">
+                import org.jetbrains.exposed.sql.delete
+
                 val join = StarWarsFilms innerJoin Actors
-                join.delete(Actors) { Actors.sequelId greater 2 }
+                join.delete(targetTable = Actors) { Actors.sequelId greater 2 }
             </code-block>
             <tip>For more information on creating and using a <code>Join</code>, see <a href="DSL-Querying-data.topic#join-tables">Joining Tables</a>.</tip>
         </chapter>


### PR DESCRIPTION
#### Description

**Summary of the change**:
Update DSL Delete section:
- Include import statements in code blocks when using `deleteWhere` and `deleteIgnoreWhere`.
- Include  note about resolving `SqlExpressionBuilder` extension functions with inclusion of these imports.
- Fix incorrect `deleteAll` code block.
- Use named parameter in `Join.delete` to make sentence before code block more clear.

**Detailed description**:
- **Why**: Recent versions of IntelliJ IDEA with K2 mode enabled no longer suggest the required imports (as part of context actions) for `deleteWhere` lambda functions (see issues below for full details & git hx). In the interim, especially for new users, documentation at least should be a guide on the necessary imports to fix any potential unresolved code errors.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-639](https://youtrack.jetbrains.com/issue/EXPOSED-639)
[EXPOSED_638](https://youtrack.jetbrains.com/issue/EXPOSED-638/K2-mode-does-not-suggest-import-for-extension-function-with-deleteWhere)
[KTIJ-32116](https://youtrack.jetbrains.com/issue/KTIJ-32116)