### PR TITLE
fix: EXPOSED-762 [MariaDB] Fix UUIDColumType to make it working with own UUID type

### DIFF
--- a/buildScripts/docker/docker-compose-mariadb.yml
+++ b/buildScripts/docker/docker-compose-mariadb.yml
@@ -1,6 +1,6 @@
 services:
     mariadb:
-        image: mariadb
+        image: mariadb:11.7.2
         restart: always
         ports:
             - "3000:3306"

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2846,7 +2846,6 @@ public final class org/jetbrains/exposed/sql/UUIDColumnType : org/jetbrains/expo
 	public fun nonNullValueToString (Ljava/util/UUID;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun notNullValueToDB (Ljava/util/UUID;)Ljava/lang/Object;
-	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/util/UUID;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2846,6 +2846,7 @@ public final class org/jetbrains/exposed/sql/UUIDColumnType : org/jetbrains/expo
 	public fun nonNullValueToString (Ljava/util/UUID;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun notNullValueToDB (Ljava/util/UUID;)Ljava/lang/Object;
+	public fun readObject (Ljava/sql/ResultSet;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/util/UUID;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.dao.id.IdTable
 import org.jetbrains.exposed.sql.statements.api.ExposedBlob
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.vendors.*
 import java.io.InputStream
 import java.math.BigDecimal
@@ -1064,6 +1065,15 @@ class UUIDColumnType : ColumnType<UUID>() {
     override fun notNullValueToDB(value: UUID): Any = currentDialect.dataTypeProvider.uuidToDB(value)
 
     override fun nonNullValueToString(value: UUID): String = "'$value'"
+
+    @Suppress("MagicNumber")
+    override fun readObject(rs: ResultSet, index: Int): Any? {
+        val db = TransactionManager.current().db
+        if (currentDialect is MariaDBDialect && !db.isVersionCovers(10, 0)) {
+            return rs.getBytes(index)
+        }
+        return super.readObject(rs, index)
+    }
 
     companion object {
         private val uuidRegexp =

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/ColumnType.kt
@@ -1065,11 +1065,6 @@ class UUIDColumnType : ColumnType<UUID>() {
 
     override fun nonNullValueToString(value: UUID): String = "'$value'"
 
-    override fun readObject(rs: ResultSet, index: Int): Any? = when (currentDialect) {
-        is MariaDBDialect -> rs.getBytes(index)
-        else -> super.readObject(rs, index)
-    }
-
     companion object {
         private val uuidRegexp =
             Regex("[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}", RegexOption.IGNORE_CASE)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UUIDColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/shared/types/UUIDColumnTypeTests.kt
@@ -1,0 +1,51 @@
+package org.jetbrains.exposed.sql.tests.shared.types
+
+import org.jetbrains.exposed.sql.StdOutSqlLogger
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.tests.DatabaseTestsBase
+import org.jetbrains.exposed.sql.tests.TestDB
+import org.jetbrains.exposed.sql.tests.shared.assertEquals
+import org.junit.Test
+import java.util.UUID
+
+class UUIDColumnTypeTests : DatabaseTestsBase() {
+    @Test
+    fun insertReadUUID() {
+        val tester = object : Table("test_uuid") {
+            val id = uuid("id")
+        }
+        withTables(tester, configure = { sqlLogger = StdOutSqlLogger }) {
+            val uuid = UUID.fromString("c128770b-e802-40ba-a85a-58592c80ba58")
+            tester.insert {
+                it[id] = uuid
+            }
+            val dbUuid = tester.selectAll().first()[tester.id]
+            assertEquals(uuid, dbUuid)
+        }
+    }
+
+    @Test
+    fun mariadbOwnUUIDType() {
+        val tester = object : Table("test_uuid") {
+            val id = uuid("id")
+        }
+        withDb(excludeSettings = TestDB.ALL - TestDB.ALL_MARIADB, configure = { sqlLogger = StdOutSqlLogger }) {
+            try {
+                // From the version 10.7 MariaDB has own 'UUID' column type, that does not work with the current column type.
+                // Even if we generate on DDL type 'BINARY(16)' we could support native UUID for IO operations.
+                exec("CREATE TABLE test_uuid (id UUID NOT NULL)")
+
+                val uuid = UUID.fromString("c128770b-e802-40ba-a85a-58592c80ba58")
+                tester.insert {
+                    it[id] = uuid
+                }
+                val dbUuid = tester.selectAll().first()[tester.id]
+                assertEquals(uuid, dbUuid)
+            } finally {
+                exec("DROP TABLE test_uuid")
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Description

When working with MariaDB 10.7+ which provides a native UUID data type, Exposed SQL currently handles it incorrectly. When retrieving data from a MariaDB UUID field, it incorrectly processes it as a byte array, when it should be handled as a string representation of the UUID.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] MariaDB

---

#### Related Issues

[EXPOSED-762](https://youtrack.jetbrains.com/issue/EXPOSED-762) Mariadb improper UUID type for dialect
