### PR TITLE
build: Enable the new Dokka Gradle plugin

### DIFF
--- a/.github/workflows/docs-workflow.yml
+++ b/.github/workflows/docs-workflow.yml
@@ -50,7 +50,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build API documentation with Dokka
-        run: ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew :dokkaGenerate
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 import org.jetbrains.exposed.gradle.configureDetekt
 import org.jetbrains.exposed.gradle.configurePublishing
 import org.jetbrains.exposed.gradle.testDb
@@ -12,8 +11,10 @@ plugins {
     alias(libs.plugins.dokka)
 }
 
-tasks.withType<DokkaMultiModuleTask> {
-    outputDirectory.set(project.file("docs/api"))
+dokka {
+    dokkaPublications.html {
+        outputDirectory.set(project.file("docs/api"))
+    }
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.parallel=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.configuration.cache=true
 org.gradle.caching=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
 group=org.jetbrains.exposed
 version=0.57.0


### PR DESCRIPTION
#### Description

- **Why**: This removes the warning that Dokka Gradle plugin V1 is deprecated.
- **How**: By following the guide [here](https://kotlinlang.org/docs/dokka-migration.html#enable-the-new-dokka-gradle-plugin).

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other - Build

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
