### PR TITLE
fix: Update resource paths in ExposedAotContribution to match current package structure

### DIFF
--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/v1/spring/boot/ExposedAotContribution.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/v1/spring/boot/ExposedAotContribution.kt
@@ -55,8 +55,8 @@ class ExposedAotContribution : BeanFactoryInitializationAotProcessor {
 
     private fun RuntimeHints.registerResourceHints() {
         listOf(
-            "META-INF/services/org.jetbrains.exposed.v1.dao.id.EntityIDFactory",
-            "META-INF/services/org.jetbrains.exposed.v1.sql.DatabaseConnectionAutoRegistration",
+            "META-INF/services/org.jetbrains.exposed.v1.core.dao.id.EntityIDFactory",
+            "META-INF/services/org.jetbrains.exposed.v1.jdbc.DatabaseConnectionAutoRegistration",
             "META-INF/services/org.jetbrains.exposed.v1.core.statements.GlobalStatementInterceptor"
         ).forEach { resource ->
             resources().registerResource(ClassPathResource(resource))


### PR DESCRIPTION
#### Description

**Summary of the change**:
Updated resource paths in ExposedAotContribution to match the current package structure, ensuring proper GraalVM native image support for Spring Boot applications using Exposed.

**Detailed description**:
- **What**: Updated the resource paths in the `registerResourceHints()` method of `ExposedAotContribution` class to match the current package structure:
  1. Changed `org.jetbrains.exposed.v1.dao.id.EntityIDFactory` to `org.jetbrains.exposed.v1.core.dao.id.EntityIDFactory`
  2. Changed `org.jetbrains.exposed.v1.sql.DatabaseConnectionAutoRegistration` to `org.jetbrains.exposed.v1.jdbc.DatabaseConnectionAutoRegistration`

- **Why**: The package structure of the Exposed framework has been reorganized, with `EntityIDFactory` moving from `dao.id` to `core.dao.id` and `DatabaseConnectionAutoRegistration` moving from `sql` to `jdbc`. The outdated resource paths were causing issues when compiling Spring Boot applications that use Exposed as a GraalVM native image.

> Exception in thread "main" java.lang.IllegalArgumentException: Resource must be a ClassPathResource that exists: class path resource [META-INF/services/org.jetbrains.exposed.v1.dao.id.EntityIDFactory]
	at org.springframework.aot.hint.ResourceHints.registerResource(ResourceHints.java:129)
	at org.jetbrains.exposed.v1.spring.boot.ExposedAotContribution.registerResourceHints(ExposedAotContribution.kt:62)
	at org.jetbrains.exposed.v1.spring.boot.ExposedAotContribution.processAheadOfTime$lambda$2(ExposedAotContribution.kt:39)
	at org.springframework.context.aot.BeanFactoryInitializationAotContributions.applyTo(BeanFactoryInitializationAotContributions.java:96)
	at org.springframework.context.aot.ApplicationContextAotGenerator.lambda$processAheadOfTime$0(ApplicationContextAotGenerator.java:59)
	at org.springframework.context.aot.ApplicationContextAotGenerator.withCglibClassHandler(ApplicationContextAotGenerator.java:68)
	at org.springframework.context.aot.ApplicationContextAotGenerator.processAheadOfTime(ApplicationContextAotGenerator.java:54)
	at org.springframework.context.aot.ContextAotProcessor.performAotProcessing(ContextAotProcessor.java:107)

---

#### Type of Change

- [X] Bug fix

#### Checklist

- [x] The build is green (including the Detekt check)

---