### PR TITLE
docs: EXPOSED-207 Add link to SQLite ALTER TABLE restrictions in SchemaUtils Kdocs

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt
@@ -317,8 +317,9 @@ object SchemaUtils {
      * By default, a description for each intermediate step, as well as its execution time, is logged at the INFO level.
      * This can be disabled by setting [withLogs] to `false`.
      *
-     * **Note:** Some dialects, like SQLite, do not support `ALTER TABLE ADD COLUMN` syntax completely.
-     * Please check the documentation.
+     * **Note:** Some databases, like **SQLite**, only support `ALTER TABLE ADD COLUMN` syntax in very restricted cases,
+     * which may cause unexpected behavior when adding some missing columns. Please check the documentation.
+     * For SQLite, please see [ALTER TABLE restrictions](https://www.sqlite.org/lang_altertable.html#alter_table_add_column).
      */
     fun addMissingColumnsStatements(vararg tables: Table, withLogs: Boolean = true): List<String> {
         if (tables.isEmpty()) return emptyList()
@@ -572,8 +573,9 @@ object SchemaUtils {
      * It creates any missing tables and, if possible, adds any missing columns for existing tables
      * (for example, when columns are nullable or have default values).
      *
-     * **Note:** Some dialects, like SQLite, do not support `ALTER TABLE ADD COLUMN` syntax completely,
-     * which restricts the behavior when adding some missing columns. Please check the documentation.
+     * **Note:** Some databases, like **SQLite**, only support `ALTER TABLE ADD COLUMN` syntax in very restricted cases,
+     * which may cause unexpected behavior when adding some missing columns. Please check the documentation.
+     * For SQLite, please see [ALTER TABLE restrictions](https://www.sqlite.org/lang_altertable.html#alter_table_add_column).
      *
      * Also, if there is inconsistency between the database schema and table objects (for example,
      * excessive or missing indices), then SQL statements to fix this will be logged at the INFO level.
@@ -625,8 +627,9 @@ object SchemaUtils {
      * Returns the SQL statements that need to be executed to make the existing database schema compatible with
      * the table objects defined using Exposed.
      *
-     * **Note:** Some dialects, like SQLite, do not support `ALTER TABLE ADD COLUMN` syntax completely,
-     * which restricts the behavior when adding some missing columns. Please check the documentation.
+     * **Note:** Some databases, like **SQLite**, only support `ALTER TABLE ADD COLUMN` syntax in very restricted cases,
+     * which may cause unexpected behavior when adding some missing columns. Please check the documentation.
+     * For SQLite, please see [ALTER TABLE restrictions](https://www.sqlite.org/lang_altertable.html#alter_table_add_column).
      *
      * By default, a description for each intermediate step, as well as its execution time, is logged at the INFO level.
      * This can be disabled by setting [withLogs] to `false`.

--- a/exposed-migration/src/main/kotlin/MigrationUtils.kt
+++ b/exposed-migration/src/main/kotlin/MigrationUtils.kt
@@ -61,8 +61,9 @@ object MigrationUtils {
      * the table objects defined using Exposed. Unlike [statementsRequiredToActualizeScheme], DROP/DELETE statements are
      * included.
      *
-     * **Note:** Some dialects, like SQLite, do not support `ALTER TABLE ADD COLUMN` syntax completely,
-     * which restricts the behavior when adding some missing columns. Please check the documentation.
+     * **Note:** Some databases, like **SQLite**, only support `ALTER TABLE ADD COLUMN` syntax in very restricted cases,
+     * which may cause unexpected behavior when adding some missing columns. Please check the documentation.
+     * For SQLite, please see [ALTER TABLE restrictions](https://www.sqlite.org/lang_altertable.html#alter_table_add_column).
      *
      * By default, a description for each intermediate step, as well as its execution time, is logged at the INFO level.
      * This can be disabled by setting [withLogs] to `false`.
@@ -97,8 +98,9 @@ object MigrationUtils {
      * By default, a description for each intermediate step, as well as its execution time, is logged at the INFO level.
      * This can be disabled by setting [withLogs] to `false`.
      *
-     * **Note:** Some dialects, like SQLite, do not support `ALTER TABLE DROP COLUMN` syntax completely.
-     * Please check the documentation.
+     * **Note:** Some databases, like **SQLite**, only support `ALTER TABLE DROP COLUMN` syntax in very restricted cases,
+     * which may cause unexpected behavior when dropping some unmapped columns. Please check the documentation.
+     * For SQLite, please see [ALTER TABLE restrictions](https://www.sqlite.org/lang_altertable.html#alter_table_drop_column).
      */
     fun dropUnmappedColumnsStatements(vararg tables: Table, withLogs: Boolean = true): List<String> {
         if (tables.isEmpty()) return emptyList()


### PR DESCRIPTION
#### Description

**Summary of the change**:
Adds a [link](https://www.sqlite.org/lang_altertable.html#alter_table_add_column) to all SQLite column restrictions for using either `ALTER TABLE ADD COLUMN` or `ALTER TABLE DROP COLUMN`.

**Detailed description**:
- **Why**: Users have approached thrown exceptions when `ALTER TABLE` is used with an SQLite database as an Exposed bug. Some examples of these restrictions are:
    - The new column to add cannot have a primary key constraint.
    - If the missing column to add is defined as `NOT NULL` (default for Exposed), it must also have a non-null default value defined.
- **How**: Relevant KDocs updated to emphasize SQLite restrictions and reference actual docs.
    - Ideally, when a section is added to documentation site for `SchemaUtils` methods, this should be also highlighted. 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

Affected databases:
- [X] SQLite

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] Documentation for my change is up to date

---

#### Related Issues
EXPOSED-207, [Slack thread](https://kotlinlang.slack.com/archives/C0CG7E0A1/p1715630627630919)
