### PR TITLE
fix: EXPOSED-593 Rollback ExposedSQLException when use SpringTransactionManager

### DIFF
--- a/exposed-spring-boot-starter/api/exposed-spring-boot-starter.api
+++ b/exposed-spring-boot-starter/api/exposed-spring-boot-starter.api
@@ -22,6 +22,7 @@ public class org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration
 	public fun <init> (Lorg/springframework/context/ApplicationContext;)V
 	public fun databaseConfig ()Lorg/jetbrains/exposed/sql/DatabaseConfig;
 	public fun databaseInitializer ()Lorg/jetbrains/exposed/spring/DatabaseInitializer;
+	public fun exposedSpringTransactionAttributeSource ()Lorg/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource;
 	public fun springTransactionManager (Ljavax/sql/DataSource;Lorg/jetbrains/exposed/sql/DatabaseConfig;)Lorg/jetbrains/exposed/spring/SpringTransactionManager;
 }
 

--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfiguration.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.spring.autoconfigure
 
 import org.jetbrains.exposed.spring.DatabaseInitializer
+import org.jetbrains.exposed.spring.ExposedSpringTransactionAttributeSource
 import org.jetbrains.exposed.spring.SpringTransactionManager
 import org.jetbrains.exposed.sql.DatabaseConfig
 import org.springframework.beans.factory.annotation.Value
@@ -10,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import javax.sql.DataSource
 
@@ -67,4 +69,18 @@ open class ExposedAutoConfiguration(private val applicationContext: ApplicationC
     @Bean
     @ConditionalOnProperty("spring.exposed.generate-ddl", havingValue = "true", matchIfMissing = false)
     open fun databaseInitializer() = DatabaseInitializer(applicationContext, excludedPackages)
+
+    /**
+     * Returns an [ExposedSpringTransactionAttributeSource] instance.
+     *
+     * To enable rollback when ExposedSQLException is Thrown
+     *
+     * @Primary annotation is used to avoid conflict with default TransactionAttributeSource bean
+     * than enable when use @EnableTransactionManagement
+     */
+    @Bean
+    @Primary
+    open fun exposedSpringTransactionAttributeSource(): ExposedSpringTransactionAttributeSource {
+        return ExposedSpringTransactionAttributeSource()
+    }
 }

--- a/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
+++ b/exposed-spring-boot-starter/src/test/kotlin/org/jetbrains/exposed/spring/autoconfigure/ExposedAutoConfigurationTest.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.spring.autoconfigure
 
 import org.jetbrains.exposed.spring.Application
 import org.jetbrains.exposed.spring.DatabaseInitializer
+import org.jetbrains.exposed.spring.ExposedSpringTransactionAttributeSource
 import org.jetbrains.exposed.spring.SpringTransactionManager
 import org.jetbrains.exposed.spring.tables.TestTable
 import org.jetbrains.exposed.sql.DatabaseConfig
