### PR TITLE
EXPOSED-689 warmUpLinkedReferences() should not return all the values from cache

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -976,7 +976,7 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
         val transaction = TransactionManager.current()
 
         val inCache = transaction.entityCache.referrers[sourceRefColumn]
-            ?.filterKeys { references.contains(it) }
+            ?.filterKeys { distinctRefIds.contains(it) }
             ?: emptyMap()
 
         val loaded = ((distinctRefIds - inCache.keys).takeIf { it.isNotEmpty() } as List<EntityID<SID>>?)?.let { idsToLoad ->

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -975,7 +975,10 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
         val distinctRefIds = references.distinct()
         val transaction = TransactionManager.current()
 
-        val inCache = transaction.entityCache.referrers[sourceRefColumn] ?: emptyMap()
+        val inCache = transaction.entityCache.referrers[sourceRefColumn]
+            ?.filterKeys { references.contains(it) }
+            ?: emptyMap()
+
         val loaded = ((distinctRefIds - inCache.keys).takeIf { it.isNotEmpty() } as List<EntityID<SID>>?)?.let { idsToLoad ->
             val alreadyInJoin = (dependsOnTables as? Join)?.alreadyInJoin(linkTable) ?: false
             val entityTables = if (alreadyInJoin) dependsOnTables else dependsOnTables.join(linkTable, JoinType.INNER, targetRefColumn, table.id)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/WarmUpLinkedReferencesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/WarmUpLinkedReferencesTests.kt
@@ -1,0 +1,54 @@
+package org.jetbrains.exposed.sql.tests.shared.entities
+
+import org.jetbrains.exposed.dao.IntEntity
+import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+
+class WarmUpLinkedReferencesTests : DatabaseTestsBase() {
+
+    object Box : IntIdTable()
+
+    class EBox(id: EntityID<Int>) : IntEntity(id) {
+
+        companion object : IntEntityClass<EBox>(Box)
+    }
+
+    object BoxItem : IntIdTable() {
+        val box = reference("box", Box)
+
+        val value = integer("value")
+    }
+
+    class EBoxItem(id: EntityID<Int>) : IntEntity(id) {
+        var value by BoxItem.value
+        var box by EBox referencedOn BoxItem.box
+
+        companion object : IntEntityClass<EBoxItem>(BoxItem)
+    }
+
+    @Test
+    fun warmUpLinkedReferencesShouldNotReturnAllTheValueFromCache() {
+        withTables(Box, BoxItem) {
+            val boxEntities = (0..4).map { EBox.new { } }
+
+            boxEntities.forEach {
+                EBoxItem.new {
+                    box = it
+                    value = it.id.value
+                }
+            }
+
+            val ids = boxEntities.map { it.id }
+
+            // Warm up all the entities to fill the cache
+            EBox.warmUpLinkedReferences(ids, BoxItem)
+
+            val warmedUp = EBox.warmUpLinkedReferences(ids.slice(0..2), BoxItem)
+            assertEquals(3, warmedUp.size)
+        }
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/WarmUpLinkedReferencesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/WarmUpLinkedReferencesTests.kt
@@ -10,9 +10,12 @@ import org.junit.Test
 
 class WarmUpLinkedReferencesTests : DatabaseTestsBase() {
 
-    object Box : IntIdTable()
+    object Box : IntIdTable() {
+        val value = integer("value")
+    }
 
     class EBox(id: EntityID<Int>) : IntEntity(id) {
+        var value by Box.value
 
         companion object : IntEntityClass<EBox>(Box)
     }
@@ -33,7 +36,11 @@ class WarmUpLinkedReferencesTests : DatabaseTestsBase() {
     @Test
     fun warmUpLinkedReferencesShouldNotReturnAllTheValueFromCache() {
         withTables(Box, BoxItem) {
-            val boxEntities = (0..4).map { EBox.new { } }
+            val boxEntities = (0..4).map {
+                EBox.new {
+                    value = it
+                }
+            }
 
             boxEntities.forEach {
                 EBoxItem.new {


### PR DESCRIPTION
#### Description

**Summary of the change**: Provide a concise summary of this PR. Describe the changes made in a single sentence or short paragraph.

**Detailed description**:
- **What**: The method `EntityClass::warmUpLinkedReferences()` was filling the cache by values from `references` argument and returning after that all the values from cache. As a result on the second call with a new list of `references` the wrong result was returned (all the values from the cache were returned)
- **How**: The solution is to filter cache values by the values from `references` argument and return the filtered result.

---

#### Type of Change

- [X] Bug fix

Affected databases:
- [X] All

#### Related Issues

[EXPOSED-689](https://youtrack.jetbrains.com/issue/EXPOSED-689) warmUpLinkedReferences() should not return all the values from cache