### PR TITLE
test: Fix spring-boot-starter test blockage following bump to 3.5.0

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/exposed/gradle/TestDbDsl.kt
@@ -100,7 +100,7 @@ private fun Project.createDbTestTaskByDialect(db: TestDb, taskName: String, dial
         if (db.ignoresSpringTests) {
             filter {
                 // exclude all test classes in (spring-transaction, exposed-spring-boot-starter) modules
-                exclude("org/jetbrains/exposed/spring/*", "org/jetbrains/exposed/jdbc-template/*")
+                exclude("org/jetbrains/exposed/v1/spring/*", "org/jetbrains/exposed/v1/jdbc-template/*")
                 isFailOnNoMatchingTests = false
             }
         }

--- a/exposed-spring-boot-starter/build.gradle.kts
+++ b/exposed-spring-boot-starter/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     testImplementation(libs.spring.boot.starter.webflux)
     testImplementation(libs.h2)
     testImplementation(project(":exposed-jdbc"))
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.withType<KotlinCompile>().configureEach {


### PR DESCRIPTION
#### Description

**Summary of the change**: Fix spring-boot tests running on H2 and ensure the same tests don't run on any db that requires docker.

**Detailed description**:
- **Why**: Since `springBoot` version was bumped to 3.5.0 and merged into `main`, not a single build off `main` has passed (it's just no longer visible in GH).

Local tests for `exposed-spring-boot-starter` fail for 2 reasons:

1. `TestDB` that require docker are no longer being ignored because of the package restructuring
2. `TestDB.H2` also fails, but because of this issue:

![spring_boot_gradle_2](https://github.com/user-attachments/assets/977ecddf-2345-4643-9b7d-68bfa4cc116c)

```bash
org.gradle.api.internal.tasks.testing.TestSuiteExecutionException: Could not complete execution for Gradle Test Executor 212.
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:65)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@17.0.7/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base@17.0.7/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@17.0.7/java.lang.reflect.Method.invoke(Method.java:568)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:92)
	at jdk.proxy1/jdk.proxy1.$Proxy4.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:200)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:132)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:103)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:63)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:121)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at app//worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: org.junit.platform.commons.JUnitException: TestEngine with ID 'junit-jupiter' failed to discover tests
	at app//org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:160)
	at app//org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverSafely(EngineDiscoveryOrchestrator.java:134)
	at app//org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:108)
	at app//org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discover(EngineDiscoveryOrchestrator.java:80)
	at app//org.junit.platform.launcher.core.DefaultLauncher.discover(DefaultLauncher.java:110)
	at app//org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at app//org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:124)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:94)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:63)
	... 18 more
Caused by: org.junit.platform.commons.JUnitException: OutputDirectoryProvider not available; probably due to unaligned versions of the junit-platform-engine and junit-platform-launcher jars on the classpath/module path.
	at app//org.junit.platform.engine.EngineDiscoveryRequest.getOutputDirectoryProvider(EngineDiscoveryRequest.java:94)
	at app//org.junit.jupiter.engine.JupiterTestEngine.discover(JupiterTestEngine.java:67)
	at app//org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:152)
	... 28 more
```

- **How**:

1. Change ignore logic to use correct package structure
2. Follow [Gradle solution](https://docs.gradle.org/current/userguide/upgrading_version_8.html#manually_declaring_dependencies). Even though Exposed is using Junit4, the solution for Junit5 fixes the issue. I'm assuming because maybe one of the spingBoot test dependencies uses junit-jupiter.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] TC tests

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
