### PR TITLE
feat: EXPOSED-740 [MySQL] Add support for modes (skip locked or no wait) with For Update Option

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -4000,11 +4000,30 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL {
 	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL;
 }
 
-public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
-	public static final field INSTANCE Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare : org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdateBase {
+	public static final field Default Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare$Default;
+	public fun <init> ()V
+	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForShare$Default : org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdateBase {
+}
+
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdate : org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdateBase {
+	public static final field Default Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdate$Default;
+	public fun <init> ()V
+	public fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdate$Default : org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdateBase {
+}
+
+public abstract class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$ForUpdateBase : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
+	public fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getQuerySuffix ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$LockInShareMode : org/jetbrains/exposed/sql/vendors/ForUpdateOption {
@@ -4012,6 +4031,15 @@ public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$LockI
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE : java/lang/Enum {
+	public static final field NO_WAIT Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
+	public static final field SKIP_LOCKED Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getStatement ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
+	public static fun values ()[Lorg/jetbrains/exposed/sql/vendors/ForUpdateOption$MySQL$MODE;
 }
 
 public final class org/jetbrains/exposed/sql/vendors/ForUpdateOption$Oracle {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/postgresql/PostgresqlTests.kt
@@ -33,35 +33,33 @@ class PostgresqlTests : DatabaseTestsBase() {
             return table.selectAll().where { table.id eq id }.forUpdate(option).city()
         }
 
-        withDb(listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG)) {
-            withTable {
-                val name = "name"
-                table.insert {
-                    it[table.id] = id
-                    it[table.name] = name
-                }
-                commit()
-
-                val defaultForUpdateRes = table.selectAll().where { table.id eq id }.city()
-                val forUpdateRes = select(ForUpdateOption.ForUpdate)
-                val forUpdateOfTableRes = select(PostgreSQL.ForUpdate(ofTables = arrayOf(table)))
-                val forShareRes = select(PostgreSQL.ForShare)
-                val forShareNoWaitOfTableRes = select(PostgreSQL.ForShare(PostgreSQL.MODE.NO_WAIT, table))
-                val forKeyShareRes = select(PostgreSQL.ForKeyShare)
-                val forKeyShareSkipLockedRes = select(PostgreSQL.ForKeyShare(PostgreSQL.MODE.SKIP_LOCKED))
-                val forNoKeyUpdateRes = select(PostgreSQL.ForNoKeyUpdate)
-                val notForUpdateRes = table.selectAll().where { table.id eq id }.notForUpdate().city()
-
-                assertEquals(name, defaultForUpdateRes)
-                assertEquals(name, forUpdateRes)
-                assertEquals(name, forUpdateOfTableRes)
-                assertEquals(name, forShareRes)
-                assertEquals(name, forShareNoWaitOfTableRes)
-                assertEquals(name, forKeyShareRes)
-                assertEquals(name, forKeyShareSkipLockedRes)
-                assertEquals(name, forNoKeyUpdateRes)
-                assertEquals(name, notForUpdateRes)
+        withTables(excludeSettings = TestDB.ALL - listOf(TestDB.POSTGRESQL, TestDB.POSTGRESQLNG), table) {
+            val name = "name"
+            table.insert {
+                it[table.id] = id
+                it[table.name] = name
             }
+            commit()
+
+            val defaultForUpdateRes = table.selectAll().where { table.id eq id }.city()
+            val forUpdateRes = select(ForUpdateOption.ForUpdate)
+            val forUpdateOfTableRes = select(PostgreSQL.ForUpdate(ofTables = arrayOf(table)))
+            val forShareRes = select(PostgreSQL.ForShare)
+            val forShareNoWaitOfTableRes = select(PostgreSQL.ForShare(PostgreSQL.MODE.NO_WAIT, table))
+            val forKeyShareRes = select(PostgreSQL.ForKeyShare)
+            val forKeyShareSkipLockedRes = select(PostgreSQL.ForKeyShare(PostgreSQL.MODE.SKIP_LOCKED))
+            val forNoKeyUpdateRes = select(PostgreSQL.ForNoKeyUpdate)
+            val notForUpdateRes = table.selectAll().where { table.id eq id }.notForUpdate().city()
+
+            assertEquals(name, defaultForUpdateRes)
+            assertEquals(name, forUpdateRes)
+            assertEquals(name, forUpdateOfTableRes)
+            assertEquals(name, forShareRes)
+            assertEquals(name, forShareNoWaitOfTableRes)
+            assertEquals(name, forKeyShareRes)
+            assertEquals(name, forKeyShareSkipLockedRes)
+            assertEquals(name, forNoKeyUpdateRes)
+            assertEquals(name, notForUpdateRes)
         }
     }
 
@@ -113,17 +111,6 @@ class PostgresqlTests : DatabaseTestsBase() {
             }
 
             SchemaUtils.drop(tester1)
-        }
-    }
-
-    private fun Transaction.withTable(statement: Transaction.() -> Unit) {
-        SchemaUtils.create(table)
-        try {
-            statement()
-            commit() // Need commit to persist data before drop tables
-        } finally {
-            SchemaUtils.drop(table)
-            commit()
         }
     }
 }


### PR DESCRIPTION
#### Description

**Detailed description**:
- **What**: Add support for `SKIP LOCKED` and `NO WAIT` options for update on MySQL 8.
- **Why**: It was added on the database side in version 8.0.1, but we don't support it (but we support it for Postgres)
- **How**: Add missed options for MySQL in the similar way like for Postgres.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Affected databases:
- [X] Mysql8

---

#### Related Issues

[EXPOSED-740](https://youtrack.jetbrains.com/issue/EXPOSED-740) [MySQL] Add support for modes (skip locked or no wait) with For Update Option
