### PR TITLE
fix: EXPOSED-701 [Oracle] Insert into table using only database default values fails

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -456,12 +456,8 @@ abstract class FunctionProvider {
             isInsertFromSelect -> columns to expr
             nextValExpression != null && columns.isNotEmpty() -> (columns + autoIncColumn) to expr.dropLast(1) + ", $nextValExpression)"
             nextValExpression != null -> listOf(autoIncColumn) to "VALUES ($nextValExpression)"
-            columns.isNotEmpty() -> columns to expr
-            currentDialect is OracleDialect -> {
-                val oracleDefaults = "VALUES(DEFAULT${", DEFAULT".repeat(table.columns.lastIndex)})"
-                emptyList<Column<*>>() to oracleDefaults
-            }
-            else -> emptyList<Column<*>>() to DEFAULT_VALUE_EXPRESSION
+            columns.isEmpty() && expr.isEmpty() -> emptyList<Column<*>>() to DEFAULT_VALUE_EXPRESSION
+            else -> columns to expr
         }
         val columnsExpr = columnsToInsert.takeIf { it.isNotEmpty() }?.joinToString(prefix = "(", postfix = ")") { transaction.identity(it) } ?: ""
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -456,8 +456,12 @@ abstract class FunctionProvider {
             isInsertFromSelect -> columns to expr
             nextValExpression != null && columns.isNotEmpty() -> (columns + autoIncColumn) to expr.dropLast(1) + ", $nextValExpression)"
             nextValExpression != null -> listOf(autoIncColumn) to "VALUES ($nextValExpression)"
-            columns.isEmpty() && expr.isEmpty() -> emptyList<Column<*>>() to DEFAULT_VALUE_EXPRESSION
-            else -> columns to expr
+            columns.isNotEmpty() -> columns to expr
+            currentDialect is OracleDialect -> {
+                val oracleDefaults = table.columns.joinToString(prefix = "VALUES(", postfix = ")") { "DEFAULT" }
+                emptyList<Column<*>>() to oracleDefaults
+            }
+            else -> emptyList<Column<*>>() to DEFAULT_VALUE_EXPRESSION
         }
         val columnsExpr = columnsToInsert.takeIf { it.isNotEmpty() }?.joinToString(prefix = "(", postfix = ")") { transaction.identity(it) } ?: ""
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -457,6 +457,10 @@ abstract class FunctionProvider {
             nextValExpression != null && columns.isNotEmpty() -> (columns + autoIncColumn) to expr.dropLast(1) + ", $nextValExpression)"
             nextValExpression != null -> listOf(autoIncColumn) to "VALUES ($nextValExpression)"
             columns.isNotEmpty() -> columns to expr
+            currentDialect is OracleDialect -> {
+                val oracleDefaults = "VALUES(DEFAULT${", DEFAULT".repeat(table.columns.lastIndex)})"
+                emptyList<Column<*>>() to oracleDefaults
+            }
             else -> emptyList<Column<*>>() to DEFAULT_VALUE_EXPRESSION
         }
         val columnsExpr = columnsToInsert.takeIf { it.isNotEmpty() }?.joinToString(prefix = "(", postfix = ")") { transaction.identity(it) } ?: ""

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -366,22 +366,6 @@ internal object OracleFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun insert(
-        ignore: Boolean,
-        table: Table,
-        columns: List<Column<*>>,
-        expr: String,
-        transaction: Transaction
-    ): String {
-        val def = super.insert(ignore, table, columns, expr, transaction)
-        return if (def.endsWith(" $DEFAULT_VALUE_EXPRESSION")) {
-            val oracleDefaults = "VALUES(DEFAULT${", DEFAULT".repeat(table.columns.lastIndex)})"
-            "${def.removeSuffix(DEFAULT_VALUE_EXPRESSION)}$oracleDefaults"
-        } else {
-            def
-        }
-    }
-
     override fun explain(
         analyze: Boolean,
         options: String?,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -366,6 +366,22 @@ internal object OracleFunctionProvider : FunctionProvider() {
         }
     }
 
+    override fun insert(
+        ignore: Boolean,
+        table: Table,
+        columns: List<Column<*>>,
+        expr: String,
+        transaction: Transaction
+    ): String {
+        val def = super.insert(ignore, table, columns, expr, transaction)
+        return if (def.endsWith(" $DEFAULT_VALUE_EXPRESSION")) {
+            val oracleDefaults = "VALUES(DEFAULT${", DEFAULT".repeat(table.columns.lastIndex)})"
+            "${def.removeSuffix(DEFAULT_VALUE_EXPRESSION)}$oracleDefaults"
+        } else {
+            def
+        }
+    }
+
     override fun explain(
         analyze: Boolean,
         options: String?,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -233,6 +233,21 @@ internal object OracleFunctionProvider : FunctionProvider() {
         }
     }
 
+    override fun insert(
+        ignore: Boolean,
+        table: Table,
+        columns: List<Column<*>>,
+        expr: String,
+        transaction: Transaction
+    ): String {
+        val newExpr = if (columns.isEmpty() && expr.isEmpty()) {
+            table.columns.joinToString(prefix = "VALUES(", postfix = ")") { "DEFAULT" }
+        } else {
+            expr
+        }
+        return super.insert(ignore, table, columns, newExpr, transaction)
+    }
+
     override fun update(
         target: Table,
         columnsAndValues: List<Pair<Column<*>, Any?>>,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -233,21 +233,6 @@ internal object OracleFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun insert(
-        ignore: Boolean,
-        table: Table,
-        columns: List<Column<*>>,
-        expr: String,
-        transaction: Transaction
-    ): String {
-        val newExpr = if (columns.isEmpty() && expr.isEmpty()) {
-            table.columns.joinToString(prefix = "VALUES(", postfix = ")") { "DEFAULT" }
-        } else {
-            expr
-        }
-        return super.insert(ignore, table, columns, newExpr, transaction)
-    }
-
     override fun update(
         target: Table,
         columnsAndValues: List<Pair<Column<*>, Any?>>,


### PR DESCRIPTION
#### Description

**Summary of the change**: Oracle insert statement now uses valid syntax for inserting only default values.

**Detailed description**:
- **Why**:

Oracle currently generates a statement like `INSERT ... DEFAULT VALUES` if an insert operation is performed with no provided column set, like `Table.insert { }`.
This was not caught because there is actually no test for insertion of only truly database-side defaults; all tests either insert at minimum 1 column, an expression, or implicit auto-inc value for example.

The above syntax causes `java.sql.SQLSyntaxErrorException: ORA-00926: missing VALUES keyword` because it is not supported. [More details here](https://forums.oracle.com/ords/apexds/post/add-support-for-insert-default-values-7537)

- **How**: Oracle no longer relies solely on the default `FunctionProvider.insert()` implementation. It uses the `INSERT ... VALUES(DEFAULT, ...)` syntax if a defaults-only expression is detected.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Oracle

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-701](https://youtrack.jetbrains.com/issue/EXPOSED-701/Oracle-Insert-into-table-using-only-database-default-values-fails)