### PR TITLE
fix: EXPOSED-651 Try to close connection in ThreadLocalTransactionManager#connectionLazy if setup fails

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -136,6 +136,7 @@ class ThreadLocalTransactionManager(
 
         private val connectionLazy = lazy(LazyThreadSafetyMode.NONE) {
             outerTransaction?.connection ?: db.connector().apply {
+                @Suppress("TooGenericExceptionCaught")
                 try {
                     setupTxConnection?.invoke(this, this@ThreadLocalTransaction) ?: run {
                         // The order of setters here is important.


### PR DESCRIPTION
#### Description

**Summary of the change**: Try to close connection in `ThreadLocalTransactionManager#connectionLazy` if setup fails

**Detailed description**:
- **What**: The connection setup in `ThreadLocalTransactionManager#connectionLazy` now catches exceptions and attempts to close the database connection in case of an exception.
- **Why**: After the connection is obtained from the `Database`, Exposed tries to perform some initial setup before using the connection in a `Transaction`. If this setup fails, the connection is not closed (neither immediately nor when closing the transaction, because the connection is not stored inside the transaction due to `lazy` semantics), which in turn leads to connection leak.
- **How**: The setup code is wrapped in a `try-catch` block, which catches all exceptions and tries to close the connection before rethrowing.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [x] Postgres **(not sure which other databases are affected, but we ran into this problem with Postgres)**
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place — **not sure how to test this, we used a heavily mocked `java.sql.Driver` to reproduce**
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs (no API changes)
- [ ] Documentation for my change is up to date — **please let me know if documentation changes are needed**

---

#### Related Issues

[EXPOSED-651](https://youtrack.jetbrains.com/issue/EXPOSED-651/Connection-leak-if-database-throws-error-during-connection-initialization)