### PR TITLE
fix: Split date/time type mapper

### DIFF
--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -481,6 +481,33 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/BinaryTypeMapper : org
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
+public final class org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeMySqlTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
+	public fun <init> ()V
+	public fun getColumnTypes ()Ljava/util/List;
+	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeNullTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
+	public fun <init> ()V
+	public fun getColumnTypes ()Ljava/util/List;
+	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeOracleTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
+	public fun <init> ()V
+	public fun getColumnTypes ()Ljava/util/List;
+	public fun getDialects ()Ljava/util/List;
+	public fun getPriority ()D
+	public fun getValue (Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
+	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
+}
+
 public final class org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper : org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper {
 	public fun <init> ()V
 	public fun getColumnTypes ()Ljava/util/List;
@@ -573,6 +600,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper$DefaultImpl
 	public static fun getDialects (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)Ljava/util/List;
 	public static fun getPriority (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;)D
 	public static fun getValue (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;Lio/r2dbc/spi/Row;Ljava/lang/Class;ILorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/core/IColumnType;)Lorg/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer;
+	public static fun setValue (Lorg/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper;Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
 public abstract interface class org/jetbrains/exposed/v1/r2dbc/mappers/ValueContainer {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeMySqlTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeMySqlTypeMapper.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.exposed.v1.r2dbc.mappers
+
+import io.r2dbc.spi.Row
+import org.jetbrains.exposed.v1.core.IColumnType
+import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
+import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
+import java.sql.Timestamp
+import java.time.Instant
+
+class DateTimeMySqlTypeMapper : TypeMapper {
+    @Suppress("MagicNumber")
+    override val priority = 0.25
+
+    override val dialects = listOf(MysqlDialect::class)
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T> getValue(
+        row: Row,
+        type: Class<T>,
+        index: Int,
+        dialect: DatabaseDialect,
+        columnType: IColumnType<*>
+    ): ValueContainer<T?> {
+        if (dialect is MariaDBDialect) {
+            return NoValueContainer()
+        }
+
+        return when (type) {
+            // It is tricky, probably the reason for MySql special case is not here but in `KotlinInstantColumnType`
+            // The problem is that the line `rs.getObject(index, java.sql.Timestamp::class.java)` in method `valueFromDB()` inside
+            // the column type changes the time according to the time zone, and reverts it back in `valueFromDB`
+            // But for R2DBC it does not happen. This line changes that behaviour to match it to JDBC behaviour.
+            Timestamp::class.java -> PresentValueContainer(
+                row.get(index - 1, Instant::class.java)?.let { Timestamp.from(it) as T }
+            )
+
+            else -> NoValueContainer()
+        }
+    }
+}

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeNullTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeNullTypeMapper.kt
@@ -1,0 +1,52 @@
+package org.jetbrains.exposed.v1.r2dbc.mappers
+
+import io.r2dbc.spi.Statement
+import org.jetbrains.exposed.v1.core.IColumnType
+import org.jetbrains.exposed.v1.core.IDateColumnType
+import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
+import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
+import org.jetbrains.exposed.v1.core.vendors.OracleDialect
+
+/**
+ * The mapper that sets the nulls into date/time columns
+ */
+class DateTimeNullTypeMapper : TypeMapper {
+
+    @Suppress("MagicNumber")
+    override val priority = 0.25
+
+    private val classOptions = listOf(
+        java.time.LocalDateTime::class.java,
+        java.time.LocalTime::class.java,
+        java.time.LocalDate::class.java,
+    )
+
+    override fun setValue(
+        statement: Statement,
+        dialect: DatabaseDialect,
+        typeMapping: R2dbcTypeMapping,
+        columnType: IColumnType<*>,
+        value: Any?,
+        index: Int
+    ): Boolean {
+        if (columnType !is IDateColumnType) return false
+        if (value != null) return false
+
+        val temporalSupported = dialect is OracleDialect || (dialect is MysqlDialect && dialect !is MariaDBDialect)
+
+        if (temporalSupported) {
+            statement.bindNull(index - 1, java.time.temporal.Temporal::class.java)
+            return true
+        } else {
+            for (option in classOptions) {
+                try {
+                    statement.bindNull(index - 1, option)
+                    return true
+                } catch (_: RuntimeException) {
+                }
+            }
+            return false
+        }
+    }
+}

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeOracleTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeOracleTypeMapper.kt
@@ -1,0 +1,54 @@
+package org.jetbrains.exposed.v1.r2dbc.mappers
+
+import io.r2dbc.spi.Statement
+import org.jetbrains.exposed.v1.core.IColumnType
+import org.jetbrains.exposed.v1.core.IDateColumnType
+import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
+import org.jetbrains.exposed.v1.core.vendors.H2Dialect
+import org.jetbrains.exposed.v1.core.vendors.OracleDialect
+import java.sql.Timestamp
+
+private const val ORACLE_START_YEAR = 1970
+
+class DateTimeOracleTypeMapper : TypeMapper {
+    @Suppress("MagicNumber")
+    override val priority = 0.25
+
+    override val dialects = listOf(H2Dialect::class, OracleDialect::class)
+
+    override fun setValue(
+        statement: Statement,
+        dialect: DatabaseDialect,
+        typeMapping: R2dbcTypeMapping,
+        columnType: IColumnType<*>,
+        value: Any?,
+        index: Int
+    ): Boolean {
+        if (columnType !is IDateColumnType) return false
+        if (value == null) return false
+
+        if (value is java.time.LocalTime) {
+            when {
+                dialect is OracleDialect -> {
+                    // For Oracle dialect, convert LocalTime to java.sql.Timestamp with a fixed date (1970-01-01)
+                    // This is because Oracle dialect defines time columns as TIMESTAMP columns
+                    val dateTime = java.time.LocalDateTime.of(java.time.LocalDate.of(ORACLE_START_YEAR, 1, 1), value)
+                    val timestamp = Timestamp.valueOf(dateTime)
+                    statement.bind(index - 1, timestamp)
+                    return true
+                }
+                dialect is H2Dialect && dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle -> {
+                    // For H2 in Oracle compatibility mode, format LocalTime as a string in the format "1970-01-01 HH:mm:ss"
+                    // This is consistent with the JDBC implementation
+                    val formatter = java.time.format.DateTimeFormatter.ofPattern("1970-01-01 HH:mm:ss", java.util.Locale.ROOT)
+                        .withZone(java.time.ZoneId.of("UTC"))
+                    val timeString = formatter.format(value)
+                    statement.bind(index - 1, timeString)
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+}

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeTypeMapper.kt
@@ -5,20 +5,12 @@ import io.r2dbc.spi.Statement
 import org.jetbrains.exposed.v1.core.IColumnType
 import org.jetbrains.exposed.v1.core.IDateColumnType
 import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
-import org.jetbrains.exposed.v1.core.vendors.H2Dialect
-import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
-import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
-import org.jetbrains.exposed.v1.core.vendors.OracleDialect
-import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import java.sql.Date
 import java.sql.Time
 import java.sql.Timestamp
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-
-private const val ORACLE_START_YEAR = 1970
 
 /**
  * Mapper for date/time related types.
@@ -39,64 +31,13 @@ class DateTimeTypeMapper : TypeMapper {
         index: Int
     ): Boolean {
         if (columnType !is IDateColumnType) return false
-
-        // TODO if we have priority for TypeMappers we could split this logic into different type mappers
-
-        // most db throw: Cannot encode [null] parameter of type [java.time.temporal.Temporal]
-        val temporalSupported = dialect is OracleDialect || (dialect is MysqlDialect && dialect !is MariaDBDialect)
-        if (value == null && temporalSupported) {
-            // For null values, we need to determine the appropriate Java class type
-            // Since we don't know the exact type, we'll use a generic approach
-            statement.bindNull(index - 1, java.time.temporal.Temporal::class.java)
-            return true
-        } else if (value == null) {
-            val classOptions = listOf(
-                java.time.LocalDateTime::class.java,
-                java.time.LocalTime::class.java,
-                java.time.LocalDate::class.java,
-            )
-            var optionIndex = 0
-            var incorrectOption = true
-            while (optionIndex < classOptions.size && incorrectOption) {
-                try {
-                    statement.bindNull(index - 1, classOptions[optionIndex])
-                    incorrectOption = false
-                } catch (_: RuntimeException) {
-                    optionIndex++
-                }
-            }
-            return true
-        }
-
-        // For Oracle dialect, we need to handle time values differently
-        // because Oracle dialect defines time columns as TIMESTAMP columns
-        if (value is java.time.LocalTime) {
-            when {
-                dialect is OracleDialect -> {
-                    // For Oracle dialect, convert LocalTime to java.sql.Timestamp with a fixed date (1970-01-01)
-                    // This is because Oracle dialect defines time columns as TIMESTAMP columns
-                    val dateTime = java.time.LocalDateTime.of(java.time.LocalDate.of(ORACLE_START_YEAR, 1, 1), value)
-                    val timestamp = Timestamp.valueOf(dateTime)
-                    statement.bind(index - 1, timestamp)
-                    return true
-                }
-                dialect is H2Dialect && dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle -> {
-                    // For H2 in Oracle compatibility mode, format LocalTime as a string in the format "1970-01-01 HH:mm:ss"
-                    // This is consistent with the JDBC implementation
-                    val formatter = java.time.format.DateTimeFormatter.ofPattern("1970-01-01 HH:mm:ss", java.util.Locale.ROOT)
-                        .withZone(java.time.ZoneId.of("UTC"))
-                    val timeString = formatter.format(value)
-                    statement.bind(index - 1, timeString)
-                    return true
-                }
-            }
-        }
+        if (value == null) return false
 
         val convertedValue = when (value) {
             is Time -> value.toLocalTime()
             is Date -> value.toLocalDate()
             is Timestamp -> value.toLocalDateTime()
-            is java.time.LocalTime -> Time.valueOf(value)
+            is LocalTime -> Time.valueOf(value)
             else -> value
         }
         statement.bind(index - 1, convertedValue)
@@ -123,24 +64,14 @@ class DateTimeTypeMapper : TypeMapper {
                 )
             }
             Timestamp::class.java -> {
-                // It is tricky, probably the reason for MySql special case is not here but in `KotlinInstantColumnType`
-                // The problem is that the line `rs.getObject(index, java.sql.Timestamp::class.java)` in method `valueFromDB()` inside
-                // the column type changes the time according to the time zone, and reverts it back in `valueFromDB`
-                // But for R2DBC it does not happen. This line changes that behaviour to match it to JDBC behaviour.
-                if (currentDialect is MysqlDialect && currentDialect !is MariaDBDialect) {
+                try {
                     PresentValueContainer(
-                        row.get(index - 1, Instant::class.java)?.let { Timestamp.from(it) as T }
+                        row.get(index - 1, LocalDateTime::class.java)?.let { Timestamp.valueOf(it) as T }
                     )
-                } else {
-                    try {
-                        PresentValueContainer(
-                            row.get(index - 1, LocalDateTime::class.java)?.let { Timestamp.valueOf(it) as T }
-                        )
-                    } catch (_: Exception) {
-                        PresentValueContainer(
-                            row.get(index - 1, String::class.java)?.let { Timestamp.valueOf(it) as T }
-                        )
-                    }
+                } catch (_: Exception) {
+                    PresentValueContainer(
+                        row.get(index - 1, String::class.java)?.let { Timestamp.valueOf(it) as T }
+                    )
                 }
             }
             else -> NoValueContainer()

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DefaultTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DefaultTypeMapper.kt
@@ -27,22 +27,15 @@ class DefaultTypeMapper : TypeMapper {
         index: Int
     ): Boolean {
         if (value == null) {
-            // TODO this code could be simplified
             if (currentDialect is PostgreSQLDialect) {
-                val typeProvider = currentDialect.dataTypeProvider
-                when (columnType.sqlType()) {
-                    typeProvider.integerType() -> statement.bindNull(index - 1, Int::class.java)
-                    typeProvider.longType() -> statement.bindNull(index - 1, Long::class.java)
-                    else -> statement.bindNull(index - 1, String::class.java)
-                }
-                return true
+                statement.bindNull(index - 1, Object::class.java)
             } else {
                 statement.bindNull(index - 1, String::class.java)
-                return true
             }
         } else {
             statement.bind(index - 1, value)
-            return true
         }
+
+        return true
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/TypeMapper.kt
@@ -61,7 +61,9 @@ interface TypeMapper {
         columnType: IColumnType<*>,
         value: Any?,
         index: Int
-    ): Boolean
+    ): Boolean {
+        return false
+    }
 
     /**
      * Retrieves a value from the given row at the specified index.

--- a/exposed-r2dbc/src/main/resources/META-INF/services/org.jetbrains.exposed.v1.r2dbc.mappers.TypeMapper
+++ b/exposed-r2dbc/src/main/resources/META-INF/services/org.jetbrains.exposed.v1.r2dbc.mappers.TypeMapper
@@ -1,5 +1,8 @@
 org.jetbrains.exposed.v1.r2dbc.mappers.ExposedColumnTypeMapper
 org.jetbrains.exposed.v1.r2dbc.mappers.PrimitiveTypeMapper
+org.jetbrains.exposed.v1.r2dbc.mappers.DateTimeMySqlTypeMapper
+org.jetbrains.exposed.v1.r2dbc.mappers.DateTimeNullTypeMapper
+org.jetbrains.exposed.v1.r2dbc.mappers.DateTimeOracleTypeMapper
 org.jetbrains.exposed.v1.r2dbc.mappers.DateTimeTypeMapper
 org.jetbrains.exposed.v1.r2dbc.mappers.BinaryTypeMapper
 org.jetbrains.exposed.v1.r2dbc.mappers.ArrayTypeMapper


### PR DESCRIPTION
#### Description

Update for r2dbc type mappers, that splits `DateTimeTypeMapper` into several smaller type mappers, that ordered by `priority`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
