### PR TITLE
test: Fix failing migration test for Windows

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -57,7 +57,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
         withTables(excludeSettings = listOf(TestDB.SQLITE), noPKTable) {
             val script = MigrationUtils.generateMigrationScript(singlePKTable, scriptDirectory = scriptDirectory, scriptName = scriptName, withLogs = false)
             assertTrue(script.exists())
-            assertEquals("src/test/resources/$scriptName.sql", script.path)
+            assertEquals("src${File.separator}test${File.separator}resources${File.separator}$scriptName.sql", script.path)
 
             val expectedStatements: List<String> = MigrationUtils.statementsRequiredForDatabaseMigration(singlePKTable, withLogs = false)
             assertEquals(1, expectedStatements.size)


### PR DESCRIPTION
#### Description

**Summary of the change**:  Fixed file separator in the test `testMigrationScriptDirectoryAndContent` to be system independent

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
