### PR TITLE
docs: Fix text that says Exposed is not an official JetBrains library

### DIFF
--- a/documentation-website/Writerside/topics/Frequently-Asked-Questions.md
+++ b/documentation-website/Writerside/topics/Frequently-Asked-Questions.md
@@ -2,7 +2,7 @@
 
 ### Q: [Squash](https://github.com/orangy/squash) is same as Exposed. Where is the difference?
 A: [Ilya Ryzhenkov](https://github.com/orangy/) (Squash maintainer) answers:
-> Squash is an attempt to refactor Exposed (long time ago) to fix DSL issues, extensibility on dialect side, support graph fetching and avoid TLS-stored transactions. Unfortunately, I didn’t have enough time to finish the work, but I still hope to return to it some day. We are talking with Exposed maintainer [@tapac](https://github.com/tapac/) about coordinating efforts and eventually joining forces. Note, that none of these libs are “official” JetBrains Kotlin SQL libs, they are both side projects of their respective authors.
+> Squash is an attempt to refactor Exposed (long time ago) to fix DSL issues, extensibility on dialect side, support graph fetching and avoid TLS-stored transactions. Unfortunately, I didn’t have enough time to finish the work, but I still hope to return to it some day. We were talking with Exposed maintainer [@tapac](https://github.com/tapac/) at the time about coordinating efforts and eventually joining forces. Note that Squash is not an “official” JetBrains Kotlin SQL library, but rather a side project of mine.
 
 ### Q: Can I use multiple Database Connections?
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Fix text that says Exposed is not an official JetBrains library

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
