### PR TITLE
refactor: EXPOSED-722 Refactor MariaDB code to reduce checks in MySQL code and make it neater

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -4207,7 +4207,9 @@ public class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbrains/ex
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
+	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun isFractionDateTimeSupported ()Z
+	public fun isTimeZoneOffsetSupported ()Z
 }
 
 public final class org/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
@@ -4221,6 +4223,7 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
 	public fun dropSchema (Lorg/jetbrains/exposed/sql/Schema;Z)Ljava/lang/String;
 	protected fun fillConstraintCacheForTables (Ljava/util/List;)V
+	protected final fun getNotAcceptableDefaults ()Ljava/util/List;
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
@@ -4228,7 +4231,7 @@ public class org/jetbrains/exposed/sql/vendors/MysqlDialect : org/jetbrains/expo
 	public fun getSupportsTernaryAffectedRowValues ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun isFractionDateTimeSupported ()Z
-	public final fun isTimeZoneOffsetSupported ()Z
+	public fun isTimeZoneOffsetSupported ()Z
 	protected fun metadataMatchesTable (Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/sql/Table;)Z
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
 }

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -4200,6 +4200,7 @@ public class org/jetbrains/exposed/sql/vendors/MariaDBDialect : org/jetbrains/ex
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/MariaDBDialect$Companion;
 	public fun <init> ()V
 	public fun createIndex (Lorg/jetbrains/exposed/sql/Index;)Ljava/lang/String;
+	public fun getDataTypeProvider ()Lorg/jetbrains/exposed/sql/vendors/DataTypeProvider;
 	public fun getFunctionProvider ()Lorg/jetbrains/exposed/sql/vendors/FunctionProvider;
 	public fun getName ()Ljava/lang/String;
 	public fun getSequenceMaxValue ()J

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/BatchReplaceStatement.kt
@@ -23,7 +23,7 @@ open class BatchReplaceStatement(
         val valuesSql = values.toSqlString(prepared)
         val dialect = transaction.db.dialect
         val functionProvider = when (dialect.h2Mode) {
-            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider()
+            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider.INSTANCE
             else -> dialect.functionProvider
         }
         return functionProvider.replace(table, values.unzip().first, valuesSql, transaction, prepared)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/ReplaceStatement.kt
@@ -20,7 +20,7 @@ open class ReplaceStatement<Key : Any>(table: Table) : InsertStatement<Key>(tabl
         val valuesSql = values.toSqlString(prepared)
         val dialect = transaction.db.dialect
         val functionProvider = when (dialect.h2Mode) {
-            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider()
+            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider.INSTANCE
             else -> dialect.functionProvider
         }
         return functionProvider.replace(table, values.unzip().first, valuesSql, transaction, prepared)
@@ -42,7 +42,7 @@ open class ReplaceSelectStatement(
         val querySql = selectQuery.prepareSQL(transaction, prepared)
         val dialect = transaction.db.dialect
         val functionProvider = when (dialect.h2Mode) {
-            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider()
+            H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider.INSTANCE
             else -> dialect.functionProvider
         }
         return functionProvider.replace(targets.single(), columns, querySql, transaction, prepared)

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MysqlDialect.kt
@@ -314,8 +314,8 @@ internal open class MysqlFunctionProvider : FunctionProvider() {
         }
     }
 
-    private fun isUpsertAliasSupported(dialect: DatabaseDialect): Boolean = when (dialect) {
-        is MysqlDialect -> dialect !is MariaDBDialect && dialect.fullVersion >= "8.0.19"
+    open fun isUpsertAliasSupported(dialect: DatabaseDialect): Boolean = when (dialect) {
+        is MysqlDialect -> dialect.fullVersion >= "8.0.19"
         else -> false // H2_MySQL mode also uses this function provider & requires older unsupported version
     }
 
@@ -361,13 +361,13 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider, Mysq
     open fun isFractionDateTimeSupported(): Boolean = TransactionManager.current().db.isVersionCovers(5, 6)
 
     /** Returns `true` if a MySQL database is being used and its version is greater than or equal to 8.0. */
-    fun isTimeZoneOffsetSupported(): Boolean = (currentDialect !is MariaDBDialect) && isMysql8
+    open fun isTimeZoneOffsetSupported(): Boolean = isMysql8
 
-    private val notAcceptableDefaults = mutableListOf("CURRENT_DATE()", "CURRENT_DATE")
+    protected val notAcceptableDefaults = mutableListOf("CURRENT_DATE()", "CURRENT_DATE")
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean {
         if (super.isAllowedAsColumnDefault(e)) return true
-        if ((currentDialect is MariaDBDialect && fullVersion >= "10.2.1") || (currentDialect !is MariaDBDialect && fullVersion >= "8.0.13")) {
+        if (fullVersion >= "8.0.13") {
             return true
         }
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Moved some things around to make the MariaDB code neater.

**Detailed description**:
- **What**:
1. Override some functions in `MariaDBDialect` and `MariaDBFunctionProvider` to be able to remove the MariaDB checks done in `MysqlDialect` and `MysqlFunctionProvider` respectively.
2. Create new object `MariaDBDataTypeProvider` and move MariaDB-specific checks to it from `MysqlDataTypeProvider`.
- **Why**:
To reduce MariaDB checks in the MySQL code and separate their concerns where possible.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other: Refactor

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
