### PR TITLE
fix: EXPOSED-718  Fix timestamp column not storing values in UTC time zone

### DIFF
--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/JavaTimeTests.kt
@@ -599,6 +599,30 @@ class JavaTimeTests : DatabaseTestsBase() {
             assertTrue(statements.isEmpty())
         }
     }
+
+    @Test
+    fun testTimestampAlwaysSavedInUTC() {
+        val tester = object : Table("tester") {
+            val timestamp_col = timestamp("timestamp_col")
+        }
+
+        withTables(tester) {
+            // Cairo time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+            assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
+
+            val instant = Instant.now()
+
+            tester.insert {
+                it[timestamp_col] = instant
+            }
+
+            assertEquals(
+                instant,
+                tester.selectAll().single()[tester.timestamp_col]
+            )
+        }
+    }
 }
 
 fun <T : Temporal> assertEqualDateTime(d1: T?, d2: T?) {

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinTimeTests.kt
@@ -616,6 +616,30 @@ class KotlinTimeTests : DatabaseTestsBase() {
             assertTrue(statements.isEmpty())
         }
     }
+
+    @Test
+    fun testTimestampAlwaysSavedInUTC() {
+        val tester = object : Table("tester") {
+            val timestamp_col = timestamp("timestamp_col")
+        }
+
+        withTables(tester) {
+            // Cairo time zone
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+            assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
+
+            val instant = Clock.System.now()
+
+            tester.insert {
+                it[timestamp_col] = instant
+            }
+
+            assertEquals(
+                instant,
+                tester.selectAll().single()[tester.timestamp_col]
+            )
+        }
+    }
 }
 
 fun <T> assertEqualDateTime(d1: T?, d2: T?) {


### PR DESCRIPTION
#### Description

**Summary of the change**: Fixed timestamp column not storing values in UTC time zone

**Detailed description**:
- **Why**:
Instant is in UTC time zone, and the expected behaviour is that the timestamp column should store values in UTC time zone since it is without a user-specified time zone. Using the session or system time zone leads to unexpected behaviour like [this](https://kotlinlang.slack.com/archives/C0CG7E0A1/p1732897615084149).
- **How**:
Created new formatters that use the UTC timezone and used these formatters for timestamp column type.
In `JavaInstantColumnType` and `KotlinInstantColumnType`, I modified the `notNullValueToDB` function to return the formatted String for MySQL (excluding MariaDB) because there was an issue with MySQL 5 where it implicitly converted the value to the session time zone when storing it and lead to an unexpected behaviour when the value is retrieved.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
