### PR TITLE
fix: Column transform doesn't forward `readObject` to the delegate

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -543,6 +543,7 @@ public class org/jetbrains/exposed/sql/ColumnWithTransform : org/jetbrains/expos
 	public final fun getTransformer ()Lorg/jetbrains/exposed/sql/ColumnTransformer;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun setNullable (Z)V
 	public fun setParameter (Lorg/jetbrains/exposed/sql/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -376,6 +376,10 @@ open class ColumnWithTransform<Unwrapped, Wrapped>(
     override fun parameterMarker(value: Wrapped?): String {
         return delegate.parameterMarker(value?.let { transformer.unwrap(it) })
     }
+
+    override fun readObject(rs: ResultSet, index: Int): Any? {
+        return delegate.readObject(rs, index)
+    }
 }
 
 internal fun <T : Expression<*>> unwrapColumnValues(values: Map<T, Any?>): Map<T, Any?> = values.mapValues { (col, value) ->


### PR DESCRIPTION
#### Description



**Detailed description**:

What: This patch adds a missing `readObject` method forwarding in the `ColumnTransformer` class that now properly delegates to the underlying column type's implementation.

Why: Without this forwarding, any custom `readObject` implementation in delegate column types was being ignored when using column transformers, causing data retrieval issues.

How: The implementation adds an override of the `readObject` method in the `ColumnTransform` class that calls the same method on the delegate column type, ensuring proper data reading behavior is preserved through the transformation chain.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

---

#### Related Issues

[EXPOSED-761](https://youtrack.jetbrains.com/issue/EXPOSED-761) Column transform doesn't forward `readObject` to the delegate
