### PR TITLE
feat: EXPOSED-462 Filtering on entity references

### DIFF
--- a/documentation-website/Writerside/snippets/exposed-dao-relationships/src/main/kotlin/org/example/entities/UserEntity.kt
+++ b/documentation-website/Writerside/snippets/exposed-dao-relationships/src/main/kotlin/org/example/entities/UserEntity.kt
@@ -46,3 +46,12 @@ class UserWithSingleRatingEntity(id: EntityID<Int>) : IntEntity(id) {
     var name by UsersTable.name
     val rating by UserRatingEntity backReferencedOn UserRatingsTable.user // make sure to use val and backReferencedOn
 }
+
+class UserWithFiveStarRatingEntity(id: EntityID<Int>) : IntEntity(id) {
+    companion object : IntEntityClass<UserWithFiveStarRatingEntity>(UsersTable)
+
+    var name by UsersTable.name
+    val ratings by UserRatingEntity referrersOn UserRatingsTable.user
+
+    val fiveStarRatings by UserRatingEntity.view { UserRatingsTable.value greaterEq 5 } referrersOn UserRatingsTable.user
+}

--- a/documentation-website/Writerside/topics/DAO-Relationships.topic
+++ b/documentation-website/Writerside/topics/DAO-Relationships.topic
@@ -122,6 +122,29 @@
                 user1.rating // returns a UserRating object
             </code-block>
         </chapter>
+        <chapter title="Filtering references" id="filtering-references">
+            <p>
+                Suppose you want to additionally filter a user's ratings to only show the films they rated 5 or more.
+                You could to this with a regular Kotlin property and the <code>filter</code> method of collections:
+            </p>
+            <code-block lang="kotlin">
+                val fiveStarRatings
+                    get() = ratings.filter { it.value > 5 }
+            </code-block>
+            <p>
+                This has a slight problem: even though we only use a fraction of the user's ratings, we still have to
+                fetch all of them from the database. A much better choice would be to add another property using
+                <code>referrersOn</code> with a <code>View</code>:
+            </p>
+            <code-block lang="kotlin"
+                        src="exposed-dao-relationships/src/main/kotlin/org/example/entities/UserEntity.kt"
+                        include-symbol="UserWithFiveStarRatingEntity"
+            />
+            <p>
+                By using a <code>View</code> you can add any conditions to the generated <code>WHERE</code> clause. However,
+                currently those relationships <b>do not support caching and eager loading</b> via <code>UserEntity::load(UserEntity::fiveStarRatings)</code>, so beware!
+            </p>
+        </chapter>
     </chapter>
     <chapter title="Optional reference" id="optional-reference">
         <p>In Exposed, you can also add an optional reference.</p>

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -641,6 +641,64 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
     }
 
     /**
+     * Registers a reference as an immutable field of the parent entity class, which returns a collection of child
+     * objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a [column] using `reference()` on the child table.
+     *
+     * By default, this also stores the loaded entities to a cache.
+     */
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> View<Target>.referrersOn(column: Column<REF>) =
+        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, true) }
+
+    /**
+     * Registers a reference as an immutable field of the parent entity class, which returns a collection of
+     * child objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a foreign key constraint on the child table,
+     * by using `foreignKey()`.
+     */
+    infix fun <TargetID : Any, Target : Entity<TargetID>> View<Target>.referrersOn(
+        table: IdTable<*>
+    ): ViewReferrers<ID, Entity<ID>, TargetID, Target, Any> {
+        val tableFK = this@EntityClass.getCompositeForeignKey(table)
+        val delegate = tableFK.from.first() as Column<Any>
+        return registerRefRule(delegate) { ViewReferrers(delegate, this, true, tableFK.references) }
+    }
+
+    /**
+     * Registers a reference as an immutable field of the parent entity class, which returns a collection of
+     * child objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a [column] using `reference()` on the child table.
+     *
+     * Set [cache] to `true` to also store the loaded entities to a cache.
+     */
+    fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> View<Target>.referrersOn(
+        column: Column<REF>,
+        cache: Boolean
+    ) =
+        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, cache) }
+
+    /**
+     * Registers a reference as an immutable field of the parent entity class, which returns a collection of
+     * child objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a foreign key constraint on the child table,
+     * by using `foreignKey()`.
+     *
+     * Set [cache] to `true` to also store the loaded entities to a cache.
+     */
+    fun <TargetID : Any, Target : Entity<TargetID>> View<Target>.referrersOn(
+        table: IdTable<*>,
+        cache: Boolean
+    ): ViewReferrers<ID, Entity<ID>, TargetID, Target, Any> {
+        val tableFK = this@EntityClass.getCompositeForeignKey(table)
+        val delegate = tableFK.from.first() as Column<Any>
+        return registerRefRule(delegate) { ViewReferrers(delegate, this, cache, tableFK.references) }
+    }
+
+    /**
      * Registers an optional reference as an immutable field of the parent entity class, which returns a collection of
      * child objects of this `EntityClass` that all reference the parent.
      *

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -775,6 +775,70 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
     }
 
     /**
+     * Registers an optional reference as an immutable field of the parent entity class, which returns a collection of
+     * child objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a [column] using either `optReference()` or
+     * reference().nullable()` on the child table.
+     *
+     * By default, this also stores the loaded entities to a cache.
+     */
+    infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> View<Target>.optionalReferrersOn(
+        column: Column<REF?>
+    ) =
+        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF?>(column, this, true) }
+
+    /**
+     * Registers an optional reference as an immutable field of the parent entity class, which returns a collection of
+     * child objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a foreign key constraint on the child table,
+     * by using `foreignKey()`.
+     *
+     * By default, this also stores the loaded entities to a cache.
+     */
+    infix fun <TargetID : Any, Target : Entity<TargetID>> View<Target>.optionalReferrersOn(
+        table: IdTable<*>
+    ): ViewReferrers<ID, Entity<ID>, TargetID, Target, Any?> {
+        val tableFK = this@EntityClass.getCompositeForeignKey(table)
+        val delegate = tableFK.from.first() as Column<Any?>
+        return registerRefRule(delegate) { ViewReferrers(delegate, this, true, tableFK.references) }
+    }
+
+    /**
+     * Registers an optional reference as an immutable field of the parent entity class, which returns a collection of
+     * child objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a [column] using either `optReference()` or
+     * `reference().nullable()` on the child table.
+     *
+     * Set [cache] to `true` to also store the loaded entities to a cache.
+     */
+    fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> View<Target>.optionalReferrersOn(
+        column: Column<REF?>,
+        cache: Boolean = false
+    ) =
+        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF?>(column, this, cache) }
+
+    /**
+     * Registers an optional reference as an immutable field of the parent entity class, which returns a collection of
+     * child objects of this `EntityClass` that all reference the parent and match the conditions in the view.
+     *
+     * The reference should have been defined by the creation of a foreign key constraint on the child table,
+     * by using `foreignKey()`.
+     *
+     * Set [cache] to `true` to also store the loaded entities to a cache.
+     */
+    fun <TargetID : Any, Target : Entity<TargetID>> View<Target>.optionalReferrersOn(
+        table: IdTable<*>,
+        cache: Boolean = false
+    ): ViewReferrers<ID, Entity<ID>, TargetID, Target, Any?> {
+        val tableFK = this@EntityClass.getCompositeForeignKey(table)
+        val delegate = tableFK.from.first() as Column<Any?>
+        return registerRefRule(delegate) { ViewReferrers(delegate, this, cache, tableFK.references) }
+    }
+
+    /**
      * Returns the child table's [ForeignKeyConstraint] that matches the primary key columns defined on the table
      * associated with this `EntityClass`.
      *

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/dao/EntityClass.kt
@@ -649,7 +649,7 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
      * By default, this also stores the loaded entities to a cache.
      */
     infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> View<Target>.referrersOn(column: Column<REF>) =
