### PR TITLE
chore: Fix docs/snippets exposed-dao project build fail

### DIFF
--- a/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/EntityWithBase64.kt
+++ b/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/EntityWithBase64.kt
@@ -4,21 +4,19 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
+import java.util.Base64
 
 object TableWithText : IntIdTable() {
     val text = varchar("text", length = 2048)
 }
 
 class EntityWithBase64(id: EntityID<Int>) : IntEntity(id) {
-    @OptIn(ExperimentalEncodingApi::class)
     var base64: String by TableWithText.text
         .memoizedTransform(
-            wrap = { Base64.encode(it.toByteArray()) },
-            unwrap = { Base64.decode(it).toString() }
+            wrap = { Base64.getEncoder().encodeToString(it.toByteArray()) },
+            unwrap = { Base64.getDecoder().decode(it).toString() }
         )
 
     companion object :
-        IntEntityClass<EntityWithUInt>(TableWithText)
+        IntEntityClass<EntityWithBase64>(TableWithText)
 }

--- a/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/EntityWithBase64.kt
+++ b/documentation-website/Writerside/snippets/exposed-dao/src/main/kotlin/org/example/entities/EntityWithBase64.kt
@@ -4,12 +4,15 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 object TableWithText : IntIdTable() {
     val text = varchar("text", length = 2048)
 }
 
 class EntityWithBase64(id: EntityID<Int>) : IntEntity(id) {
+    @OptIn(ExperimentalEncodingApi::class)
     var base64: String by TableWithText.text
         .memoizedTransform(
             wrap = { Base64.encode(it.toByteArray()) },


### PR DESCRIPTION
#### Description

**Summary of the change**:
Add missing import statements to documentation `exposed-dao` project file so that it can build & run successfully.

**Detailed description**:
- **Why**:  A dependency was bumped recently in PR #2322 , so projects in documentation `snippets` were run to ensure the new version would not cause any issue. It was found that the `exposed-dao` project could not compile even without the bump due to unresolved object errors.
- **What**: `EntityWithBase64.kt` was throwing compile errors due to unresolved `Base64` object.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

#### Checklist

- [X] The build is green (including the Detekt check)

---
