### PR TITLE
feat: EXPOSED-729 [Oracle] Allow setting limit with DELETE

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/DeleteTests.kt
@@ -22,7 +22,7 @@ import kotlin.test.expect
 class DeleteTests : DatabaseTestsBase() {
     private val limitNotSupported by lazy {
         val extra = setOf(TestDB.SQLITE).takeUnless { SQLiteDialect.ENABLE_UPDATE_DELETE_LIMIT }.orEmpty()
-        TestDB.ALL_POSTGRES_LIKE + TestDB.ALL_ORACLE_LIKE + extra
+        TestDB.ALL_POSTGRES_LIKE + extra
     }
 
     @Test


### PR DESCRIPTION
#### Description

**Summary of the change**: Using `Table.delete(limit = #)` with Oracle no longer throws unsupported exception.

**Detailed description**:
- **Why**:

Oracle does not support the `LIMIT` syntax, but it is still possibly to limit the number of rows on which an update or delete operation takes place. This can be done using the `ROWNUM` [pseudocolumn](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/ROWNUM-Pseudocolumn.html), which is the current implementation for `Table.update(limit = #)`. For some reason, this syntax was never extended to `DELETE`.

- **How**:
    - Extract common string building logic to private function
    - Use the above in `delete()` instead of throwing

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Feature - dialect extension

Affected databases:
- [X] Oracle

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)

---

#### Related Issues
[EXPOSED-729](https://youtrack.jetbrains.com/issue/EXPOSED-729/Oracle-Allow-setting-limit-with-DELETE)