### PR TITLE
fix: Add support for creating sequence in MariaDB

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -662,6 +662,8 @@ public final class org/jetbrains/exposed/sql/Database {
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDialect ()Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;
 	public final fun getIdentifierManager ()Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi;
+	public final fun getMajorVersion ()I
+	public final fun getMinorVersion ()I
 	public final fun getSupportsAlterTableWithAddColumn ()Z
 	public final fun getSupportsAlterTableWithDropColumn ()Z
 	public final fun getSupportsMultipleResultSets ()Z
@@ -669,6 +671,7 @@ public final class org/jetbrains/exposed/sql/Database {
 	public final fun getUseNestedTransactions ()Z
 	public final fun getVendor ()Ljava/lang/String;
 	public final fun getVersion ()Ljava/math/BigDecimal;
+	public final fun isVersionCovers (II)Z
 	public final fun isVersionCovers (Ljava/math/BigDecimal;)Z
 	public final fun setUseNestedTransactions (Z)V
 	public fun toString ()Ljava/lang/String;
@@ -3562,6 +3565,8 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun getDatabaseProductVersion ()Ljava/lang/String;
 	public abstract fun getDefaultIsolationLevel ()I
 	public abstract fun getIdentifierManager ()Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi;
+	public abstract fun getMajorVersion ()I
+	public abstract fun getMinorVersion ()I
 	public abstract fun getSchemaNames ()Ljava/util/List;
 	public abstract fun getSupportsAlterTableWithAddColumn ()Z
 	public abstract fun getSupportsAlterTableWithDropColumn ()Z
@@ -4142,10 +4147,13 @@ public final class org/jetbrains/exposed/sql/vendors/KeywordsKt {
 
 public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbrains/exposed/sql/vendors/MysqlDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion;
+	public static final field SEQUENCE_MIN_MAJOR_VERSION I
+	public static final field SEQUENCE_MIN_MINOR_VERSION I
 	public fun <init> ()V
 	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	public fun getFunctionProvider ()Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;
 	public fun getName ()Ljava/lang/String;
+	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -64,6 +64,16 @@ class Database private constructor(
     /** Whether the version number of the database is equal to or greater than the provided [version]. */
     fun isVersionCovers(version: BigDecimal) = this.version >= version
 
+    /** The major version number of the database as a [Int]. */
+    val majorVersion by lazy { metadata { majorVersion } }
+
+    /** The minor version number of the database as a [Int]. */
+    val minorVersion by lazy { metadata { minorVersion } }
+
+    /** Whether the version number of the database is equal to or greater than the provided [majorVersion] and [minorVersion]. */
+    fun isVersionCovers(majorVersion: Int, minorVersion: Int) =
+        this.majorVersion >= majorVersion && this.minorVersion >= minorVersion
+
     /** Whether the database supports ALTER TABLE with an add column clause. */
     val supportsAlterTableWithAddColumn by lazy(
         LazyThreadSafetyMode.NONE

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -18,6 +18,12 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     /** The version number of the database as a `BigDecimal`. */
     abstract val version: BigDecimal
 
+    /**  The major version number of the database. */
+    abstract val majorVersion: Int
+
+    /**  The minor version number of the database. */
+    abstract val minorVersion: Int
+
     /** The name of the database based on the name of the underlying JDBC driver. */
     abstract val databaseDialectName: String
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.sql.vendors
 
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 
 internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
     override fun nextVal(seq: Sequence, builder: QueryBuilder) = builder {
@@ -58,6 +59,9 @@ class MariaDBDialect : MysqlDialect() {
     override val functionProvider: FunctionProvider = MariaDBFunctionProvider
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
     override val supportsSetDefaultReferenceOption: Boolean = false
+    override val supportsCreateSequence: Boolean by lazy {
+        TransactionManager.current().db.isVersionCovers(SEQUENCE_MIN_MAJOR_VERSION, SEQUENCE_MIN_MINOR_VERSION)
+    }
 
     override fun createIndex(index: Index): String {
         if (index.functions != null) {
@@ -69,5 +73,8 @@ class MariaDBDialect : MysqlDialect() {
         return super.createIndex(index)
     }
 
-    companion object : DialectNameProvider("MariaDB")
+    companion object : DialectNameProvider("MariaDB") {
+        const val SEQUENCE_MIN_MAJOR_VERSION = 10
+        const val SEQUENCE_MIN_MINOR_VERSION = 3
+    }
 }

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -42,7 +42,9 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun getDatabaseProductVersion ()Ljava/lang/String;
 	public fun getDefaultIsolationLevel ()I
 	public fun getIdentifierManager ()Lorg/jetbrains/exposed/sql/statements/api/IdentifierManagerApi;
+	public fun getMajorVersion ()I
 	public final fun getMetadata ()Ljava/sql/DatabaseMetaData;
+	public fun getMinorVersion ()I
 	public fun getSchemaNames ()Ljava/util/List;
 	public fun getSupportsAlterTableWithAddColumn ()Z
 	public fun getSupportsAlterTableWithDropColumn ()Z

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -17,6 +17,8 @@ import java.util.concurrent.ConcurrentHashMap
 class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData) : ExposedDatabaseMetadata(database) {
     override val url: String by lazyMetadata { url }
     override val version: BigDecimal by lazyMetadata { BigDecimal("$databaseMajorVersion.$databaseMinorVersion") }
+    override val majorVersion: Int by lazyMetadata { databaseMajorVersion }
+    override val minorVersion: Int by lazyMetadata { databaseMinorVersion }
 
     override val databaseDialectName: String by lazyMetadata {
         when (driverName) {


### PR DESCRIPTION

#### Description

**Summary of the change**: Add support for creating sequence in MariaDB.

**Detailed description**:
- **What**: Variable supportsCreateSequence overrided from MysqlDialect(). Now it checks db version and return true for version upper or equal than 10.3.

- **Why**: It was nessesary because existing isVersionCovers compares version as BigDecimal. Due to it 10.11 < 10.3.

- **How**: There were added majorVersion and minorVersion in ExposedDatabaseMetadata. They were implemented in JdbcDatabaseMetadataImpl. isVersionCovers function implemented with two parameters major and minor versions.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [x] Is breaking change

Affected databases:
- [X] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
