### PR TITLE
fix: EXPOSED-737 Timestamp column broken for MySQL 8.0

### DIFF
--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/sql/kotlin/datetime/KotlinDateColumnType.kt
@@ -6,6 +6,7 @@ import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.ColumnType
 import org.jetbrains.exposed.sql.IDateColumnType
 import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
 import java.sql.ResultSet
 import java.time.OffsetDateTime
@@ -393,12 +394,13 @@ class KotlinInstantColumnType : ColumnType<Instant>(), IDateColumnType {
         return rs.getTimestamp(index)
     }
 
+    @Suppress("MagicNumber")
     override fun notNullValueToDB(value: Instant): Any {
         val dialect = currentDialect
         return when {
             dialect is SQLiteDialect ->
                 SQLITE_AND_ORACLE_TIMESTAMP_STRING_FORMATTER.format(value.toJavaInstant())
-            dialect is MysqlDialect && dialect !is MariaDBDialect -> {
+            dialect is MysqlDialect && dialect !is MariaDBDialect && !TransactionManager.current().db.isVersionCovers(8, 0) -> {
                 val formatter = if (dialect.isFractionDateTimeSupported()) MYSQL_FRACTION_TIMESTAMP_STRING_FORMATTER else MYSQL_TIMESTAMP_STRING_FORMATTER
                 formatter.format(value.toJavaInstant())
             }


### PR DESCRIPTION
**Detailed description**:
- **Why**:
In this [PR](https://github.com/JetBrains/Exposed/pull/2386), I modified the notNullValueToDB function to return the formatted String for MySQL (excluding MariaDB) because there was an issue with MySQL 5 where it implicitly converted the value to the session time zone when storing it and lead to an unexpected behaviour when the value is retrieved. This should have been done for MySQL 5 only and not for MySQL 8.0. This commit fixes that.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
