### PR TITLE
refactor: EXPOSED-728 [SQLite] Remove ENABLE_UPDATE_DELETE_LIMIT metadata check from core function provider

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3627,6 +3627,7 @@ public abstract class org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMe
 	public abstract fun resetCurrentScheme ()V
 	public abstract fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public abstract fun sequences ()Ljava/util/List;
+	public abstract fun supportsLimitWithUpdateOrDelete ()Z
 	public abstract fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
 	public abstract fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
 }
@@ -3922,6 +3923,7 @@ public abstract interface class org/jetbrains/exposed/sql/vendors/DatabaseDialec
 	public abstract fun sequenceExists (Lorg/jetbrains/exposed/sql/Sequence;)Z
 	public abstract fun sequences ()Ljava/util/List;
 	public abstract fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
+	public abstract fun supportsLimitWithUpdateOrDelete ()Z
 	public abstract fun supportsSelectForUpdate ()Z
 	public abstract fun tableColumns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public abstract fun tableExists (Lorg/jetbrains/exposed/sql/Table;)Z
@@ -4289,6 +4291,7 @@ public class org/jetbrains/exposed/sql/vendors/PostgreSQLDialect : org/jetbrains
 	public fun listDatabases ()Ljava/lang/String;
 	public fun modifyColumn (Lorg/jetbrains/exposed/sql/Column;Lorg/jetbrains/exposed/sql/ColumnDiff;)Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
+	public fun supportsLimitWithUpdateOrDelete ()Z
 }
 
 public final class org/jetbrains/exposed/sql/vendors/PostgreSQLDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
@@ -4355,6 +4358,7 @@ public class org/jetbrains/exposed/sql/vendors/SQLiteDialect : org/jetbrains/exp
 	public fun getSupportsWindowFrameGroupsMode ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/sql/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
