### PR TITLE
chore: Deprecate functions that should be replaced by migration functions

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -590,6 +590,12 @@ object SchemaUtils {
      * to use a lock based on synchronization with a dummy table.
      * @see SchemaUtils.withDataBaseLock
      */
+    @Deprecated(
+        "Execution of this function might lead to unpredictable state in the database if a failure occurs at any point. " +
+            "To prevent this, please use `MigrationUtils.statementsRequiredForDatabaseMigration` with a third-party migration tool (e.g., Flyway).",
+        ReplaceWith("MigrationUtils.statementsRequiredForDatabaseMigration"),
+        DeprecationLevel.WARNING
+    )
     fun createMissingTablesAndColumns(vararg tables: Table, inBatch: Boolean = false, withLogs: Boolean = true) {
         with(TransactionManager.current()) {
             db.dialect.resetCaches()
@@ -631,6 +637,11 @@ object SchemaUtils {
      * By default, a description for each intermediate step, as well as its execution time, is logged at the INFO level.
      * This can be disabled by setting [withLogs] to `false`.
      */
+    @Deprecated(
+        "This function will be removed in future releases.",
+        ReplaceWith("MigrationUtils.statementsRequiredForDatabaseMigration"),
+        DeprecationLevel.WARNING
+    )
     fun statementsRequiredToActualizeScheme(vararg tables: Table, withLogs: Boolean = true): List<String> {
         val (tablesToCreate, tablesToAlter) = tables.partition { !it.exists() }
         val createStatements = logTimeSpent("Preparing create tables statements", withLogs) {


### PR DESCRIPTION
#### Description

**Summary of the change**: Deprecate functions that should be replaced by migration functions

**Detailed description**:
- **Why**: These schema-altering functions will be replaced by migrations.
- **How**: Added WARNING deprecation level to the functions.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
