### PR TITLE
docs: EXPOSED-705 Clarify optionalBackReferencedOn() usage in KDocs

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -74,6 +74,7 @@ interface DatabaseDialect {
     /** Returns true if autoCommit should be enabled to create/drop a database. */
     val requiresAutoCommitOnCreateDrop: Boolean get() = false
 
+    /** Returns the allowed maximum sequence value for a dialect, as a [Long]. */
     val sequenceMaxValue: Long get() = Long.MAX_VALUE
 
     /** Returns the name of the current database. */

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -520,10 +520,11 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
 
     /**
      * Registers an optional reference as an immutable field of the parent entity class, which returns a child object of
-     * this `EntityClass`.
+     * this `EntityClass` or `null` if no child references the parent entity.
      *
-     * The reference should have been defined by the creation of a [column] using either `optReference()` or
-     * `reference().nullable()` on the child table.
+     * The reference could have been defined on the child table in 1 of the following ways:
+     * - By the creation of a [column] using either `optReference()` or `reference().nullable()`
+     * - By the creation of a non-nullable `reference()` [column] where either 0 or 1 row(s) is expected in the relationship
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Student
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.StudentBios
@@ -536,10 +537,11 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
 
     /**
      * Registers an optional reference as an immutable field of the parent entity class, which returns a child object of
-     * this `EntityClass`.
+     * this `EntityClass` or `null` if no child references the parent entity.
      *
-     * The reference should have been defined by the creation of a [column] using either `optReference()` or
-     * `reference().nullable()` on the child table.
+     * The reference could have been defined on the child table in 1 of the following ways:
+     * - By the creation of a [column] using either `optReference()` or `reference().nullable()`
+     * - By the creation of a non-nullable `reference()` [column] where either 0 or 1 row(s) is expected in the relationship
      *
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.Student
      * @sample org.jetbrains.exposed.sql.tests.shared.entities.EntityTests.StudentBios
@@ -553,7 +555,7 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
 
     /**
      * Registers an optional reference as an immutable field of the parent entity class, which returns a child object of
-     * this `EntityClass`.
+     * this `EntityClass` or `null` if no child references the parent entity.
      *
      * The reference should have been defined by the creation of a foreign key constraint on the child table,
      * by using `foreignKey()`.


### PR DESCRIPTION
#### Description

**Summary of the change**: Edit KDocs of all `optionalBackReferencedOn()` overloads to clarify that it is possible to use even in non-nullable parent to non-nullable child relationships.

**Detailed description**:
- **Why**: User mentioned that current KDocs makes it seem like using `optionalBackReferencedOn()` will not be possible if the child entity's table does not have a nullable reference. Existing tests for the function actually use a relationship example where the child table has a non-nullable reference. In this case, if no record in the child table references the parent entity and an attempt is made to retrieve a child value, `optionalBackReferencedOn()` simply returns `null`.

- **What**: Update all 3 variants of `optionalBackReferencedOn()` to mention that child reference can be non-nullable if a "one-to-zero-or-one" relationship is expected.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-705](https://youtrack.jetbrains.com/issue/EXPOSED-705/optionalBackReferencedOn-documentation-clarification)