### PR TITLE
fix: EXPOSED-744 Consume InsertSuspendExecutable row count and results from single Result

### DIFF
--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/dml/InsertTests.kt
@@ -1,0 +1,193 @@
+package org.jetbrains.exposed.sql.tests.shared.dml
+
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.singleOrNull
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.r2dbc.sql.exists
+import org.jetbrains.exposed.r2dbc.sql.insert
+import org.jetbrains.exposed.r2dbc.sql.insertAndGetId
+import org.jetbrains.exposed.r2dbc.sql.selectAll
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.stringLiteral
+import org.jetbrains.exposed.sql.substring
+import org.jetbrains.exposed.sql.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.jetbrains.exposed.sql.tests.shared.assertFailAndRollback
+import org.jetbrains.exposed.sql.trim
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class InsertTests : R2dbcDatabaseTestsBase() {
+    // Sanity check to ensure previous DDL tests still pass
+    @Test
+    fun tableExists() = runTest {
+        val testTable = object : Table() {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(testTable) {
+            assertEquals(true, testTable.exists())
+        }
+    }
+
+    @Test
+    fun testInsertAndGetId() = runTest {
+        val idTable = object : IntIdTable("tmp") {
+            val name = varchar("foo", 10).uniqueIndex()
+        }
+
+        withTables(idTable) {
+            idTable.insertAndGetId {
+                it[idTable.name] = "1"
+            }
+
+            assertEquals(1L, idTable.selectAll().count())
+
+            idTable.insertAndGetId {
+                it[idTable.name] = "2"
+            }
+
+            assertEquals(2L, idTable.selectAll().count())
+
+            assertFailAndRollback("Unique constraint") {
+                idTable.insertAndGetId {
+                    it[idTable.name] = "2"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test insert and get id when column has different name and get value by id column`() = runTest {
+        val testTableWithId = object : IdTable<Int>("testTableWithId") {
+            val code = integer("code")
+            override val id = code.entityId()
+        }
+
+        withTables(testTableWithId) {
+            val id1 = testTableWithId.insertAndGetId {
+                it[code] = 1
+            }
+            assertNotNull(id1)
+            assertEquals(1, id1.value)
+
+            val id2 = testTableWithId.insert {
+                it[code] = 2
+            } get testTableWithId.id
+            assertNotNull(id2)
+            assertEquals(2, id2.value)
+        }
+    }
+
+    @Test
+    fun `test id and column have different names and get value by original column`() = runTest {
+        val exampleTable = object : IdTable<String>("test_id_and_column_table") {
+            val exampleColumn = varchar("example_column", 200)
+            override val id = exampleColumn.entityId()
+        }
+
+        withTables(exampleTable) {
+            val value = "value"
+            exampleTable.insert {
+                it[exampleColumn] = value
+            }
+
+            val resultValues: List<String> = exampleTable.selectAll().map { it[exampleTable.exampleColumn] }.toList()
+
+            assertEquals(value, resultValues.first())
+        }
+    }
+
+    object LongIdTable : Table() {
+        val id = long("id").autoIncrement()
+        val name = text("name")
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    @Test
+    fun testGeneratedKey() = runTest {
+        withTables(LongIdTable) {
+            val id = LongIdTable.insert {
+                it[LongIdTable.name] = "Foo"
+            } get LongIdTable.id
+
+            assertEquals(1, LongIdTable.selectAll().count())
+            assertEquals(LongIdTable.selectAll().last()[LongIdTable.id], id)
+        }
+    }
+
+    @Test
+    fun testInsertWithPredefinedId() = runTest {
+        val stringTable = object : IdTable<String>("stringTable") {
+            override val id = varchar("id", 15).entityId()
+            val name = varchar("name", 10)
+        }
+        withTables(stringTable) {
+            val entityID = EntityID("id1", stringTable)
+            val id1 = stringTable.insertAndGetId {
+                it[id] = entityID
+                it[name] = "foo"
+            }
+
+            stringTable.insertAndGetId {
+                it[id] = EntityID("testId", stringTable)
+                it[name] = "bar"
+            }
+
+            assertEquals(id1, entityID)
+            val row1 = stringTable.selectAll().where { stringTable.id eq entityID }.singleOrNull()
+            assertEquals(row1?.get(stringTable.id), entityID)
+
+            val row2 = stringTable.selectAll().where { stringTable.id like "id%" }.singleOrNull()
+            assertEquals(row2?.get(stringTable.id), entityID)
+        }
+    }
+
+    @Test
+    fun testInsertWithExpression() = runTest {
+        val tbl = object : IntIdTable("testInsert") {
+            val nullableInt = integer("nullableIntCol").nullable()
+            val string = varchar("stringCol", 20)
+        }
+
+        fun expression(value: String) = stringLiteral(value).trim().substring(2, 4)
+
+        suspend fun verify(value: String) {
+            val row = tbl.selectAll().where { tbl.string eq value }.single()
+            assertEquals(row[tbl.string], value)
+        }
+
+        withTables(tbl) {
+            tbl.insert {
+                it[string] = expression(" _exp1_ ")
+            }
+
+            verify("exp1")
+
+            tbl.insert {
+                it[string] = expression(" _exp2_ ")
+                it[nullableInt] = 5
+            }
+
+            verify("exp2")
+
+            tbl.insert {
+                it[string] = expression(" _exp3_ ")
+                it[nullableInt] = null
+            }
+
+            verify("exp3")
+        }
+    }
+}

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/sql/Query.kt
@@ -276,7 +276,9 @@ open class Query(
         try {
             if (!isForUpdate()) limit = 1
             val rs = transaction.exec(this) as R2dbcResult
-            return rs.result.awaitFirstOrNull() != null
+            return rs.result.awaitFirstOrNull()
+                ?.map { _, rm -> rm.columnMetadatas.firstOrNull() }
+                ?.awaitFirstOrNull() == null
         } finally {
             limit = oldLimit
         }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/r2dbc/R2dbcPreparedStatementImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/sql/statements/r2dbc/R2dbcPreparedStatementImpl.kt
@@ -4,10 +4,7 @@ import io.r2dbc.spi.Connection
 import io.r2dbc.spi.Parameters
 import io.r2dbc.spi.R2dbcType
 import io.r2dbc.spi.Statement
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.reactive.awaitFirstOrNull
-import kotlinx.coroutines.reactive.collect
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.statements.api.R2dbcPreparedStatementApi
 import java.io.InputStream
@@ -47,12 +44,9 @@ class R2dbcPreparedStatementImpl(
     override suspend fun executeQuery(): R2dbcResult = R2dbcResult(statement.execute())
 
     override suspend fun executeUpdate(): Int {
-        resultRow = R2dbcResult(statement.execute())
-        return flow {
-            resultRow!!.result.collect {
-                emit(it.rowsUpdated.awaitFirstOrNull()?.toInt() ?: 0)
-            }
-        }.single()
+        val result = statement.execute()
+        resultRow = R2dbcResult(result)
+        return result.awaitFirstOrNull()?.rowsUpdated?.awaitFirstOrNull()?.toInt() ?: 0
     }
 
     override fun set(index: Int, value: Any) {


### PR DESCRIPTION
#### Description

**Summary of the change**: Refactor `InsertSuspendExecutable` logic to consume both the affected row count and the generated key results from the same `Result` instance.

**Detailed description**:
- **Why**:

Any test of `insert()` (and its variants) that either counts the number of inserted rows or involves a unique constraint check is failing because these statements are currently being duplicated when executed.

R2DBC does not allow its `Result` to be passed around so conveniently like with JDBC's `ResultSet` & attempting to subscribe or collect from the publisher more than once leads to failures.

Ideally, both retrievals should happen in a single subscription and this works for H2 and MySQL/MariaDB for example, but documentation is unclear about how it can be done. [R2DBC-SPI docs](https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/#results.characteristics) state that it is not always possible:

> After emitting the update count, a Result object gets invalidated and rows from the same Result object can no longer be consumed... Due to its nature, a result allows consumption of either tabular results, out parameters, or an update count but not both. Depending on how the underlying database materializes results, an R2DBC driver can lift this limitation.

There was an [open issue](https://github.com/pgjdbc/r2dbc-postgresql/issues/415) for it, with a response that made it seem like the feature was [added](https://github.com/r2dbc/r2dbc-spi/pull/215), but how exactly to use `Result.filter()` or `Result.flatMap()` is beyond me. More [discussions here](https://github.com/r2dbc/r2dbc-spi/issues/27)

- **How**:

Replaced `executeUpdate()` in `execInsertFunction()` with `executeQuery()` so that an untouched `Result` is returned.
Attempt to filter the result and retrieve both affected row count values and tabular results in same flow.
Retained `executeUpdate()` implementation in `PreparedStatementImpl` to cover cases when plain SQL might be executed:

```kt
exec("INSERT INTO ...") {
    // user should be able to consume result here (for the first time!) as normal
}
```

Fixed `IndexOutOfBounds` exception.
 Fixed cause of failing `empty()` tests.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues
[EXPOSED-744](https://youtrack.jetbrains.com/issue/EXPOSED-744/Consume-InsertStatement-row-count-and-generated-results-from-single-Result)