+	public fun supportsLimitWithUpdateOrDelete ()Z
 }
 
 public final class org/jetbrains/exposed/sql/vendors/SQLiteDialect$Companion : org/jetbrains/exposed/sql/vendors/VendorDialect$DialectNameProvider {
@@ -4434,6 +4438,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/VendorDialect : org/jetb
 	public fun sequenceExists (Lorg/jetbrains/exposed/sql/Sequence;)Z
 	public fun sequences ()Ljava/util/List;
 	public fun setSchema (Lorg/jetbrains/exposed/sql/Schema;)Ljava/lang/String;
+	public fun supportsLimitWithUpdateOrDelete ()Z
 	public fun supportsSelectForUpdate ()Z
 	public fun tableColumns ([Lorg/jetbrains/exposed/sql/Table;)Ljava/util/Map;
 	public fun tableExists (Lorg/jetbrains/exposed/sql/Table;)Z

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Queries.kt
@@ -7,21 +7,6 @@ import org.jetbrains.exposed.sql.statements.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.SQLServerDialect
 import org.jetbrains.exposed.sql.vendors.currentDialect
-import kotlin.collections.ArrayList
-import kotlin.collections.Iterable
-import kotlin.collections.Iterator
-import kotlin.collections.List
-import kotlin.collections.emptyList
-import kotlin.collections.filter
-import kotlin.collections.first
-import kotlin.collections.forEach
-import kotlin.collections.isNotEmpty
-import kotlin.collections.last
-import kotlin.collections.listOf
-import kotlin.collections.orEmpty
-import kotlin.collections.plus
-import kotlin.collections.plusAssign
-import kotlin.collections.putAll
 import kotlin.sequences.Sequence
 
 @Deprecated(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/statements/api/ExposedDatabaseMetadata.kt
@@ -51,6 +51,9 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     /** Whether the database supports `SELECT FOR UPDATE` statements. */
     abstract val supportsSelectForUpdate: Boolean
 
+    /** Whether the database supports the `LIMIT` clause with update and delete statements. */
+    abstract fun supportsLimitWithUpdateOrDelete(): Boolean
+
     /** Clears and resets any stored information about the database's current schema to default values. */
     abstract fun resetCurrentScheme()
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/DatabaseDialect.kt
@@ -77,6 +77,9 @@ interface DatabaseDialect {
     /** Returns the allowed maximum sequence value for a dialect, as a [Long]. */
     val sequenceMaxValue: Long get() = Long.MAX_VALUE
 
+    /** Returns `true` if the database supports the `LIMIT` clause with update and delete statements. */
+    fun supportsLimitWithUpdateOrDelete(): Boolean
+
     /** Returns the name of the current database. */
     fun getDatabase(): String
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/PostgreSQL.kt
@@ -225,19 +225,6 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
     }
 
     override fun update(
-        target: Table,
-        columnsAndValues: List<Pair<Column<*>, Any?>>,
-        limit: Int?,
-        where: Op<Boolean>?,
-        transaction: Transaction
-    ): String {
-        if (limit != null) {
-            transaction.throwUnsupportedException("PostgreSQL doesn't support LIMIT in UPDATE clause.")
-        }
-        return super.update(target, columnsAndValues, null, where, transaction)
-    }
-
-    override fun update(
         targets: Join,
         columnsAndValues: List<Pair<Column<*>, Any?>>,
         limit: Int?,
@@ -303,19 +290,6 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
     }
 
     override fun insertValue(columnName: String, queryBuilder: QueryBuilder) { queryBuilder { +"EXCLUDED.$columnName" } }
-
-    override fun delete(
-        ignore: Boolean,
-        table: Table,
-        where: String?,
-        limit: Int?,
-        transaction: Transaction
-    ): String {
-        if (limit != null) {
-            transaction.throwUnsupportedException("PostgreSQL doesn't support LIMIT in DELETE clause.")
-        }
-        return super.delete(ignore, table, where, null, transaction)
-    }
 
     override fun delete(
         ignore: Boolean,
@@ -389,6 +363,8 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
     override val requiresAutoCommitOnCreateDrop: Boolean = true
 
     override val supportsWindowFrameGroupsMode: Boolean = true
+
+    override fun supportsLimitWithUpdateOrDelete(): Boolean = false
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/VendorDialect.kt
@@ -47,6 +47,8 @@ abstract class VendorDialect(
 
     override val supportsMultipleGeneratedKeys: Boolean = true
 
+    override fun supportsLimitWithUpdateOrDelete(): Boolean = true
+
     override fun getDatabase(): String = catalog(TransactionManager.current())
 
     /**

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -58,6 +58,7 @@ public final class org/jetbrains/exposed/sql/statements/jdbc/JdbcDatabaseMetadat
 	public fun resetCurrentScheme ()V
 	public fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/ReferenceOption;
 	public fun sequences ()Ljava/util/List;
+	public fun supportsLimitWithUpdateOrDelete ()Z
 	public fun tableConstraints (Ljava/util/List;)Ljava/util/Map;
 	public fun tableNamesByCurrentSchema (Ljava/util/Map;)Lorg/jetbrains/exposed/sql/vendors/SchemaMetadata;
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -9,7 +9,6 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.like
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
 import org.jetbrains.exposed.sql.tests.currentDialectTest
-import org.jetbrains.exposed.sql.tests.currentTestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.H2Dialect

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -14,17 +14,11 @@ import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.MysqlDialect
-import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Test
 import kotlin.test.assertTrue
 import kotlin.test.expect
 
 class DeleteTests : DatabaseTestsBase() {
-    private val limitNotSupported by lazy {
-        val extra = setOf(TestDB.SQLITE).takeUnless { SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT }.orEmpty()
-        TestDB.ALL_POSTGRES_LIKE + extra
-    }
-
     @Test
     fun testDelete01() {
         withCitiesAndUsers { cities, users, userData ->
@@ -76,7 +70,7 @@ class DeleteTests : DatabaseTestsBase() {
     @Test
     fun testDeleteWithLimit() {
         withCitiesAndUsers { _, _, userData ->
-            if (currentTestDB in limitNotSupported) {
+            if (!currentDialectTest.supportsLimitWithUpdateOrDelete()) {
                 expectException<UnsupportedByDialectException> {
                     userData.deleteWhere(limit = 1) { userData.value eq 20 }
                 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/UpdateTests.kt
@@ -6,19 +6,14 @@ import org.jetbrains.exposed.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
 import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.currentDialectTest
 import org.jetbrains.exposed.sql.tests.currentTestDB
 import org.jetbrains.exposed.sql.tests.shared.assertEquals
 import org.jetbrains.exposed.sql.tests.shared.expectException
-import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 import org.junit.Test
 import kotlin.test.assertTrue
 
 class UpdateTests : DatabaseTestsBase() {
-    private val limitNotSupported by lazy {
-        val extra = setOf(TestDB.SQLITE).takeUnless { SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT }.orEmpty()
-        TestDB.ALL_POSTGRES_LIKE + extra
-    }
-
     @Test
     fun testUpdate01() {
         withCitiesAndUsers { _, users, _ ->
@@ -39,7 +34,7 @@ class UpdateTests : DatabaseTestsBase() {
     @Test
     fun testUpdateWithLimit() {
         withCitiesAndUsers { _, users, _ ->
-            if (currentTestDB in limitNotSupported) {
+            if (!currentDialectTest.supportsLimitWithUpdateOrDelete()) {
                 expectException<UnsupportedByDialectException> {
                     users.update({ users.id like "a%" }, limit = 1) {
                         it[users.id] = "NewName"


### PR DESCRIPTION
#### Description

**Summary of the change**: Deprecate `SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT` and replace with metadata functions that perform the same query, but which can be extracted into separate modules when R2DBC is introduced.

**Detailed description**:
- **Why**:

`SQLiteDialect` has a companion property that sends a low-level JDBC connection query to check if `LIMIT` clause is allowed in either update or delete statements. The latter is only possible if SQLite is built from the source with the compile-time flag `ENABLE_UPDATE_DELETE_LIMIT` enabled ([source docs](https://www.sqlite.org/lang_update.html#optional_limit_and_order_by_clauses)).

In preparation for R2DBC, this query needs to be removed from `exposed-core` so that it can be implemented in both a blocking and non-blocking way.
`FunctionProvider` is not expected to have jdbc vs r2dbc versions. So the metadata check is instead placed in `ExposedDatabaseMetadata` and invoked in `update()` and `delete()` directly, since they will all be extracted to their respective modules.

This was missed from previous refactors because it doesn't use `exec()`.

- **How**:
    - Deprecate  `SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT` 
    - Replace with `DatabaseDialect.supportsLimitWithUpdateOrDelete()`, which calls `ExposedDatabaseMetadata.supportsLimitWithUpdateOrDelete()` to send the same query with SQLite. All other dialects are hard-coded with a boolean value.
    - Remove this check from `SQLiteDialect`'s function provider and place directly in `Table.update()` and `Table.delete` variants.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - refactor
- [X] Deprecation

Affected databases:
- [X] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues
[EXPOSED-728](https://youtrack.jetbrains.com/issue/EXPOSED-728/SQLite-Remove-ENABLEUPDATEDELETELIMIT-metadata-check-from-core-function-provider)