-        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, true) }
+        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF>(column, this, false) }
 
     /**
      * Registers a reference as an immutable field of the parent entity class, which returns a collection of
@@ -786,7 +786,7 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
     infix fun <TargetID : Any, Target : Entity<TargetID>, REF : Any> View<Target>.optionalReferrersOn(
         column: Column<REF?>
     ) =
-        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF?>(column, this, true) }
+        registerRefRule(column) { ViewReferrers<ID, Entity<ID>, TargetID, Target, REF?>(column, this, false) }
 
     /**
      * Registers an optional reference as an immutable field of the parent entity class, which returns a collection of

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/dao/SamplesDao.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/sql/tests/demo/dao/SamplesDao.kt
@@ -32,6 +32,7 @@ class City(id: EntityID<Int>) : IntEntity(id) {
 
     var name by Cities.name
     val users by User referrersOn Users.city
+    val kids by User.view { Users.age less 18 } referrersOn Users.city
 }
 
 fun main() {
@@ -72,6 +73,7 @@ fun main() {
         println("Cities: ${City.all().joinToString { it.name }}")
         println("Users in ${stPete.name}: ${stPete.users.joinToString { it.name }}")
         println("Adults: ${User.find { Users.age greaterEq 18 }.joinToString { it.name }}")
+        println("Kids in ${stPete.name}: ${stPete.kids.joinToString { it.name }}")
     }
 }
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Adds a way to filter `referrersOn`/`optionalReferrersOn` 

**Detailed description**:
- **What**: Two new methods for the DAO API: `View.referrersOn` and `View.optionalReferrersOn`.
- **Why**: This seems like a niche yet requested feature that has been stale for 9 months according to the YouTrack issue.
- **How**:
  - moved the condition generating logic in `Referrers` to a separate method subclasses can override
  - added a new `ViewReferrers` class representing a `referrersOn` with a `View` left-hand side parameter (as opposed to `EntityClass`)

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-462](https://youtrack.jetbrains.com/issue/EXPOSED-462)