### PR TITLE
fix: Ordering of type mappers, interface for type mappers registry

### DIFF
--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -471,7 +471,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/ArrayTypeMapper : org/
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
@@ -480,7 +480,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/BinaryTypeMapper : org
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
@@ -489,7 +489,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper : o
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
@@ -498,7 +498,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/DefaultTypeMapper : or
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
@@ -507,8 +507,14 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/ExposedColumnTypeMappe
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/mappers/NoValueContainer : org/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer {
+	public fun <init> ()V
+	public fun isPresent ()Z
+	public fun value ()Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/PostgresSpecificTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
@@ -516,8 +522,15 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/PostgresSpecificTypeMa
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/mappers/PresentValueContainer : org/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getValue ()Ljava/lang/Object;
+	public fun isPresent ()Z
+	public fun value ()Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
@@ -525,7 +538,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper : 
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
@@ -554,7 +567,7 @@ public abstract interface class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMappe
 	public abstract fun getColumnTypes ()Ljava/util/List;
 	public abstract fun getDialects ()Ljava/util/List;
 	public abstract fun getPriority ()D
-	public abstract fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public abstract fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public abstract fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
@@ -562,24 +575,12 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$DefaultImpl
 	public static fun getColumnTypes (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Ljava/util/List;
 	public static fun getDialects (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Ljava/util/List;
 	public static fun getPriority (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)D
-	public static fun getValue (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public static fun getValue (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 }
 
-public abstract class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer {
-	public synthetic fun <init> (ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun isPresent ()Z
+public abstract interface class org/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer {
+	public abstract fun isPresent ()Z
 	public abstract fun value ()Ljava/lang/Object;
-}
-
-public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer$NoValue : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer {
-	public fun <init> ()V
-	public fun value ()Ljava/lang/Object;
-}
-
-public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer$PresentValue : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer {
-	public fun <init> (Ljava/lang/Object;)V
-	public final fun getValue ()Ljava/lang/Object;
-	public fun value ()Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/ValueTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
@@ -587,7 +588,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/ValueTypeMapper : org/
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
 	public fun getPriority ()D
-	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -258,7 +258,7 @@ public abstract interface class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConf
 	public abstract fun getConnectionFactoryOptions ()Lio/r2dbc/spi/ConnectionFactoryOptions;
 	public abstract fun getDefaultR2dbcIsolationLevel ()Lio/r2dbc/spi/IsolationLevel;
 	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public abstract fun getTypeMapperRegistry ()Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;
+	public abstract fun getTypeMapping ()Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;
 	public abstract fun getUseExposedCodecs ()Z
 }
 
@@ -270,13 +270,13 @@ public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder : 
 	public fun getDefaultIsolationLevel ()I
 	public final fun getDefaultR2dbcIsolationLevel ()Lio/r2dbc/spi/IsolationLevel;
 	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun getTypeMapperRegistry ()Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;
+	public final fun getTypeMapping ()Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;
 	public final fun getUseExposedCodecs ()Z
 	public final fun setConnectionFactoryOptions (Lio/r2dbc/spi/ConnectionFactoryOptions;)V
 	public fun setDefaultIsolationLevel (I)V
 	public final fun setDefaultR2dbcIsolationLevel (Lio/r2dbc/spi/IsolationLevel;)V
 	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
-	public final fun setTypeMapperRegistry (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;)V
+	public final fun setTypeMapping (Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;)V
 	public final fun setUrl (Ljava/lang/String;)V
 	public final fun setUseExposedCodecs (Z)V
 }
@@ -470,68 +470,98 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/ArrayTypeMapper : org/
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/BinaryTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/DefaultTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/ExposedColumnTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/PostgresSpecificTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+}
+
+public abstract interface class org/jetbrains/exposed/v1/r2dbc/mappers/R2dbcRegistryTypeMapping : org/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping {
+	public static final field Companion Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcRegistryTypeMapping$Companion;
+	public abstract fun register (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcRegistryTypeMappingImpl;
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/mappers/R2dbcRegistryTypeMapping$Companion {
+	public final fun default ()Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/mappers/R2dbcRegistryTypeMappingImpl : org/jetbrains/exposed/v1/r2dbc/mappers/R2dbcRegistryTypeMapping {
+	public fun <init> ()V
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
+	public fun register (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcRegistryTypeMappingImpl;
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+}
+
+public abstract interface class org/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping {
+	public abstract fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
+	public abstract fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public abstract interface class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public abstract fun getColumnTypes ()Ljava/util/List;
 	public abstract fun getDialects ()Ljava/util/List;
+	public abstract fun getPriority ()D
 	public abstract fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public abstract fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public abstract fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$DefaultImpls {
 	public static fun getColumnTypes (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Ljava/util/List;
 	public static fun getDialects (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Ljava/util/List;
+	public static fun getPriority (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)D
 	public static fun getValue (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
 }
 
@@ -552,26 +582,13 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContai
 	public fun value ()Ljava/lang/Object;
 }
 
-public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry {
-	public static final field Companion Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
-	public final fun register (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;
-	public final fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
-}
-
-public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry$Companion {
-	public final fun default ()Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;
-}
-
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/ValueTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
 	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
 	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$ValueContainer;
-	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/mtc/ThreadLocalMap : java/lang/InheritableThreadLocal {
@@ -648,7 +665,7 @@ public class org/jetbrains/exposed/v1/r2dbc/statements/MergeSuspendExecutable : 
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl : org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcExposedConnection {
-	public fun <init> (Lorg/reactivestreams/Publisher;Ljava/lang/String;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcScope;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;)V
+	public fun <init> (Lorg/reactivestreams/Publisher;Ljava/lang/String;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcScope;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun commit (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun executeInBatch (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -674,7 +691,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/statements/R2dbcPreparedStatementImpl : org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi {
-	public fun <init> (Lio/r2dbc/spi/Statement;Lio/r2dbc/spi/Connection;ZLorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;)V
+	public fun <init> (Lio/r2dbc/spi/Statement;Lio/r2dbc/spi/Connection;ZLorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;)V
 	public fun addBatch (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun cancel (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun closeIfPossible (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -749,7 +766,7 @@ public class org/jetbrains/exposed/v1/r2dbc/statements/UpsertSuspendExecutable :
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2DBCRow : org/jetbrains/exposed/v1/core/statements/api/RowApi {
-	public fun <init> (Lio/r2dbc/spi/Row;Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapperRegistry;)V
+	public fun <init> (Lio/r2dbc/spi/Row;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;)V
 	public fun getObject (I)Ljava/lang/Object;
 	public fun getObject (ILjava/lang/Class;)Ljava/lang/Object;
 	public fun getObject (ILjava/lang/Class;Lorg/jetbrains/exposed/v1/core/ColumnType;)Ljava/lang/Object;

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabase.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabase.kt
@@ -140,7 +140,7 @@ class R2dbcDatabase private constructor(
             val factory = connectionFactory ?: ConnectionFactories.get(options)
 
             return R2dbcDatabase(explicitVendor, config) {
-                R2dbcConnectionImpl(factory.create(), explicitVendor, R2dbcScope(config.dispatcher), config.typeMapperRegistry)
+                R2dbcConnectionImpl(factory.create(), explicitVendor, R2dbcScope(config.dispatcher), config.typeMapping)
             }.apply {
                 connectionUrl = options.urlString
                 CoreTransactionManager.registerDatabaseManager(this, manager(this))

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig.kt
@@ -6,7 +6,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
-import org.jetbrains.exposed.v1.r2dbc.mappers.TypeMapperRegistry
+import org.jetbrains.exposed.v1.r2dbc.mappers.R2dbcRegistryTypeMapping
+import org.jetbrains.exposed.v1.r2dbc.mappers.R2dbcTypeMapping
 import org.jetbrains.exposed.v1.r2dbc.statements.asInt
 
 // TODO add KDocs
@@ -18,7 +19,7 @@ interface R2dbcDatabaseConfig : DatabaseConfig {
 
     val useExposedCodecs: Boolean
 
-    val typeMapperRegistry: TypeMapperRegistry
+    val typeMapping: R2dbcTypeMapping
 
     val defaultR2dbcIsolationLevel: IsolationLevel?
 
@@ -30,7 +31,7 @@ interface R2dbcDatabaseConfig : DatabaseConfig {
 
         var dispatcher: CoroutineDispatcher = Dispatchers.IO
 
-        var typeMapperRegistry: TypeMapperRegistry = TypeMapperRegistry.default()
+        var typeMapping: R2dbcTypeMapping = R2dbcRegistryTypeMapping.default()
 
         var defaultR2dbcIsolationLevel: IsolationLevel? = null
 
@@ -92,8 +93,8 @@ interface R2dbcDatabaseConfig : DatabaseConfig {
                     get() = this@Builder.connectionFactoryOptions
                 override val useExposedCodecs: Boolean
                     get() = this@Builder.useExposedCodecs
-                override val typeMapperRegistry: TypeMapperRegistry
-                    get() = this@Builder.typeMapperRegistry
+                override val typeMapping: R2dbcTypeMapping
+                    get() = this@Builder.typeMapping
                 override val defaultR2dbcIsolationLevel: IsolationLevel?
                     get() = this@Builder.defaultR2dbcIsolationLevel
             }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/BinaryTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/BinaryTypeMapper.kt
@@ -15,6 +15,9 @@ import kotlin.reflect.KClass
  * Mapper for binary data types.
  */
 class BinaryTypeMapper : TypeMapper {
+    @Suppress("MagicNumber")
+    override val priority = 0.2
+
     override val columnTypes: List<KClass<out IColumnType<*>>>
         get() = listOf(
             BasicBinaryColumnType::class,
@@ -24,7 +27,7 @@ class BinaryTypeMapper : TypeMapper {
     override fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper.kt
@@ -110,15 +110,15 @@ class DateTimeTypeMapper : TypeMapper {
         index: Int,
         dialect: DatabaseDialect,
         columnType: IColumnType<*>
-    ): TypeMapper.ValueContainer<T?> {
+    ): ValueContainer<T?> {
         return when (type) {
             Time::class.java -> {
-                TypeMapper.ValueContainer.PresentValue(
+                PresentValueContainer(
                     row.get(index - 1, LocalTime::class.java)?.let { Time.valueOf(it) as T }
                 )
             }
             Date::class.java -> {
-                TypeMapper.ValueContainer.PresentValue(
+                PresentValueContainer(
                     row.get(index - 1, LocalDate::class.java)?.let { Date.valueOf(it) as T }
                 )
             }
@@ -128,22 +128,22 @@ class DateTimeTypeMapper : TypeMapper {
                 // the column type changes the time according to the time zone, and reverts it back in `valueFromDB`
                 // But for R2DBC it does not happen. This line changes that behaviour to match it to JDBC behaviour.
                 if (currentDialect is MysqlDialect && currentDialect !is MariaDBDialect) {
-                    TypeMapper.ValueContainer.PresentValue(
+                    PresentValueContainer(
                         row.get(index - 1, Instant::class.java)?.let { Timestamp.from(it) as T }
                     )
                 } else {
                     try {
-                        TypeMapper.ValueContainer.PresentValue(
+                        PresentValueContainer(
                             row.get(index - 1, LocalDateTime::class.java)?.let { Timestamp.valueOf(it) as T }
                         )
                     } catch (_: Exception) {
-                        TypeMapper.ValueContainer.PresentValue(
+                        PresentValueContainer(
                             row.get(index - 1, String::class.java)?.let { Timestamp.valueOf(it) as T }
                         )
                     }
                 }
             }
-            else -> TypeMapper.ValueContainer.NoValue()
+            else -> NoValueContainer()
         }
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper.kt
@@ -27,10 +27,13 @@ class DateTimeTypeMapper : TypeMapper {
     // We don't specify columnTypes because IDateColumnType is an interface, not a class that extends IColumnType<*>
     // Instead, we'll check for IDateColumnType in the setValue method
 
+    @Suppress("MagicNumber")
+    override val priority = 0.2
+
     override fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DefaultTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DefaultTypeMapper.kt
@@ -15,13 +15,13 @@ import org.jetbrains.exposed.v1.core.vendors.currentDialect
  */
 class DefaultTypeMapper : TypeMapper {
 
-    // TODO we could add ordering for column mappers based on priority
-    //  fun priority(): Double = 0.5
+    @Suppress("MagicNumber")
+    override val priority: Double = 0.01
 
     override fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ExposedColumnTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ExposedColumnTypeMapper.kt
@@ -10,6 +10,9 @@ import kotlin.reflect.KClass
  * This mapper should be registered first in the registry.
  */
 class ExposedColumnTypeMapper : TypeMapper {
+    @Suppress("MagicNumber")
+    override val priority = 0.5
+
     override val columnTypes: List<KClass<out IColumnType<*>>>
         get() = listOf(
             EntityIDColumnType::class,
@@ -19,17 +22,17 @@ class ExposedColumnTypeMapper : TypeMapper {
     override fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int
     ): Boolean {
         when (columnType) {
             is EntityIDColumnType<*> -> {
-                return mapperRegistry.setValue(statement, dialect, columnType.idColumn.columnType, value, index)
+                return typeMapping.setValue(statement, dialect, columnType.idColumn.columnType, value, index)
             }
             is ColumnWithTransform<*, *> -> {
-                return mapperRegistry.setValue(statement, dialect, columnType.delegate, value, index)
+                return typeMapping.setValue(statement, dialect, columnType.delegate, value, index)
             }
         }
         return false

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PostgresSpecificTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PostgresSpecificTypeMapper.kt
@@ -12,6 +12,10 @@ import kotlin.reflect.KClass
  * Mapper for PostgreSQL-specific types.
  */
 class PostgresSpecificTypeMapper : TypeMapper {
+
+    @Suppress("MagicNumber")
+    override val priority = 0.2
+
     override val dialects: List<KClass<out DatabaseDialect>>
         get() = listOf(PostgreSQLDialect::class)
 
@@ -21,7 +25,7 @@ class PostgresSpecificTypeMapper : TypeMapper {
     override fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper.kt
@@ -9,6 +9,9 @@ import kotlin.reflect.KClass
  * Mapper for primitive types (Int, Long, Float, Double, etc.).
  */
 class PrimitiveTypeMapper : TypeMapper {
+    @Suppress("MagicNumber")
+    override val priority = 0.3
+
     override val columnTypes: List<KClass<out IColumnType<*>>>
         get() = listOf(
             ByteColumnType::class,
@@ -30,7 +33,7 @@ class PrimitiveTypeMapper : TypeMapper {
     override fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper.kt
@@ -86,39 +86,6 @@ interface TypeMapper {
         dialect: DatabaseDialect,
         columnType: IColumnType<*>,
     ): ValueContainer<T?> {
-        return ValueContainer.NoValue()
-    }
-
-    /**
-     * Sealed class representing the result of a getValue operation.
-     * Contains either a present value or indicates that no value was provided.
-     *
-     * @param T The type of the value being retrieved.
-     * @param isPresent True if the container holds a value, false otherwise.
-     */
-    sealed class ValueContainer<T>(val isPresent: Boolean) {
-        /**
-         * Retrieves the present value from the container.
-         * @return The present value if [isPresent] is true.
-         * @throws IllegalStateException if called on a container with no present value.
-         */
-        abstract fun value(): T
-
-        /**
-         * Represents a container with no present value.
-         * This is used when the mapper cannot or should not provide a value.
-         */
-        class NoValue<T> : ValueContainer<T>(false) {
-            override fun value(): T = error("No value provided")
-        }
-
-        /**
-         * Represents a container with a present value.
-         *
-         * @param value The present value to be contained.
-         */
-        class PresentValue<T>(val value: T) : ValueContainer<T>(true) {
-            override fun value() = value
-        }
+        return NoValueContainer()
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper.kt
@@ -12,6 +12,24 @@ import kotlin.reflect.KClass
  * based on the column type and dialect.
  */
 interface TypeMapper {
+
+    /**
+     * The priority of this type mapper used for ordering during mapper resolution.
+     *
+     * Mappers with higher priority values are consulted first when the registry
+     * searches for a suitable mapper. This allows more specific or custom mappers
+     * to override default implementations. The default priority is 0.
+     *
+     * Common priority ranges:
+     * - High priority (0.5+, 1.]: Custom user mappers that should override defaults
+     * - Standard priority (0., 0.5]: Priority of default Exposed type mappers
+     * - Default priority (0.)
+     *
+     * @return The priority value, with higher values indicating higher priority
+     */
+    val priority: Double
+        get() = 0.0
+
     /**
      * List of dialects this mapper supports.
      * If empty, the mapper supports all dialects.
@@ -30,7 +48,7 @@ interface TypeMapper {
      * Sets a value in the statement.
      * @param statement The statement to set the value in.
      * @param dialect The database dialect.
-     * @param mapperRegistry The registry of type mappers.
+     * @param typeMapping The registry of type mappers.
      * @param columnType The column type.
      * @param value The value to set (can be null).
      * @param index The index of the parameter in the statement.
@@ -39,11 +57,37 @@ interface TypeMapper {
     fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int
     ): Boolean
+
+    /**
+     * Retrieves a value from the given row at the specified index.
+     * This method attempts to extract and convert a value from the database row
+     * to the requested type, taking into account the database dialect and column type.
+     *
+     * @param T The expected type of the value to retrieve.
+     * @param row The R2DBC Row containing the data.
+     * @param type The Java Class representing the expected type T.
+     * @param index The 1-based index of the column in the row.
+     * @param dialect The database dialect being used.
+     * @param columnType The column type definition from Exposed.
+     * @return A [ValueContainer] containing either the retrieved value
+     *         or indicating that no value could be provided. The default implementation
+     *         returns [TypeMapperGetValueContainer.NoValue], indicating that this
+     *         mapper cannot handle the requested type conversion.
+     */
+    fun <T> getValue(
+        row: Row,
+        type: Class<T>,
+        index: Int,
+        dialect: DatabaseDialect,
+        columnType: IColumnType<*>,
+    ): ValueContainer<T?> {
+        return ValueContainer.NoValue()
+    }
 
     /**
      * Sealed class representing the result of a getValue operation.
@@ -76,31 +120,5 @@ interface TypeMapper {
         class PresentValue<T>(val value: T) : ValueContainer<T>(true) {
             override fun value() = value
         }
-    }
-
-    /**
-     * Retrieves a value from the given row at the specified index.
-     * This method attempts to extract and convert a value from the database row
-     * to the requested type, taking into account the database dialect and column type.
-     *
-     * @param T The expected type of the value to retrieve.
-     * @param row The R2DBC Row containing the data.
-     * @param type The Java Class representing the expected type T.
-     * @param index The 1-based index of the column in the row.
-     * @param dialect The database dialect being used.
-     * @param columnType The column type definition from Exposed.
-     * @return A [ValueContainer] containing either the retrieved value
-     *         or indicating that no value could be provided. The default implementation
-     *         returns [TypeMapperGetValueContainer.NoValue], indicating that this
-     *         mapper cannot handle the requested type conversion.
-     */
-    fun <T> getValue(
-        row: Row,
-        type: Class<T>,
-        index: Int,
-        dialect: DatabaseDialect,
-        columnType: IColumnType<*>,
-    ): ValueContainer<T?> {
-        return ValueContainer.NoValue()
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer.kt
@@ -1,0 +1,42 @@
+package org.jetbrains.exposed.v1.r2dbc.mappers
+
+/**
+ * Sealed class representing the result of a getValue operation.
+ * Contains either a present value or indicates that no value was provided.
+ *
+ * @param T The type of the value being retrieved.
+ */
+interface ValueContainer<T> {
+    /**
+     * True if the container holds a value, false otherwise.
+     */
+    val isPresent: Boolean
+
+    /**
+     * Retrieves the present value from the container.
+     * @return The present value if [isPresent] is true.
+     * @throws IllegalStateException if called on a container with no present value.
+     */
+    fun value(): T
+}
+
+/**
+ * Represents a container with no present value.
+ * This is used when the mapper cannot or should not provide a value.
+ */
+class NoValueContainer<T> : ValueContainer<T> {
+    override val isPresent = false
+
+    override fun value(): T = error("No value provided")
+}
+
+/**
+ * Represents a container with a present value.
+ *
+ * @param value The present value to be contained.
+ */
+class PresentValueContainer<T>(val value: T) : ValueContainer<T> {
+    override val isPresent = true
+
+    override fun value() = value
+}

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ValueTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ValueTypeMapper.kt
@@ -15,10 +15,13 @@ class ValueTypeMapper : TypeMapper {
     // This mapper handles all column types, but only for specific value types
     // It's a fallback for values that don't have a specific mapper
 
+    @Suppress("MagicNumber")
+    override val priority = 0.1
+
     override fun setValue(
         statement: Statement,
         dialect: DatabaseDialect,
-        mapperRegistry: TypeMapperRegistry,
+        typeMapping: R2dbcTypeMapping,
         columnType: IColumnType<*>,
         value: Any?,
         index: Int

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
@@ -151,7 +151,7 @@ open class InsertSuspendExecutable<Key : Any, S : InsertStatement<Key>>(
             }
 
             if (segment is Result.RowSegment) {
-                val row = R2DBCRow(segment.row(), typeMapperRegistry)
+                val row = R2DBCRow(segment.row(), typeMapping)
 
                 if (columnIndexesInResultSet == null) {
                     columnIndexesInResultSet = row.metadata.returnedColumns()
@@ -279,6 +279,7 @@ open class InsertSuspendExecutable<Key : Any, S : InsertStatement<Key>>(
     @OptIn(InternalApi::class)
     private fun columnsGeneratedOnDB(): Collection<Column<*>> = (autoIncColumns + statement.columnsWithDatabaseDefaults()).toSet()
 
+    @Suppress("UNCHECKED_CAST")
     private fun <T : Expression<*>> unwrapColumnValues(values: Map<T, Any?>): Map<T, Any?> = values.mapValues { (col, value) ->
         if (col !is ExpressionWithColumnType<*>) return@mapValues value
 

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
@@ -19,7 +19,7 @@ import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.r2dbc.R2dbcScope
-import org.jetbrains.exposed.v1.r2dbc.mappers.TypeMapperRegistry
+import org.jetbrains.exposed.v1.r2dbc.mappers.R2dbcTypeMapping
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcDatabaseMetadataImpl
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcExposedConnection
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcExposedDatabaseMetadata
@@ -38,7 +38,7 @@ class R2dbcConnectionImpl(
     override val connection: Publisher<out Connection>,
     private val vendorDialect: String,
     private val scope: R2dbcScope,
-    private val typeMapperRegistry: TypeMapperRegistry
+    private val typeMapping: R2dbcTypeMapping
 ) : R2dbcExposedConnection<Publisher<out Connection>> {
     private val metadataProvider: MetadataProvider = MetadataProvider.getProvider(vendorDialect)
 
@@ -114,7 +114,7 @@ class R2dbcConnectionImpl(
 //        TODO
 //        val r2dbcQuery = if (returnKeys) "$preparedSql RETURNING *" else preparedSql
 //        R2dbcPreparedStatementImpl(createStatement(r2dbcQuery), this, returnKeys, isInsert = r2dbcQuery.startsWith("INSERT"))
-        R2dbcPreparedStatementImpl(r2dbcStatement, this, returnKeys, currentDialect, typeMapperRegistry)
+        R2dbcPreparedStatementImpl(r2dbcStatement, this, returnKeys, currentDialect, typeMapping)
     }
 
     override suspend fun prepareStatement(
@@ -123,7 +123,7 @@ class R2dbcConnectionImpl(
     ): R2dbcPreparedStatementImpl = withConnection {
         val preparedSql = r2dbcPreparedSql(sql)
         val r2dbcStatement = createStatement(preparedSql).returnGeneratedValues(*columns)
-        R2dbcPreparedStatementImpl(r2dbcStatement, this, true, currentDialect, typeMapperRegistry)
+        R2dbcPreparedStatementImpl(r2dbcStatement, this, true, currentDialect, typeMapping)
     }
 
     private fun r2dbcPreparedSql(sql: String): String {


### PR DESCRIPTION
#### Description

`TypeMapperRegistry` class was  abstracted with 2 interfaces `R2dbcTypeMapping` and `R2dbcRegistryTypeMapping`.

The first one `R2dbcTypeMapping` is the base class for any implementation for r2dbc type mapping that we expect from the user. It contains 2 methods `setValue` and `getValue`.

The second one `R2dbcRegistryTypeMapping` is a more specific type mapping that is aware of `TypeMapper` and extends `TypeMapperRegistry`. It has method `register` to add new type mappers. 

The old class `TypeMapperRegistry` become `R2dbcRegistryTypeMappingImpl` and implements `R2dbcRegistryTypeMapping`. 

So that confiuguration allows to write own type mappers, and use our `R2dbcRegistryTypeMappingImpl`, or create complete own type mapping based on anything else.

I'm not sure about naming, I personally don't like word `Impl` in classes.

Also added ordering for type mappers based on `priority` field of type mapper, what allows to load mappers from the configuration without ordering issues.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix


