### PR TITLE
fix: EXPOSED-713 Allow entity batchInsert() to generate SQL for column values that match the default

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -389,14 +389,12 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
         } finally {
             entityCache.finishEntityInitialization(prototype)
         }
-        if (entityId._value == null) {
-            val readValues = prototype._readValues!!
-            val writeValues = prototype.writeValues
-            table.columns.filter { col ->
-                col.defaultValueFun != null && col !in writeValues && readValues.hasValue(col)
-            }.forEach { col ->
-                writeValues[col as Column<Any?>] = readValues[col]
-            }
+        val readValues = prototype._readValues!!
+        val writeValues = prototype.writeValues
+        table.columns.filter { col ->
+            col.defaultValueFun != null && col !in writeValues && readValues.hasValue(col)
+        }.forEach { col ->
+            writeValues[col as Column<Any?>] = readValues[col]
         }
         entityCache.scheduleInsert(this, prototype)
         return prototype


### PR DESCRIPTION
#### Description

**Summary of the change**: Changed the new function for Entities under EntityClass to explicitly insert default values (when provided for columns that have default values) even when an ID is provided. This should not have any impact other than the generated SQL explicitly including columns with default values if they are specified.

**Detailed description**:
- **What**: Entity insertion via new will generate SQL that will explicitly insert columns whose values match their default value.
- **Why**: To align the DAO SQL generation with the DSL, which will explicitly insert columns whose values match their default value.
- **How**: Removed an _if_ statement that prevented explicit insertion if an ID was provided to the new() function

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