@@ -21,6 +22,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.interceptor.TransactionAttributeSource
 import java.util.concurrent.CompletableFuture
 
 @SpringBootTest(
@@ -37,6 +39,9 @@ open class ExposedAutoConfigurationTest {
 
     @Autowired
     private var databaseConfig: DatabaseConfig? = null
+
+    @Autowired
+    private var transactionAttributeSource: TransactionAttributeSource? = null
 
     @Test
     fun `should initialize the database connection`() {
@@ -68,6 +73,13 @@ open class ExposedAutoConfigurationTest {
                 context.getBean(DataSourceTransactionManagerAutoConfiguration::class.java)
             }
         }
+    }
+
+    @Test
+    fun `load ExposedSpringTransactionAttributeSource`() {
+        transactionAttributeSource?.let {
+            assertEquals(ExposedSpringTransactionAttributeSource::class.java, it.javaClass)
+        } ?: fail("TransactionAttributeSource bean not found")
     }
 
     @TestConfiguration

--- a/spring-transaction/api/spring-transaction.api
+++ b/spring-transaction/api/spring-transaction.api
@@ -1,3 +1,10 @@
+public final class org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource : org/springframework/transaction/interceptor/TransactionAttributeSource {
+	public fun <init> ()V
+	public fun <init> (Lorg/springframework/transaction/interceptor/TransactionAttributeSource;)V
+	public synthetic fun <init> (Lorg/springframework/transaction/interceptor/TransactionAttributeSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getTransactionAttribute (Ljava/lang/reflect/Method;Ljava/lang/Class;)Lorg/springframework/transaction/interceptor/TransactionAttribute;
+}
+
 public final class org/jetbrains/exposed/spring/SpringTransactionManager : org/springframework/transaction/support/AbstractPlatformTransactionManager {
 	public fun <init> (Ljavax/sql/DataSource;Lorg/jetbrains/exposed/sql/DatabaseConfig;Z)V
 	public synthetic fun <init> (Ljavax/sql/DataSource;Lorg/jetbrains/exposed/sql/DatabaseConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
@@ -16,14 +16,13 @@ import java.lang.reflect.Method
  */
 class ExposedSpringTransactionAttributeSource(
     private val delegate: TransactionAttributeSource = AnnotationTransactionAttributeSource(),
-    private val rollbackExceptions: List<Class<ExposedSQLException>> = listOf(ExposedSQLException::class.java)
+    private val rollbackExceptions: List<Class<out Throwable>> = listOf(ExposedSQLException::class.java)
 ) : TransactionAttributeSource {
 
     override fun getTransactionAttribute(method: Method, targetClass: Class<*>?): TransactionAttribute? {
         val attr = delegate.getTransactionAttribute(method, targetClass)
         if (attr is RuleBasedTransactionAttribute) {
             val rules = attr.rollbackRules.toMutableList()
-
             rollbackExceptions.forEach { exception ->
                 val exceptionName = exception.name
                 val containsException = rules.any {
@@ -34,7 +33,6 @@ class ExposedSpringTransactionAttributeSource(
                     rules.add(RollbackRuleAttribute(exception))
                 }
             }
-
             attr.rollbackRules = rules
         }
         return attr

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
@@ -8,15 +8,23 @@ import org.springframework.transaction.interceptor.TransactionAttribute
 import org.springframework.transaction.interceptor.TransactionAttributeSource
 import java.lang.reflect.Method
 
+/**
+ * A [TransactionAttributeSource] that adds [ExposedSQLException] to the rollback rules of the delegate.
+ *
+ * @property delegate The delegate [TransactionAttributeSource] to use. Defaults to [AnnotationTransactionAttributeSource].
+ * If you use a custom [TransactionAttributeSource], you can pass it here.
+ */
 class ExposedSpringTransactionAttributeSource(
     private val delegate: TransactionAttributeSource = AnnotationTransactionAttributeSource()
 ) : TransactionAttributeSource {
+
+    private val rollbackExceptions = listOf(ExposedSQLException::class.java)
 
     override fun getTransactionAttribute(method: Method, targetClass: Class<*>?): TransactionAttribute? {
         val attr = delegate.getTransactionAttribute(method, targetClass)
         if (attr is RuleBasedTransactionAttribute) {
             val rules = attr.rollbackRules.toMutableList()
-            val containsExposed = rules.any { it.exceptionName == ExposedSQLException::class.java.name }
+            val containsExposed = rules.any { it is RollbackRuleAttribute && it.exceptionName in rollbackExceptions.map(Class<*>::getName) }
             if (!containsExposed) {
                 rules.add(RollbackRuleAttribute(ExposedSQLException::class.java))
                 attr.rollbackRules = rules

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute
 import org.springframework.transaction.interceptor.TransactionAttribute
 import org.springframework.transaction.interceptor.TransactionAttributeSource
 import java.lang.reflect.Method
+import java.sql.SQLException
 
 /**
  * A [TransactionAttributeSource] that adds [ExposedSQLException] to the rollback rules of the delegate.
@@ -16,7 +17,7 @@ import java.lang.reflect.Method
  */
 class ExposedSpringTransactionAttributeSource(
     private val delegate: TransactionAttributeSource = AnnotationTransactionAttributeSource(),
-    private val rollbackExceptions: List<Class<out Throwable>> = listOf(ExposedSQLException::class.java)
+    private val rollbackExceptions: List<Class<out Throwable>> = listOf(SQLException::class.java)
 ) : TransactionAttributeSource {
 
     override fun getTransactionAttribute(method: Method, targetClass: Class<*>?): TransactionAttribute? {

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
@@ -1,0 +1,27 @@
+package org.jetbrains.exposed.spring
+
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource
+import org.springframework.transaction.interceptor.RollbackRuleAttribute
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute
+import org.springframework.transaction.interceptor.TransactionAttribute
+import org.springframework.transaction.interceptor.TransactionAttributeSource
+import java.lang.reflect.Method
+
+class ExposedSpringTransactionAttributeSource(
+    private val delegate: TransactionAttributeSource = AnnotationTransactionAttributeSource()
+) : TransactionAttributeSource {
+
+    override fun getTransactionAttribute(method: Method, targetClass: Class<*>?): TransactionAttribute? {
+        val attr = delegate.getTransactionAttribute(method, targetClass)
+        if (attr is RuleBasedTransactionAttribute) {
+            val rules = attr.rollbackRules.toMutableList()
+            val containsExposed = rules.any { it.exceptionName == ExposedSQLException::class.java.name }
+            if (!containsExposed) {
+                rules.add(RollbackRuleAttribute(ExposedSQLException::class.java))
+                attr.rollbackRules = rules
+            }
+        }
+        return attr
+    }
+}

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionAttributeSource.kt
@@ -24,11 +24,9 @@ class ExposedSpringTransactionAttributeSource(
         if (attr is RuleBasedTransactionAttribute) {
             val rules = attr.rollbackRules.toMutableList()
             rollbackExceptions.forEach { exception ->
-                val exceptionName = exception.name
                 val containsException = rules.any {
-                    it is RollbackRuleAttribute && it.exceptionName == exceptionName
+                    it is RollbackRuleAttribute && it.exceptionName == exception.name
                 }
-
                 if (!containsException) {
                     rules.add(RollbackRuleAttribute(exception))
                 }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionManagerAttributeSourceTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/ExposedSpringTransactionManagerAttributeSourceTest.kt
@@ -1,0 +1,102 @@
+package org.jetbrains.exposed.spring
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.exceptions.ExposedSQLException
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.junit.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import org.springframework.transaction.annotation.Transactional
+import javax.sql.DataSource
+import kotlin.test.BeforeTest
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * @author ivan@daangn.com
+ */
+class ExposedSpringTransactionManagerAttributeSourceTest {
+
+    val container = AnnotationConfigApplicationContext(TransactionManagerAttributeSourceTestConfig::class.java)
+
+    @BeforeTest
+    fun beforeTest() {
+        val testRollback = container.getBean(TestRollback::class.java)
+        testRollback.init()
+    }
+
+    @Test
+    fun `test rollback`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+        assertFailsWith<ExposedSQLException> {
+            testRollback.transaction {
+                insertOriginTable()
+                insertWrongTable("1234567890")
+            }
+        }
+
+        assertEquals(0, testRollback.entireTableSize())
+    }
+}
+
+@Configuration
+@EnableTransactionManagement(proxyTargetClass = true)
+open class TransactionManagerAttributeSourceTestConfig {
+
+    @Bean
+    open fun dataSource(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName("embeddedTest1").setType(
+        EmbeddedDatabaseType.H2
+    ).build()
+
+    @Bean
+    open fun transactionManager(dataSource: DataSource) = SpringTransactionManager(dataSource)
+
+    @Bean
+    open fun transactionAttributeSource() = ExposedSpringTransactionAttributeSource()
+
+    @Bean
+    open fun testRollback() = TestRollback()
+}
+
+@Transactional
+open class TestRollback {
+
+    open fun init() {
+        SchemaUtils.create(RollbackTable)
+    }
+
+    open fun transaction(block: TestRollback.() -> Unit) {
+        block()
+    }
+
+    open fun insertOriginTable() {
+        RollbackTable.insert {
+            it[RollbackTable.name] = "1"
+        }
+    }
+
+    open fun insertWrongTable(name: String) {
+        WrongDefinedRollbackTable.insert {
+            it[WrongDefinedRollbackTable.name] = name
+        }
+    }
+
+    open fun entireTableSize(): Long {
+        return RollbackTable.selectAll().count()
+    }
+}
+
+object RollbackTable : LongIdTable("test_rollback") {
+    val name = varchar("name", 5)
+}
+
+object WrongDefinedRollbackTable : LongIdTable("test_rollback") {
+    val name = varchar("name", 10)
+}

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertFailsWith
 /**
  * @author ivan@daangn.com
  */
-class ExposedSpringTransactionManagerAttributeSourceTest {
+class SpringTransactionRollbackTest {
 
     val container = AnnotationConfigApplicationContext(TransactionManagerAttributeSourceTestConfig::class.java)
 

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.spring
 import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.junit.Test
@@ -15,6 +16,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import org.springframework.transaction.annotation.Transactional
 import javax.sql.DataSource
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -72,6 +74,11 @@ class SpringTransactionRollbackTest {
 
         assertEquals(1, testRollback.entireTableSize())
     }
+
+    @AfterTest
+    fun afterTest() {
+        container.close()
+    }
 }
 
 @Configuration
@@ -98,6 +105,7 @@ open class TestRollback {
 
     open fun init() {
         SchemaUtils.create(RollbackTable)
+        RollbackTable.deleteAll()
     }
 
     open fun transaction(block: TestRollback.() -> Unit) {

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
@@ -33,7 +33,7 @@ class SpringTransactionRollbackTest {
     }
 
     @Test
-    fun `test rollback`() {
+    fun `test ExposedSQLException rollback`() {
         val testRollback = container.getBean(TestRollback::class.java)
         assertFailsWith<ExposedSQLException> {
             testRollback.transaction {
@@ -43,6 +43,34 @@ class SpringTransactionRollbackTest {
         }
 
         assertEquals(0, testRollback.entireTableSize())
+    }
+
+    @Test
+    fun `test RuntimeException rollback`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+        assertFailsWith<RuntimeException> {
+            testRollback.transaction {
+                insertOriginTable()
+                @Suppress("TooGenericExceptionThrown")
+                throw RuntimeException()
+            }
+        }
+
+        assertEquals(0, testRollback.entireTableSize())
+    }
+
+    @Test
+    fun `test check exception commit`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+        assertFailsWith<Exception> {
+            testRollback.transaction {
+                insertOriginTable()
+                @Suppress("TooGenericExceptionThrown")
+                throw Exception()
+            }
+        }
+
+        assertEquals(1, testRollback.entireTableSize())
     }
 }
 


### PR DESCRIPTION
#### Description

**Summary of the change**:

- Add `ExposedSpringTransactionAttributeSource` to fix transaction not rollback when an `ExposedSQLException` thrown when using `SpringTransactionManager`.

- Added @Bean settings to `spring-boot-starter`


**Detailed description**:
- **What**: Introduces `ExposedSpringTransactionAttributeSource`. This is an implementation of `TransactionAttributeSource`, a class for setting attributes on a transaction, and a class for adding `ExposedSQLException` as a rollback rule.
- **Why**: Spring only rolls back `UncheckedExceptions` when using the `@Transactional` annotation, but `ExposedSQLException` is a `CheckedException` and cannot be rolled back. This makes the behavior different from the default exposed transaction, and we want to fix it.
- **How**: 
  - Implemented `ExposedSpringTransactionAttributeSource` to allow you to add an exception to the rollback rule.
    - If you use spring-boot-starter, it will automatically register the bean for you.
    - If you set it up yourself, you can register the ExposedSpringTransactionAttributeSource as a bean yourself and use it. (set up same as spring-boot-starter).
---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
- https://github.com/JetBrains/Exposed/issues/1419