### PR TITLE
chore!: EXPOSED-693 Change timestamp column type for MariaDB from "DATETIME" to "TIMESTAMP"

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3855,6 +3855,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/DataTypeProvider {
 	public fun shortType ()Ljava/lang/String;
 	public fun textType ()Ljava/lang/String;
 	public fun timeType ()Ljava/lang/String;
+	public fun timestampType ()Ljava/lang/String;
 	public fun timestampWithTimeZoneType ()Ljava/lang/String;
 	public fun ubyteType ()Ljava/lang/String;
 	public fun uintegerAutoincType ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DataTypeProvider.kt
@@ -108,6 +108,8 @@ abstract class DataTypeProvider {
     /** Data type for storing both date and time without a time zone. */
     open fun dateTimeType(): String = "DATETIME"
 
+    open fun timestampType(): String = dateTimeType()
+
     /** Data type for storing both date and time with a time zone. */
     open fun timestampWithTimeZoneType(): String = "TIMESTAMP WITH TIME ZONE"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/MariaDBDialect.kt
@@ -6,6 +6,8 @@ import org.jetbrains.exposed.sql.Function
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 
 internal object MariaDBDataTypeProvider : MysqlDataTypeProvider() {
+    override fun timestampType(): String = if ((currentDialect as? MariaDBDialect)?.isFractionDateTimeSupported() == true) "TIMESTAMP(6)" else "TIMESTAMP"
+
     override fun timestampWithTimeZoneType(): String {
         throw UnsupportedByDialectException("This vendor does not support timestamp with time zone data type", currentDialect)
     }

--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/sql/javatime/JavaDateColumnType.kt
@@ -350,7 +350,7 @@ class JavaLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
 class JavaInstantColumnType : ColumnType<Instant>(), IDateColumnType {
     override val hasTimePart: Boolean = true
 
-    override fun sqlType(): String = currentDialect.dataTypeProvider.dateTimeType()
+    override fun sqlType(): String = currentDialect.dataTypeProvider.timestampType()
 
     override fun nonNullValueToString(value: Instant): String {
         return when (val dialect = currentDialect) {

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/DefaultsTest.kt
@@ -249,6 +249,7 @@ class DefaultsTest : DatabaseTestsBase() {
         withTables(testTable) { testDb ->
             val dtType = currentDialectTest.dataTypeProvider.dateTimeType()
             val dType = currentDialectTest.dataTypeProvider.dateType()
+            val timestampType = currentDialectTest.dataTypeProvider.timestampType()
             val longType = currentDialectTest.dataTypeProvider.longType()
             val timeType = currentDialectTest.dataTypeProvider.timeType()
             val varcharType = currentDialectTest.dataTypeProvider.varcharType(100)
@@ -266,8 +267,8 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t2".inProperCase()} $dtType${testTable.t2.constraintNamePart()} ${nowExpression.itOrNull()}, " +
                 "${"t3".inProperCase()} $dtType${testTable.t3.constraintNamePart()} ${dtLiteral.itOrNull()}, " +
                 "${"t4".inProperCase()} $dType${testTable.t4.constraintNamePart()} ${dLiteral.itOrNull()}, " +
-                "${"t5".inProperCase()} $dtType${testTable.t5.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
-                "${"t6".inProperCase()} $dtType${testTable.t6.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
+                "${"t5".inProperCase()} $timestampType${testTable.t5.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
+                "${"t6".inProperCase()} $timestampType${testTable.t6.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
                 "${"t7".inProperCase()} $longType${testTable.t7.constraintNamePart()} ${durLiteral.itOrNull()}, " +
                 "${"t8".inProperCase()} $longType${testTable.t8.constraintNamePart()} ${durLiteral.itOrNull()}, " +
                 "${"t9".inProperCase()} $timeType${testTable.t9.constraintNamePart()} ${tLiteral.itOrNull()}, " +

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -363,7 +363,7 @@ class KotlinLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
 class KotlinInstantColumnType : ColumnType<Instant>(), IDateColumnType {
     override val hasTimePart: Boolean = true
 
-    override fun sqlType(): String = currentDialect.dataTypeProvider.dateTimeType()
+    override fun sqlType(): String = currentDialect.dataTypeProvider.timestampType()
 
     override fun nonNullValueToString(value: Instant): String {
         val instant = value.toJavaInstant()

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/DefaultsTest.kt
@@ -247,6 +247,7 @@ class DefaultsTest : DatabaseTestsBase() {
         withTables(testTable) { testDb ->
             val dtType = currentDialectTest.dataTypeProvider.dateTimeType()
             val dType = currentDialectTest.dataTypeProvider.dateType()
+            val timestampType = currentDialectTest.dataTypeProvider.timestampType()
             val longType = currentDialectTest.dataTypeProvider.longType()
             val timeType = currentDialectTest.dataTypeProvider.timeType()
             val varCharType = currentDialectTest.dataTypeProvider.varcharType(100)
@@ -264,8 +265,8 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t2".inProperCase()} $dtType${testTable.t2.constraintNamePart()} ${nowExpression.itOrNull()}, " +
                 "${"t3".inProperCase()} $dtType${testTable.t3.constraintNamePart()} ${dtLiteral.itOrNull()}, " +
                 "${"t4".inProperCase()} $dType${testTable.t4.constraintNamePart()} ${dLiteral.itOrNull()}, " +
-                "${"t5".inProperCase()} $dtType${testTable.t5.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
-                "${"t6".inProperCase()} $dtType${testTable.t6.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
+                "${"t5".inProperCase()} $timestampType${testTable.t5.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
+                "${"t6".inProperCase()} $timestampType${testTable.t6.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
                 "${"t7".inProperCase()} $longType${testTable.t7.constraintNamePart()} ${durLiteral.itOrNull()}, " +
                 "${"t8".inProperCase()} $longType${testTable.t8.constraintNamePart()} ${durLiteral.itOrNull()}, " +
                 "${"t9".inProperCase()} $timeType${testTable.t9.constraintNamePart()} ${tLiteral.itOrNull()}, " +

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/MiscTableTest.kt
@@ -23,23 +23,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
 
-object Misc : MiscTable() {
-    val d = date("d")
-    val dn = date("dn").nullable()
-
-    val t = time("t")
-    val tn = time("tn").nullable()
-
-    val dt = datetime("dt")
-    val dtn = datetime("dtn").nullable()
-
-    val ts = timestamp("ts")
-    val tsn = timestamp("tsn").nullable()
-
-    val dr = duration("dr")
-    val drn = duration("drn").nullable()
-}
-
 @Suppress("LargeClass")
 class MiscTableTest : DatabaseTestsBase() {
     @Test
@@ -1234,6 +1217,7 @@ class MiscTableTest : DatabaseTestsBase() {
 
         override val primaryKey = PrimaryKey(id)
     }
+
     private val zeroDateTimeTableDdl = """
         CREATE TABLE `zerodatetimetable` (
         `id` INT NOT NULL AUTO_INCREMENT,
@@ -1265,6 +1249,23 @@ class MiscTableTest : DatabaseTestsBase() {
             }
         }
     }
+}
+
+object Misc : MiscTable() {
+    val d = date("d")
+    val dn = date("dn").nullable()
+
+    val t = time("t")
+    val tn = time("tn").nullable()
+
+    val dt = datetime("dt")
+    val dtn = datetime("dtn").nullable()
+
+    val ts = timestamp("ts")
+    val tsn = timestamp("tsn").nullable()
+
+    val dr = duration("dr")
+    val drn = duration("drn").nullable()
 }
 
 @Suppress("LongParameterList")


### PR DESCRIPTION
#### Description

**Summary of the change**: Change timestamp column type for MariaDB from "DATETIME" to "TIMESTAMP"

**Detailed description**:
- **Why**: Oracle, PostgreSQL are the only ones that use type "TIMESTAMP" for the timestamp column. MariaDB also has that type but "DATETIME" was being used instead for some reason.
- **How**: Added `timestampType()` in `DataTypeProvider` and overrided it in `MariaDBDataTypeProvider`.

Note: Using "TIMESTAMP" instead of "DATETIME" for MySQL 5 fails for `testUpdate02`.  The reason is that when updating another TIMESTAMP column, the first TIMESTAMP column's value is changing when retrieving it from the database because the database silently adds ON UPDATE CURRENTTIMESTAMP, so it's best to leave it as "DATETIME" for MySQL. I could also change it just for MySQL 8 in a separate follow-up PR. If you are reviewing this, please let me know what you think.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other: Column type change

Updates/remove existing public API methods:
- [x] Is breaking change

Affected databases:
- [x] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
