### PR TITLE
fix: EXPOSED-653 Split H2 gradle test task by dialects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ subprojects {
 
     apply(plugin = rootProject.libs.plugins.jvm.get().pluginId)
 
-    testDb("h2") {
+    testDb("h2_v2") {
         withContainer = false
         dialects("H2_V2", "H2_V2_MYSQL", "H2_V2_PSQL", "H2_V2_MARIADB", "H2_V2_ORACLE", "H2_V2_SQLSERVER")
 
@@ -71,16 +71,18 @@ subprojects {
         }
     }
 
-    testDb("mysql5") {
+    testDb("mysql_v5") {
         port = 3001
+        container = "mysql5"
         dialects("MYSQL_V5")
         dependencies {
             dependency(rootProject.libs.mysql51)
         }
     }
 
-    testDb("mysql8") {
+    testDb("mysql_v8") {
         port = 3002
+        container = "mysql8"
         dialects("MYSQL_V8")
         dependencies {
             dependency(rootProject.libs.mysql)

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
@@ -24,7 +24,7 @@ class TestDb(val name: String) {
 
     internal val dependencies = mutableListOf<String>()
 
-    internal val ignoresSpringTests = name != "h2"
+    internal val ignoresSpringTests = name != "h2_v2"
 
     inner class DependencyBlock {
         fun dependency(dependencyNotation: String) {

--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
@@ -8,12 +8,10 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import java.time.Duration
-import java.util.*
 
 const val HEALTH_TIMEOUT: Long = 60
 
@@ -54,12 +52,49 @@ fun Project.testDb(name: String, block: TestDb.() -> Unit) {
         configureCompose(db)
     }
 
-    val testTask = tasks.register<Test>("test${db.name.capitalized()}") {
-        description = "Runs tests using ${db.name} database"
+    val dbTask = createDbTestTask(db)
+    tasks.named<Test>("test") {
+        delegatedTo(dbTask)
+    }
+}
+
+private fun Project.createDbTestTask(db: TestDb): TaskProvider<Test> {
+    return if (db.dialects.size == 1) {
+        createDbTestTaskByDialect(db, "test_${db.name.lowercase()}", db.dialects.first())
+    } else {
+        val dialectTasks = db.dialects.map { dialect ->
+            createDbTestTaskByDialect(db, formatDatabaseWithDialectTaskName(db.name.lowercase(), dialect.lowercase()), dialect)
+        }
+
+        tasks.register<Test>("test_all_${db.name.lowercase()}") {
+            description = "Runs tests using ${db.name} database"
+            group = "verification"
+
+            delegatedTo(
+                tasks = dialectTasks.toTypedArray()
+            )
+        }
+    }
+}
+
+private fun formatDatabaseWithDialectTaskName(db: String, dialect: String): String {
+    return listOfNotNull(
+        "test",
+        db,
+        // It's the dialect name without prefixed db name
+        dialect.replaceFirst(db, "").trim('_').takeIf { it.isNotEmpty() }
+    )
+        .filter { it.isNotEmpty() }
+        .joinToString(separator = "_")
+}
+
+private fun Project.createDbTestTaskByDialect(db: TestDb, taskName: String, dialect: String): TaskProvider<Test> {
+    return tasks.register<Test>(taskName) {
+        description = "Runs tests using ${db.name} database with $dialect dialect"
         group = "verification"
         systemProperties["exposed.test.name"] = db.name
         systemProperties["exposed.test.container"] = if (db.withContainer) db.container else "none"
-        systemProperties["exposed.test.dialects"] = db.dialects.joinToString(",") { it.uppercase(Locale.getDefault()) }
+        systemProperties["exposed.test.dialects"] = dialect
         outputs.cacheIf { false }
 
         if (db.ignoresSpringTests) {
@@ -70,7 +105,7 @@ fun Project.testDb(name: String, block: TestDb.() -> Unit) {
             }
         }
 
-        val driverConfiguration = configurations.create("${db.name}DriverConfiguration")
+        val driverConfiguration = configurations.create("${db.name}DriverConfiguration_$dialect")
         dependencies {
             db.dependencies.forEach {
                 driverConfiguration(it)
@@ -82,10 +117,6 @@ fun Project.testDb(name: String, block: TestDb.() -> Unit) {
         if (db.withContainer) {
             dependsOn(rootProject.tasks.getByName("${db.container}ComposeUp"))
         }
-    }
-
-    tasks.named<Test>("test") {
-        delegatedTo(testTask)
     }
 }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/H2Tests.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.inProperCase
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertTrue
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transactionManager
 import org.jetbrains.exposed.sql.vendors.H2Dialect
@@ -26,7 +27,9 @@ class H2Tests : DatabaseTestsBase() {
                     it.next()
                     it.getString(1)
                 }
-                if (systemTestName == "h2") {
+
+                assertTrue(systemTestName == "h2_v2" || systemTestName == "h2_v1")
+                if (systemTestName == "h2_v2") {
                     assertEquals("2", version?.first()?.toString())
                 }
                 if (systemTestName == "h2_v1") {


### PR DESCRIPTION
#### Description

Here is a small fix of our gradle test tasks. Before it was not possible to run the tests for particular H2 dialect (or the one without dialect). It was not always convenient for local testing and especially debugging.

With these changes for every database that has multiple dialects (H2_v1, H2_v2 actually) would be created separated gradle task with the name `test_${db}_${dialect}`. The task that would run tests with all the dialects (as it was working before) would be named `test_all_${db}`.

The full list of test tasks will look like:

```
test
test_all_h2_v1
test_all_h2_v2
test_h2_v1
test_h2_v1_mysql
test_h2_v2
test_h2_v2_mariadb
test_h2_v2_mysql
test_h2_v2_oracle
test_h2_v2_psql
test_h2_v2_sqlserver
test_mariadb_v2
test_mariadb_v3
test_mysql_v5
test_mysql_v8
test_oracle
test_postgres
test_postgresng
test_sqlite
test_sqlserver
```

I also renamed mysql databases so it matches other database names.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] H2
- [X] MySql

---

#### Related Issues

[EXPOSED-653](https://youtrack.jetbrains.com/issue/EXPOSED-653) Split H2 gradle test task by dialects
