### PR TITLE
docs: Change urls for site pages in Changelog and ReadMe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Breaking changes:
 * fix!: EXPOSED-691 [PostgreSQL] Restrict dropping unmapped sequences to related tables only by @bog-walk in https://github.com/JetBrains/Exposed/pull/2357
 * chore!: Change H2 Oracle longType and longAutoincType from NUMBER(19) to BIGINT and add CHECK constraint in Oracle by @joc-a in https://github.com/JetBrains/Exposed/pull/2273
 * chore!: EXPOSED-693 Change timestamp column type for MariaDB from "DATETIME" to "TIMESTAMP" by @joc-a in https://github.com/JetBrains/Exposed/pull/2389
-* More details at [Breaking Changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-59-0)
+* More details at [Breaking Changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-59-0)
 
 Deprecations:
 * deprecate: Raise deprecation levels of API elements by @bog-walk in https://github.com/JetBrains/Exposed/pull/2384
@@ -134,7 +134,7 @@ Breaking changes:
 * chore!: Change Oracle and H2 Oracle integerType and integerAutoincType from NUMBER(12) to NUMBER(10) and INTEGER respectively and add CHECK constraint in SQLite by @joc-a in https://github.com/JetBrains/Exposed/pull/2270
 * feat!: EXPOSED-359 Add support for multidimensional arrays by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2250
 * feat!: EXPOSED-577 Allow Entity and EntityID parameters to not be Comparable by @bog-walk in https://github.com/JetBrains/Exposed/pull/2277
-* More details at [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-56-0)
+* More details at [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-56-0)
 
 Features:
 * feat: Support partially filled composite IDs by @sickfar in https://github.com/JetBrains/Exposed/pull/2282
@@ -335,7 +335,7 @@ Breaking changes:
 * build!: EXPOSED-315 Use the slimmer `spring-boot-starter-jdbc` instead of `spring-boot-starter-data-jdbc` by @bystam
   in https://github.com/JetBrains/Exposed/pull/2055
 * fix!: EXPOSED-360 Storing ULong.MAX_VALUE in ulong column not working by @joc-a in https://github.com/JetBrains/Exposed/pull/2068
-* More details at [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-51-0)
+* More details at [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-51-0)
 
 Features:
 * feat: Add support for variable-length binary columns in H2 by @rnett in https://github.com/JetBrains/Exposed/pull/2100
@@ -371,7 +371,7 @@ Infrastructure:
 Breaking changes:
 * fix!: EXPOSED-317 repetitionAttempts property is misleading by @bog-walk in https://github.com/JetBrains/Exposed/pull/2042
 * refactor!: Column type safety by @joc-a in https://github.com/JetBrains/Exposed/pull/2027
-* More details at [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-50-0)
+* More details at [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-50-0)
 
 Deprecations:
 * deprecate: Raise deprecation levels of API elements by @bog-walk in https://github.com/JetBrains/Exposed/pull/2038
@@ -410,7 +410,7 @@ Infrastructure:
 * PostgreSQL driver 42.7.3
 * Detekt 1.23.6
 
-[Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-49-0):
+[Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-49-0):
 * fix!: EXPOSED-269 Incompatible with sqlite-jdbc 3.45.0.0 by @joc-a in https://github.com/JetBrains/Exposed/pull/2030
 
 Features:
@@ -447,7 +447,7 @@ Breaking changes:
 * `nonNullValueToString()` in some date/time column types now uses more appropriate string formatters.
 * `anyFrom(array)` and `allFrom(array)` may require an additional argument if a matching column type cannot be resolved for the array contents.
 * `exposed-crypt` module now uses Spring Security Crypto 6.+, which requires Java 17 as a minimum version.
-* More details at [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-48-0)
+* More details at [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-48-0)
 
 Features:
 * feat: EXPOSED-248 Support array column type by @bog-walk in https://github.com/JetBrains/Exposed/pull/1986
@@ -491,7 +491,7 @@ Infrastructure:
 * Java Money Moneta 1.4.4
 
 Breaking changes:
-* [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-47-0)
+* [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-47-0)
 
 Features:
 * feat: Add `ALL` and `ANY` operators accepting array, subquery, or table parameters by @ShreckYe in https://github.com/JetBrains/Exposed/pull/1886
@@ -534,11 +534,11 @@ Infrastructure:
 
 Breaking changes:
 * chore!: EXPOSED-239 Set `preserveKeywordCasing` flag to true by default by @bog-walk in https://github.com/JetBrains/Exposed/pull/1948
