### PR TITLE
fix: EXPOSED-719 H2 upsert operation converts arrays to string

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -214,6 +214,8 @@ public final class org/jetbrains/exposed/sql/ArrayColumnType : org/jetbrains/exp
 	public fun nonNullValueToString (Ljava/util/List;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun notNullValueToDB (Ljava/util/List;)Ljava/lang/Object;
+	public synthetic fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
+	public fun parameterMarker (Ljava/util/List;)Ljava/lang/String;
 	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
@@ -537,6 +539,7 @@ public class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/expos
 	public final fun getOriginalColumnType ()Lorg/jetbrains/exposed/sql/IColumnType;
 	public final fun getTransformer ()Lorg/jetbrains/exposed/sql/ColumnTransformer;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
 	public fun setNullable (Z)V
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;


### PR DESCRIPTION
#### Description

- **What**: Upsert command fails for H2 if it contains array column.
- **Why**: The problem is that H2 has problems with type inference and fails with `Data conversion error converting` for such columns
- **How**: The only way I found is cast explicitly parameter markers for array values on H2 database. The list of particular types was added, and the test checks that everything works for these types, but in general such a cast could not work for other types (for example it was not working for BigDecimal)

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] H2

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-719](https://youtrack.jetbrains.com/issue/EXPOSED-719) H2 upsert operation converts arrays to string