### PR TITLE
fix: EXPOSED-707 Handle MariaDB fractional seconds support since version 5.3

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -4196,7 +4196,7 @@ public final class org/jetbrains/exposed/sql/vendors/KeywordsKt {
 	public static final fun getVENDORS_KEYWORDS ()Ljava/util/Map;
 }
 
-public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbrains/exposed/sql/vendors/MysqlDialect {
+public class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbrains/exposed/sql/vendors/MysqlDialect {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion;
 	public fun <init> ()V
 	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -4207,6 +4207,7 @@ public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbra
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
+	public fun isFractionDateTimeSupported ()Z
 }
 
 public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
@@ -4226,7 +4227,7 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	public fun getSupportsSubqueryUnions ()Z
 	public fun getSupportsTernaryAffectedRowValues ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
-	public final fun isFractionDateTimeSupported ()Z
+	public fun isFractionDateTimeSupported ()Z
 	public final fun isTimeZoneOffsetSupported ()Z
 	protected fun metadataMatchesTable (Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Table;)Z
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -72,7 +72,7 @@ class Database private constructor(
 
     /** Whether the version number of the database is equal to or greater than the provided [majorVersion] and [minorVersion]. */
     fun isVersionCovers(majorVersion: Int, minorVersion: Int) =
-        this.majorVersion >= majorVersion && this.minorVersion >= minorVersion
+        this.majorVersion > majorVersion || (this.majorVersion == majorVersion && this.minorVersion >= minorVersion)
 
     /** Whether the database supports ALTER TABLE with an add column clause. */
     val supportsAlterTableWithAddColumn by lazy(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -66,7 +66,7 @@ internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
 /**
  * MariaDB dialect implementation.
  */
-class MariaDBDialect : MysqlDialect() {
+open class MariaDBDialect : MysqlDialect() {
     override val name: String = dialectName
     override val functionProvider: FunctionProvider = MariaDBFunctionProvider
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -87,6 +87,10 @@ class MariaDBDialect : MysqlDialect() {
         }
     }
 
+    /** Returns `true` if the MariaDB database version is greater than or equal to 5.3. */
+    @Suppress("MagicNumber")
+    override fun isFractionDateTimeSupported(): Boolean = TransactionManager.current().db.isVersionCovers(5, 3)
+
     override fun createIndex(index: Index): String {
         if (index.functions != null) {
             exposedLogger.warn(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -356,10 +356,11 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
 
     override val supportsSetDefaultReferenceOption: Boolean = false
 
-    /** Returns `true` if the MySQL JDBC connector version is greater than or equal to 5.6. */
-    fun isFractionDateTimeSupported(): Boolean = TransactionManager.current().db.isVersionCovers(BigDecimal("5.6"))
+    /** Returns `true` if the MySQL database version is greater than or equal to 5.6. */
+    @Suppress("MagicNumber")
+    open fun isFractionDateTimeSupported(): Boolean = TransactionManager.current().db.isVersionCovers(5, 6)
 
-    /** Returns `true` if a MySQL JDBC connector is being used and its version is greater than or equal to 8.0. */
+    /** Returns `true` if a MySQL database is being used and its version is greater than or equal to 8.0. */
     fun isTimeZoneOffsetSupported(): Boolean = (currentDialect !is MariaDBDialect) && isMysql8
 
     private val notAcceptableDefaults = mutableListOf("CURRENT_DATE()", "CURRENT_DATE")


### PR DESCRIPTION
**Detailed description**:
- **What**:
1. Handle MariaDB fractional seconds support since version 5.3.
2. Fixed mistake in KDocs referring to JDBC connector version instead of database version.
3. Fixed `isVersionCovers` function to handle comparison of 8.0 with 5.6.
4. Made the `MariaDBDialect` class extendable to be consistent with other dialect classes.
- **Why**:
According to the documentation [here](https://mariadb.com/kb/en/changes-improvements-in-mariadb-5-3/#datatypes), MariaDB introduced fractional seconds support in temporal data types from version 5.3. For MySQL, it's from version 5.6. Previously, Exposed was assuming it was 5.6 for both MariaDB and MySQL.
- **How**:
Modified `isFractionDateTimeSupported` in `MysqlDialect` to be open and overrided it in `MariaDBDialect` to return the correct result for MariaDB 5.3 onwards.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
