### PR TITLE
feat: [MariaDB] Support RETURNING clause

### DIFF
--- a/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
+++ b/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
@@ -406,6 +406,7 @@
             <p>Supported on: PostgreSQL and SQLite</p>
         </tldr>
         <p>Some databases allow the return of additional data every time a row is either inserted, updated, or deleted.
+            Please note that MariaDB only allows the return of this data for insertions and deletions.
             This can be accomplished by using one of the following functions:
         </p>
         <list>

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -48,6 +48,18 @@ internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
             sql
         }
     }
+
+    override fun returning(
+        mainSql: String,
+        returning: List<Expression<*>>,
+        transaction: Transaction
+    ): String {
+        return with(QueryBuilder(true)) {
+            +"$mainSql RETURNING "
+            returning.appendTo { +it }
+            toString()
+        }
+    }
 }
 
 /**

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/ReturningTests.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class ReturningTests : DatabaseTestsBase() {
-    private val returningSupportedDb = TestDB.ALL_POSTGRES.toSet() + TestDB.SQLITE
+    private val returningSupportedDb = TestDB.ALL_POSTGRES.toSet() + TestDB.SQLITE + TestDB.MARIADB
 
     object Items : IntIdTable("items") {
         val name = varchar("name", 32)
@@ -89,7 +89,7 @@ class ReturningTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertReturning() {
-        withTables(TestDB.ALL - returningSupportedDb, Items) {
+        withTables(TestDB.ALL - returningSupportedDb + TestDB.MARIADB, Items) {
             // return all columns by default
             val result1 = Items.upsertReturning {
                 it[name] = "A"
@@ -196,7 +196,7 @@ class ReturningTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdateReturning() {
-        withTables(TestDB.enabledDialects() - returningSupportedDb, Items) {
+        withTables(TestDB.enabledDialects() - returningSupportedDb + TestDB.MARIADB, Items) {
             val input = listOf("A" to 99.0, "B" to 100.0, "C" to 200.0)
             Items.batchInsert(input) { (n, p) ->
                 this[Items.name] = n


### PR DESCRIPTION
#### Description

**Summary of the change**: Returning clause was implemented for MariaDB

**Detailed description**:
- **What**: Returning clause was implemented for MariaDB.
- **Why**: Returning clause is widely used, but MariaDB support was not included when `RETURNING` clause was introduced in either #2060 or #2061. 
- **How**: FunctionProvider.returning(...) was overridden in MariaDBFunctionProvider. Some tests were fixed and MariaDB is excluded from tests for `updateReturning()` because `UPDATE ... RETURNING` is not yet supported by the database ([open issue MDEV-5092](https://jira.mariadb.org/browse/MDEV-5092)).
---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
