### PR TITLE
fix: EXPOSED-761 Forward ColumnWithTransform.readObject to delegate

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -543,6 +543,7 @@ public class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/expos
 	public final fun getTransformer ()Lorg/jetbrains/exposed/sql/ColumnTransformer;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun setNullable (Z)V
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -369,6 +369,8 @@ open class ColumnWithTransform<Unwrapped, Wrapped>(
         return delegate.notNullValueToDB(transformer.unwrap(value)!!)
     }
 
+    override fun readObject(rs: ResultSet, index: Int): Any? = delegate.readObject(rs, index)
+
     override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
         return delegate.setParameter(stmt, index, value)
     }


### PR DESCRIPTION
#### Description

`ColumnWithTranform` currently doesn't forward `readObject` to the delegate. This can cause exceptions to be thrown after (not) reading special objects from the database driver.

[EXPOSED-761](https://youtrack.jetbrains.com/issue/EXPOSED-761/Column-transform-doesnt-forward-readObject-to-the-delegate) explains this issue with more details and gives an example.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [X] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

(possibly other ones as well, untested)

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-761](https://youtrack.jetbrains.com/issue/EXPOSED-761/Column-transform-doesnt-forward-readObject-to-the-delegate)