### PR TITLE
fix: EXPOSED-754 Fix Global Rollback Mark Not Set on Unchecked Exception in Spring Transaction

### DIFF
--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
@@ -95,10 +95,11 @@ class SpringTransactionRollbackTest {
                     testRollback.transaction { // inner logicTx start
                         testRollback.insertOriginTable("Tx2")
 
+                        @Suppress("TooGenericExceptionThrown")
                         throw RuntimeException()
                         // isGlobalRollbackOnParticipationFailure == true -> doSetRollbackOnly() -> mark as globalRollBack
                     }
-                } catch (e: Exception) {
+                } catch (@Suppress("SwallowedException") e: RuntimeException) {
                     // something...
                 }
             } // when outer logicTx commit() -> check globalRollBack mark -> throw UnexpectedRollbackException -> rollback
@@ -121,9 +122,10 @@ class SpringTransactionRollbackTest {
                         val innerTx = TransactionManager.currentOrNull()
                         assertFalse(innerTx!!.isMarkedRollback())
 
+                        @Suppress("TooGenericExceptionThrown")
                         throw RuntimeException() // mark as globalRollBack
                     }
-                } catch (e: Exception) {
+                } catch (@Suppress("SwallowedException") e: RuntimeException) {
                     // something...
                 }
 
@@ -141,7 +143,7 @@ class SpringTransactionRollbackTest {
             }
         }
 
-        testRollback.transaction{ // other transaction not affected by previous transaction rollback status
+        testRollback.transaction { // other transaction not affected by previous transaction rollback status
             val newTx = TransactionManager.currentOrNull()
             assertFalse(newTx!!.isMarkedRollback())
         }
@@ -158,9 +160,10 @@ class SpringTransactionRollbackTest {
                 testRollback.transactionWithRequiresNew {
                     testRollback.insertOriginTable("Tx2")
 
+                    @Suppress("TooGenericExceptionThrown")
                     throw RuntimeException()
                 }
-            } catch (e: Exception) {
+            } catch (@Suppress("SwallowedException") e: RuntimeException) {
                 // something...
             }
         }
