### PR TITLE
fix: support actively cached null values in entity-local cache

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/Entity.kt
@@ -113,6 +113,10 @@ open class Entity<ID : Any>(val id: EntityID<ID>) {
         return referenceCache[ref] as T
     }
 
+    internal fun hasInReferenceCache(ref: Column<*>): Boolean {
+        return ref in referenceCache
+    }
+
     internal fun storeReferenceInCache(ref: Column<*>, value: Any?) {
         if (db.config.keepLoadedReferencesOutOfTransaction) {
             referenceCache[ref] = value

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/EntityReferenceCacheTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/h2/EntityReferenceCacheTest.kt
@@ -120,6 +120,28 @@ class EntityReferenceCacheTest : DatabaseTestsBase() {
     }
 
     @Test
+    fun `test optionalBackReferencedOn and optionalReferencedOn work when value is missing`() {
+        var y1: EntityTestsData.YEntity by Delegates.notNull()
+        var b1: EntityTestsData.BEntity by Delegates.notNull()
+        executeOnH2(EntityTestsData.XTable, EntityTestsData.YTable) {
+            transaction(db) {
+                y1 = EntityTestsData.YEntity.new {}
+                b1 = EntityTestsData.BEntity.new {}
+            }
+
+            transaction(dbWithCache) {
+                y1.refresh()
+                b1.refresh()
+                y1.load(EntityTestsData.YEntity::bOpt)
+                b1.load(EntityTestsData.BEntity::y)
+            }
+
+            assertNull(y1.bOpt)
+            assertNull(b1.y)
+        }
+    }
+
+    @Test
     fun `test referenceOn works out of transaction via with`() {
         var b1: EntityTests.Board by Delegates.notNull()
         var p1: EntityTests.Post by Delegates.notNull()


### PR DESCRIPTION
#### Description

**Summary of the change**: Provide a concise summary of this PR. Describe the changes made in a single sentence or short paragraph.

**Detailed description**:
- **What**: Attempt at supporting actively cached `null` values for optional references instead of throwing exceptions
- **Why**: This was surfaced in an issue (linked below)
- **How**: In the case an entity-cached value comes back as `null`, we distinguish between whether the `Entity.referenceCache` contains the key or not. If it actively cached the value `null` for the key, then return an empty reference rather than crash

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

https://youtrack.jetbrains.com/issue/EXPOSED-739/EXPOSED-704-introduced-a-bug-for-referrersOn-if-no-child-references-reference-the-entity
