### PR TITLE
chore: docs: Add a build-script.xml file with disabled universal zip artifact

### DIFF
--- a/documentation-website/Writerside/cfg/build-script.xml
+++ b/documentation-website/Writerside/cfg/build-script.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root
+    SYSTEM "https://resources.jetbrains.com/writerside/1.0/build-script.dtd">
+<root>
+    <builds>
+        <instance id="exposed" master="writerside.cfg" family="idea">
+            <artifact type="web2" universal-zip="false"/>
+        </instance>
+    </builds>
+</root>


### PR DESCRIPTION
Add a `build-script.xml` file with disabled universal zip artifact 

#### Related Issues

[WH-5582](https://youtrack.jetbrains.com/issue/WH-5582) Create build configuration for publishing Exposed Documentation