### PR TITLE
chore!: EXPOSED-727 Change timestamp column type for H2 from "DATETIME(9)" to "TIMESTAMP(9)"

### DIFF
--- a/.github/workflows/commit-message-validation.yml
+++ b/.github/workflows/commit-message-validation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Validate commit messages
         run: |
           # Regex for Conventional Commits specification
-          COMMIT_REGEX="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^\)]*\))?:\s?(EXPOSED-[0-9]+\s?)?.+$"
+          COMMIT_REGEX="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(!)?(\([^\)]*\))?:\s?(EXPOSED-[0-9]+\s?)?.+$"
           
           # Get all commits in the pull request (from base to head)
           COMMITS=$(git log --format=%s --no-merges origin/main..${{ github.sha }})

--- a/.github/workflows/pull-request-title-validation.yml
+++ b/.github/workflows/pull-request-title-validation.yml
@@ -25,12 +25,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Regex for Conventional Commits specification
-          PR_TITLE_REGEX="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^\)]*\))?:\s?(EXPOSED-[0-9]+\s?)?.+$"
-
-          # Get the PR title
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE_REGEX="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(!)?(\([^\)]*\))?:\s?(EXPOSED-[0-9]+\s?)?.+$"
 
           # Check if PR title matches the regex
           if [[ ! "$PR_TITLE" =~ $PR_TITLE_REGEX ]]; then

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,8 @@
 # Breaking Changes
 
+## 0.60.0
+* In H2, the `timestamp()` column now maps to data type `TIMESTAMP(9)` instead of `DATETIME(9)`.
+
 ## 0.59.0
 * [PostgreSQL] `MigrationUtils.statementsRequiredForDatabaseMigration(*tables)` used to potentially return `DROP` statements for any database sequence not
   mapped to an Exposed table object. Now it only checks against database sequences that have a relational dependency on any of the specified tables
@@ -28,6 +31,7 @@ val long = long("long_column").nullable().check { column ->
     column.isNull() or typeCondition
 }
 ```
+* In MariaDB, the `timestamp()` column now maps to data type `TIMESTAMP` instead of `DATETIME`.
 
 ## 0.57.0
 * Insert, Upsert, and Replace statements will no longer implicitly send all default values (except for client-side default values) in every SQL request. 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/H2.kt
@@ -10,8 +10,12 @@ internal object H2DataTypeProvider : DataTypeProvider() {
     override fun binaryType(): String = "VARBINARY"
 
     override fun uuidType(): String = "UUID"
+
     override fun uuidToDB(value: UUID): Any = value.toString()
+
     override fun dateTimeType(): String = "DATETIME(9)"
+
+    override fun timestampType(): String = "TIMESTAMP(9)"
 
     override fun timestampWithTimeZoneType(): String = "TIMESTAMP(9) WITH TIME ZONE"
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Change timestamp column type for H2 from "DATETIME(9)" to "TIMESTAMP(9)"

**Detailed description**:
- **Why**:
1. Oracle, PostgreSQL, and MariaDB are the only ones that use type "TIMESTAMP" for the timestamp column. H2 also has that type but "DATETIME" was being used instead for some reason.
2. This is a preparation step that makes detecting column type change for migration easier.
- **How**:
Overrided `timestampType()` in `H2DataTypeProvider`

⚠️ Note: Some issues were discovered and fixed in the Pull Request Title Validation and Commit Message Validation scripts.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other: Column type change

Updates/remove existing public API methods:
- [x] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [x] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
