### PR TITLE
fix: EXPOSED-787 Disparity between create/drop index statements when …

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MysqlDialect.kt
@@ -393,7 +393,7 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider.INSTA
     }
 
     override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String =
-        "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
+        "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP INDEX ${identifierManager.cutIfNecessaryAndQuote(indexName)}"
 
     override fun setSchema(schema: Schema): String = "USE ${schema.identifier}"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
@@ -452,7 +452,7 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
     override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String {
-        return "DROP INDEX ${identifierManager.quoteIfNecessary(indexName)}"
+        return "DROP INDEX ${identifierManager.cutIfNecessaryAndQuote(indexName)}"
     }
 
     override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
@@ -441,7 +441,7 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
         return if (isUnique && !isPartialOrFunctional) {
             "ALTER TABLE IF EXISTS ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
         } else {
-            "DROP INDEX IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
+            "DROP INDEX IF EXISTS ${identifierManager.cutIfNecessaryAndQuote(indexName)}"
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
@@ -466,7 +466,7 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
         return if (isUnique && !isPartialOrFunctional) {
             "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
         } else {
-            "DROP INDEX IF EXISTS ${identifierManager.quoteIfNecessary(indexName)} ON ${identifierManager.quoteIfNecessary(tableName)}"
+            "DROP INDEX IF EXISTS ${identifierManager.cutIfNecessaryAndQuote(indexName)} ON ${identifierManager.quoteIfNecessary(tableName)}"
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
@@ -255,7 +255,9 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
         toString()
     }
 
-    override fun insertValue(columnName: String, queryBuilder: QueryBuilder) { queryBuilder { +"EXCLUDED.$columnName" } }
+    override fun insertValue(columnName: String, queryBuilder: QueryBuilder) {
+        queryBuilder { +"EXCLUDED.$columnName" }
+    }
 
     override fun queryLimitAndOffset(size: Int?, offset: Long, alreadyOrdered: Boolean): String {
         @OptIn(InternalApi::class)
@@ -321,7 +323,7 @@ open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQ
     }
 
     override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String {
-        return "DROP INDEX IF EXISTS ${identifierManager.quoteIfNecessary(indexName)}"
+        return "DROP INDEX IF EXISTS ${identifierManager.cutIfNecessaryAndQuote(indexName)}"
     }
 
     override fun createDatabase(name: String) = "ATTACH DATABASE '${name.lowercase()}.db' AS ${name.inProperCase()}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/VendorDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/VendorDialect.kt
@@ -105,7 +105,7 @@ abstract class VendorDialect(
     }
 
     override fun dropIndex(tableName: String, indexName: String, isUnique: Boolean, isPartialOrFunctional: Boolean): String {
-        return "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT ${identifierManager.quoteIfNecessary(indexName)}"
+        return "ALTER TABLE ${identifierManager.quoteIfNecessary(tableName)} DROP CONSTRAINT ${identifierManager.cutIfNecessaryAndQuote(indexName)}"
     }
 
     override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> =

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateIndexTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateIndexTests.kt
@@ -287,6 +287,25 @@ class CreateIndexTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testCreateAndDropIndexWithLongName() {
+        // Long index name
+        val indexName = "index-" + (0..100).joinToString(separator = "-") { "$it" }
+
+        val tester = object : Table("tester") {
+            val value = integer("value").index(indexName)
+        }
+
+        withDb {
+            val createStatement = tester.indices.single().createStatement().single()
+
+            val dropStatement = tester.indices.single().dropStatement().single()
+
+            // Both statements must have either full index name or shortened index name
+            assertEquals(createStatement.contains(indexName), dropStatement.contains(indexName))
+        }
+    }
+
     private fun JdbcTransaction.getIndices(table: Table): List<Index> {
         db.dialectMetadata.resetCaches()
         return currentDialectMetadataTest.existingIndices(table)[table].orEmpty()


### PR DESCRIPTION
#### Description

At the current moment Exposed DDL tries to remove indexes that do not exists in the case when index has long name. We cut that name on creating index, but do not do the same on dropping.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

---

#### Related Issues

[EXPOSED-787](https://youtrack.jetbrains.com/issue/EXPOSED-787) Disparity between create/drop index statements when indices have long index names