### PR TITLE
fix: EXPOSED-768 UUID inserts into BINARY(16) column types in H2

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
@@ -35,12 +35,7 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
 
     override fun blobType(): String = "VARBINARY(MAX)"
     override fun uuidType(): String = "uniqueidentifier"
-    override fun uuidToDB(value: UUID): Any =
-        if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
-            value
-        } else {
-            value.toString()
-        }
+    override fun uuidToDB(value: UUID): Any = value.toString()
     override fun dateTimeType(): String = "DATETIME2"
     override fun timestampWithTimeZoneType(): String =
         if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
@@ -35,7 +35,12 @@ internal object SQLServerDataTypeProvider : DataTypeProvider() {
 
     override fun blobType(): String = "VARBINARY(MAX)"
     override fun uuidType(): String = "uniqueidentifier"
-    override fun uuidToDB(value: UUID): Any = value.toString()
+    override fun uuidToDB(value: UUID): Any =
+        if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {
+            value
+        } else {
+            value.toString()
+        }
     override fun dateTimeType(): String = "DATETIME2"
     override fun timestampWithTimeZoneType(): String =
         if (currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.SQLServer) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/H2Tests.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.avg
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
 import org.jetbrains.exposed.v1.core.transactions.CoreTransactionManager
 import org.jetbrains.exposed.v1.core.transactions.TransactionManagerApi
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
@@ -18,6 +19,7 @@ import org.jetbrains.exposed.v1.tests.currentDialectMetadataTest
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.assertTrue
 import org.junit.Test
+import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertNotEquals

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/H2Tests.kt
@@ -134,6 +134,24 @@ class H2Tests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testH2UUIDConversionWithBinary16ColumnType() {
+        val testTable = object : UUIDTable("test_table") {
+        }
+
+        withDb(TestDB.ALL_H2) {
+            exec("CREATE TABLE test_table (id BINARY(16) NOT NULL, CONSTRAINT PK_TEST_TABLE PRIMARY KEY (id))")
+
+            val uuid = UUID.randomUUID()
+
+            testTable.insert { it[testTable.id] = uuid }
+
+            val actualId = testTable.select(testTable.id).single()[testTable.id].value
+
+            assertEquals(uuid, actualId)
+        }
+    }
+
     class WrappedTransactionManager(val transactionManager: TransactionManagerApi) :
         TransactionManagerApi by transactionManager
 


### PR DESCRIPTION
#### Description

See https://youtrack.jetbrains.com/issue/EXPOSED-768. Exposed does not currently support the inserts of UUIDs into columns of type BINARY(16) in H2.

This PR attempts to use the UUID type instead of String when inserting java.util.UUIDs into the database.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [x] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues

https://youtrack.jetbrains.com/issue/EXPOSED-768
https://youtrack.jetbrains.com/issue/EXPOSED-116