### PR TITLE
EXPOSED-723 Reading databaseGenerated value from entity fails and does not trigger flush cache

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -273,7 +273,12 @@ open class Entity<ID : Any>(val id: EntityID<ID>) {
     @Suppress("UNCHECKED_CAST", "USELESS_CAST")
     fun <T> Column<T>.lookup(): T = when {
         writeValues.containsKey(this as Column<out Any?>) -> writeValues[this as Column<out Any?>] as T
-        id._value == null && _readValues?.hasValue(this)?.not() ?: true -> defaultValueFun?.invoke() as T
+        id._value == null && _readValues?.hasValue(this)?.not() ?: true -> {
+            when {
+                isDatabaseGenerated() -> flush().let { readValues[this]!! }
+                else -> defaultValueFun?.invoke() as T
+            }
+        }
         columnType.nullable -> readValues[this]
         else -> readValues[this]!!
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/entities/EntityTests.kt
@@ -1597,9 +1597,8 @@ class EntityTests : DatabaseTestsBase() {
 
             val creditCard = CreditCard.new {
                 number = "0000111122223333"
-            }.apply {
-                flush()
             }
+
             assertEquals(10000uL, creditCard.spendingLimit)
         }
     }


### PR DESCRIPTION
#### Description

Entity cache lookup may fail if the `databaseGenerated` value is read before the flush. 

**Detailed description**:
- **What**: Entity lookup cache fails with NPE because it tries to read the value from `Entity::_readValues` where it's actually not present (it contains `NotInitializedValue` in this moment)
- **Why**: DAO does not flush entity on attempt to read `databaseGenerated` value.
- **How**: Fixed `lookup` method of the Entity to force it flush the changes if such a value is requested.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

---

#### Related Issues

[EXPOSED-723](https://youtrack.jetbrains.com/issue/EXPOSED-723) Reading databaseGenerated value from entity fails and does not trigger flush cache
