### PR TITLE
fix!: EXPOSED-691 [PostgreSQL] Restrict dropping unmapped sequences to related tables only

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,11 @@
 # Breaking Changes
 
+## 0.59.0
+* [PostgreSQL] `MigrationUtils.statementsRequiredForDatabaseMigration(*tables)` used to potentially return `DROP` statements for any database sequence not
+  mapped to an Exposed table object. Now it only checks against database sequences that have a relational dependency on any of the specified tables
+  (for example, any sequence automatically associated with a `SERIAL` column registered to `IdTable`). An unbound sequence created manually
+  via the `CREATE SEQUENCE` command will no longer be checked and will not generate a `DROP` statement.
+
 ## 0.57.0
 * Insert, Upsert, and Replace statements will no longer implicitly send all default values (except for client-side default values) in every SQL request. 
   This change will reduce the amount of data Exposed sends to the database and make Exposed rely more on the database's default values. 

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2226,6 +2226,7 @@ public final class org/jetbrains/exposed/sql/Sequence {
 	public final fun getMinValue ()Ljava/lang/Long;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getStartWith ()Ljava/lang/Long;
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class org/jetbrains/exposed/sql/SetOperation : org/jetbrains/exposed/sql/AbstractQuery {
@@ -3564,6 +3565,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun columns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public abstract fun existingSequences ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public final fun getDatabase ()Ljava/lang/String;
 	public abstract fun getDatabaseDialectName ()Ljava/lang/String;
 	public abstract fun getDatabaseProductVersion ()Ljava/lang/String;
@@ -3837,6 +3839,7 @@ public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialec
 	public abstract fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public abstract fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public abstract fun existingSequences ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun getDataTypeProvider ()Lorg/jetbrains/exposed/sql/vendors/DataTypeProvider;
 	public abstract fun getDatabase ()Ljava/lang/String;
 	public abstract fun getDefaultReferenceOption ()Lorg/jetbrains/exposed/sql/ReferenceOption;
@@ -3888,6 +3891,7 @@ public final class org/jetbrains/exposed/sql/vendors/DatabaseDialect$DefaultImpl
 	public static fun dropSchema (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public static fun existingIndices (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;[Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public static fun existingPrimaryKeys (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;[Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public static fun existingSequences (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;[Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public static fun getDefaultReferenceOption (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public static fun getLikePatternSpecialChars (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Ljava/util/Map;
 	public static fun getNeedsQuotesWhenSymbolsInNames (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
@@ -4335,6 +4339,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	public fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public fun existingSequences ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	protected fun fillConstraintCacheForTables (Ljava/util/List;)V
 	public final fun filterCondition (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	protected final fun getAllTableNamesCache ()Ljava/util/Map;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
@@ -29,7 +29,7 @@ class Sequence(
     val identifier
         get() = TransactionManager.current().db.identifierManager.cutIfNecessaryAndQuote(name)
 
-    override fun toString(): String = identifier
+    override fun toString(): String = "Sequence(identifier=$identifier)"
 
     /** The SQL statements that create this sequence. */
     val ddl: List<String>

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Sequence.kt
@@ -29,6 +29,8 @@ class Sequence(
     val identifier
         get() = TransactionManager.current().db.identifierManager.cutIfNecessaryAndQuote(name)
 
+    override fun toString(): String = identifier
+
     /** The SQL statements that create this sequence. */
     val ddl: List<String>
         get() = createStatement()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.sql.statements.api
 
 import org.jetbrains.exposed.sql.ForeignKeyConstraint
 import org.jetbrains.exposed.sql.Index
+import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.vendors.ColumnMetadata
 import org.jetbrains.exposed.sql.vendors.PrimaryKeyMetadata
@@ -63,6 +64,16 @@ abstract class ExposedDatabaseMetadata(val database: String) {
 
     /** Returns a map with the [PrimaryKeyMetadata] in each of the specified [tables]. */
     abstract fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?>
+
+    /**
+     * Returns a map with all the defined sequences that hold a relation to the specified [tables] in the database.
+     *
+     * **Note** PostgreSQL is currently the only database that maps relational dependencies for sequences created when
+     * a SERIAL column is registered to a table. Any sequence created using the CREATE SEQUENCE command will be ignored
+     * as it is not necessarily bound to any particular table. Sequences that are used in a table via triggers will also
+     * not be returned.
+     */
+    abstract fun existingSequences(vararg tables: Table): Map<Table, List<Sequence>>
 
     /** Returns a list of the names of all sequences in the database. */
     abstract fun sequences(): List<String>

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -69,7 +69,9 @@ abstract class ExposedDatabaseMetadata(val database: String) {
      * Returns a map with all the defined sequences that hold a relation to the specified [tables] in the database.
      *
      * **Note** PostgreSQL is currently the only database that maps relational dependencies for sequences created when
-     * a SERIAL column is registered to a table. Any sequence created using the CREATE SEQUENCE command will be ignored
+     * a SERIAL column is registered to an `IdTable`. Using this method with any other database returns an empty map.
+     *
+     * Any sequence created using the CREATE SEQUENCE command will be ignored
      * as it is not necessarily bound to any particular table. Sequences that are used in a table via triggers will also
      * not be returned.
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -120,7 +120,9 @@ interface DatabaseDialect {
      * Returns a map with all the defined sequences that hold a relation to the specified [tables] in the database.
      *
      * **Note** PostgreSQL is currently the only database that maps relational dependencies for sequences created when
-     * a SERIAL column is registered to a table. Any sequence created using the CREATE SEQUENCE command will be ignored
+     * a SERIAL column is registered to an `IdTable`. Using this method with any other database returns an empty map.
+     *
+     * Any sequence created using the CREATE SEQUENCE command will be ignored
      * as it is not necessarily bound to any particular table. Sequences that are used in a table via triggers will also
      * not be returned.
      */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -116,6 +116,16 @@ interface DatabaseDialect {
     /** Returns a map with the primary key metadata in each of the specified [tables]. */
     fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> = emptyMap()
 
+    /**
+     * Returns a map with all the defined sequences that hold a relation to the specified [tables] in the database.
+     *
+     * **Note** PostgreSQL is currently the only database that maps relational dependencies for sequences created when
+     * a SERIAL column is registered to a table. Any sequence created using the CREATE SEQUENCE command will be ignored
+     * as it is not necessarily bound to any particular table. Sequences that are used in a table via triggers will also
+     * not be returned.
+     */
+    fun existingSequences(vararg tables: Table): Map<Table, List<Sequence>> = emptyMap()
+
     /** Returns a list of the names of all sequences in the database. */
     fun sequences(): List<String>
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
@@ -129,6 +129,9 @@ abstract class VendorDialect(
     override fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> =
         TransactionManager.current().db.metadata { existingPrimaryKeys(*tables) }
 
+    override fun existingSequences(vararg tables: Table): Map<Table, List<Sequence>> =
+        TransactionManager.current().db.metadata { existingSequences(*tables) }
+
     override fun sequences(): List<String> =
         TransactionManager.current().db.metadata { sequences() }
 

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -38,6 +38,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun columns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public fun existingSequences ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun getDatabaseDialectName ()Ljava/lang/String;
 	public fun getDatabaseProductVersion ()Ljava/lang/String;
 	public fun getDefaultIsolationLevel ()I


### PR DESCRIPTION
#### Description

**Summary of the change**: SQL generated by `MigrationUtils` methods no longer includes `DROP` statements for every sequence that exists in a PostgreSQL database but not in an Exposed table. These statements are only generated if the database stored a relational dependency between the sequence and table (namely through a `SERIAL` column).

**Detailed description**:
- **Why**: If `MigrationUtils.statementsRequiredForDatabaseMigration()` is called for only a subset of Exposed tables, it will invoke `checkUnmappedSequences()`, which disregards the specified tables and performs a metadata query for every single sequence (related or unrelated to any table) that exists in the database. The result of this query is used to check against mapped sequences, leading to undesirable `DROP` commands being potentially generated for unrelated sequences.
- **How**:
    - Add new method `ExposedDatabaseMetadata.existingSequences(*tables)` with corresponding `DatabaseDialect.existingSequences(*tables)`
    - **NOTE:** These new methods return an empty map for every database other than PostgreSQL because it seems not possible to query for sequences specifically by the table(s) that uses them, since sequences can be technically used by 0 or more tables at a time.  For example:
        - **PostgreSQL:** It's possible to filter (with mentioned dependency limitations) thanks to catalog `pg_depend`.
        - **SQL SERVER:**  Identity column sequence is hidden & not even retrieved through `sys.sequences`.
        - **SQLite, MySQL, MariaDB:** Autoincrement keyword is used with no detectable sequence.
        - Setting an Exposed `Sequence` as an argument to `Column.autoIncrement()` does not create a database relation between the 2. It just creates the sequence (if needed) and ensures inserts use the correct autoincrement prompt. 

**NOTE**
Behavior will not be consistent across DBs as new `Sequence` auto-created by Exposed in PostgreSQL will no longer drop once column is altered to no longer use it.
Is this potentially a problem?
And if we do find queries that work for the other DB, will the new behavior be acceptable? For example, particularly with Oracle that relies on a new `CREATE SEQUENCE` for every identity column in tables.

Given this sequence and 2 tables as a (maybe too basic) example:
```kt
val mySeq = Sequence(name = "my_sequence", startWith = 99)

object OldTable : IdTable<Int>("test_table") {
    override val id: Column<EntityID<Int>> = integer("id").autoIncrement(mySeq).entityId()
    override val primaryKey = PrimaryKey(id)
}

object NewTable : IdTable<Int>("test_table") {
    override val id: Column<EntityID<Int>> = integer("id").entityId()
    override val primaryKey = PrimaryKey(id)
}
```

**Old behavior [all DB]:**
```kt
MigrationUtils.statementsRequiredForDatabaseMigration(NewTable)
// [DROP SEQUENCE IF EXISTS my_sequence]
```


**New behavior [PostgreSQL only]:**
```kt
MigrationUtils.statementsRequiredForDatabaseMigration(NewTable)
// [] - no commands generated, so my_sequence still exists in database
```
---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] Postgres

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-691](https://youtrack.jetbrains.com/issue/EXPOSED-691/PostgreSQL-statementsRequiredForDatabaseMigration-returns-DROP-statements-for-unrelated-table-sequences)
[EXPOSED-692](https://youtrack.jetbrains.com/issue/EXPOSED-692/Oracle-statementsRequiredForDatabaseMigration-returns-DROP-statements-for-unrelated-table-sequences)