### PR TITLE
Refactor transaction database resolution logic.

### DIFF
--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
@@ -360,8 +360,8 @@ private suspend fun <T> withTransactionScope(
 
     @OptIn(InternalApi::class)
     suspend fun newScope(currentTransaction: R2dbcTransaction?): T {
-        val currentDatabase: R2dbcDatabase? = currentTransaction?.db
-            ?: db
+        val currentDatabase: R2dbcDatabase? = db
+            ?: currentTransaction?.db
             ?: CoreTransactionManager.getDefaultDatabase() as? R2dbcDatabase
         val manager = currentDatabase?.transactionManager ?: TransactionManager.manager
 


### PR DESCRIPTION
Swapped the resolution order for the database in `newScope` to prioritize the `db` property over the current transaction's database. This ensures consistency and aligns with the intended fallback logic.

#### Description

**Summary of the change**: Explicitly passing of `database` is often required, and the order is currently not respected resulting into:

```
java.lang.IllegalStateException: No transaction in context.
	at org.jetbrains.exposed.v1.core.transactions.CoreTransactionManager.currentTransaction(TransactionManagerApi.kt:110)
	at org.jetbrains.exposed.v1.core.vendors.DatabaseDialectKt.getCurrentDialect(DatabaseDialect.kt:160)
	at org.jetbrains.exposed.v1.r2dbc.vendors.metadata.H2PropertyProvider.getStoresUpperCaseIdentifiers(H2Metadata.kt:10)
	at org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcIdentifierManager.<init>(R2dbcIdentifierManager.kt:16)
	at org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcDatabaseMetadataImpl.identifierManager_delegate$lambda$8(R2dbcDatabaseMetadataImpl.kt:107)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:83)
	at org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcDatabaseMetadataImpl.getIdentifierManager(R2dbcDatabaseMetadataImpl.kt:104)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase$identifierManager$2$1$1.invokeSuspend(R2dbcDatabase.kt:99)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase$identifierManager$2$1$1.invoke(R2dbcDatabase.kt)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase$identifierManager$2$1$1.invoke(R2dbcDatabase.kt)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$metadata$2.invokeSuspend(R2dbcConnectionImpl.kt:214)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$metadata$2.invoke(R2dbcConnectionImpl.kt)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$metadata$2.invoke(R2dbcConnectionImpl.kt)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$withConnection$2.invokeSuspend(R2dbcConnectionImpl.kt:226)
	at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase.metadata$exposed_r2dbc(R2dbcDatabase.kt:39)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase$identifierManager$2$1.invokeSuspend(R2dbcDatabase.kt:99)
	at org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManagerKt$suspendTransaction$2.invokeSuspend(TransactionManager.kt:299)
	at org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManagerKt.withTransactionScope$newScope(TransactionManager.kt:381)
	at org.jetbrains.customers.CustomerRoutesKt$configureCustomerRoutes$1$1$4.invokeSuspend(CustomerRoutes.kt:39)
	at io.ktor.server.routing.RoutingNode$buildPipeline$1$1.invokeSuspend(RoutingNode.kt:126)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.util.pipeline.PipelineKt$execute$2.invokeSuspend(Pipeline.kt:510)
	at io.ktor.server.routing.RoutingRoot.executeResult(RoutingRoot.kt:206)
	at io.ktor.server.routing.RoutingRoot.interceptor(RoutingRoot.kt:71)
	at io.ktor.server.routing.RoutingRoot$Plugin$install$1.invokeSuspend(RoutingRoot.kt:154)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.server.engine.BaseApplicationEngineKt$installDefaultTransformationChecker$1.invokeSuspend(BaseApplicationEngine.kt:119)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.util.pipeline.PipelineKt$execute$2.invokeSuspend(Pipeline.kt:510)
	at io.ktor.server.testing.TestApplicationEngine$2.invokeSuspend(TestApplicationEngine.kt:230)
	at io.ktor.server.testing.TestApplicationEngine$1.invokeSuspend(TestApplicationEngine.kt:104)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.server.engine.BaseApplicationResponse$Companion$setupFallbackResponse$1.invokeSuspend(BaseApplicationResponse.kt:349)
	at io.ktor.util.pipeline.DebugPipelineContext.proceedLoop(DebugPipelineContext.kt:79)
	at io.ktor.util.pipeline.PipelineKt$execute$2.invokeSuspend(Pipeline.kt:510)
	at io.ktor.server.testing.TestApplicationEngine$handleRequest$2.invokeSuspend(TestApplicationEngine.kt:229)
	at io.ktor.server.testing.TestApplicationEngine.handleRequest$ktor_server_test_host(TestApplicationEngine.kt:194)
	at io.ktor.server.testing.client.TestHttpClientEngine.execute(TestHttpClientEngine.kt:56)
	at io.ktor.server.testing.client.DelegatingTestClientEngine.execute(DelegatingTestClientEngine.kt:58)
	at io.ktor.client.engine.HttpClientEngine$executeWithinCallContext$2.invokeSuspend(HttpClientEngine.kt:183)
Caused by: java.lang.IllegalStateException: No transaction in context.
	at org.jetbrains.exposed.v1.core.transactions.CoreTransactionManager.currentTransaction(TransactionManagerApi.kt:110)
	at org.jetbrains.exposed.v1.core.vendors.DatabaseDialectKt.getCurrentDialect(DatabaseDialect.kt:160)
	at org.jetbrains.exposed.v1.r2dbc.vendors.metadata.H2PropertyProvider.getStoresUpperCaseIdentifiers(H2Metadata.kt:10)
	at org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcIdentifierManager.<init>(R2dbcIdentifierManager.kt:16)
	at org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcDatabaseMetadataImpl.identifierManager_delegate$lambda$8(R2dbcDatabaseMetadataImpl.kt:107)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:83)
	at org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcDatabaseMetadataImpl.getIdentifierManager(R2dbcDatabaseMetadataImpl.kt:104)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase$identifierManager$2$1$1.invokeSuspend(R2dbcDatabase.kt:99)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase$identifierManager$2$1$1.invoke(R2dbcDatabase.kt)
	at org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase$identifierManager$2$1$1.invoke(R2dbcDatabase.kt)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$metadata$2.invokeSuspend(R2dbcConnectionImpl.kt:214)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$metadata$2.invoke(R2dbcConnectionImpl.kt)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$metadata$2.invoke(R2dbcConnectionImpl.kt)
	at org.jetbrains.exposed.v1.r2dbc.statements.R2dbcConnectionImpl$withConnection$2.invokeSuspend(R2dbcConnectionImpl.kt:226)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```

**Detailed description**:
- **What**: Respect db parameter
- **Why**: Current priority of the user override is not respected 
- **How**: If user provided database, prefer it over the current transaction in the transaction manager.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
