### PR TITLE
refactor: EXPOSED-709 Remove plain SQL execution from core DatabaseDialect

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3606,6 +3606,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun existingSequences ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public final fun getDatabase ()Ljava/lang/String;
+	public abstract fun getDatabaseDialectMode ()Ljava/lang/String;
 	public abstract fun getDatabaseDialectName ()Ljava/lang/String;
 	public abstract fun getDatabaseProductVersion ()Ljava/lang/String;
 	public abstract fun getDefaultIsolationLevel ()I
@@ -3645,6 +3646,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/IdentifierManager
 	protected abstract fun getSupportsMixedIdentifiers ()Z
 	protected abstract fun getSupportsMixedQuotedIdentifiers ()Z
 	public final fun inProperCase (Ljava/lang/String;)Ljava/lang/String;
+	public final fun isDotPrefixedAndUnquoted (Ljava/lang/String;)Z
 	protected abstract fun isLowerCaseIdentifiers ()Z
 	protected abstract fun isLowerCaseQuotedIdentifiers ()Z
 	protected abstract fun isUpperCaseIdentifiers ()Z
@@ -4158,7 +4160,6 @@ public class org/jetbrains/exposed/sql/vendors/H2Dialect : org/jetbrains/exposed
 	public final fun isSecondVersion ()Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
-	public fun sequences ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -4253,7 +4254,6 @@ public class org/jetbrains/exposed/sql/vendors/OracleDialect : org/jetbrains/exp
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
-	public fun sequences ()Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 }
 
@@ -4325,7 +4325,6 @@ public class org/jetbrains/exposed/sql/vendors/SQLServerDialect : org/jetbrains/
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
-	public fun sequences ()Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -30,6 +30,9 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     /** The name of the database based on the name of the underlying JDBC driver. */
     abstract val databaseDialectName: String
 
+    /** The name of the mode of the database. This is currently applicable only to H2 databases. */
+    abstract val databaseDialectMode: String?
+
     /** The version number of the database product as a `String`. */
     abstract val databaseProductVersion: String
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/IdentifierManagerApi.kt
@@ -126,12 +126,15 @@ abstract class IdentifierManagerApi {
 
     /** Returns an SQL token wrapped in quotations, if validated as necessary. */
     fun quoteIfNecessary(identity: String): String {
-        return if (identity.contains('.') && !identity.isAlreadyQuoted()) {
+        return if (isDotPrefixedAndUnquoted(identity)) {
             identity.split('.').joinToString(".") { quoteTokenIfNecessary(it) }
         } else {
             quoteTokenIfNecessary(identity)
         }
     }
+
+    /** Returns whether an [identity] is both unquoted and contains dot characters. */
+    fun isDotPrefixedAndUnquoted(identity: String): Boolean = identity.contains('.') && !identity.isAlreadyQuoted()
 
     /** Returns an [identity] wrapped in quotations, if validated as necessary. */
     fun quoteIdentifierWhenWrongCaseOrNecessary(identity: String): String {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.sql.vendors
 
-import org.intellij.lang.annotations.Language
 import org.jetbrains.exposed.exceptions.throwUnsupportedException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.StatementType
@@ -259,17 +258,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
 
     /** The H2 database compatibility mode retrieved from metadata. */
     val h2Mode: H2CompatibilityMode? by lazy {
-        val (settingNameField, settingValueField) = when (majorVersion) {
-            H2MajorVersion.One -> "NAME" to "VALUE"
-            H2MajorVersion.Two -> "SETTING_NAME" to "SETTING_VALUE"
-        }
-
-        @Language("H2")
-        val fetchModeQuery = "SELECT $settingValueField FROM INFORMATION_SCHEMA.SETTINGS WHERE $settingNameField = 'MODE'"
-        val modeValue = TransactionManager.current().exec(fetchModeQuery) { rs ->
-            rs.next()
-            rs.getString(settingValueField)
-        }
+        val modeValue = TransactionManager.current().db.metadata { databaseDialectMode }
         when {
             modeValue == null -> null
             modeValue.equals("MySQL", ignoreCase = true) -> H2CompatibilityMode.MySQL
@@ -344,23 +333,6 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         super.modifyColumn(column, columnDiff).map { it.replace("MODIFY COLUMN", "ALTER COLUMN") }
 
     override fun dropDatabase(name: String) = "DROP SCHEMA IF EXISTS ${name.inProperCase()}"
-
-    override fun sequences(): List<String> {
-        val sequences = mutableListOf<String>()
-        TransactionManager.current().exec("SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SEQUENCES") { rs ->
-            while (rs.next()) {
-                val result = rs.getString("SEQUENCE_NAME")
-                val sequenceName = if (h2Mode == H2CompatibilityMode.Oracle) {
-                    val q = if (result.contains('.') && !result.isAlreadyQuoted()) "\"" else ""
-                    "$q$result$q"
-                } else {
-                    result
-                }
-                sequences.add(sequenceName)
-            }
-        }
-        return sequences
-    }
 
     companion object : DialectNameProvider("H2")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/OracleDialect.kt
@@ -474,18 +474,5 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
         }
     }
 
-    override fun sequences(): List<String> {
-        val sequences = mutableListOf<String>()
-        TransactionManager.current().exec("SELECT SEQUENCE_NAME FROM USER_SEQUENCES") { rs ->
-            while (rs.next()) {
-                val result = rs.getString("SEQUENCE_NAME")
-                val q = if (result.contains('.') && !result.isAlreadyQuoted()) "\"" else ""
-                val sequenceName = "$q$result$q"
-                sequences.add(sequenceName)
-            }
-        }
-        return sequences
-    }
-
     companion object : DialectNameProvider("Oracle")
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/SQLServerDialect.kt
@@ -467,16 +467,6 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
     // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/like-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15#arguments
     override val likePatternSpecialChars = sqlServerLikePatternSpecialChars
 
-    override fun sequences(): List<String> {
-        val sequences = mutableListOf<String>()
-        TransactionManager.current().exec("SELECT name FROM sys.sequences") { rs ->
-            while (rs.next()) {
-                sequences.add(rs.getString("name"))
-            }
-        }
-        return sequences
-    }
-
     companion object : DialectNameProvider("SQLServer") {
         private val sqlServerLikePatternSpecialChars = mapOf('%' to null, '_' to null, '[' to ']')
     }

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -39,6 +39,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun existingIndices ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingPrimaryKeys ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun existingSequences ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
+	public fun getDatabaseDialectMode ()Ljava/lang/String;
 	public fun getDatabaseDialectName ()Ljava/lang/String;
 	public fun getDatabaseProductVersion ()Ljava/lang/String;
 	public fun getDefaultIsolationLevel ()I


### PR DESCRIPTION
#### Description

**Summary of the change**: `vendors` package no longer has any metadata retrieved via `Transaction.exec()`. PR #2380 is open in conjunction to this one, since the extraction required a bit more.

**Detailed description**:
- **Why**:

In preparation for R2DBC, instances of JDBC transaction-specific execution need to be removed from `exposed-core` and this focuses on the metadata retrieval queries in `vendors`, namely:
    - H2 mode retrieval
    - Query for all sequences in db

- **How**:
    - Add new `ExposedDatabaseMetadatat.databaseDialectMode` property that can be called by `H2Dialect.h2Mode` and extract its logic to `exposed-jdbc`. 
    - Add `isDotPrefixedAndUnquoted()` for identifier manager to be used when processing sequence results. Both this method and the 1 above are introduced as they will both need to be used by the new R2DBC module.
    - Move database-specific queries for sequences from overrides & place in jdbc `sequences()`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other: refactor

Affected databases:
- [X] Oracle
- [X] SqlServer
- [X] H2

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues
[EXPOSED-709](https://youtrack.jetbrains.com/issue/EXPOSED-709/Remove-plain-SQL-execution-from-core-DatabaseDialect)
R2DBC parent - [EXPOSED-517](https://youtrack.jetbrains.com/issue/EXPOSED-517/Implement-IdentifierManagerApi-and-ExposedDatabaseMetadata-for-R2DBC)