### PR TITLE
deprecate: Raise deprecation levels of API elements

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -492,8 +492,8 @@ public abstract class org/jetbrains/exposed/sql/ColumnSet : org/jetbrains/expose
 	public abstract fun rightJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
 	public final fun select (Ljava/util/List;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun select (Lorg/jetbrains/exposed/sql/Expression;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/Query;
-	public final fun slice (Ljava/util/List;)Lorg/jetbrains/exposed/sql/FieldSet;
-	public final fun slice (Lorg/jetbrains/exposed/sql/Expression;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/FieldSet;
+	public final synthetic fun slice (Ljava/util/List;)Lorg/jetbrains/exposed/sql/FieldSet;
+	public final synthetic fun slice (Lorg/jetbrains/exposed/sql/Expression;[Lorg/jetbrains/exposed/sql/Expression;)Lorg/jetbrains/exposed/sql/FieldSet;
 }
 
 public abstract interface class org/jetbrains/exposed/sql/ColumnTransformer {
@@ -656,7 +656,7 @@ public class org/jetbrains/exposed/sql/CustomOperator : org/jetbrains/exposed/sq
 public final class org/jetbrains/exposed/sql/Database {
 	public static final field Companion Lorg/jetbrains/exposed/sql/Database$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun defaultFetchSize (I)Lorg/jetbrains/exposed/sql/Database;
+	public final synthetic fun defaultFetchSize (I)Lorg/jetbrains/exposed/sql/Database;
 	public final fun getConfig ()Lorg/jetbrains/exposed/sql/DatabaseConfig;
 	public final fun getConnector ()Lkotlin/jvm/functions/Function0;
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
@@ -673,7 +673,7 @@ public final class org/jetbrains/exposed/sql/Database {
 	public final fun getVersion ()Ljava/math/BigDecimal;
 	public final fun isVersionCovers (II)Z
 	public final fun isVersionCovers (Ljava/math/BigDecimal;)Z
-	public final fun setUseNestedTransactions (Z)V
+	public final synthetic fun setUseNestedTransactions (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -684,7 +684,7 @@ public final class org/jetbrains/exposed/sql/Database$Companion {
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/sql/Database$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lorg/jetbrains/exposed/sql/DatabaseConnectionAutoRegistration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/sql/Database$Companion;Ljavax/sql/DataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lorg/jetbrains/exposed/sql/DatabaseConnectionAutoRegistration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/sql/Database$Companion;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lorg/jetbrains/exposed/sql/DatabaseConnectionAutoRegistration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
-	public final fun connectPool (Ljavax/sql/ConnectionPoolDataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lorg/jetbrains/exposed/sql/DatabaseConnectionAutoRegistration;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Database;
+	public final synthetic fun connectPool (Ljavax/sql/ConnectionPoolDataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lorg/jetbrains/exposed/sql/DatabaseConnectionAutoRegistration;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Database;
 	public static synthetic fun connectPool$default (Lorg/jetbrains/exposed/sql/Database$Companion;Ljavax/sql/ConnectionPoolDataSource;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/sql/DatabaseConfig;Lorg/jetbrains/exposed/sql/DatabaseConnectionAutoRegistration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Database;
 	public final fun getDefaultIsolationLevel (Lorg/jetbrains/exposed/sql/Database;)I
 	public final fun getDialectName (Ljava/lang/String;)Ljava/lang/String;
@@ -698,12 +698,12 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig {
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDefaultIsolationLevel ()I
 	public final fun getDefaultMaxAttempts ()I
-	public final fun getDefaultMaxRepetitionDelay ()J
+	public final synthetic fun getDefaultMaxRepetitionDelay ()J
 	public final fun getDefaultMaxRetryDelay ()J
-	public final fun getDefaultMinRepetitionDelay ()J
+	public final synthetic fun getDefaultMinRepetitionDelay ()J
 	public final fun getDefaultMinRetryDelay ()J
 	public final fun getDefaultReadOnly ()Z
-	public final fun getDefaultRepetitionAttempts ()I
+	public final synthetic fun getDefaultRepetitionAttempts ()I
 	public final fun getDefaultSchema ()Lorg/jetbrains/exposed/sql/Schema;
 	public final fun getExplicitDialect ()Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;
 	public final fun getKeepLoadedReferencesOutOfTransaction ()Z
@@ -722,12 +722,12 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public final fun getDefaultFetchSize ()Ljava/lang/Integer;
 	public final fun getDefaultIsolationLevel ()I
 	public final fun getDefaultMaxAttempts ()I
-	public final fun getDefaultMaxRepetitionDelay ()J
+	public final synthetic fun getDefaultMaxRepetitionDelay ()J
 	public final fun getDefaultMaxRetryDelay ()J
-	public final fun getDefaultMinRepetitionDelay ()J
+	public final synthetic fun getDefaultMinRepetitionDelay ()J
 	public final fun getDefaultMinRetryDelay ()J
 	public final fun getDefaultReadOnly ()Z
-	public final fun getDefaultRepetitionAttempts ()I
+	public final synthetic fun getDefaultRepetitionAttempts ()I
 	public final fun getDefaultSchema ()Lorg/jetbrains/exposed/sql/Schema;
 	public final fun getExplicitDialect ()Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;
 	public final fun getKeepLoadedReferencesOutOfTransaction ()Z
@@ -740,12 +740,12 @@ public final class org/jetbrains/exposed/sql/DatabaseConfig$Builder {
 	public final fun setDefaultFetchSize (Ljava/lang/Integer;)V
 	public final fun setDefaultIsolationLevel (I)V
 	public final fun setDefaultMaxAttempts (I)V
-	public final fun setDefaultMaxRepetitionDelay (J)V
+	public final synthetic fun setDefaultMaxRepetitionDelay (J)V
 	public final fun setDefaultMaxRetryDelay (J)V
-	public final fun setDefaultMinRepetitionDelay (J)V
+	public final synthetic fun setDefaultMinRepetitionDelay (J)V
 	public final fun setDefaultMinRetryDelay (J)V
 	public final fun setDefaultReadOnly (Z)V
-	public final fun setDefaultRepetitionAttempts (I)V
+	public final synthetic fun setDefaultRepetitionAttempts (I)V
 	public final fun setDefaultSchema (Lorg/jetbrains/exposed/sql/Schema;)V
 	public final fun setExplicitDialect (Lorg/jetbrains/exposed/sql/vendors/DatabaseDialect;)V
 	public final fun setKeepLoadedReferencesOutOfTransaction (Z)V
@@ -1551,9 +1551,7 @@ public abstract interface class org/jetbrains/exposed/sql/LazySizedIterable : or
 
 public final class org/jetbrains/exposed/sql/LazySizedIterable$DefaultImpls {
 	public static fun forUpdate (Lorg/jetbrains/exposed/sql/LazySizedIterable;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public static fun limit (Lorg/jetbrains/exposed/sql/LazySizedIterable;I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public static fun notForUpdate (Lorg/jetbrains/exposed/sql/LazySizedIterable;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public static fun offset (Lorg/jetbrains/exposed/sql/LazySizedIterable;J)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
 public final class org/jetbrains/exposed/sql/Lead : org/jetbrains/exposed/sql/WindowFunction {
@@ -1895,17 +1893,17 @@ public final class org/jetbrains/exposed/sql/QueriesKt {
 	public static final fun replace (Lorg/jetbrains/exposed/sql/Table;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/statements/ReplaceStatement;
 	public static final fun replace (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;)Ljava/lang/Integer;
 	public static synthetic fun replace$default (Lorg/jetbrains/exposed/sql/Table;Lorg/jetbrains/exposed/sql/AbstractQuery;Ljava/util/List;ILjava/lang/Object;)Ljava/lang/Integer;
-	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
-	public static final fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
-	public static final fun select (Lorg/jetbrains/exposed/sql/Query;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
-	public static final fun select (Lorg/jetbrains/exposed/sql/Query;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
+	public static final synthetic fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
+	public static final synthetic fun select (Lorg/jetbrains/exposed/sql/FieldSet;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
+	public static final synthetic fun select (Lorg/jetbrains/exposed/sql/Query;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
+	public static final synthetic fun select (Lorg/jetbrains/exposed/sql/Query;Lorg/jetbrains/exposed/sql/Op;)Lorg/jetbrains/exposed/sql/Query;
 	public static final fun selectAll (Lorg/jetbrains/exposed/sql/FieldSet;)Lorg/jetbrains/exposed/sql/Query;
-	public static final fun selectAllBatched (Lorg/jetbrains/exposed/sql/FieldSet;I)Ljava/lang/Iterable;
-	public static final fun selectAllBatched (Lorg/jetbrains/exposed/sql/Query;I)Ljava/lang/Iterable;
+	public static final synthetic fun selectAllBatched (Lorg/jetbrains/exposed/sql/FieldSet;I)Ljava/lang/Iterable;
+	public static final synthetic fun selectAllBatched (Lorg/jetbrains/exposed/sql/Query;I)Ljava/lang/Iterable;
 	public static synthetic fun selectAllBatched$default (Lorg/jetbrains/exposed/sql/FieldSet;IILjava/lang/Object;)Ljava/lang/Iterable;
 	public static synthetic fun selectAllBatched$default (Lorg/jetbrains/exposed/sql/Query;IILjava/lang/Object;)Ljava/lang/Iterable;
-	public static final fun selectBatched (Lorg/jetbrains/exposed/sql/FieldSet;ILkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
-	public static final fun selectBatched (Lorg/jetbrains/exposed/sql/Query;ILkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
+	public static final synthetic fun selectBatched (Lorg/jetbrains/exposed/sql/FieldSet;ILkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
+	public static final synthetic fun selectBatched (Lorg/jetbrains/exposed/sql/Query;ILkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
 	public static synthetic fun selectBatched$default (Lorg/jetbrains/exposed/sql/FieldSet;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Iterable;
 	public static synthetic fun selectBatched$default (Lorg/jetbrains/exposed/sql/Query;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Iterable;
 	public static final fun update (Lorg/jetbrains/exposed/sql/Join;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;)I
@@ -1943,7 +1941,7 @@ public class org/jetbrains/exposed/sql/Query : org/jetbrains/exposed/sql/Abstrac
 	public static synthetic fun adjustComments$default (Lorg/jetbrains/exposed/sql/Query;Lorg/jetbrains/exposed/sql/Query$CommentPosition;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun adjustHaving (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun adjustSelect (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/Query;
-	public final fun adjustSlice (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/Query;
+	public final synthetic fun adjustSlice (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun adjustWhere (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/sql/Query;
 	public final fun comment (Ljava/lang/String;Lorg/jetbrains/exposed/sql/Query$CommentPosition;)Lorg/jetbrains/exposed/sql/Query;
 	public static synthetic fun comment$default (Lorg/jetbrains/exposed/sql/Query;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Query$CommentPosition;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Query;
@@ -2300,9 +2298,7 @@ public abstract interface class org/jetbrains/exposed/sql/SizedIterable : java/l
 public final class org/jetbrains/exposed/sql/SizedIterable$DefaultImpls {
 	public static fun forUpdate (Lorg/jetbrains/exposed/sql/SizedIterable;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public static synthetic fun forUpdate$default (Lorg/jetbrains/exposed/sql/SizedIterable;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public static fun limit (Lorg/jetbrains/exposed/sql/SizedIterable;I)Lorg/jetbrains/exposed/sql/SizedIterable;
 	public static fun notForUpdate (Lorg/jetbrains/exposed/sql/SizedIterable;)Lorg/jetbrains/exposed/sql/SizedIterable;
-	public static fun offset (Lorg/jetbrains/exposed/sql/SizedIterable;J)Lorg/jetbrains/exposed/sql/SizedIterable;
 }
 
 public final class org/jetbrains/exposed/sql/Slf4jSqlDebugLogger : org/jetbrains/exposed/sql/SqlLogger {
@@ -2726,14 +2722,14 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 	public final fun getDuration ()J
 	public final fun getId ()Ljava/lang/String;
 	public final fun getMaxAttempts ()I
-	public final fun getMaxRepetitionDelay ()J
+	public final synthetic fun getMaxRepetitionDelay ()J
 	public final fun getMaxRetryDelay ()J
-	public final fun getMinRepetitionDelay ()J
+	public final synthetic fun getMinRepetitionDelay ()J
 	public final fun getMinRetryDelay ()J
 	public fun getOuterTransaction ()Lorg/jetbrains/exposed/sql/Transaction;
 	public final fun getQueryTimeout ()Ljava/lang/Integer;
 	public fun getReadOnly ()Z
-	public final fun getRepetitionAttempts ()I
+	public final synthetic fun getRepetitionAttempts ()I
 	public final fun getStatementCount ()I
 	public final fun getStatementStats ()Ljava/util/HashMap;
 	public final fun getStatements ()Ljava/lang/StringBuilder;
@@ -2747,12 +2743,12 @@ public class org/jetbrains/exposed/sql/Transaction : org/jetbrains/exposed/sql/U
 	public final fun setDebug (Z)V
 	public final fun setDuration (J)V
 	public final fun setMaxAttempts (I)V
-	public final fun setMaxRepetitionDelay (J)V
+	public final synthetic fun setMaxRepetitionDelay (J)V
 	public final fun setMaxRetryDelay (J)V
-	public final fun setMinRepetitionDelay (J)V
+	public final synthetic fun setMinRepetitionDelay (J)V
 	public final fun setMinRetryDelay (J)V
 	public final fun setQueryTimeout (Ljava/lang/Integer;)V
-	public final fun setRepetitionAttempts (I)V
+	public final synthetic fun setRepetitionAttempts (I)V
 	public final fun setStatementCount (I)V
 	public final fun setWarnLongQueriesDuration (Ljava/lang/Long;)V
 	public final fun unregisterInterceptor (Lorg/jetbrains/exposed/sql/statements/StatementInterceptor;)Z
@@ -3671,22 +3667,22 @@ public final class org/jetbrains/exposed/sql/transactions/ThreadLocalTransaction
 	public fun currentOrNull ()Lorg/jetbrains/exposed/sql/Transaction;
 	public fun getDefaultIsolationLevel ()I
 	public fun getDefaultMaxAttempts ()I
-	public fun getDefaultMaxRepetitionDelay ()J
+	public synthetic fun getDefaultMaxRepetitionDelay ()J
 	public fun getDefaultMaxRetryDelay ()J
-	public fun getDefaultMinRepetitionDelay ()J
+	public synthetic fun getDefaultMinRepetitionDelay ()J
 	public fun getDefaultMinRetryDelay ()J
 	public fun getDefaultReadOnly ()Z
-	public fun getDefaultRepetitionAttempts ()I
+	public synthetic fun getDefaultRepetitionAttempts ()I
 	public final fun getThreadLocal ()Ljava/lang/ThreadLocal;
 	public fun newTransaction (IZLorg/jetbrains/exposed/sql/Transaction;)Lorg/jetbrains/exposed/sql/Transaction;
-	public fun setDefaultIsolationLevel (I)V
+	public synthetic fun setDefaultIsolationLevel (I)V
 	public fun setDefaultMaxAttempts (I)V
-	public fun setDefaultMaxRepetitionDelay (J)V
+	public synthetic fun setDefaultMaxRepetitionDelay (J)V
 	public fun setDefaultMaxRetryDelay (J)V
-	public fun setDefaultMinRepetitionDelay (J)V
+	public synthetic fun setDefaultMinRepetitionDelay (J)V
 	public fun setDefaultMinRetryDelay (J)V
 	public fun setDefaultReadOnly (Z)V
-	public fun setDefaultRepetitionAttempts (I)V
+	public synthetic fun setDefaultRepetitionAttempts (I)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -3720,21 +3716,21 @@ public abstract interface class org/jetbrains/exposed/sql/transactions/Transacti
 	public abstract fun currentOrNull ()Lorg/jetbrains/exposed/sql/Transaction;
 	public abstract fun getDefaultIsolationLevel ()I
 	public abstract fun getDefaultMaxAttempts ()I
-	public abstract fun getDefaultMaxRepetitionDelay ()J
+	public abstract synthetic fun getDefaultMaxRepetitionDelay ()J
 	public abstract fun getDefaultMaxRetryDelay ()J
-	public abstract fun getDefaultMinRepetitionDelay ()J
+	public abstract synthetic fun getDefaultMinRepetitionDelay ()J
 	public abstract fun getDefaultMinRetryDelay ()J
 	public abstract fun getDefaultReadOnly ()Z
-	public abstract fun getDefaultRepetitionAttempts ()I
+	public abstract synthetic fun getDefaultRepetitionAttempts ()I
 	public abstract fun newTransaction (IZLorg/jetbrains/exposed/sql/Transaction;)Lorg/jetbrains/exposed/sql/Transaction;
 	public abstract fun setDefaultIsolationLevel (I)V
 	public abstract fun setDefaultMaxAttempts (I)V
-	public abstract fun setDefaultMaxRepetitionDelay (J)V
+	public abstract synthetic fun setDefaultMaxRepetitionDelay (J)V
 	public abstract fun setDefaultMaxRetryDelay (J)V
-	public abstract fun setDefaultMinRepetitionDelay (J)V
+	public abstract synthetic fun setDefaultMinRepetitionDelay (J)V
 	public abstract fun setDefaultMinRetryDelay (J)V
 	public abstract fun setDefaultReadOnly (Z)V
-	public abstract fun setDefaultRepetitionAttempts (I)V
+	public abstract synthetic fun setDefaultRepetitionAttempts (I)V
 }
 
 public final class org/jetbrains/exposed/sql/transactions/TransactionManager$Companion {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/AbstractQuery.kt
@@ -59,7 +59,7 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
     @Deprecated(
         "This function will be removed in future releases.",
         ReplaceWith("limit(n).offset(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     override fun limit(n: Int, offset: Long): T = apply {
         limit = n

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Database.kt
@@ -24,7 +24,7 @@ class Database private constructor(
 ) {
     /** Whether nested transaction blocks are configured to act like top-level transactions. */
     var useNestedTransactions: Boolean = config.useNestedTransactions
-        @Deprecated("Use DatabaseConfig to define the useNestedTransactions", level = DeprecationLevel.ERROR)
+        @Deprecated("Use DatabaseConfig to define the useNestedTransactions", level = DeprecationLevel.HIDDEN)
         @TestOnly
         set
 
@@ -94,7 +94,7 @@ class Database private constructor(
     var defaultFetchSize: Int? = config.defaultFetchSize
         private set
 
-    @Deprecated("Use DatabaseConfig to define the defaultFetchSize", level = DeprecationLevel.ERROR)
+    @Deprecated("Use DatabaseConfig to define the defaultFetchSize", level = DeprecationLevel.HIDDEN)
     @TestOnly
     fun defaultFetchSize(size: Int): Database {
         defaultFetchSize = size
@@ -236,7 +236,7 @@ class Database private constructor(
          */
         @Deprecated(
             message = "Use Database.connect() with a connection pool DataSource instead. This may be removed in future releases.",
-            level = DeprecationLevel.ERROR
+            level = DeprecationLevel.HIDDEN
         )
         fun connectPool(
             datasource: ConnectionPoolDataSource,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/DatabaseConfig.kt
@@ -20,19 +20,19 @@ class DatabaseConfig private constructor(
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxAttempts"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     val defaultRepetitionAttempts: Int,
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMinRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     val defaultMinRepetitionDelay: Long,
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     val defaultMaxRepetitionDelay: Long,
     val defaultReadOnly: Boolean,
@@ -140,7 +140,7 @@ class DatabaseConfig private constructor(
         @Deprecated(
             message = "This property will be removed in future releases",
             replaceWith = ReplaceWith("defaultMaxAttempts"),
-            level = DeprecationLevel.ERROR
+            level = DeprecationLevel.HIDDEN
         )
         var defaultRepetitionAttempts: Int
             get() = defaultMaxAttempts
@@ -149,7 +149,7 @@ class DatabaseConfig private constructor(
         @Deprecated(
             message = "This property will be removed in future releases",
             replaceWith = ReplaceWith("defaultMinRetryDelay"),
-            level = DeprecationLevel.ERROR
+            level = DeprecationLevel.HIDDEN
         )
         var defaultMinRepetitionDelay: Long
             get() = defaultMinRetryDelay
@@ -158,7 +158,7 @@ class DatabaseConfig private constructor(
         @Deprecated(
             message = "This property will be removed in future releases",
             replaceWith = ReplaceWith("defaultMaxRetryDelay"),
-            level = DeprecationLevel.ERROR
+            level = DeprecationLevel.HIDDEN
         )
         var defaultMaxRepetitionDelay: Long
             get() = defaultMaxRetryDelay

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/IterableEx.kt
@@ -5,17 +5,18 @@ import org.jetbrains.exposed.sql.vendors.ForUpdateOption
 /** Represents the iterable elements of a database result. */
 interface SizedIterable<out T> : Iterable<T> {
     @Deprecated(
-        "This function will be removed in future releases.",
+        "This function will be removed in future releases. Overrides for replacement methods limit(count) " +
+            "& offset(start) must be provided when implementing this interface.",
         ReplaceWith("limit(n).offset(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     fun limit(n: Int, offset: Long): SizedIterable<T>
 
     /** Returns a new [SizedIterable] containing only [count] elements. */
-    fun limit(count: Int): SizedIterable<T> = limit(count, 0)
+    fun limit(count: Int): SizedIterable<T>
 
     /** Returns a new [SizedIterable] containing only elements starting from the specified [start]. */
-    fun offset(start: Long): SizedIterable<T> = limit(Int.MAX_VALUE, start)
+    fun offset(start: Long): SizedIterable<T>
 
     /** Returns the number of elements stored. */
     fun count(): Long
@@ -53,7 +54,7 @@ class EmptySizedIterable<out T> : SizedIterable<T>, Iterator<T> {
     @Deprecated(
         "This function will be removed in future releases.",
         ReplaceWith("limit(n).offset(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     override fun limit(n: Int, offset: Long): SizedIterable<T> = this
 
@@ -83,7 +84,7 @@ class SizedCollection<out T>(val delegate: Collection<T>) : SizedIterable<T> {
     @Deprecated(
         "This function will be removed in future releases.",
         ReplaceWith("limit(n).offset(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     override fun limit(n: Int, offset: Long): SizedIterable<T> {
         return if (offset >= Int.MAX_VALUE) {
@@ -126,7 +127,7 @@ class LazySizedCollection<out T>(_delegate: SizedIterable<T>) : SizedIterable<T>
     @Deprecated(
         "This function will be removed in future releases.",
         ReplaceWith("limit(n).offset(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     override fun limit(n: Int, offset: Long): SizedIterable<T> = LazySizedCollection(delegate.limit(n).offset(offset))
     override fun limit(count: Int): SizedIterable<T> = LazySizedCollection(delegate.limit(count))
@@ -196,7 +197,7 @@ infix fun <T, R> SizedIterable<T>.mapLazy(f: (T) -> R): SizedIterable<R> {
         @Deprecated(
             "This function will be removed in future releases.",
             ReplaceWith("limit(n).offset(offset)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         override fun limit(n: Int, offset: Long): SizedIterable<R> = source.copy().limit(n).offset(offset).mapLazy(f)
         override fun limit(count: Int): SizedIterable<R> = source.copy().limit(count).mapLazy(f)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -11,7 +11,7 @@ import kotlin.sequences.Sequence
 @Deprecated(
     message = "As part of SELECT DSL design changes, this will be removed in future releases.",
     replaceWith = ReplaceWith("selectAll().where { where.invoke() }", "import org.jetbrains.exposed.sql.selectAll"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 inline fun FieldSet.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = Query(this, SqlExpressionBuilder.where())
 
@@ -19,14 +19,14 @@ inline fun FieldSet.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query
 @Deprecated(
     message = "This method only exists as part of the migration for SELECT DSL design changes.",
     replaceWith = ReplaceWith("where { where.invoke() }"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 inline fun Query.select(where: SqlExpressionBuilder.() -> Op<Boolean>): Query = this
 
 @Deprecated(
     message = "As part of SELECT DSL design changes, this will be removed in future releases.",
     replaceWith = ReplaceWith("selectAll().where(where)", "import org.jetbrains.exposed.sql.selectAll"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
 
@@ -34,7 +34,7 @@ fun FieldSet.select(where: Op<Boolean>): Query = Query(this, where)
 @Deprecated(
     message = "This method only exists as part of the migration for SELECT DSL design changes.",
     replaceWith = ReplaceWith("where(where)"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 fun Query.select(where: Op<Boolean>): Query = this
 
@@ -53,7 +53,7 @@ fun FieldSet.selectAll(): Query = Query(this, null)
         "selectAll().where { where.invoke() }.fetchBatchedResults(batchSize)",
         "import org.jetbrains.exposed.sql.selectAll"
     ),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 fun FieldSet.selectBatched(
     batchSize: Int = 1000,
@@ -65,7 +65,7 @@ fun FieldSet.selectBatched(
 @Deprecated(
     message = "This method only exists as part of the migration for SELECT DSL design changes.",
     replaceWith = ReplaceWith("where { where.invoke() }.fetchBatchedResults(batchSize)"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 fun Query.selectBatched(
     batchSize: Int = 1000,
@@ -80,7 +80,7 @@ fun Query.selectBatched(
         "selectAll().fetchBatchedResults(batchSize)",
         "import org.jetbrains.exposed.sql.selectAll"
     ),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 fun FieldSet.selectAllBatched(
     batchSize: Int = 1000
@@ -91,7 +91,7 @@ fun FieldSet.selectAllBatched(
 @Deprecated(
     message = "This method only exists as part of the migration for SELECT DSL design changes.",
     replaceWith = ReplaceWith("fetchBatchedResults(batchSize)"),
-    level = DeprecationLevel.ERROR
+    level = DeprecationLevel.HIDDEN
 )
 fun Query.selectAllBatched(
     batchSize: Int = 1000
@@ -104,7 +104,7 @@ fun Query.selectAllBatched(
         "[YouTrack](https://youtrack.jetbrains.com/issue/EXPOSED-550/DeleteStatement-holds-unused-offset-property) " +
         "with a use-case if your database supports the OFFSET clause in a DELETE statement.",
     ReplaceWith("deleteWhere(limit) { op.invoke() }"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 @Suppress("UnusedParameter")
 fun <T : Table> T.deleteWhere(limit: Int? = null, offset: Long? = null, op: T.(ISqlExpressionBuilder) -> Op<Boolean>): Int =
@@ -129,7 +129,7 @@ inline fun <T : Table> T.deleteWhere(
         "[YouTrack](https://youtrack.jetbrains.com/issue/EXPOSED-550/DeleteStatement-holds-unused-offset-property) " +
         "with a use-case if your database supports the OFFSET clause in a DELETE statement.",
     ReplaceWith("deleteIgnoreWhere(limit) { op.invoke() }"),
-    DeprecationLevel.WARNING
+    DeprecationLevel.ERROR
 )
 @Suppress("UnusedParameter")
 fun <T : Table> T.deleteIgnoreWhere(limit: Int? = null, offset: Long? = null, op: T.(ISqlExpressionBuilder) -> Op<Boolean>): Int =
@@ -742,7 +742,7 @@ fun <T : Table> T.upsert(
 @Deprecated(
     "This `upsert()` with `onUpdate` parameter that accepts a List will be removed in future releases. " +
         "Please use `upsert()` with `onUpdate` parameter that takes an `UpdateStatement` lambda block instead.",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 fun <T : Table> T.upsert(
     vararg keys: Column<*>,
@@ -793,7 +793,7 @@ fun <T : Table> T.upsertReturning(
 @Deprecated(
     "This `upsertReturning()` with `onUpdate` parameter that accepts a List will be removed in future releases. " +
         "Please use `upsertReturning()` with `onUpdate` parameter that takes an `UpdateStatement` lambda block instead.",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 fun <T : Table> T.upsertReturning(
     vararg keys: Column<*>,
@@ -841,7 +841,7 @@ fun <T : Table, E : Any> T.batchUpsert(
 @Deprecated(
     "This `batchUpsert()` with `onUpdate` parameter that accepts a List will be removed in future releases. " +
         "Please use `batchUpsert()` with `onUpdate` parameter that takes an `UpdateStatement` lambda block instead.",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 fun <T : Table, E : Any> T.batchUpsert(
     data: Iterable<E>,
@@ -887,7 +887,7 @@ fun <T : Table, E : Any> T.batchUpsert(
 @Deprecated(
     "This `batchUpsert()` with `onUpdate` parameter that accepts a List will be removed in future releases. " +
         "Please use `batchUpsert()` with `onUpdate` parameter that takes an `UpdateStatement` lambda block instead.",
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 fun <T : Table, E : Any> T.batchUpsert(
     data: Sequence<E>,

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -130,7 +130,7 @@ open class Query(override var set: FieldSet, where: Op<Boolean>?) : AbstractQuer
     @Deprecated(
         message = "As part of SELECT DSL design changes, this will be removed in future releases.",
         replaceWith = ReplaceWith("adjustSelect { body.invoke() }"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     fun adjustSlice(body: ColumnSet.(FieldSet) -> FieldSet): Query = apply { set = set.source.body(set) }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -111,14 +111,14 @@ abstract class ColumnSet : FieldSet {
     @Deprecated(
         message = "As part of SELECT DSL design changes, this will be removed in future releases.",
         replaceWith = ReplaceWith("select(column, *columns)"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     fun slice(column: Expression<*>, vararg columns: Expression<*>): FieldSet = Slice(this, listOf(column) + columns)
 
     @Deprecated(
         message = "As part of SELECT DSL design changes, this will be removed in future releases.",
         replaceWith = ReplaceWith("select(columns)"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     fun slice(columns: List<Expression<*>>): FieldSet = Slice(this, columns)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Transaction.kt
@@ -87,7 +87,7 @@ open class Transaction(
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("maxAttempts"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     var repetitionAttempts: Int
         get() = maxAttempts
@@ -96,7 +96,7 @@ open class Transaction(
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("minRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     var minRepetitionDelay: Long
         get() = minRetryDelay
@@ -105,7 +105,7 @@ open class Transaction(
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("maxRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     var maxRepetitionDelay: Long
         get() = maxRetryDelay

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchUpsertStatement.kt
@@ -27,7 +27,7 @@ open class BatchUpsertStatement(
 ) : BaseBatchInsertStatement(table, ignore = false, shouldReturnGeneratedValues), UpsertBuilder {
     @Deprecated(
         "This constructor with `onUpdate` that takes a List may be removed in future releases.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     constructor(
         table: Table,
@@ -38,12 +38,11 @@ open class BatchUpsertStatement(
         shouldReturnGeneratedValues: Boolean
     ) : this(table, keys = keys, onUpdateExclude, where, shouldReturnGeneratedValues) {
         onUpdate?.let {
-            this.onUpdate = it
             updateValues.putAll(it)
         }
     }
 
-    @Deprecated("This property will be removed in future releases.", level = DeprecationLevel.WARNING)
+    @Deprecated("This property will be removed in future releases.", level = DeprecationLevel.ERROR)
     var onUpdate: List<Pair<Column<*>, Expression<*>>>? = null
         private set
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/DeleteStatement.kt
@@ -27,7 +27,7 @@ open class DeleteStatement(
     @Deprecated(
         "This constructor will be removed in future releases.",
         ReplaceWith("DeleteStatement(targetsSet = table, where, isIgnore, limit, emptyList())"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     @Suppress("UnusedPrivateProperty")
     constructor(
@@ -42,7 +42,7 @@ open class DeleteStatement(
         "This property will be removed in future releases and replaced with a property that stores a `ColumnSet`," +
             "which may be a `Table` or a `Join`. To access the table(s) to which the columns belong, use `ColumnSet.targetTables()`",
         ReplaceWith("targetsSet"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     val table: Table = targets.first()
 
@@ -50,7 +50,7 @@ open class DeleteStatement(
         "This property is not being used and will be removed in future releases. Please leave a comment on " +
             "[YouTrack](https://youtrack.jetbrains.com/issue/EXPOSED-550/DeleteStatement-holds-unused-offset-property) " +
             "with a use-case if your database supports the OFFSET clause in a DELETE statement.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     val offset: Long? = null
 
@@ -92,7 +92,7 @@ open class DeleteStatement(
                 "[YouTrack](https://youtrack.jetbrains.com/issue/EXPOSED-550/DeleteStatement-holds-unused-offset-property) " +
                 "with a use-case if your database supports the OFFSET clause in a DELETE statement.",
             ReplaceWith("where(transaction, table, op, isIgnore, limit)"),
-            DeprecationLevel.WARNING
+            DeprecationLevel.ERROR
         )
         @Suppress("UnusedParameter")
         fun where(transaction: Transaction, table: Table, op: Op<Boolean>, isIgnore: Boolean = false, limit: Int? = null, offset: Long? = null): Int =

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/InsertStatement.kt
@@ -166,7 +166,8 @@ open class InsertStatement<Key : Any>(
         "This function is used in derived classes to build a list of arguments. " +
             "It's recommended to avoid including all default and nullable values in insert statements, " +
             "as these values can often be generated automatically by the database. " +
-            "There are no usages of that function inside Exposed. Saved as deprecated for back compatability"
+            "There are no usages of that function inside Exposed. Saved as deprecated for back compatability",
+        level = DeprecationLevel.WARNING
     )
     protected open fun valuesAndDefaults(values: Map<Column<*>, Any?> = this.values): Map<Column<*>, Any?> {
         val result = values.toMutableMap()
@@ -187,7 +188,8 @@ open class InsertStatement<Key : Any>(
     @Deprecated(
         "This function has been obsolete since version 0.57.0, " +
             "following the removal of default values from insert statements. " +
-            "It's safe to remove any overrides of this function from your code."
+            "It's safe to remove any overrides of this function from your code.",
+        level = DeprecationLevel.WARNING
     )
     protected open fun isColumnValuePreferredFromResultSet(column: Column<*>, value: Any?): Boolean {
         return column.columnType.isAutoInc || value is NextVal<*>

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/UpsertStatement.kt
@@ -23,7 +23,7 @@ open class UpsertStatement<Key : Any>(
 ) : InsertStatement<Key>(table), UpsertBuilder {
     @Deprecated(
         "This constructor with `onUpdate` that takes a List may be removed in future releases.",
-        level = DeprecationLevel.WARNING
+        level = DeprecationLevel.ERROR
     )
     constructor(
         table: Table,
@@ -33,12 +33,11 @@ open class UpsertStatement<Key : Any>(
         where: Op<Boolean>?
     ) : this(table, keys = keys, onUpdateExclude, where) {
         onUpdate?.let {
-            this.onUpdate = it
             updateValues.putAll(it)
         }
     }
 
-    @Deprecated("This property will be removed in future releases.", level = DeprecationLevel.WARNING)
+    @Deprecated("This property will be removed in future releases.", level = DeprecationLevel.ERROR)
     var onUpdate: List<Pair<Column<*>, Expression<*>>>? = null
         private set
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/ThreadLocalTransactionManager.kt
@@ -34,7 +34,7 @@ class ThreadLocalTransactionManager(
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxAttempts"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     override var defaultRepetitionAttempts: Int
         get() = defaultMaxAttempts
@@ -43,7 +43,7 @@ class ThreadLocalTransactionManager(
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMinRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     override var defaultMinRepetitionDelay: Long
         get() = defaultMinRetryDelay
@@ -52,7 +52,7 @@ class ThreadLocalTransactionManager(
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     override var defaultMaxRepetitionDelay: Long
         get() = defaultMaxRetryDelay
@@ -76,7 +76,7 @@ class ThreadLocalTransactionManager(
             return field
         }
 
-        @Deprecated("Use DatabaseConfig to define the defaultIsolationLevel", level = DeprecationLevel.ERROR)
+        @Deprecated("Use DatabaseConfig to define the defaultIsolationLevel", level = DeprecationLevel.HIDDEN)
         @TestOnly
         set
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/transactions/TransactionApi.kt
@@ -45,13 +45,13 @@ private object NotInitializedManager : TransactionManager {
 
     override var defaultMaxRetryDelay: Long = 0
 
-    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.ERROR)
+    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.HIDDEN)
     override var defaultRepetitionAttempts: Int = -1
 
-    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.ERROR)
+    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.HIDDEN)
     override var defaultMinRepetitionDelay: Long = 0
 
-    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.ERROR)
+    @Deprecated("This will be removed when the interface property is fully deprecated", level = DeprecationLevel.HIDDEN)
     override var defaultMaxRepetitionDelay: Long = 0
 
     override fun newTransaction(isolation: Int, readOnly: Boolean, outerTransaction: Transaction?): Transaction =
@@ -87,21 +87,21 @@ interface TransactionManager {
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxAttempts"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     var defaultRepetitionAttempts: Int
 
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMinRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     var defaultMinRepetitionDelay: Long
 
     @Deprecated(
         message = "This property will be removed in future releases",
         replaceWith = ReplaceWith("defaultMaxRetryDelay"),
-        level = DeprecationLevel.ERROR
+        level = DeprecationLevel.HIDDEN
     )
     var defaultMaxRepetitionDelay: Long
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/FunctionProvider.kt
@@ -833,7 +833,7 @@ abstract class FunctionProvider {
     @Deprecated(
         "This function will be removed in future releases.",
         ReplaceWith("queryLimitAndOffset(size, offset, alreadyOrdered)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     open fun queryLimit(size: Int, offset: Long, alreadyOrdered: Boolean): String = queryLimitAndOffset(size, offset, alreadyOrdered)
 

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/View.kt
@@ -18,7 +18,7 @@ class View<out Target : Entity<*>> (val op: Op<Boolean>, val factory: EntityClas
     @Deprecated(
         "This function will be removed in future releases.",
         ReplaceWith("limit(n).offset(offset)"),
-        DeprecationLevel.WARNING
+        DeprecationLevel.ERROR
     )
     override fun limit(n: Int, offset: Long): SizedIterable<Target> = factory.find(op).limit(n).offset(offset)
     override fun limit(count: Int): SizedIterable<Target> = factory.find(op).limit(count)


### PR DESCRIPTION
#### Description

**Summary of the change**: Raise the deprecation levels of API elements that have been deprecated for more than 3 releases.

**Detailed description**:
- **How**:

The following elements had most recent level change in release 0.46.0 (January 2024) ->

**Raise from ERROR to HIDDEN:**
- `Query.select(where)`
- `Query.selectBatched()`
- `Query.selectAllBatched()`

The following elements had most recent level change in release 0.54.0 (August 2024) ->

**Raise from WARNING to ERROR:**
- `Table.upsert(onUpdate = List<>)`
- `Table.upsertReturning(onUpdate = List<>)`
- `Table.batchUpsert(onUpdate = List<>)` - both variants
- `BatchUpsertStatement.onUpdate` and its secondary constructor
- `UpsertStatement.onUpdate` and its secondary constructor


**Raise from ERROR to HIDDEN:**

- `FieldSet.select(where)`
- `FieldSet.selectBatched()`
- `FieldSet.selectAllBatched()`
- `Query.adjustSlice()`
- `ColumnSet.slice()`
- `Database.connectPool()`
- `Database.useNestedTransactions`
- `Database.defaultFetchSize`
- `DatabaseConfig.defaultRepetitionAttempts` and `Transaction.repetitionAttempts`
- `DatabaseConfig.defaultMinRepetitionDelay` and Transaction.minRepetitionDelay
- `DatabaseConfig.defaultMaxRepetitionDelay` and `Transaction.maxRepetitionDelay`
- `ThreadLocalTransactionManager.defaultIsolationLevel`


The following elements had most recent level change in release 0.55.0 (September 2024) ->

**Raise from WARNING to ERROR:**
- `AbstractQuery.limit(n, offset)`
- `SizedIterable.limit(n, offset)` - interface methods no longer have defaults
- `EmptySizedIterable.limit(n, offset)`
- `SizedCollection.limit(n, offset)`
- `LazySizedCollection.limit(n, offset)`
- `SizedIterable.limit(n, offset)`
- `View.limit(n, offset)` - dao
- `FunctionProvider.queryLimit()`
- `Table.deleteWhere(limit, offset)`
- `Table.deleteIgnoreWhere(limit, offset)`
- `DeleteStatement.table` (and `offset` and `where()`) and its secondary constructor

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other: Bump deprecation levels

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
