### PR TITLE
test: EXPOSED-683 Fix flaky task sqlserverComposeUp on TC build

### DIFF
--- a/buildScripts/docker/docker-compose-sqlserver.yml
+++ b/buildScripts/docker/docker-compose-sqlserver.yml
@@ -2,7 +2,7 @@ services:
     sqlserver:
         container_name: SQLServer
         restart: always
-        image: mcr.microsoft.com/azure-sql-edge:1.0.7
+        image: mcr.microsoft.com/azure-sql-edge:2.0.0
         ports:
             - "3005:1433"
         environment:


### PR DESCRIPTION
#### Description

**Summary of the change**: Bump [SQL Server docker image](https://hub.docker.com/r/microsoft/azure-sql-edge) version to latest to rule it out as a possible cause for recent bouts of flaky TC builds that fail on task `:sqlserverComposeUp`.

**Detailed description**:
- **Why**: TC [builds](https://exposed.teamcity.com/buildConfiguration/Exposed_Build) have been failing sporadically for the past 2 months without a clear pattern as to why. Please see [EXPOSED-683](https://youtrack.jetbrains.com/issue/EXPOSED-683/Flaky-outcomes-for-task-sqlserverComposeUp-on-TC-build) for more details, build links, internal threads, etc.
- **How**: Bump SQL Server image version to [latest](https://mcr.microsoft.com/v2/azure-sql-edge/tags/list) 2.0.0.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Test config update (Docker images)

Affected databases:
- [X] SqlServer

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-683](https://youtrack.jetbrains.com/issue/EXPOSED-683/Flaky-outcomes-for-task-sqlserverComposeUp-on-TC-build)