### PR TITLE
feat!: EXPOSED-740  Add support for modes (SKIP LOCKED or NOWAIT) with ForUpdate and ForShare Option for MySQL

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3985,6 +3985,15 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdate :
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateBase : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
+	public fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateOrShareMode;[Lorg/jetbrains/exposed/sql/Table;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateOrShareMode;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getQuerySuffix ()Ljava/lang/String;
+}
+
+public abstract interface class org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateOrShareMode {
+}
+
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MariaDB {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MariaDB;
 }
@@ -4000,11 +4009,18 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL;
 }
 
-public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
-	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateBase {
+	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare$Companion;
+	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;[Lorg/jetbrains/exposed/sql/Table;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare$Companion : org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare {
+}
+
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdate : org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateBase {
+	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;[Lorg/jetbrains/exposed/sql/Table;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$LockInShareMode : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
@@ -4012,6 +4028,15 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$LockI
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE : java/lang/Enum, org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateOrShareMode {
+	public static final field NO_WAIT Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
+	public static final field SKIP_LOCKED Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getStatement ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
+	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$Oracle {
@@ -4033,7 +4058,7 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL 
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL;
 }
 
-public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForKeyShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForUpdateBase {
+public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForKeyShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateBase {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForKeyShare$Companion;
 	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4042,7 +4067,7 @@ public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForKey
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForKeyShare$Companion : org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForKeyShare {
 }
 
-public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForNoKeyUpdate : org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForUpdateBase {
+public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForNoKeyUpdate : org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateBase {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForNoKeyUpdate$Companion;
 	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4051,7 +4076,7 @@ public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForNoK
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForNoKeyUpdate$Companion : org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForNoKeyUpdate {
 }
 
-public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForUpdateBase {
+public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateBase {
 	public static final field Companion Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForShare$Companion;
 	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4060,18 +4085,12 @@ public class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForSha
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForShare$Companion : org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForShare {
 }
 
-public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForUpdate : org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForUpdateBase {
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForUpdate : org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateBase {
 	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$ForUpdateBase : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
-	public fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;)V
-	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;[Lorg/jetbrains/exposed/sql/Table;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getQuerySuffix ()Ljava/lang/String;
-}
-
-public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE : java/lang/Enum {
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE : java/lang/Enum, org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateOrShareMode {
 	public static final field NO_WAIT Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 	public static final field SKIP_LOCKED Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3992,6 +3992,7 @@ public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdat
 }
 
 public abstract interface class org/jetbrains/exposed/sql/vendors/ForUpdateOption$ForUpdateOrShareMode {
+	public abstract fun getStatement ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MariaDB {
@@ -4034,7 +4035,7 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE 
 	public static final field NO_WAIT Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
 	public static final field SKIP_LOCKED Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public final fun getStatement ()Ljava/lang/String;
+	public fun getStatement ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
 }
@@ -4094,7 +4095,7 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$
 	public static final field NO_WAIT Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 	public static final field SKIP_LOCKED Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public final fun getStatement ()Ljava/lang/String;
+	public fun getStatement ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$PostgreSQL$MODE;
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/ForUpdateOption.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/vendors/ForUpdateOption.kt
@@ -14,7 +14,9 @@ sealed class ForUpdateOption(open val querySuffix: String) {
     }
 
     /** Interface that can be implemented in each database if they support modes **/
-    sealed interface ForUpdateOrShareMode
+    interface ForUpdateOrShareMode {
+        val statement: String
+    }
 
     /** Common class since this is being used by at least two DBs **/
     abstract class ForUpdateBase(
@@ -29,11 +31,7 @@ sealed class ForUpdateOption(open val querySuffix: String) {
                 tables.joinTo(this, separator = ",") { it.tableName }
             }
             mode?.let {
-                val statement = when (it) {
-                    is PostgreSQL.MODE -> it.statement
-                    is MySQL.MODE -> it.statement
-                }
-                append(" $statement")
+                append(" ${it.statement}")
             }
         }
         final override val querySuffix: String = preparedQuerySuffix
@@ -46,7 +44,7 @@ sealed class ForUpdateOption(open val querySuffix: String) {
     object MySQL {
         /** Optional modes that determine what should happen if the retrieved rows are not immediately available. */
         // https://dev.mysql.com/doc/refman/8.4/en/select.html
-        enum class MODE(val statement: String) : ForUpdateOrShareMode {
+        enum class MODE(override val statement: String) : ForUpdateOrShareMode {
             /** Indicates that an error should be reported. */
             NO_WAIT("NOWAIT"),
 
@@ -82,7 +80,7 @@ sealed class ForUpdateOption(open val querySuffix: String) {
     // https://www.postgresql.org/docs/12/explicit-locking.html#LOCKING-ROWS for clarification
     object PostgreSQL {
         /** Optional modes that determine what should happen if the retrieved rows are not immediately available. */
-        enum class MODE(val statement: String) : ForUpdateOrShareMode {
+        enum class MODE(override val statement: String) : ForUpdateOrShareMode {
             /** Indicates that an error should be reported. */
             NO_WAIT("NOWAIT"),
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/mysql/MysqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/mysql/MysqlTests.kt
@@ -146,6 +146,17 @@ class MysqlTests : DatabaseTestsBase() {
             val name = varchar("name", 50)
         }
 
+        fun Transaction.withTable(statement: Transaction.() -> Unit) {
+            SchemaUtils.create(table)
+            try {
+                statement()
+                commit() // Need commit to persist data before drop tables
+            } finally {
+                SchemaUtils.drop(table)
+                commit()
+            }
+        }
+
         val id = 1
 
         fun Query.city() = map { it[table.name] }.single()
@@ -154,8 +165,8 @@ class MysqlTests : DatabaseTestsBase() {
             return table.selectAll().where { table.id eq id }.forUpdate(option).city()
         }
 
-        withDb(TestDB.ALL_MYSQL) {
-            withTables {
+        withDb(TestDB.MYSQL_V8) {
+            withTable {
                 val name = "name"
                 table.insert {
                     it[table.id] = id

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
@@ -33,35 +33,33 @@ class PostgresqlTests : DatabaseTestsBase() {
             return table.selectAll().where { table.id eq id }.forUpdate(option).city()
         }
 
-        withDb(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
-            withTable {
-                val name = "name"
-                table.insert {
-                    it[table.id] = id
-                    it[table.name] = name
-                }
-                commit()
-
-                val defaultForUpdateRes = table.selectAll().where { table.id eq id }.city()
-                val forUpdateRes = select(ForUpdateOption.ForUpdate)
-                val forUpdateOfTableRes = select(PostgreSQL.ForUpdate(ofTables = arrayOf(table)))
-                val forShareRes = select(PostgreSQL.ForShare)
-                val forShareNoWaitOfTableRes = select(PostgreSQL.ForShare(PostgreSQL.MODE.NO_WAIT, table))
-                val forKeyShareRes = select(PostgreSQL.ForKeyShare)
-                val forKeyShareSkipLockedRes = select(PostgreSQL.ForKeyShare(PostgreSQL.MODE.SKIP_LOCKED))
-                val forNoKeyUpdateRes = select(PostgreSQL.ForNoKeyUpdate)
-                val notForUpdateRes = table.selectAll().where { table.id eq id }.notForUpdate().city()
-
-                assertEquals(name, defaultForUpdateRes)
-                assertEquals(name, forUpdateRes)
-                assertEquals(name, forUpdateOfTableRes)
-                assertEquals(name, forShareRes)
-                assertEquals(name, forShareNoWaitOfTableRes)
-                assertEquals(name, forKeyShareRes)
-                assertEquals(name, forKeyShareSkipLockedRes)
-                assertEquals(name, forNoKeyUpdateRes)
-                assertEquals(name, notForUpdateRes)
+        withTables(excludeSettings = TestDB.ALL - listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG), table) {
+            val name = "name"
+            table.insert {
+                it[table.id] = id
+                it[table.name] = name
             }
+            commit()
+
+            val defaultForUpdateRes = table.selectAll().where { table.id eq id }.city()
+            val forUpdateRes = select(ForUpdateOption.ForUpdate)
+            val forUpdateOfTableRes = select(PostgreSQL.ForUpdate(ofTables = arrayOf(table)))
+            val forShareRes = select(PostgreSQL.ForShare)
+            val forShareNoWaitOfTableRes = select(PostgreSQL.ForShare(PostgreSQL.MODE.NO_WAIT, table))
+            val forKeyShareRes = select(PostgreSQL.ForKeyShare)
+            val forKeyShareSkipLockedRes = select(PostgreSQL.ForKeyShare(PostgreSQL.MODE.SKIP_LOCKED))
+            val forNoKeyUpdateRes = select(PostgreSQL.ForNoKeyUpdate)
+            val notForUpdateRes = table.selectAll().where { table.id eq id }.notForUpdate().city()
+
+            assertEquals(name, defaultForUpdateRes)
+            assertEquals(name, forUpdateRes)
+            assertEquals(name, forUpdateOfTableRes)
+            assertEquals(name, forShareRes)
+            assertEquals(name, forShareNoWaitOfTableRes)
+            assertEquals(name, forKeyShareRes)
+            assertEquals(name, forKeyShareSkipLockedRes)
+            assertEquals(name, forNoKeyUpdateRes)
+            assertEquals(name, notForUpdateRes)
         }
     }
 
@@ -113,17 +111,6 @@ class PostgresqlTests : DatabaseTestsBase() {
             }
 
             SchemaUtils.drop(tester1)
-        }
-    }
-
-    private fun Transaction.withTable(statement: Transaction.() -> Unit) {
-        SchemaUtils.create(table)
-        try {
-            statement()
-            commit() // Need commit to persist data before drop tables
-        } finally {
-            SchemaUtils.drop(table)
-            commit()
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Adds the `SKIP LOCKED` and `NO WAIT` modes when using `SELECT ... FOR UPDATE`. Also adds tests to make sure that the queries are generated as expected.  Breaking change: Moved ForUpdateBase outside Postgres.

**Detailed description**:
- **What**: 
  - Added the `MODE` option for MySQL, that can be used to define modes for ForUpdate and ForShare.
  - Refactored the ForUpdateOption class so that some of the methods are available across DBs
  - The ForUpdateBase class has been moved out of Postgres, which is a breaking change.
  - Mostly repackages the tests for Postgres.

- **Why**: 
  - Since MySQL 8.0.1, there has been support for ForUpdate and ForShare modes. 
  - https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html
  - However, the implementation only supported it for Postgres.
  - For work, I've been having to use raw SQL when I needed the functionality. This would help avoid the need for that for myself as well as others.

- **How**: 
  - I'm new to the repo (and Kotlin), so I tried to make sure I minimize the amount of code I touched. 
  - `ForUpdateBase` was moved outside the Postgres implementation to make it available for MySQL as well.
  - Introduced a sealed interface which allows us to define the enum in different DBs accordingly. All DBs do not always support all the modes we have.
  - Since we use an enum, I could not use a `sealed class`, and there is some conditional logic to get statements in `ForUpdateOption`. 

---

#### Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [X] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
- https://youtrack.jetbrains.com/issue/EXPOSED-740/MySQL-Add-support-for-modes-skip-locked-or-no-wait-with-For-Update-Option