### PR TITLE
fix: when using entityId() will lost foreignKey

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/Table.kt
@@ -683,6 +683,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
             it.extraDefinitions = extraDefinitions
         }
         (table as IdTable<T>).addIdColumnInternal(newColumn)
+        newColumn.foreignKey = this.foreignKey
         return replaceColumn(this, newColumn)
     }
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Provide a concise summary of this PR. Describe the changes made in a single sentence or short paragraph.

**Detailed description**:
- **What**: Detail what changes have been made in the PR.
- **Why**: Explain the reasons behind the changes. Why were they necessary?
- **How**: Describe how the changes were implemented, including any key aspects of the code modified or new features added.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [X] SqlServer
- [X] H2
- [X] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

```kt
import org.jetbrains.exposed.dao.id.EntityID
import org.jetbrains.exposed.dao.id.IdTable
import org.jetbrains.exposed.sql.Database
import org.jetbrains.exposed.sql.Table
import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
import org.jetbrains.exposed.sql.transactions.transaction
import kotlin.test.Test

class EntityIdTest {
    object KVTable : IdTable<String> ("test_kv_table") {
        override val id = text("key").entityId()
        override val primaryKey = PrimaryKey(id)
        val value = text("value")
    }
    object KVExpiredTable : Table("test_kv_expired") {
        val id = reference("key", KVTable.id).transform(wrap = { it.value }, unwrap = { EntityID(table = KVTable, id = it) })
        override val primaryKey = PrimaryKey(id)
        val expiredAt = timestamp("expired_at")
    }
    object KVExpiredTableWithEntityId : IdTable<String>("test_kv_expired_with_entity_id") {
        override val id = reference("key", KVTable.id).transform(wrap = { it.value }, unwrap = { EntityID(table = KVTable, id = it) }).entityId().apply {
//            foreignKey = ForeignKeyConstraint(
//                from = this,
//                target = KVTable.id,
//                onUpdate = null,
//                onDelete = null,
//                name = "test_kv_expired_with_entity_id__id_foreign_key"
//            )
        }
        override val primaryKey = PrimaryKey(id)
        val expiresAt = timestamp("expires_at")
    }
    init {
        Database.connect(
            url = "jdbc:postgresql://localhost:5432/app",
            user = "app",
            password = "app",
        )
//        transaction {
//            SchemaUtils.create(KVTable, KVExpiredTable, KVExpiredTableWithEntityId)
//        }
    }
    @Test
    fun testReference() {
        transaction {
            val tables = listOf(
                KVExpiredTable,
                KVExpiredTableWithEntityId,
            )
            tables.forEach { table ->
                require(table.foreignKeys.isNotEmpty()) {
                    "${table.tableName} lost foreignKey"
                }
            }
        }
    }
}
```
```log
test_kv_expired_with_entity_id lost foreignKey
java.lang.IllegalArgumentException: test_kv_expired_with_entity_id lost foreignKey
	at EntityIdTest.testReference$lambda$2(EntityIdTest.kt:51)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$run(ThreadLocalTransactionManager.kt:355)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction$lambda$11(ThreadLocalTransactionManager.kt:402)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:410)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.inTopLevelTransaction(ThreadLocalTransactionManager.kt:401)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction$lambda$5(ThreadLocalTransactionManager.kt:310)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.keepAndRestoreTransactionRefAfterRun(ThreadLocalTransactionManager.kt:410)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction(ThreadLocalTransactionManager.kt:259)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction(ThreadLocalTransactionManager.kt:237)
	at org.jetbrains.exposed.sql.transactions.ThreadLocalTransactionManagerKt.transaction$default(ThreadLocalTransactionManager.kt:236)
	at EntityIdTest.testReference(EntityIdTest.kt:45)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)


> Task :test FAILED
EntityIdTest > testReference() FAILED
    java.lang.IllegalArgumentException at EntityIdTest.kt:51
```