### PR TITLE
fix: EXPOSED-641 Byte, Short, Int, Long, UInt, ULong falsely generate database migration statements when they have a default (PostgreSQL and SQL Server)

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -199,6 +199,41 @@ object SchemaUtils {
                         else -> processForDefaultValue(exp)
                     }
 
+                    is Byte -> when {
+                        dialect is PostgreSQLDialect && value < 0 -> "'${processForDefaultValue(exp)}'::integer"
+                        else -> processForDefaultValue(exp)
+                    }
+
+                    is Short -> when {
+                        dialect is PostgreSQLDialect && value < 0 -> "'${processForDefaultValue(exp)}'::integer"
+                        else -> processForDefaultValue(exp)
+                    }
+
+                    is Int -> when {
+                        dialect is PostgreSQLDialect && value < 0 -> "'${processForDefaultValue(exp)}'::integer"
+                        else -> processForDefaultValue(exp)
+                    }
+
+                    is Long -> when {
+                        currentDialect is SQLServerDialect && (value < 0 || value > Int.MAX_VALUE.toLong()) ->
+                            "${processForDefaultValue(exp)}."
+                        currentDialect is PostgreSQLDialect && (value < 0 || value > Int.MAX_VALUE.toLong()) ->
+                            "'${processForDefaultValue(exp)}'::bigint"
+                        else -> processForDefaultValue(exp)
+                    }
+
+                    is UInt -> when {
+                        dialect is SQLServerDialect && value > Int.MAX_VALUE.toUInt() -> "${processForDefaultValue(exp)}."
+                        dialect is PostgreSQLDialect && value > Int.MAX_VALUE.toUInt() -> "'${processForDefaultValue(exp)}'::bigint"
+                        else -> processForDefaultValue(exp)
+                    }
+
+                    is ULong -> when {
+                        currentDialect is SQLServerDialect && value > Int.MAX_VALUE.toULong() -> "${processForDefaultValue(exp)}."
+                        currentDialect is PostgreSQLDialect && value > Int.MAX_VALUE.toULong() -> "'${processForDefaultValue(exp)}'::bigint"
+                        else -> processForDefaultValue(exp)
+                    }
+
                     else -> {
                         when {
                             column.columnType is JsonColumnMarker -> {


### PR DESCRIPTION
#### Description

- **What**:
Fixed false generation of migration statements for some column types with some values (in PostgreSQL and SQL Server).
- **Why**:
The default value obtained from the column metadata was not matching the default value set for the column in the table definition, and that mismatch was leading to the generation of unnecessary migration statements. This mismatch was only happening for certain ranges of values and not for all values.
- **How**:
In `dbDefaultToString` in `SchemaUtils`, the value returned now matches the default value obtained from the column metadata for the column types that had the issue.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [x] Postgres
- [x] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
