### PR TITLE
chore: Add missing R2DBC Dokka dependency handler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     dokka(projects.exposed.exposedKotlinDatetime)
     dokka(projects.exposed.exposedMigration)
     dokka(projects.exposed.exposedMoney)
+    dokka(projects.exposed.exposedR2dbc)
     dokka(projects.exposed.exposedSpringBootStarter)
     dokka(projects.exposed.springTransaction)
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Add missing `dokka()` dependency for R2DBC to `build.gradle.kts`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Build chore

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues
