### PR TITLE
fix: EXPOSED-714 [exposed-spring-boot-starter] Fix NPE from DatabaseInitializer when non-object Table is defined

### DIFF
--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/DatabaseInitializer.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/DatabaseInitializer.kt
@@ -53,5 +53,5 @@ fun discoverExposedTables(applicationContext: ApplicationContext, excludedPackag
     excludedPackages.forEach { provider.addExcludeFilter(RegexPatternTypeFilter(Pattern.compile(it.replace(".", "\\.") + ".*"))) }
     val packages = AutoConfigurationPackages.get(applicationContext)
     val components = packages.map { provider.findCandidateComponents(it) }.flatten()
-    return components.map { Class.forName(it.beanClassName).kotlin.objectInstance as Table }
+    return components.mapNotNull { Class.forName(it.beanClassName).kotlin.objectInstance as? Table }
 }

--- a/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/DatabaseInitializerTest.kt
+++ b/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/DatabaseInitializerTest.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -32,5 +33,13 @@ open class DatabaseInitializerTest {
                 IgnoreTable.selectAll().count()
             }
         }
+    }
+
+    @Test
+    fun `ignore non object Table`() {
+        Database.connect("jdbc:h2:mem:test-spring", user = "sa", driver = "org.h2.Driver")
+        val tables = discoverExposedTables(applicationContext, listOf())
+        assertEquals(2, tables.size)
+        assertArrayEquals(listOf(TestTable, IgnoreTable).toTypedArray(), tables.toTypedArray())
     }
 }

--- a/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/tables/NonObjectTable.kt
+++ b/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/tables/NonObjectTable.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.exposed.spring.tables
+
+import org.jetbrains.exposed.sql.Table
+
+open class NonObjectTable : Table()


### PR DESCRIPTION
#### Description

If `spring.exposed.generate-ddl` option is enabled, `DatabaseInitializer` discover exposed tables using following function.

```kotlin
fun discoverExposedTables(applicationContext: ApplicationContext, excludedPackages: List<String>): List<Table> {
    val provider = ClassPathScanningCandidateComponentProvider(false)
    provider.addIncludeFilter(AssignableTypeFilter(Table::class.java))
    excludedPackages.forEach { provider.addExcludeFilter(RegexPatternTypeFilter(Pattern.compile(it.replace(".", "\\.") + ".*"))) }
    val packages = AutoConfigurationPackages.get(applicationContext)
    val components = packages.map { provider.findCandidateComponents(it) }.flatten()
    return components.map { Class.forName(it.beanClassName).kotlin.objectInstance as Table }
    //                                                                             ^ Here
}
```

The `discoverExposedTables` function finds that

1. Class that assignable from `Table` type
2. Not in the `excludedPackages` package that cames from Spring property

And directly cast bean's `objectInstance` to `Table`.



The problem is that found bean can be a normal class not singleton `object`. For example, If I created open class like this

```kotlin
open class BaseTable() : Table()
```

and getting `objectInstance` of `BaseTable` class returns null.

Casting null to Table throws NPE like this.

```kotlin
java.lang.NullPointerException: null cannot be cast to non-null type org.jetbrains.exposed.sql.Table
	at org.jetbrains.exposed.spring.DatabaseInitializerKt.discoverExposedTables(DatabaseInitializer.kt:56) ~[exposed-spring-boot-starter-0.58.0.jar:na]
```
---

#### Type of Change
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-714](https://youtrack.jetbrains.com/issue/EXPOSED-714/exposed-spring-boot-starter-Throws-NullPointerException-when-Table-class-isnt-object) Throws NullPointerException when Table class isn't object