@@ -175,10 +178,11 @@ class SpringTransactionRollbackTest {
         val testRollback = container.getBean(TestRollback::class.java)
 
         assertFailsWith<RuntimeException> {
-
             // Execute without a transaction -> Should not be rolled back
             testRollback.transactionWithSupports {
                 testRollback.insertOriginTable("No Tx")
+
+                @Suppress("TooGenericExceptionThrown")
                 throw RuntimeException() // Non-transactional, so it should not be rolled back
             }
         }
@@ -187,12 +191,13 @@ class SpringTransactionRollbackTest {
 
         // Execute within a transaction -> Should be rolled back
         assertFailsWith<RuntimeException> {
-
             testRollback.transaction {
                 testRollback.insertOriginTable("With Tx")
 
                 testRollback.transactionWithSupports {
                     testRollback.insertOriginTable("Supports Tx")
+
+                    @Suppress("TooGenericExceptionThrown")
                     throw RuntimeException() // Should trigger rollback
                 }
             }
@@ -213,9 +218,11 @@ class SpringTransactionRollbackTest {
             try {
                 testRollback.transactionWithNotSupported {
                     testRollback.insertOriginTable("No Tx")
+
+                    @Suppress("TooGenericExceptionThrown")
                     throw RuntimeException() // Since it's non-transactional, it won't be rolled back
                 }
-            } catch (e: Exception) {
+            } catch (@Suppress("SwallowedException") e: RuntimeException) {
                 // Ignore exception
             }
         }
@@ -253,9 +260,11 @@ class SpringTransactionRollbackTest {
             try {
                 testRollback.transactionWithNested {
                     testRollback.insertOriginTable("Tx2")
+
+                    @Suppress("TooGenericExceptionThrown")
                     throw RuntimeException() // Rollback only the inner transaction
                 }
-            } catch (e: Exception) {
+            } catch (@Suppress("SwallowedException") e: RuntimeException) {
                 // something...
             }
         }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/spring/SpringTransactionRollbackTest.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.exposed.spring
 
+import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.junit.Test
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean
@@ -13,16 +15,22 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
+import org.springframework.transaction.IllegalTransactionStateException
+import org.springframework.transaction.UnexpectedRollbackException
 import org.springframework.transaction.annotation.EnableTransactionManagement
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import javax.sql.DataSource
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * @author ivan@daangn.com
+ * @author zbqmgldjfh@gmail.com
  */
 class SpringTransactionRollbackTest {
 
@@ -39,8 +47,8 @@ class SpringTransactionRollbackTest {
         val testRollback = container.getBean(TestRollback::class.java)
         assertFailsWith<ExposedSQLException> {
             testRollback.transaction {
-                insertOriginTable()
-                insertWrongTable("1234567890")
+                insertOriginTable("1")
+                insertWrongTable("12345678901234567890")
             }
         }
 
@@ -52,7 +60,7 @@ class SpringTransactionRollbackTest {
         val testRollback = container.getBean(TestRollback::class.java)
         assertFailsWith<RuntimeException> {
             testRollback.transaction {
-                insertOriginTable()
+                insertOriginTable("1")
                 @Suppress("TooGenericExceptionThrown")
                 throw RuntimeException()
             }
@@ -66,13 +74,195 @@ class SpringTransactionRollbackTest {
         val testRollback = container.getBean(TestRollback::class.java)
         assertFailsWith<Exception> {
             testRollback.transaction {
-                insertOriginTable()
+                insertOriginTable("1")
                 @Suppress("TooGenericExceptionThrown")
                 throw Exception()
             }
         }
 
         assertEquals(1, testRollback.entireTableSize())
+    }
+
+    @Test
+    fun `exception in inner Tx causes rollback of outer Tx`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+
+        assertFailsWith<UnexpectedRollbackException> {
+            testRollback.transaction { // outer logicTx start
+                testRollback.insertOriginTable("Tx1")
+
+                try {
+                    testRollback.transaction { // inner logicTx start
+                        testRollback.insertOriginTable("Tx2")
+
+                        throw RuntimeException()
+                        // isGlobalRollbackOnParticipationFailure == true -> doSetRollbackOnly() -> mark as globalRollBack
+                    }
+                } catch (e: Exception) {
+                    // something...
+                }
+            } // when outer logicTx commit() -> check globalRollBack mark -> throw UnexpectedRollbackException -> rollback
+        }
+
+        assertEquals(0, testRollback.entireTableSize())
+    }
+
+    @Test
+    fun `isRollback is managed separately for different transactions`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+
+        assertFailsWith<UnexpectedRollbackException> {
+            testRollback.transaction { // outer logicTx start
+                val outerTx = TransactionManager.currentOrNull()
+                assertFalse(outerTx!!.isMarkedRollback())
+
+                try {
+                    testRollback.transaction { // inner logicTx start
+                        val innerTx = TransactionManager.currentOrNull()
+                        assertFalse(innerTx!!.isMarkedRollback())
+
+                        throw RuntimeException() // mark as globalRollBack
+                    }
+                } catch (e: Exception) {
+                    // something...
+                }
+
+                assertTrue(outerTx.isMarkedRollback())
+
+                testRollback.transactionWithRequiresNew { // separate transaction
+                    val innerTx = TransactionManager.currentOrNull()
+                    assertFalse(innerTx!!.isMarkedRollback())
+                }
+
+                testRollback.transaction {
+                    val innerTx = TransactionManager.currentOrNull()
+                    assertTrue(innerTx!!.isMarkedRollback())
+                }
+            }
+        }
+
+        testRollback.transaction{ // other transaction not affected by previous transaction rollback status
+            val newTx = TransactionManager.currentOrNull()
+            assertFalse(newTx!!.isMarkedRollback())
+        }
+    }
+
+    @Test
+    fun `requiresNew should rollback innerTx without affecting outerTx`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+
+        testRollback.transaction {
+            testRollback.insertOriginTable("Tx1")
+
+            try {
+                testRollback.transactionWithRequiresNew {
+                    testRollback.insertOriginTable("Tx2")
+
+                    throw RuntimeException()
+                }
+            } catch (e: Exception) {
+                // something...
+            }
+        }
+
+        val entities = testRollback.selectAll()
+        assertEquals(1, entities.size)
+        assertEquals("Tx1", entities.first().name)
+    }
+
+    @Test
+    fun `supports should participate in existing transaction but not rollback when none exists`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+
+        assertFailsWith<RuntimeException> {
+
+            // Execute without a transaction -> Should not be rolled back
+            testRollback.transactionWithSupports {
+                testRollback.insertOriginTable("No Tx")
+                throw RuntimeException() // Non-transactional, so it should not be rolled back
+            }
+        }
+
+        assertEquals(1, testRollback.entireTableSize()) // Data should remain
+
+        // Execute within a transaction -> Should be rolled back
+        assertFailsWith<RuntimeException> {
+
+            testRollback.transaction {
+                testRollback.insertOriginTable("With Tx")
+
+                testRollback.transactionWithSupports {
+                    testRollback.insertOriginTable("Supports Tx")
+                    throw RuntimeException() // Should trigger rollback
+                }
+            }
+        }
+
+        val entities = testRollback.selectAll()
+        assertEquals(1, entities.size) // Only the first case's data should remain
+        assertEquals("No Tx", entities.first().name)
+    }
+
+    @Test
+    fun `notSupported should suspend outer transaction and execute without transaction`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+
+        testRollback.transaction {
+            testRollback.insertOriginTable("Outer Tx")
+
+            try {
+                testRollback.transactionWithNotSupported {
+                    testRollback.insertOriginTable("No Tx")
+                    throw RuntimeException() // Since it's non-transactional, it won't be rolled back
+                }
+            } catch (e: Exception) {
+                // Ignore exception
+            }
+        }
+
+        assertEquals(2, testRollback.entireTableSize()) // Both records should remain
+    }
+
+    @Test
+    fun `mandatory should fail if no existing transaction but participate if one exists`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+
+        assertFailsWith<IllegalTransactionStateException> {
+            testRollback.transactionWithMandatory {
+                testRollback.insertOriginTable("No Parent Tx")
+            }
+        }
+
+        testRollback.transaction {
+            testRollback.insertOriginTable("Parent Tx")
+            testRollback.transactionWithMandatory {
+                testRollback.insertOriginTable("Mandatory Tx")
+            }
+        }
+
+        assertEquals(2, testRollback.entireTableSize()) // Both records should remain
+    }
+
+    @Test
+    fun `nested should rollback innerTx without affecting outerTx`() {
+        val testRollback = container.getBean(TestRollback::class.java)
+
+        testRollback.transaction {
+            testRollback.insertOriginTable("Tx1")
+
+            try {
+                testRollback.transactionWithNested {
+                    testRollback.insertOriginTable("Tx2")
+                    throw RuntimeException() // Rollback only the inner transaction
+                }
+            } catch (e: Exception) {
+                // something...
+            }
+        }
+
+        val entities = testRollback.selectAll()
+        assertEquals(1, entities.size)
+        assertEquals("Tx1", entities.first().name) // Only the outer transaction should remain
     }
 
     @AfterTest
@@ -100,39 +290,80 @@ open class TransactionManagerAttributeSourceTestConfig {
     open fun testRollback() = TestRollback()
 }
 
-@Transactional
 open class TestRollback {
 
+    @Transactional
     open fun init() {
         SchemaUtils.create(RollbackTable)
         RollbackTable.deleteAll()
     }
 
+    @Transactional
     open fun transaction(block: TestRollback.() -> Unit) {
         block()
     }
 
-    open fun insertOriginTable() {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    open fun transactionWithRequiresNew(block: TestRollback.() -> Unit) {
+        block()
+    }
+
+    @Transactional(propagation = Propagation.NESTED)
+    open fun transactionWithNested(block: TestRollback.() -> Unit) {
+        block()
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS)
+    open fun transactionWithSupports(block: TestRollback.() -> Unit) {
+        block()
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    open fun transactionWithNotSupported(block: TestRollback.() -> Unit) {
+        block()
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    open fun transactionWithMandatory(block: TestRollback.() -> Unit) {
+        block()
+    }
+
+    @Transactional
+    open fun insertOriginTable(name: String) {
         RollbackTable.insert {
-            it[RollbackTable.name] = "1"
+            it[RollbackTable.name] = name
         }
     }
 
+    @Transactional
     open fun insertWrongTable(name: String) {
         WrongDefinedRollbackTable.insert {
             it[WrongDefinedRollbackTable.name] = name
         }
     }
 
+    @Transactional
     open fun entireTableSize(): Long {
         return RollbackTable.selectAll().count()
+    }
+
+    @Transactional
+    open fun selectAll(): List<RollbackEntity> {
+        return RollbackTable.selectAll().map {
+            RollbackEntity(
+                id = it[RollbackTable.id],
+                name = it[RollbackTable.name]
+            )
+        }
     }
 }
 
 object RollbackTable : LongIdTable("test_rollback") {
-    val name = varchar("name", 5)
+    val name = varchar("name", 15)
 }
 
 object WrongDefinedRollbackTable : LongIdTable("test_rollback") {
-    val name = varchar("name", 10)
+    val name = varchar("name", 20)
 }
+
+data class RollbackEntity(val id: EntityID<Long>, val name: String)


### PR DESCRIPTION
#### Description

**Summary of the change**:
- Added a property `isRollback` managed by TransactionScope in an individual transaction. : `SpringTransactionManager`
- Add more test : `SpringTransactionRollbackTest`

**Detailed description**:
- **What**: Global Rollback Mark Not Set on Unchecked Exception in Spring Transaction
![tx_flow](https://github.com/user-attachments/assets/235e78ba-b858-407c-84ab-0f4b6a52adbf)

- **Why**: The issue arises when a method with a transaction is called more than once in a nested manner. In this case, the results from the inner transactions are not being propagated to the outer one.
- **How**: Add a simple `isRollback` property for Tx

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
https://youtrack.jetbrains.com/issue/EXPOSED-754/Global-Rollback-Mark-Not-Properly-Set-on-Unchecked-Exception-in-Spring-Transaction