### PR TITLE
fix: EXPOSED-706 Handle MariaDB sequence max value for versions earlier than 11.5

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3854,6 +3854,7 @@ public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialec
 	public abstract fun getNeedsQuotesWhenSymbolsInNames ()Z
 	public abstract fun getNeedsSequenceToAutoInc ()Z
 	public abstract fun getRequiresAutoCommitOnCreateDrop ()Z
+	public abstract fun getSequenceMaxValue ()J
 	public abstract fun getSupportsCreateSchema ()Z
 	public abstract fun getSupportsCreateSequence ()Z
 	public abstract fun getSupportsDualTableConcept ()Z
@@ -3902,6 +3903,7 @@ public final class org/jetbrains/exposed/sql/vendors/DatabaseDialect$DefaultImpl
 	public static fun getNeedsQuotesWhenSymbolsInNames (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getNeedsSequenceToAutoInc (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getRequiresAutoCommitOnCreateDrop (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
+	public static fun getSequenceMaxValue (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)J
 	public static fun getSupportsCreateSchema (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsCreateSequence (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
 	public static fun getSupportsDualTableConcept (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)Z
@@ -4163,6 +4165,7 @@ public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbra
 	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
 	public fun getFunctionProvider ()Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;
 	public fun getName ()Ljava/lang/String;
+	public fun getSequenceMaxValue ()J
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
@@ -4362,6 +4365,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun getNeedsQuotesWhenSymbolsInNames ()Z
 	public fun getNeedsSequenceToAutoInc ()Z
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
+	public fun getSequenceMaxValue ()J
 	public fun getSupportsCreateSchema ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsDualTableConcept ()Z

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -148,7 +148,7 @@ class AutoIncColumnType<T>(
                 it,
                 startWith = 1,
                 minValue = 1,
-                maxValue = Long.MAX_VALUE
+                maxValue = currentDialect.sequenceMaxValue
             )
         }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -516,7 +516,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
                         fallbackSequenceName,
                         startWith = 1,
                         minValue = 1,
-                        maxValue = Long.MAX_VALUE
+                        maxValue = currentDialect.sequenceMaxValue
                     )
                 }
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -75,6 +75,8 @@ interface DatabaseDialect {
     /** Returns true if autoCommit should be enabled to create/drop a database. */
     val requiresAutoCommitOnCreateDrop: Boolean get() = false
 
+    val sequenceMaxValue: Long get() = Long.MAX_VALUE
+
     /** Returns the name of the current database. */
     fun getDatabase(): String
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -78,6 +78,15 @@ class MariaDBDialect : MysqlDialect() {
     // actually MariaDb supports it but jdbc driver prepares statement without RETURNING clause
     override val supportsSequenceAsGeneratedKeys: Boolean = false
 
+    @Suppress("MagicNumber")
+    override val sequenceMaxValue: Long by lazy {
+        if (TransactionManager.current().db.isVersionCovers(11, 5)) {
+            super.sequenceMaxValue
+        } else {
+            Long.MAX_VALUE - 1
+        }
+    }
+
     override fun createIndex(index: Index): String {
         if (index.functions != null) {
             exposedLogger.warn(


### PR DESCRIPTION
#### Description

**Detailed description**:
- **What**: Handle MariaDB sequence max value for versions earlier than 11.5.
- **Why**: According to the documentation [here](https://mariadb.com/kb/en/create-sequence/#maxvalue), MariaDB versions less than 11.5 have a max value for sequences that is lower than the one Exposed currently allows and that causes errors. Exposed allows a max of **9223372036854775807**, while MariaDB allows a max of **9223372036854775806**.
- **How**: I added a new property, `sequenceMaxValue`, to `DatabaseDialect`, and that is overridden in `MariaDBDialect` and used to set the `maxValue` of `Sequence` wherever a sequence is created.

**How to test:**
1. Go to `docker-compose-mariadb.yml`
2. Modify it to use this image: `image: mariadb:10.3.0`
3. Run `SequencesTests` and `DatabaseMigrationTests` for MariaDB v2 and v3 and they should pass
---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
