### PR TITLE
fix: EXPOSED-704 ClassCastException when referencing an eager-loaded backReferencedOn with keepLoadedReferencesOutOfTransaction = true

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/References.kt
@@ -154,7 +154,10 @@ open class Referrers<ParentID : Any, in Parent : Entity<ParentID>, ChildID : Any
         }
         val transaction = TransactionManager.currentOrNull()
         return when {
-            transaction == null -> thisRef.getReferenceFromCache(reference)
+            transaction == null -> {
+                val cachedValue = thisRef.getReferenceFromCache<Any?>(reference)
+                cachedValue as? SizedIterable<Child> ?: LazySizedCollection(SizedCollection(cachedValue as Child))
+            }
             cache -> {
                 transaction.entityCache.getOrPutReferrers(thisRef.id, reference, query).also {
                     thisRef.storeReferenceInCache(reference, it)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/EntityReferenceCacheTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/EntityReferenceCacheTest.kt
@@ -95,7 +95,7 @@ class EntityReferenceCacheTest : DatabaseTestsBase() {
     }
 
     @Test
-    fun `test backReferencedOn works out of transaction via warmup`() {
+    fun `test backReferencedOn & optionalBackReferencedOn work out of transaction via load`() {
         var y1: EntityTestsData.YEntity by Delegates.notNull()
         var b1: EntityTestsData.BEntity by Delegates.notNull()
         executeOnH2(EntityTestsData.XTable, EntityTestsData.YTable) {
@@ -106,14 +106,16 @@ class EntityReferenceCacheTest : DatabaseTestsBase() {
                 }
             }
             assertFails { y1.b }
+            assertFails { y1.bOpt }
 
             transaction(dbWithCache) {
                 y1.refresh()
                 b1.refresh()
-                y1.load(EntityTestsData.YEntity::b)
+                y1.load(EntityTestsData.YEntity::b, EntityTestsData.YEntity::bOpt)
             }
 
             assertEquals(b1.id, y1.b?.id)
+            assertEquals(b1.id, y1.bOpt?.id)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -88,6 +88,7 @@ object EntityTestsData {
     class YEntity(id: EntityID<String>) : Entity<String>(id) {
         var x by YTable.x
         val b: BEntity? by BEntity.backReferencedOn(XTable.y1)
+        val bOpt by BEntity optionalBackReferencedOn XTable.y1
 
         companion object : EntityClass<String, YEntity>(YTable)
     }


### PR DESCRIPTION
#### Description

Both `BackReference` and `OptionalBackReference` classes use `Referrers` as their delegate class when `getValue()` is invoked. This means that, when there is no transaction context, the delegate correctly attempts to get a child value from the cache, but incorrectly assumes that it will be a `SizedIterable` (expected type for `Referrers`). Causing the retrieval to fail with something like:
```bash
org.jetbrains.exposed.sql.tests.shared.entities.EntityTestsData$BEntity cannot be cast to org.jetbrains.exposed.sql.SizedIterable
```

This fix ensures that an attempt is made to store the child value as a `LazySizedCollection` if it is not found to be a collection itself already.

Contains a test that reproduces a crash with eager loading of `backReferencedOn` (and `optionalBackReferencedOn`) references. Prior to the fix, the test would also have failed if `load()` was swapped for `with()`, but this now works too.

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-704](https://youtrack.jetbrains.com/issue/EXPOSED-704/ClassCastException-when-referencing-an-eager-loaded-backReferencedOn-with-keepLoadedReferencesOutOfTransaction-true)