### PR TITLE
fix: EXPOSED-696 [PostgreSQL] Drop of auto-increment sequence fails after column modified without dropping default

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnDiff.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnDiff.kt
@@ -4,15 +4,15 @@ package org.jetbrains.exposed.sql
  * Represents differences between a column definition and database metadata for the existing column.
  */
 data class ColumnDiff(
-    /** Whether the nullability of the existing column is correct. */
+    /** Whether there is a mismatch between nullability of the existing column and the defined column. */
     val nullability: Boolean,
-    /** Whether the existing column has a matching auto-increment sequence. */
+    /** Whether there is a mismatch between auto-increment status of the existing column and the defined column. */
     val autoInc: Boolean,
-    /** Whether the default value of the existing column is correct. */
+    /** Whether the default value of the existing column matches that of the defined column. */
     val defaults: Boolean,
-    /** Whether the existing column identifier matches and has the correct casing. */
+    /** Whether the existing column identifier matches that of the defined column and has the correct casing. */
     val caseSensitiveName: Boolean,
-    /** Whether the size and scale of the existing column, if applicable, is correct. */
+    /** Whether the size and scale of the existing column, if applicable, match those of the defined column. */
     val sizeAndScale: Boolean,
 ) {
     /** Returns `true` if there is a difference between the column definition and the existing column in the database. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -408,6 +408,11 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
                         val fallbackSequenceName = fallbackSequenceName(tableName = column.table.tableName, columnName = column.name)
                         append("ALTER COLUMN $colName SET DEFAULT nextval('$fallbackSequenceName')")
                     }
+                } else if (columnDiff.autoInc && column.autoIncColumnType == null) {
+                    // based on logic in SchemaUtils.isIncorrectAutoInc this should only be possible if the existing
+                    // column in database is auto-incrementing while defined table is not
+                    append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
+                    append(", ALTER COLUMN $colName DROP DEFAULT")
                 } else {
                     append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
                 }


### PR DESCRIPTION
#### Description

**Summary of the change**:
Add `ALTER COLUMN ... DROP DEFAULT` string to modified columns that lose their auto-increment status.

**Detailed description**:
- **Why**:

When a column is modified to no longer be auto-incrementing, `MigrationUtils.statementsRequiredForDatabaseMigration()` currently generates statements to `ALTER` the column type and `DROP` the associated sequence. If these statements are actually executed using PostgreSQL, they will fail with an exception like:
```bash
ERROR: cannot drop sequence test_table_id_seq because other objects depend on it
  Detail: default value for column id of table test_table depends on sequence test_table_id_seq
  Hint: Use DROP ... CASCADE to drop the dependent objects too.. Statement(s): DROP SEQUENCE IF EXISTS test_table_id_seq 
```

Before dropping the sequence, the default value of the no-longer-auto-incrementing column must also be dropped to ensure that the column no longer depends on it.

**Note about Defaults:**

Technically, metadata results correctly return a mismatch, with the existing column in the database having a default of something like `nextval('test_table_id_seq'::regclass)`. But [this line](https://github.com/JetBrains/Exposed/blob/main/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt#L182) purposefully ignores the value, resulting in a _technically incorrect_ `ColumnDiff.defauts == false`, so the necessary string isn't currently appended.

That line currently cannot be changed as it leads to failures in many other parts of the source code that depend on it.

- **How**:
    - Add branch to `PostgreSQLDialect.modifyColumn()` for condition when the existing column in the database is auto-incrementing but the defined column in the new table object is not.
    - Update `ColumnDiff` KDocs to be more clear.
    - Adjust test from previous PR #2357 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Postgres

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-696](https://youtrack.jetbrains.com/issue/EXPOSED-696/PostgreSQL-Drop-of-auto-increment-sequence-fails-after-column-modified-without-dropping-default)
[EXPOSED-691](https://youtrack.jetbrains.com/issue/EXPOSED-691/PostgreSQL-statementsRequiredForDatabaseMigration-returns-DROP-statements-for-unrelated-table-sequences)
