### PR TITLE
fix: EXPOSED-646 count() voids distinctOn call on query

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -434,7 +434,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
      * @sample org.jetbrains.exposed.sql.tests.shared.dml.InsertSelectTests.testInsertSelect02
      */
     override fun count(): Long {
-        return if (distinct || groupedByColumns.isNotEmpty() || limit != null || offset > 0) {
+        return if (distinct || distinctOn != null || groupedByColumns.isNotEmpty() || limit != null || offset > 0) {
             fun Column<*>.makeAlias() =
                 alias(transaction.db.identifierManager.quoteIfNecessary("${table.tableNameWithoutSchemeSanitized}_$name"))
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DistinctOnTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DistinctOnTests.kt
@@ -101,4 +101,22 @@ class DistinctOnTests : DatabaseTestsBase() {
             assertEquals(1, value)
         }
     }
+
+    @Test
+    fun testDistinctOnWithCount() {
+        val tester = object : IntIdTable() {
+            val name = varchar("name", 50)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - distinctOnSupportedDb, tester) {
+            tester.batchInsert(listOf("tester1", "tester1", "tester2", "tester3", "tester2")) {
+                this[tester.name] = it
+            }
+
+            val count = tester.selectAll()
+                .withDistinctOn(tester.name)
+                .count()
+            assertEquals(3, count)
+        }
+    }
 }


### PR DESCRIPTION
#### Description

Here is the fix for the `count()` function that does not take into account the `distinctOn` parameter of the query.

By default `count()` performs `select(*) from <table>` query, In several case like queries with `distinct`, `limit` or `offset` parameters the `count()` would perform `select count(*) from (<the-whole-query>) subquery`.

The solution - trigger second option for `distinctOn` also.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Postgres
- [X] H2

---

#### Related Issues

- [EXPOSED-646](https://youtrack.jetbrains.com/issue/EXPOSED-646) count() voids distinctOn call on query
