### PR TITLE
refactor: EXPOSED-708 Remove JDBC DatabaseMetaData from exposed-core module

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3597,6 +3597,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun getUrl ()Ljava/lang/String;
 	public abstract fun getVersion ()Ljava/math/BigDecimal;
 	public abstract fun resetCurrentScheme ()V
+	public abstract fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public abstract fun sequences ()Ljava/util/List;
 	public abstract fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
 	public abstract fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
@@ -4133,7 +4134,6 @@ public class org/jetbrains/exposed/sql/vendors/H2Dialect : org/jetbrains/exposed
 	public final fun isSecondVersion ()Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
-	public fun resolveRefOptionFromJdbc (I)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public fun sequences ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }
@@ -4229,7 +4229,6 @@ public class org/jetbrains/exposed/sql/vendors/OracleDialect : org/jetbrains/exp
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
-	public fun resolveRefOptionFromJdbc (I)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public fun sequences ()Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -2,6 +2,8 @@ package org.jetbrains.exposed.sql.statements.api
 
 import org.jetbrains.exposed.sql.ForeignKeyConstraint
 import org.jetbrains.exposed.sql.Index
+import org.jetbrains.exposed.sql.InternalApi
+import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.Sequence
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.vendors.ColumnMetadata
@@ -91,6 +93,14 @@ abstract class ExposedDatabaseMetadata(val database: String) {
      * with the table name used as the key.
      */
     abstract fun tableConstraints(tables: List<Table>): Map<String, List<ForeignKeyConstraint>>
+
+    // THIS should become protected after the usage in DatabaseDialect is fully deprecated
+    /**
+     * Returns the corresponding [ReferenceOption] for the specified [refOption] result,
+     * or `null` if the database result is an invalid string without a corresponding match.
+     */
+    @InternalApi
+    abstract fun resolveReferenceOption(refOption: String): ReferenceOption?
 
     /** Clears any cached values. */
     abstract fun cleanCache()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -2,7 +2,6 @@ package org.jetbrains.exposed.sql.vendors
 
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
-import java.sql.DatabaseMetaData
 
 /**
  * Common interface for all database dialects.
@@ -188,14 +187,13 @@ interface DatabaseDialect {
         }
     }
 
-    /** Returns the corresponding [ReferenceOption] for the specified [refOption] from JDBC. */
-    fun resolveRefOptionFromJdbc(refOption: Int): ReferenceOption = when (refOption) {
-        DatabaseMetaData.importedKeyCascade -> ReferenceOption.CASCADE
-        DatabaseMetaData.importedKeySetNull -> ReferenceOption.SET_NULL
-        DatabaseMetaData.importedKeyRestrict -> ReferenceOption.RESTRICT
-        DatabaseMetaData.importedKeyNoAction -> ReferenceOption.NO_ACTION
-        DatabaseMetaData.importedKeySetDefault -> ReferenceOption.SET_DEFAULT
-        else -> currentDialect.defaultReferenceOption
+    @Deprecated(
+        message = "This function will be removed in future releases.",
+        level = DeprecationLevel.WARNING
+    )
+    fun resolveRefOptionFromJdbc(refOption: Int): ReferenceOption {
+        @OptIn(InternalApi::class)
+        return TransactionManager.current().db.metadata { resolveReferenceOption(refOption.toString())!! }
     }
 
     companion object {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -5,7 +5,6 @@ import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.transactions.TransactionManager
-import java.sql.DatabaseMetaData
 import java.util.*
 
 internal object H2DataTypeProvider : DataTypeProvider() {
@@ -345,15 +344,6 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         super.modifyColumn(column, columnDiff).map { it.replace("MODIFY COLUMN", "ALTER COLUMN") }
 
     override fun dropDatabase(name: String) = "DROP SCHEMA IF EXISTS ${name.inProperCase()}"
-
-    override fun resolveRefOptionFromJdbc(refOption: Int): ReferenceOption {
-        val modeDelegatesRefOption = h2Mode == H2CompatibilityMode.Oracle || h2Mode == H2CompatibilityMode.SQLServer
-        return when {
-            refOption == DatabaseMetaData.importedKeyRestrict && modeDelegatesRefOption -> ReferenceOption.NO_ACTION
-            refOption == DatabaseMetaData.importedKeyRestrict -> ReferenceOption.RESTRICT
-            else -> super.resolveRefOptionFromJdbc(refOption)
-        }
-    }
 
     override fun sequences(): List<String> {
         val sequences = mutableListOf<String>()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -8,7 +8,6 @@ import org.jetbrains.exposed.sql.statements.MergeStatement.ClauseAction.INSERT
 import org.jetbrains.exposed.sql.statements.MergeStatement.ClauseAction.UPDATE
 import org.jetbrains.exposed.sql.statements.StatementType
 import org.jetbrains.exposed.sql.transactions.TransactionManager
-import java.sql.DatabaseMetaData
 import java.util.*
 
 @Suppress("TooManyFunctions")
@@ -473,17 +472,6 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
         if (cascade) {
             append(" CASCADE")
         }
-    }
-
-    /**
-     * The SQL that gets the constraint information for Oracle returns a 1 for NO ACTION and does not support RESTRICT.
-     * `decode (f.delete_rule, 'CASCADE', 0, 'SET NULL', 2, 1) as delete_rule`
-     */
-    override fun resolveRefOptionFromJdbc(refOption: Int): ReferenceOption = when (refOption) {
-        DatabaseMetaData.importedKeyCascade -> ReferenceOption.CASCADE
-        DatabaseMetaData.importedKeySetNull -> ReferenceOption.SET_NULL
-        DatabaseMetaData.importedKeyRestrict -> ReferenceOption.NO_ACTION
-        else -> currentDialect.defaultReferenceOption
     }
 
     override fun sequences(): List<String> {

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -55,6 +55,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun getUrl ()Ljava/lang/String;
 	public fun getVersion ()Ljava/math/BigDecimal;
 	public fun resetCurrentScheme ()V
+	public fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public fun sequences ()Ljava/util/List;
 	public fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
 	public fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -434,11 +434,6 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
     override fun resolveReferenceOption(refOption: String): ReferenceOption? {
         val dialect = currentDialect
 
-        // MySQL/MariaDB use custom query that returns string-name values
-        if (dialect is MysqlDialect) {
-            return ReferenceOption.valueOf(refOption.replace(" ", "_"))
-        }
-
         val refOptionInt = refOption.toIntOrNull() ?: return null
 
         return when (refOptionInt) {


### PR DESCRIPTION
#### Description

**Summary of the change**: `exposed-core` no longer uses JDBC `DatabaseMetaData` to resolve metadata query results into `ReferenceOption` constants.

**Detailed description**:
- **Why**:

In preparation for R2DBC, all JDBC specific metadata processing must be extracted from the core module. `DatabaseDialect.resolveRefOptionFromJdbc()` currently relies on JDBC `DatabaseMetaData` to find a matching `ReferenceOption` when table constraints are being generated by metadata query results.

- **How**:
    -  Add new `ExposedDatabaseMetadata.resolveReferenceOption()` (so that it can be implemented for JDBC now and R2DBC later)
    - Deprecate old `DatabaseDialect.resolveRefOptionFromJdbc()` and have it call the above.
    - Move dialect specific logic to `exposed-jdbc`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other: refactor
- [X] Other: deprecation

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues
[EXPOSED-708](https://youtrack.jetbrains.com/issue/EXPOSED-708/Remove-JDBC-DatabaseMetaData-from-exposed-core-module)
R2DBC parent - [EXPOSED-517](https://youtrack.jetbrains.com/issue/EXPOSED-517/Implement-IdentifierManagerApi-and-ExposedDatabaseMetadata-for-R2DBC)