### PR TITLE
fix: EXPOSED-806 Inconsistent migration of JSON generated columns on Postgres

### DIFF
--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -2,6 +2,8 @@ import org.gradle.api.tasks.testing.logging.*
 
 plugins {
     kotlin("jvm") apply true
+
+    alias(libs.plugins.serialization)
 }
 
 kotlin {


### PR DESCRIPTION
#### Description

The issue occurs when MigrationUtils attempts to generate a migration for a column that has a default value in the database but lacks a default value in the table object (though it's marked as `databaseGenerated`).

The `databaseGenerated` flag indicates that the column's value will be generated by the database (through a default value, trigger, or other mechanism), but we cannot define this value in the table object itself.

The solution is to skip default value validation for `databaseGenerated` columns. Otherwise, the migration utilities will attempt to remove the existing default value.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Postgres
---

#### Related Issues

[EXPOSED-806](https://youtrack.jetbrains.com/issue/EXPOSED-806) Inconsistent migration of JSON generated columns on Postgres
