### PR TITLE
docs: EXPOSED-601 Add Exposed logo favicon to Writerside config

### DIFF
--- a/documentation-website/Writerside/cfg/buildprofiles.xml
+++ b/documentation-website/Writerside/cfg/buildprofiles.xml
@@ -7,6 +7,9 @@
         <algolia-id>MMA5Z3JT91</algolia-id>
         <algolia-index>prod_exposed</algolia-index>
         <algolia-api-key>119a138f76e4c043bcbb9f0c16119094</algolia-api-key>
+        <custom-favicons>
+            exposed-logo.svg
+        </custom-favicons>
     </variables>
     <build-profile instance="hi">
         <variables>


### PR DESCRIPTION
#### Description

[EXPOSED-601](https://youtrack.jetbrains.com/issue/EXPOSED-601) Replace the default Writerside favicon with the Exposed logo

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
