### PR TITLE
EXPOSED-690 fix Table name quotation

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/ddl/CreateTableTests.kt
@@ -714,4 +714,12 @@ class CreateTableTests : DatabaseTestsBase() {
             }
         }
     }
+
+    // https://youtrack.jetbrains.com/issue/EXPOSED-690
+    @Test
+    fun `identity with names required to be in quotes`() {
+        withDb {
+            assertEquals("\"prefix:my.company.package.my-service:table\"", this.identity(Table("prefix:my.company.package.my-service:table")))
+        }
+    }
 }


### PR DESCRIPTION
#### Description
This PR should eventually fix a quotation issue encountered when using invalid characters in table names.
Tracked by https://youtrack.jetbrains.com/issue/EXPOSED-690, details are there

#### Status
Currently, just a (obviously failing) test case is implemented to demonstrate this issue. Should a maintainer be kind enough to tackle this problem (as I am not familiar with the codebase and potential blast radius of a change), they are free to update my branch (edits for maintainers are enabled).

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [X] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [X] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues	
https://youtrack.jetbrains.com/issue/EXPOSED-690