-* More details at [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-46-0)
+* More details at [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-46-0)
 
 Features:
 * feat: EXPOSED-65 Design query DSL consistent with SQL language by @bog-walk in https://github.com/JetBrains/Exposed/pull/1916
-* More details in the [Migration guide](https://jetbrains.github.io/Exposed/migration-guide.html)
+* More details in the [Migration guide](https://www.jetbrains.com/help/exposed/migration-guide.html)
 
 Bug fixes:
 * perf: EXPOSED-204 Performance problem with getConnection() by @bog-walk in https://github.com/JetBrains/Exposed/pull/1943
@@ -615,7 +615,7 @@ Breaking changes:
 * `spring-transaction` and `exposed-spring-boot-starter` modules now use Spring Framework 6.0 and Spring Boot 3.0, which require Java 17 as a minimum version.
 * A table that is created with a keyword identifier now logs a warning that the identifier's case may be lost when it is automatically quoted in generated SQL.
   `DatabaseConfig` now includes the property `preserveKeywordCasing`, which can be set to `true` to remove these warnings and to ensure that the identifier matches the exact case used.
-* More details at [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-44-0)
+* More details at [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-44-0)
 
 Features:
 * feat!: EXPOSED-109 Improve implementation of Spring transaction manager by @FullOfOrange in https://github.com/JetBrains/Exposed/pull/1840
@@ -674,7 +674,7 @@ Bug fixes:
 * fix: Remove false warning log by @joc-a in https://github.com/JetBrains/Exposed/pull/1843
 
 Breaking changes:
-* [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-43-0)
+* [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-43-0)
 
 # 0.42.1
 Infrastructure:
@@ -691,7 +691,7 @@ Deprecations:
 * deprecate: EXPOSED-84 Raise deprecation levels of API elements by @bog-walk in https://github.com/JetBrains/Exposed/pull/1771
 
 Breaking changes:
-* [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html#0-42-0)
+* [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html#0-42-0)
 
 Features:
 * Add CHARINDEX function for sqlserver by @eukleshnin in https://github.com/JetBrains/Exposed/pull/1675

--- a/README.md
+++ b/README.md
@@ -189,14 +189,14 @@ Check out the [samples](samples/README.md) for a quick start.
 
 ## Links
 
-Currently, Exposed is available for **maven/gradle builds**. Check the [Maven Central](https://search.maven.org/search?q=g:org.jetbrains.exposed) and read [Getting Started](https://jetbrains.github.io/Exposed/getting-started-with-exposed.html) to get an insight on setting up Exposed.
+Currently, Exposed is available for **maven/gradle builds**. Check the [Maven Central](https://search.maven.org/search?q=g:org.jetbrains.exposed) and read [Getting Started](https://www.jetbrains.com/help/exposed/getting-started-with-exposed.html) to get an insight on setting up Exposed.
 <br><br>
 For more information visit the links below:
 
--   [Documentation](https://jetbrains.github.io/Exposed/home.html) with examples and docs
+-   [Documentation](https://www.jetbrains.com/help/exposed/home.html) with examples and docs
 -   [Contributing to Exposed](#contributing)
--   [Migration Guide](https://jetbrains.github.io/Exposed/migration-guide.html)
--   [Breaking changes](https://jetbrains.github.io/Exposed/breaking-changes.html) and any migration details
+-   [Migration Guide](https://www.jetbrains.com/help/exposed/migration-guide.html)
+-   [Breaking changes](https://www.jetbrains.com/help/exposed/breaking-changes.html) and any migration details
 -   [Slack Channel](https://kotlinlang.slack.com/messages/exposed/)
 -   [Filing Issues](#contributing)
 -   [Issue Tracker](https://youtrack.jetbrains.com/issues/EXPOSED)
@@ -215,7 +215,7 @@ While issues are visible publicly, either creating a new issue or commenting on 
 We also actively welcome your pull requests. However, linking your work to an [existing issue](https://youtrack.jetbrains.com/issues/EXPOSED) is preferred.
 
 
-See the full [contribution guide](https://jetbrains.github.io/Exposed/contributing.html) for more details.
+See the full [contribution guide](https://www.jetbrains.com/help/exposed/contributing.html) for more details.
 
 By contributing to the Exposed project, you agree that your contributions will be licensed under [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 <br><br>


### PR DESCRIPTION
#### Description

**Summary of the change**: Change urls in CHANGELOG & README from using 'https://jetbrains.github.io/Exposed' to using 'https://www.jetbrains.com/help/exposed'

**Detailed description**:
- **Why**: Version releases usually come with a link to a changelog with breaking changes links that should be updated.
- **How**: All found instances have been switched to a url that is synced.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

