### PR TITLE
test: Enable PostgreSQL tests for R2DBC customEnumeration()

### DIFF
--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/EnumerationTests.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.update
@@ -74,7 +75,7 @@ class EnumerationTests : DatabaseTestsBase() {
                     exec("CREATE TYPE FooEnum AS ENUM ('Bar', 'Baz');")
                 }
                 EnumTable.initEnumColumn(sqlType)
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(EnumTable)
+                SchemaUtils.create(EnumTable)
                 // drop shared table object's unique index if created in other test
                 if (EnumTable.indices.isNotEmpty()) {
                     exec(EnumTable.indices.first().dropStatement().single())
@@ -99,7 +100,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 assertEquals(Foo.Bar, enumClass.reload(entity, true)!!.enum)
             } finally {
                 try {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(EnumTable)
+                    SchemaUtils.drop(EnumTable)
                 } catch (ignore: Exception) {}
             }
         }
@@ -122,7 +123,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 with(EnumTable) {
                     enumColumn.default(Foo.Bar)
                 }
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(EnumTable)
+                SchemaUtils.create(EnumTable)
                 // drop shared table object's unique index if created in other test
                 if (EnumTable.indices.isNotEmpty()) {
                     exec(EnumTable.indices.first().dropStatement().single())
@@ -133,7 +134,7 @@ class EnumerationTests : DatabaseTestsBase() {
                 assertEquals(Foo.Bar, default)
             } finally {
                 try {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(EnumTable)
+                    SchemaUtils.drop(EnumTable)
                 } catch (ignore: Exception) {}
             }
         }
@@ -165,10 +166,10 @@ class EnumerationTests : DatabaseTestsBase() {
                 with(EnumTable) {
                     if (indices.isEmpty()) enumColumn.uniqueIndex()
                 }
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(EnumTable)
+                SchemaUtils.create(EnumTable)
 
                 referenceTable.initRefColumn()
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(referenceTable)
+                SchemaUtils.create(referenceTable)
 
                 val fooBar = Foo.Bar
                 val id1 = EnumTable.insert {
@@ -181,9 +182,9 @@ class EnumerationTests : DatabaseTestsBase() {
                 assertEquals(fooBar, EnumTable.selectAll().single()[EnumTable.enumColumn])
                 assertEquals(fooBar, referenceTable.selectAll().single()[referenceTable.referenceColumn])
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(referenceTable)
+                SchemaUtils.drop(referenceTable)
                 exec(EnumTable.indices.first().dropStatement().single())
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(EnumTable)
+                SchemaUtils.drop(EnumTable)
             }
         }
     }


### PR DESCRIPTION
#### Description

**Summary of the change**: Enable `TestDB.POSTGRESQL` in all existing R2DBC `customEnumeration()` tests

**Detailed description**:
- **Why**: Tests with `customEnumeration()` were not running on PostgreSQL because they would fail with `Cannot decode parameter of type...` errors. This is because PostgreSQL Enum types require special [enum codec registration on r2dbc connection](https://github.com/pgjdbc/r2dbc-postgresql?tab=readme-ov-file#postgres-enum-types).

- **What**:
    - Create `R2dbcDatabase.connect()` instance that uses PG-specific connection factory with `.codecRegistrar()` configuration.
    - Use this instance for any connections that require binding a Kotlin Enum constant to a statement parameter 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - test refactor

Affected databases:
- [X] Postgres

#### Checklist

- [X] Unit tests are in place