### PR TITLE
docs: EXPOSED-682 Switch api link from deprecated select()

### DIFF
--- a/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
+++ b/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
@@ -154,7 +154,7 @@
     <chapter title="Read" id="read">
         <chapter title="Retrieve a record" id="select">
             <p>The
-                <a href="https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.sql/select.html">
+                <a href="https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.sql/-column-set/select.html">
                     <code>.select()</code>
                 </a>
                 function allows you to select specific columns or/and expressions.</p>


### PR DESCRIPTION
#### Description

**Summary of the change**: Switch link to `.select()` API reference in [DSL Read topic](https://jetbrains.github.io/Exposed/dsl-crud-operations.html#read)

**Detailed description**:
- **Why**: Previous link went to [this deprecated method](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.sql/select.html), when it should go to its [replacement](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.sql/-column-set/select.html).

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-682](https://youtrack.jetbrains.com/issue/EXPOSED-682/Documentation-for-DSL-CRUD-operations-describes-the-Deprecated-Select-method.)