### PR TITLE
feat: EXPOSED-742 Allow customizing the CHECK constraint name of `long()` column

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2633,7 +2633,8 @@ public class org/jetbrains/exposed/sql/Table : org/jetbrains/exposed/sql/ColumnS
 	public final fun largeText (Ljava/lang/String;Ljava/lang/String;Z)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun largeText$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public fun leftJoin (Lorg/jetbrains/exposed/sql/ColumnSet;)Lorg/jetbrains/exposed/sql/Join;
-	public final fun long (Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public final fun long (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/exposed/sql/Column;
+	public static synthetic fun long$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public final fun mediumText (Ljava/lang/String;Ljava/lang/String;Z)Lorg/jetbrains/exposed/sql/Column;
 	public static synthetic fun mediumText$default (Lorg/jetbrains/exposed/sql/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lorg/jetbrains/exposed/sql/Column;
 	public fun modifyStatement ()Ljava/util/List;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -757,9 +757,11 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
         check(checkConstraintName ?: "$generatedUnsignedCheckPrefix${this.unquotedName()}") { it.between(0u, UInt.MAX_VALUE) }
     }
 
-    /** Creates a numeric column, with the specified [name], for storing 8-byte integers. */
-    fun long(name: String): Column<Long> = registerColumn(name, LongColumnType()).apply {
-        check("${generatedSignedCheckPrefix}long_${this.unquotedName()}") { it.between(Long.MIN_VALUE, Long.MAX_VALUE) }
+    /** Creates a numeric column, with the specified [name], for storing 8-byte integers.
+     * An optional [checkConstraintName] can be passed to allow customizing the check constraint name when needed.
+     */
+    fun long(name: String, checkConstraintName: String? = null): Column<Long> = registerColumn(name, LongColumnType()).apply {
+        check(checkConstraintName ?: "${generatedSignedCheckPrefix}long_${this.unquotedName()}") { it.between(Long.MIN_VALUE, Long.MAX_VALUE) }
     }
 
     /** Creates a numeric column, with the specified [name], for storing 8-byte unsigned integers.

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/NumericColumnTypesTests.kt
@@ -205,6 +205,7 @@ class NumericColumnTypesTests : DatabaseTestsBase() {
             val ushort = ushort("ushort_column", checkConstraintName = "custom_ushort_check")
             val integer = integer("integer_column", checkConstraintName = "custom_integer_check")
             val uinteger = uinteger("uinteger_column", checkConstraintName = "custom_uinteger_check")
+            val long = long("long_column", checkConstraintName = "custom_long_check")
         }
 
         withTables(tester) {
@@ -216,12 +217,14 @@ class NumericColumnTypesTests : DatabaseTestsBase() {
                     "${tester.ushort.nameInDatabaseCase()} ${tester.ushort.columnType} NOT NULL, " +
                     "${tester.integer.nameInDatabaseCase()} ${tester.integer.columnType} NOT NULL, " +
                     "${tester.uinteger.nameInDatabaseCase()} ${tester.uinteger.columnType} NOT NULL, " +
+                    "${tester.long.nameInDatabaseCase()} ${tester.long.columnType} NOT NULL, " +
                     "CONSTRAINT custom_byte_check CHECK (${tester.byte.nameInDatabaseCase()} BETWEEN ${Byte.MIN_VALUE} AND ${Byte.MAX_VALUE}), " +
                     "CONSTRAINT custom_ubyte_check CHECK (${tester.ubyte.nameInDatabaseCase()} BETWEEN 0 AND ${UByte.MAX_VALUE}), " +
                     "CONSTRAINT custom_short_check CHECK (${tester.short.nameInDatabaseCase()} BETWEEN ${Short.MIN_VALUE} AND ${Short.MAX_VALUE}), " +
                     "CONSTRAINT custom_ushort_check CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
                     "CONSTRAINT custom_integer_check CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
-                    "CONSTRAINT custom_uinteger_check CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}))",
+                    "CONSTRAINT custom_uinteger_check CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}), " +
+                    "CONSTRAINT custom_long_check CHECK (${tester.long.nameInDatabaseCase()} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE}))",
                 tester.ddl
             )
         }


### PR DESCRIPTION
#### Description

- **Why**: Because the length limit of identifiers is being reached sometimes with the CHECK constraint name that Exposed generates, so it is useful for users sometimes to be in control of the name.
- **How**: Added a nullable String parameter `checkConstraintName` to `long()` column.

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
