### PR TITLE
fix: Remove duplications of inProperCase()

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3530,6 +3530,7 @@ public final class org/jetbrains/exposed/v1/core/vendors/DatabaseDialect$Default
 
 public final class org/jetbrains/exposed/v1/core/vendors/DatabaseDialectKt {
 	public static final fun getCurrentDialect ()Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;
+	public static final fun inProperCase (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract class org/jetbrains/exposed/v1/core/vendors/ForUpdateOption {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Column.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Column.kt
@@ -49,6 +49,7 @@ class Column<T>(
     }
 
     /** Returns the column name in proper case. */
+    @OptIn(InternalApi::class)
     fun nameInDatabaseCase(): String = name.inProperCase()
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Constraints.kt
@@ -259,6 +259,7 @@ data class Index(
     val table: Table
 
     /** Name of the index. */
+    @OptIn(InternalApi::class)
     val indexName: String
         get() = customName ?: buildString {
             append(table.nameInDatabaseCaseUnquoted())

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
@@ -280,6 +280,7 @@ abstract class SchemaUtilityApi {
         }
     }
 
+    @OptIn(InternalApi::class)
     private fun Map<Column<*>, ColumnMetadata>.mapColumnDiffs(): Map<Column<*>, ColumnDiff> {
         val dialect = currentDialect
         return mapValues { (col, existingCol) ->

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Table.kt
@@ -528,6 +528,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
      * Returns the table name in proper case.
      * Should be called within transaction or default [tableName] will be returned.
      */
+    @OptIn(InternalApi::class)
     fun nameInDatabaseCase(): String = tableName.inProperCase()
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
@@ -78,6 +78,7 @@ abstract class Transaction : UserDataHolder(), TransactionInterface {
     val statementStats by lazy { hashMapOf<String, Pair<Int, Long>>() }
 
     /** Returns the string identifier of a [table], based on its [Table.tableName] and [Table.alias], if applicable. */
+    @OptIn(InternalApi::class)
     fun identity(table: Table): String =
         (table as? Alias<*>)?.let { "${identity(it.delegate)} ${db.identifierManager.quoteIfNecessary(it.alias)}" }
             ?: db.identifierManager.quoteIfNecessary(table.tableName.inProperCase())
@@ -87,6 +88,7 @@ abstract class Transaction : UserDataHolder(), TransactionInterface {
         fullIdentity(column, it)
     }.toString()
 
+    @OptIn(InternalApi::class)
     internal fun fullIdentity(column: Column<*>, queryBuilder: QueryBuilder) = queryBuilder {
         if (column.table is Alias<*>) {
             append(db.identifierManager.quoteIfNecessary(column.table.alias))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
@@ -101,12 +101,14 @@ interface DatabaseDialect {
     fun addPrimaryKey(table: Table, pkName: String?, vararg pkColumns: Column<*>): String
 
     /** Returns the SQL statement that creates a database with the specified [name]. */
+    @OptIn(InternalApi::class)
     fun createDatabase(name: String) = "CREATE DATABASE IF NOT EXISTS ${name.inProperCase()}"
 
     /** Returns the SQL query that retrieves a set of existing databases. */
     fun listDatabases(): String = "SHOW DATABASES"
 
     /** Returns the SQL statement that drops the database with the specified [name]. */
+    @OptIn(InternalApi::class)
     fun dropDatabase(name: String) = "DROP DATABASE IF EXISTS ${name.inProperCase()}"
 
     /** Returns the SQL statement that sets the current schema to the specified [schema]. */
@@ -169,5 +171,6 @@ internal val currentDialectIfAvailable: DatabaseDialect?
     }
 
 @OptIn(InternalApi::class)
-internal fun String.inProperCase(): String =
+@InternalApi
+fun String.inProperCase(): String =
     CoreTransactionManager.currentTransactionOrNull()?.db?.identifierManager?.inProperCase(this@inProperCase) ?: this

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
@@ -330,6 +330,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         return super.createIndex(index)
     }
 
+    @OptIn(InternalApi::class)
     override fun createDatabase(name: String) = "CREATE SCHEMA IF NOT EXISTS ${name.inProperCase()}"
 
     override fun listDatabases(): String = "SHOW SCHEMAS"
@@ -337,6 +338,7 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
     override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> =
         super.modifyColumn(column, columnDiff).map { it.replace("MODIFY COLUMN", "ALTER COLUMN") }
 
+    @OptIn(InternalApi::class)
     override fun dropDatabase(name: String) = "DROP SCHEMA IF EXISTS ${name.inProperCase()}"
 
     @Suppress("CyclomaticComplexMethod")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
@@ -469,6 +469,7 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
         }
     }
 
+    @OptIn(InternalApi::class)
     override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
 
     override fun listDatabases(): String = error("This operation is not supported by Oracle dialect")

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
@@ -19,6 +19,7 @@ internal object PostgreSQLDataTypeProvider : DataTypeProvider() {
         exposedLogger.warn("The length of the binary column is not required.")
         return binaryType()
     }
+
     override fun blobType(): String = "bytea"
     override fun uuidToDB(value: UUID): Any = value
     override fun dateTimeType(): String = "TIMESTAMP"
@@ -292,7 +293,9 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun insertValue(columnName: String, queryBuilder: QueryBuilder) { queryBuilder { +"EXCLUDED.$columnName" } }
+    override fun insertValue(columnName: String, queryBuilder: QueryBuilder) {
+        queryBuilder { +"EXCLUDED.$columnName" }
+    }
 
     override fun delete(
         ignore: Boolean,
@@ -340,7 +343,9 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
         }
     }
 
-    override fun StringBuilder.appendOptionsToExplain(options: String) { append("($options) ") }
+    override fun StringBuilder.appendOptionsToExplain(options: String) {
+        append("($options) ")
+    }
 
     override fun returning(
         mainSql: String,
@@ -425,10 +430,12 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
         return list
     }
 
+    @OptIn(InternalApi::class)
     override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
 
     override fun listDatabases(): String = "SELECT datname FROM pg_database"
 
+    @OptIn(InternalApi::class)
     override fun dropDatabase(name: String): String = "DROP DATABASE ${name.inProperCase()}"
 
     override fun setSchema(schema: Schema): String = "SET search_path TO ${schema.identifier}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
@@ -427,10 +427,12 @@ open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvid
         return statements
     }
 
+    @OptIn(InternalApi::class)
     override fun createDatabase(name: String): String = "CREATE DATABASE ${name.inProperCase()}"
 
     override fun listDatabases(): String = "SELECT name FROM sys.databases"
 
+    @OptIn(InternalApi::class)
     override fun dropDatabase(name: String) = "DROP DATABASE ${name.inProperCase()}"
 
     override fun setSchema(schema: Schema): String = "ALTER USER ${schema.authorization} WITH DEFAULT_SCHEMA = ${schema.identifier}"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
@@ -326,10 +326,12 @@ open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQ
         return "DROP INDEX IF EXISTS ${identifierManager.cutIfNecessaryAndQuote(indexName)}"
     }
 
+    @OptIn(InternalApi::class)
     override fun createDatabase(name: String) = "ATTACH DATABASE '${name.lowercase()}.db' AS ${name.inProperCase()}"
 
     override fun listDatabases(): String = "SELECT name FROM pragma_database_list"
 
+    @OptIn(InternalApi::class)
     override fun dropDatabase(name: String) = "DETACH DATABASE ${name.inProperCase()}"
 
     companion object : DialectNameProvider("SQLite")

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DefaultsTest.kt
@@ -6,12 +6,7 @@ import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
-import org.jetbrains.exposed.v1.core.vendors.H2Dialect
-import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
-import org.jetbrains.exposed.v1.core.vendors.OracleDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
-import org.jetbrains.exposed.v1.core.vendors.h2Mode
+import org.jetbrains.exposed.v1.core.vendors.*
 import org.jetbrains.exposed.v1.dao.Entity
 import org.jetbrains.exposed.v1.dao.EntityClass
 import org.jetbrains.exposed.v1.dao.IntEntity
@@ -22,7 +17,6 @@ import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.constraintNamePart
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.insertAndWait
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
@@ -201,6 +195,7 @@ class DefaultsTest : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testDefaults01() {
         val currentDT = CurrentDateTime
@@ -401,6 +396,7 @@ class DefaultsTest : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testTimestampWithTimeZoneDefaults() {
         // UTC time zone

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
@@ -4,10 +4,10 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.statements.InsertStatement
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
-import org.jetbrains.exposed.v1.jdbc.statements.jdbc.inProperCase
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import java.sql.ResultSet
 import java.sql.SQLException
@@ -40,6 +40,7 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
         }
     }
 
+    @OptIn(InternalApi::class)
     override fun prepared(transaction: JdbcTransaction, sql: String): JdbcPreparedStatementApi = when {
         // https://github.com/pgjdbc/pgjdbc/issues/1168
         // Column names always escaped/quoted in RETURNING clause

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcIdentifierManager.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcIdentifierManager.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.v1.jdbc.statements.jdbc
 
 import org.jetbrains.exposed.v1.core.statements.api.IdentifierManagerApi
-import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import java.sql.DatabaseMetaData
 
 /**
@@ -28,7 +27,3 @@ internal class JdbcIdentifierManager(metadata: DatabaseMetaData) : IdentifierMan
     }
     override val maxColumnNameLength: Int = metadata.maxColumnNameLength
 }
-
-// TODO could we make it public for internal API and remove duplication functions like org.jetbrains.exposed.v1.sql.vendors.DatabaseDialectKt.inProperCase
-internal fun String.inProperCase(): String =
-    TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this@inProperCase) ?: this

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/DatabaseDialectMetadata.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/DatabaseDialectMetadata.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.v1.jdbc.vendors
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.vendors.ColumnMetadata
 import org.jetbrains.exposed.v1.core.vendors.PrimaryKeyMetadata
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import java.util.concurrent.ConcurrentHashMap
@@ -67,6 +68,7 @@ abstract class DatabaseDialectMetadata {
     }
 
     /** Checks if the specified table exists in the database. */
+    @OptIn(InternalApi::class)
     fun tableExists(table: Table): Boolean {
         return table.schemaName?.let { schema ->
             getAllTableNamesCache().getValue(schema.inProperCase()).any {
@@ -82,6 +84,7 @@ abstract class DatabaseDialectMetadata {
         }
     }
 
+    @OptIn(InternalApi::class)
     protected open fun String.metadataMatchesTable(schema: String, table: Table): Boolean {
         return when {
             schema.isEmpty() -> this == table.nameInDatabaseCaseUnquoted()
@@ -95,12 +98,14 @@ abstract class DatabaseDialectMetadata {
     }
 
     /** Checks if the specified schema exists. */
+    @OptIn(InternalApi::class)
     fun schemaExists(schema: Schema): Boolean {
         val allSchemas = getAllSchemaNamesCache()
         return allSchemas.any { it == schema.identifier.inProperCase() }
     }
 
     /** Returns whether the specified sequence exists. */
+    @OptIn(InternalApi::class)
     fun sequenceExists(sequence: Sequence): Boolean {
         return sequences().any { it == sequence.identifier.inProperCase() }
     }
@@ -187,6 +192,3 @@ private val explicitDialect = ThreadLocal<DatabaseDialectMetadata?>()
 /** Returns the dialect used in the current transaction, may throw an exception if there is no current transaction. */
 val currentDialectMetadata: DatabaseDialectMetadata
     get() = explicitDialect.get() ?: TransactionManager.current().db.dialectMetadata
-
-internal fun String.inProperCase(): String =
-    TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this@inProperCase) ?: this

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/MysqlDialectMetadata.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/MysqlDialectMetadata.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.v1.jdbc.vendors
 
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 
 /**
  * Mysql dialect metadata implementation.

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeDefaultsTest.kt
@@ -16,7 +16,6 @@ import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.constraintNamePart
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.insertAndWait
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
@@ -147,6 +146,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testDefaults01() {
         val currentDT = CurrentDateTime
@@ -388,6 +388,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
         assertEquals(date.millis, list1?.get(testData.dateTime)?.millis)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testTimestampWithTimeZoneDefaults() {
         // UTC time zone

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
@@ -6,12 +6,7 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
-import org.jetbrains.exposed.v1.core.vendors.H2Dialect
-import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
-import org.jetbrains.exposed.v1.core.vendors.OracleDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
-import org.jetbrains.exposed.v1.core.vendors.h2Mode
+import org.jetbrains.exposed.v1.core.vendors.*
 import org.jetbrains.exposed.v1.dao.Entity
 import org.jetbrains.exposed.v1.dao.EntityClass
 import org.jetbrains.exposed.v1.dao.IntEntity
@@ -22,7 +17,6 @@ import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.constraintNamePart
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.insertAndWait
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
@@ -196,6 +190,7 @@ class DefaultsTest : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testDefaults01() {
         val currentDT = CurrentDateTime
@@ -404,6 +399,7 @@ class DefaultsTest : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testTimestampWithTimeZoneDefaults() {
         // UTC time zone

--- a/exposed-migration/api/exposed-migration.api
+++ b/exposed-migration/api/exposed-migration.api
@@ -2,7 +2,6 @@ public abstract class org/jetbrains/exposed/v1/migration/MigrationUtilityApi : o
 	public fun <init> ()V
 	protected final fun filterMissingSequences (Ljava/util/Set;[Lorg/jetbrains/exposed/v1/core/Table;)Ljava/util/List;
 	protected final fun filterUnmappedSequences (Ljava/util/Set;[Lorg/jetbrains/exposed/v1/core/Table;)Ljava/util/List;
-	protected final fun inProperCase (Ljava/lang/String;)Ljava/lang/String;
 	protected final fun mapUnmappedColumnStatementsTo (Lorg/jetbrains/exposed/v1/core/Table;Ljava/util/Collection;Ljava/util/List;)Ljava/util/Collection;
 	protected final fun writeMigrationScriptTo (Ljava/util/List;Ljava/lang/String;)Ljava/io/File;
 }

--- a/exposed-migration/src/main/kotlin/org/jetbrains/exposed/v1/migration/MigrationUtilityApi.kt
+++ b/exposed-migration/src/main/kotlin/org/jetbrains/exposed/v1/migration/MigrationUtilityApi.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.v1.core.SchemaUtilityApi
 import org.jetbrains.exposed.v1.core.Sequence
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.vendors.ColumnMetadata
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import java.io.File
 
@@ -68,9 +69,4 @@ abstract class MigrationUtilityApi : SchemaUtilityApi() {
         unmappedSequences.addAll(subtract(mappedSequencesNames).map { Sequence(it) })
         return unmappedSequences.toList()
     }
-
-    /** Returns an identity in a casing appropriate for its identifier status and the database, then caches the returned value. */
-    @InternalApi
-    protected fun String.inProperCase(): String =
-        TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this@inProperCase) ?: this
 }

--- a/exposed-r2dbc-tests/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/tests/TestUtils.kt
+++ b/exposed-r2dbc-tests/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/tests/TestUtils.kt
@@ -16,8 +16,6 @@ import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.r2dbc.vendors.DatabaseDialectMetadata
 import java.util.*
 
-fun String.inProperCase(): String = TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this) ?: this
-
 val currentDialectTest: DatabaseDialect get() = TransactionManager.current().db.dialect
 
 val currentDialectMetadataTest: DatabaseDialectMetadata

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/H2Tests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/H2Tests.kt
@@ -10,6 +10,7 @@ import org.jetbrains.exposed.v1.core.transactions.CoreTransactionManager
 import org.jetbrains.exposed.v1.core.transactions.TransactionManagerApi
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.batchInsert
 import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.replace
@@ -19,7 +20,6 @@ import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.currentDialectMetadataTest
 import org.jetbrains.exposed.v1.r2dbc.tests.getString
-import org.jetbrains.exposed.v1.r2dbc.tests.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
 import org.jetbrains.exposed.v1.r2dbc.transactions.transactionManager
@@ -93,6 +93,7 @@ class H2Tests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun addAutoPrimaryKey() {
         val tableName = "Foo"

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/DefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/DefaultsTest.kt
@@ -7,12 +7,7 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
-import org.jetbrains.exposed.v1.core.vendors.H2Dialect
-import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
-import org.jetbrains.exposed.v1.core.vendors.OracleDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
-import org.jetbrains.exposed.v1.core.vendors.h2Mode
+import org.jetbrains.exposed.v1.core.vendors.*
 import org.jetbrains.exposed.v1.javatime.*
 import org.jetbrains.exposed.v1.r2dbc.batchInsert
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -119,6 +114,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testDefaults01() {
         val currentDT = CurrentDateTime
@@ -317,6 +313,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testTimestampWithTimeZoneDefaults() {
         // UTC time zone

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/jodatime/JodaTimeDefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/jodatime/JodaTimeDefaultsTest.kt
@@ -77,6 +77,7 @@ class JodaTimeDefaultsTest : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testDefaults01() {
         val currentDT = CurrentDateTime
@@ -283,6 +284,7 @@ class JodaTimeDefaultsTest : R2dbcDatabaseTestsBase() {
         assertEquals(date.millis, list1?.get(testData.dateTime)?.millis)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testTimestampWithTimeZoneDefaults() {
         // UTC time zone

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
@@ -8,12 +8,7 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
-import org.jetbrains.exposed.v1.core.vendors.H2Dialect
-import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
-import org.jetbrains.exposed.v1.core.vendors.OracleDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
-import org.jetbrains.exposed.v1.core.vendors.h2Mode
+import org.jetbrains.exposed.v1.core.vendors.*
 import org.jetbrains.exposed.v1.datetime.*
 import org.jetbrains.exposed.v1.r2dbc.*
 import org.jetbrains.exposed.v1.r2dbc.tests.*
@@ -119,6 +114,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testDefaults01() {
         val currentDT = CurrentDateTime
@@ -325,6 +321,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testTimestampWithTimeZoneDefaults() {
         // UTC time zone

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
@@ -15,12 +15,12 @@ import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.*
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.currentDialectTest
 import org.jetbrains.exposed.v1.r2dbc.tests.forEach
-import org.jetbrains.exposed.v1.r2dbc.tests.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertFailAndRollback
@@ -173,6 +173,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         override val primaryKey = PrimaryKey(id)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun unnamedTableWithQuotesSQL() {
         withTables(tables = arrayOf(unnamedTable)) { testDb ->
@@ -198,6 +199,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun namedEmptyTableWithoutQuotesSQL() {
         val testTable = object : Table("test_named_table") {}
@@ -207,6 +209,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun tableWithDifferentColumnTypesSQL01() {
         val testTable = object : Table("different_column_types") {
@@ -230,6 +233,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun tableWithDifferentColumnTypesSQL02() {
         val testTable = object : Table("with_different_column_types") {
@@ -333,6 +337,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndices01() {
         val t = object : Table("t1") {
@@ -343,12 +348,13 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
 
         withTables(t) {
-            val alter = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[0])
+            val alter = SchemaUtils.createIndex(t.indices[0])
             val q = db.identifierManager.quoteString
             assertEquals("CREATE INDEX ${"t1_name".inProperCase()} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q)", alter)
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndices02() {
         val t = object : Table("t2") {
@@ -365,17 +371,18 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
 
         withTables(t) {
-            val a1 = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[0])
+            val a1 = SchemaUtils.createIndex(t.indices[0])
             val q = db.identifierManager.quoteString
             assertEquals("CREATE INDEX ${"t2_name".inProperCase()} ON ${"t2".inProperCase()} ($q${"name".inProperCase()}$q)", a1)
 
-            val a2 = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[1])
+            val a2 = SchemaUtils.createIndex(t.indices[1])
             assertEquals(
                 "CREATE INDEX ${"t2_lvalue_rvalue".inProperCase()} ON ${"t2".inProperCase()} " + "(${"lvalue".inProperCase()}, ${"rvalue".inProperCase()})", a2
             )
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndexOnTextColumnInH2() {
         val testTable = object : Table("test_index_table") {
@@ -393,7 +400,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
             val columnProperName = testTable.columns.single().name.inProperCase()
             val indexProperName = "${tableProperName}_$columnProperName"
 
-            val indexStatement = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(testTable.indices.single())
+            val indexStatement = SchemaUtils.createIndex(testTable.indices.single())
 
             assertEquals(
                 "CREATE TABLE " + addIfNotExistsIfSupported() + tableProperName + " (" + testTable.columns.single().descriptionDdl(false) + ")", testTable.ddl
@@ -409,6 +416,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testUniqueIndices01() {
         val t = object : Table("t1") {
@@ -419,12 +427,13 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
 
         withTables(t) {
-            val alter = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[0])
+            val alter = SchemaUtils.createIndex(t.indices[0])
             val q = db.identifierManager.quoteString
             assertEquals("ALTER TABLE ${"t1".inProperCase()} ADD CONSTRAINT ${"t1_name_unique".inProperCase()} UNIQUE ($q${"name".inProperCase()}$q)", alter)
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testUniqueIndicesCustomName() {
         val t = object : Table("t1") {
@@ -436,11 +445,12 @@ class DDLTests : R2dbcDatabaseTestsBase() {
 
         withTables(t) {
             val q = db.identifierManager.quoteString
-            val alter = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[0])
+            val alter = SchemaUtils.createIndex(t.indices[0])
             assertEquals("ALTER TABLE ${"t1".inProperCase()} ADD CONSTRAINT ${"U_T1_NAME"} UNIQUE ($q${"name".inProperCase()}$q)", alter)
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     @Suppress("MaximumLineLength")
     fun testMultiColumnIndex() {
@@ -455,8 +465,8 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
 
         withTables(t) {
-            val indexAlter = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[0])
-            val uniqueAlter = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[1])
+            val indexAlter = SchemaUtils.createIndex(t.indices[0])
+            val uniqueAlter = SchemaUtils.createIndex(t.indices[1])
             val q = db.identifierManager.quoteString
             assertEquals(
                 "CREATE INDEX ${"t1_name_type".inProperCase()} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q, $q${"type".inProperCase()}$q)", indexAlter
@@ -468,6 +478,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testMultiColumnIndexCustomName() {
         val t = object : Table("t1") {
@@ -481,8 +492,8 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
 
         withTables(t) {
-            val indexAlter = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[0])
-            val uniqueAlter = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(t.indices[1])
+            val indexAlter = SchemaUtils.createIndex(t.indices[0])
+            val uniqueAlter = SchemaUtils.createIndex(t.indices[1])
             val q = db.identifierManager.quoteString
             assertEquals("CREATE INDEX ${"I_T1_NAME_TYPE"} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q, $q${"type".inProperCase()}$q)", indexAlter)
             assertEquals(
@@ -492,6 +503,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndexWithFunctions() {
         val tester = object : Table("tester") {
@@ -536,7 +548,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
             }
 
             repeat(3) { i ->
-                val actualStatement = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createIndex(tester.indices[i])
+                val actualStatement = SchemaUtils.createIndex(tester.indices[i])
                 assertEquals(expectedStatements[i], actualStatement)
             }
         }
@@ -746,6 +758,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun tableWithDifferentTextTypes() {
         val testTable = object : Table("different_text_column_types") {
@@ -870,6 +883,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateAndDropCheckConstraint() {
         val tester = object : Table("tester") {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ParameterizationTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ParameterizationTests.kt
@@ -3,15 +3,16 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared
 import kotlinx.coroutines.flow.single
 import org.jetbrains.exposed.v1.core.BooleanColumnType
 import org.jetbrains.exposed.v1.core.IntegerColumnType
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.StdOutSqlLogger
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.VarCharColumnType
 import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.addLogger
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
-import org.jetbrains.exposed.v1.r2dbc.tests.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.junit.Test
 import kotlin.test.assertNotNull
@@ -41,6 +42,7 @@ class ParameterizationTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testSingleParametersWithMultipleStatements() {
         withTables(excludeSettings = multipleStatementsNotSupported, TempTable) {
@@ -72,6 +74,7 @@ class ParameterizationTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testMultipleParametersWithMultipleStatements() {
         val tester = object : Table("tester") {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionExecTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionExecTests.kt
@@ -3,9 +3,11 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.autoIncColumnType
 import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.batchInsert
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -13,7 +15,6 @@ import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.getInt
 import org.jetbrains.exposed.v1.r2dbc.tests.getString
-import org.jetbrains.exposed.v1.r2dbc.tests.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.junit.Test
@@ -27,6 +28,7 @@ class TransactionExecTests : R2dbcDatabaseTestsBase() {
         override val primaryKey = PrimaryKey(id)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExecWithSingleStatementQuery() {
         withTables(ExecTable) {
@@ -81,6 +83,7 @@ class TransactionExecTests : R2dbcDatabaseTestsBase() {
 //        TransactionManager.closeAndUnregister(db)
 //    }
 
+    @OptIn(InternalApi::class)
     private suspend fun R2dbcTransaction.testInsertAndSelectInSingleExec(testDb: TestDB) {
         ExecTable.insert {
             it[amount] = 99
@@ -127,6 +130,7 @@ class TransactionExecTests : R2dbcDatabaseTestsBase() {
         assertEquals(2, result)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExecWithNullableAndEmptyResultSets() {
         val tester = object : Table("tester") {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/CreateTableTests.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.ddl
 
 import kotlinx.coroutines.flow.singleOrNull
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.v1.core.Table
@@ -11,6 +12,7 @@ import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.deleteWhere
 import org.jetbrains.exposed.v1.r2dbc.exists
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -20,7 +22,6 @@ import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.currentDialectTest
-import org.jetbrains.exposed.v1.r2dbc.tests.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.Category
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.Item
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualCollections
@@ -51,6 +52,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateIdTableWithPrimaryKeyByEntityID() {
         val testTable = object : IdTable<String>("test_table") {
@@ -73,6 +75,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateIdTableWithPrimaryKeyByColumn() {
         val testTable = object : IdTable<String>("test_table") {
@@ -95,6 +98,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateIdTableWithNamedPrimaryKeyByColumn() {
         val pkConstraintName = "PK_Constraint_name"
@@ -118,6 +122,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateTableWithSingleColumnPrimaryKey() {
         val stringPKTable = object : Table("string_pk_table") {
@@ -157,6 +162,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun primaryKeyCreateTableTest() {
         val account = object : Table("Account") {
@@ -186,6 +192,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun primaryKeyWithConstraintNameCreateTableTest() {
         val pkConstraintName = "PKConstraintName"
@@ -232,6 +239,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun addCompositePrimaryKeyToTableTest() {
         withDb { testDb ->
@@ -264,6 +272,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun addOneColumnPrimaryKeyToTableTest() {
         withTables(Book) { testDb ->
@@ -316,6 +325,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         val reference = reference("id", TableWithDuplicatedColumn.id1)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName1() {
         val fkName = "MyForeignKey1"
@@ -349,6 +359,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithQuotes() {
         val parent = object : LongIdTable("\"Parent\"") {}
@@ -376,6 +387,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithSingleQuotes() {
         val parent = object : LongIdTable("'Parent2'") {}
@@ -403,6 +415,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName2() {
         val fkName = "MyForeignKey2"
@@ -438,6 +451,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName3() {
         val fkName = "MyForeignKey3"
@@ -471,6 +485,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName4() {
         val fkName = "MyForeignKey4"
@@ -507,6 +522,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitCompositeForeignKeyName1() {
         val fkName = "MyForeignKey1"
@@ -552,6 +568,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitCompositeForeignKeyName2() {
         val fkName = "MyForeignKey2"
@@ -597,6 +614,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithOnDeleteSetDefault() {
         withDb(excludeSettings = TestDB.ALL_MYSQL + TestDB.ALL_MARIADB + listOf(TestDB.ORACLE)) { testDb ->

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/SequencesTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/SequencesTests.kt
@@ -1,17 +1,13 @@
 package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.ddl
 
 import kotlinx.coroutines.flow.single
-import org.jetbrains.exposed.v1.core.Column
-import org.jetbrains.exposed.v1.core.Sequence
-import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.core.autoIncColumnType
+import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
-import org.jetbrains.exposed.v1.core.nextIntVal
-import org.jetbrains.exposed.v1.core.nextLongVal
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import org.jetbrains.exposed.v1.r2dbc.exists
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -21,7 +17,6 @@ import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.currentDialectMetadataTest
 import org.jetbrains.exposed.v1.r2dbc.tests.currentDialectTest
-import org.jetbrains.exposed.v1.r2dbc.tests.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertFalse
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
@@ -54,7 +49,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withTables(Developer) {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createSequence(myseq)
+                    SchemaUtils.createSequence(myseq)
 
                     var developerId = Developer.insert {
                         it[Developer.id] = myseq.nextIntVal()
@@ -70,7 +65,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
 
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, developerId.toLong())
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
@@ -87,7 +82,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withDb {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(tester)
+                    SchemaUtils.create(tester)
                     assertTrue(myseq.exists())
 
                     var testerId = tester.insert {
@@ -102,7 +97,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
 
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, testerId.toLong())
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(tester)
+                    SchemaUtils.drop(tester)
                     assertFalse(myseq.exists())
                 }
             }
@@ -114,7 +109,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withTables(DeveloperWithLongId) {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createSequence(myseq)
+                    SchemaUtils.createSequence(myseq)
 
                     var developerId = DeveloperWithLongId.insertAndGetId {
                         it[id] = myseq.nextLongVal()
@@ -129,7 +124,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
                     }
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, developerId.value)
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
@@ -146,7 +141,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withDb {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(tester)
+                    SchemaUtils.create(tester)
                     assertTrue(myseq.exists())
 
                     var testerId = tester.insert {
@@ -161,7 +156,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
 
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, testerId.value)
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(tester)
+                    SchemaUtils.drop(tester)
                     assertFalse(myseq.exists())
                 }
             }
@@ -173,7 +168,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withDb {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(DeveloperWithAutoIncrementBySequence)
+                    SchemaUtils.create(DeveloperWithAutoIncrementBySequence)
                     val developerId = DeveloperWithAutoIncrementBySequence.insertAndGetId {
                         it[name] = "Hichem"
                     }
@@ -185,7 +180,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
                     }
                     assertEquals(developerId.value + 1, developerId2.value)
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(DeveloperWithAutoIncrementBySequence)
+                    SchemaUtils.drop(DeveloperWithAutoIncrementBySequence)
                 }
             }
         }
@@ -196,7 +191,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withTables(Developer) {
             if (currentDialectTest.supportsCreateSequence) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createSequence(myseq)
+                    SchemaUtils.createSequence(myseq)
                     val nextVal = myseq.nextIntVal()
                     Developer.insert {
                         it[Developer.id] = nextVal
@@ -212,7 +207,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
                     val expSecondValue = expFirstValue + myseq.incrementBy!!
                     assertEquals(expSecondValue, secondValue.toLong())
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
@@ -223,16 +218,17 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withDb {
             if (currentDialectTest.supportsCreateSequence) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createSequence(myseq)
+                    SchemaUtils.createSequence(myseq)
 
                     assertTrue(myseq.exists())
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExistingSequencesForAutoIncrementWithCustomSequence() {
         val tableWithExplicitSequenceName = object : IdTable<Long>() {
@@ -242,19 +238,20 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withDb {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(tableWithExplicitSequenceName)
+                    SchemaUtils.create(tableWithExplicitSequenceName)
 
                     val sequences = currentDialectMetadataTest.sequences()
 
                     assertTrue(sequences.isNotEmpty())
                     assertTrue(sequences.any { it == myseq.name.inProperCase() })
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(tableWithExplicitSequenceName)
+                    SchemaUtils.drop(tableWithExplicitSequenceName)
                 }
             }
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExistingSequencesForAutoIncrementWithExplicitSequenceName() {
         val sequenceName = "id_seq"
@@ -265,19 +262,20 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withDb {
             if (currentDialectTest.supportsSequenceAsGeneratedKeys) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(tableWithExplicitSequenceName)
+                    SchemaUtils.create(tableWithExplicitSequenceName)
 
                     val sequences = currentDialectMetadataTest.sequences()
 
                     assertTrue(sequences.isNotEmpty())
                     assertTrue(sequences.any { it == sequenceName.inProperCase() })
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(tableWithExplicitSequenceName)
+                    SchemaUtils.drop(tableWithExplicitSequenceName)
                 }
             }
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExistingSequencesForAutoIncrementWithoutExplicitSequenceName() {
         val tableWithoutExplicitSequenceName = object : IdTable<Long>() {
@@ -287,7 +285,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
         withDb { testDb ->
             if (currentDialect.needsSequenceToAutoInc) {
                 try {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(tableWithoutExplicitSequenceName)
+                    SchemaUtils.create(tableWithoutExplicitSequenceName)
 
                     val sequences = currentDialectMetadataTest.sequences()
 
@@ -296,7 +294,7 @@ class SequencesTests : R2dbcDatabaseTestsBase() {
                     val expected = tableWithoutExplicitSequenceName.id.autoIncColumnType!!.autoincSeq!!
                     assertTrue(sequences.any { it == if (testDb == TestDB.ORACLE) expected.inProperCase() else expected })
                 } finally {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(tableWithoutExplicitSequenceName)
+                    SchemaUtils.drop(tableWithoutExplicitSequenceName)
                 }
             }
         }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -15,6 +15,7 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
 import org.jetbrains.exposed.v1.datetime.timestamp
 import org.jetbrains.exposed.v1.r2dbc.*
@@ -22,7 +23,6 @@ import org.jetbrains.exposed.v1.r2dbc.statements.BatchInsertSuspendExecutable
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.currentTestDB
-import org.jetbrains.exposed.v1.r2dbc.tests.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertFailAndRollback
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
@@ -566,6 +566,7 @@ class InsertTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testInsertIntoNullableGeneratedColumn() {
         withDb { testDb ->

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
@@ -13,13 +13,13 @@ import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2DBCRow
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcPreparedStatementApi
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcResult
 import org.jetbrains.exposed.v1.r2dbc.statements.api.metadata
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
-import org.jetbrains.exposed.v1.r2dbc.vendors.inProperCase
 
 /**
  * Represents the execution logic for an SQL statement that inserts a new row into a table.
@@ -63,6 +63,7 @@ open class InsertSuspendExecutable<Key : Any, S : InsertStatement<Key>>(
         return affectedRowCount
     }
 
+    @OptIn(InternalApi::class)
     override suspend fun prepared(transaction: R2dbcTransaction, sql: String): R2dbcPreparedStatementApi = when {
         // https://github.com/pgjdbc/pgjdbc/issues/1168
         // Column names always escaped/quoted in RETURNING clause

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/vendors/MysqlDialectMetadata.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/vendors/MysqlDialectMetadata.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.v1.r2dbc.vendors
 
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 
 /**
  * MySQL dialect metadata implementation.

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/TestUtils.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/TestUtils.kt
@@ -9,8 +9,6 @@ import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.vendors.DatabaseDialectMetadata
 import java.util.*
 
-fun String.inProperCase(): String = TransactionManager.currentOrNull()?.db?.identifierManager?.inProperCase(this) ?: this
-
 val currentDialectTest: DatabaseDialect get() = TransactionManager.current().db.dialect
 
 val currentDialectMetadataTest: DatabaseDialectMetadata

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/H2Tests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/H2Tests.kt
@@ -8,13 +8,13 @@ import org.jetbrains.exposed.v1.core.transactions.CoreTransactionManager
 import org.jetbrains.exposed.v1.core.transactions.TransactionManagerApi
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transactionManager
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentDialectMetadataTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.assertTrue
 import org.junit.Test
@@ -88,6 +88,7 @@ class H2Tests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun addAutoPrimaryKey() {
         val tableName = "Foo"
@@ -98,7 +99,7 @@ class H2Tests : DatabaseTestsBase() {
 
         withDb(listOf(TestDB.H2_V2, TestDB.H2_V2_MYSQL)) {
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(initialTable)
+                SchemaUtils.createMissingTablesAndColumns(initialTable)
                 assertEquals(
                     "ALTER TABLE ${tableName.inProperCase()} ADD ${"id".inProperCase()} ${t.id.columnType.sqlType()}",
                     t.id.ddl.first()
@@ -108,10 +109,10 @@ class H2Tests : DatabaseTestsBase() {
                     t.id.ddl[1]
                 )
                 assertEquals(1, currentDialectMetadataTest.tableColumns(t)[t]!!.size)
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t)
+                SchemaUtils.createMissingTablesAndColumns(t)
                 assertEquals(2, currentDialectMetadataTest.tableColumns(t)[t]!!.size)
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t)
+                SchemaUtils.drop(t)
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/DDLTests.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
@@ -21,7 +22,6 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.junit.Assume
 import org.junit.Test
 import java.util.*
@@ -172,6 +172,7 @@ class DDLTests : DatabaseTestsBase() {
         override val primaryKey = PrimaryKey(id)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun unnamedTableWithQuotesSQL() {
         withTables(excludeSettings = listOf(TestDB.SQLITE), tables = arrayOf(unnamedTable)) { testDb ->
@@ -196,6 +197,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun unnamedTableWithQuotesSQLInSQLite() {
         withDb(TestDB.SQLITE) {
@@ -216,6 +218,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun namedEmptyTableWithoutQuotesSQL() {
         val testTable = object : Table("test_named_table") {}
@@ -225,6 +228,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun tableWithDifferentColumnTypesSQL01() {
         val testTable = object : Table("different_column_types") {
@@ -247,6 +251,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun tableWithDifferentColumnTypesSQL02() {
         val testTable = object : Table("with_different_column_types") {
@@ -276,6 +281,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun tableWithDifferentColumnTypesInSQLite() {
         val testTable = object : Table("with_different_column_types") {
@@ -383,6 +389,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndices01() {
         val t = object : Table("t1") {
@@ -393,12 +400,13 @@ class DDLTests : DatabaseTestsBase() {
         }
 
         withTables(t) {
-            val alter = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[0])
+            val alter = SchemaUtils.createIndex(t.indices[0])
             val q = db.identifierManager.quoteString
             assertEquals("CREATE INDEX ${"t1_name".inProperCase()} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q)", alter)
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndices02() {
         val t = object : Table("t2") {
@@ -415,11 +423,11 @@ class DDLTests : DatabaseTestsBase() {
         }
 
         withTables(t) {
-            val a1 = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[0])
+            val a1 = SchemaUtils.createIndex(t.indices[0])
             val q = db.identifierManager.quoteString
             assertEquals("CREATE INDEX ${"t2_name".inProperCase()} ON ${"t2".inProperCase()} ($q${"name".inProperCase()}$q)", a1)
 
-            val a2 = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[1])
+            val a2 = SchemaUtils.createIndex(t.indices[1])
             assertEquals(
                 "CREATE INDEX ${"t2_lvalue_rvalue".inProperCase()} ON ${"t2".inProperCase()} " +
                     "(${"lvalue".inProperCase()}, ${"rvalue".inProperCase()})",
@@ -428,6 +436,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndexOnTextColumnInH2() {
         val testTable = object : Table("test_index_table") {
@@ -445,7 +454,7 @@ class DDLTests : DatabaseTestsBase() {
             val columnProperName = testTable.columns.single().name.inProperCase()
             val indexProperName = "${tableProperName}_$columnProperName"
 
-            val indexStatement = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(testTable.indices.single())
+            val indexStatement = SchemaUtils.createIndex(testTable.indices.single())
 
             assertEquals(
                 "CREATE TABLE " + addIfNotExistsIfSupported() + tableProperName +
@@ -464,6 +473,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testUniqueIndices01() {
         val t = object : Table("t1") {
@@ -474,7 +484,7 @@ class DDLTests : DatabaseTestsBase() {
         }
 
         withTables(t) {
-            val alter = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[0])
+            val alter = SchemaUtils.createIndex(t.indices[0])
             val q = db.identifierManager.quoteString
             if (currentDialectTest is SQLiteDialect) {
                 assertEquals("CREATE UNIQUE INDEX ${"t1_name".inProperCase()} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q)", alter)
@@ -484,6 +494,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testUniqueIndicesCustomName() {
         val t = object : Table("t1") {
@@ -495,7 +506,7 @@ class DDLTests : DatabaseTestsBase() {
 
         withTables(t) {
             val q = db.identifierManager.quoteString
-            val alter = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[0])
+            val alter = SchemaUtils.createIndex(t.indices[0])
             if (currentDialectTest is SQLiteDialect) {
                 assertEquals("CREATE UNIQUE INDEX ${"U_T1_NAME"} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q)", alter)
             } else {
@@ -504,6 +515,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     @Suppress("MaximumLineLength")
     fun testMultiColumnIndex() {
@@ -518,8 +530,8 @@ class DDLTests : DatabaseTestsBase() {
         }
 
         withTables(t) {
-            val indexAlter = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[0])
-            val uniqueAlter = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[1])
+            val indexAlter = SchemaUtils.createIndex(t.indices[0])
+            val uniqueAlter = SchemaUtils.createIndex(t.indices[1])
             val q = db.identifierManager.quoteString
             assertEquals(
                 "CREATE INDEX ${"t1_name_type".inProperCase()} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q, $q${"type".inProperCase()}$q)",
@@ -539,6 +551,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testMultiColumnIndexCustomName() {
         val t = object : Table("t1") {
@@ -552,8 +565,8 @@ class DDLTests : DatabaseTestsBase() {
         }
 
         withTables(t) {
-            val indexAlter = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[0])
-            val uniqueAlter = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(t.indices[1])
+            val indexAlter = SchemaUtils.createIndex(t.indices[0])
+            val uniqueAlter = SchemaUtils.createIndex(t.indices[1])
             val q = db.identifierManager.quoteString
             assertEquals("CREATE INDEX ${"I_T1_NAME_TYPE"} ON ${"t1".inProperCase()} ($q${"name".inProperCase()}$q, $q${"type".inProperCase()}$q)", indexAlter)
             if (currentDialectTest is SQLiteDialect) {
@@ -570,6 +583,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testIndexWithFunctions() {
         val tester = object : Table("tester") {
@@ -616,7 +630,7 @@ class DDLTests : DatabaseTestsBase() {
             }
 
             repeat(3) { i ->
-                val actualStatement = org.jetbrains.exposed.v1.jdbc.SchemaUtils.createIndex(tester.indices[i])
+                val actualStatement = SchemaUtils.createIndex(tester.indices[i])
                 assertEquals(expectedStatements[i], actualStatement)
             }
         }
@@ -828,6 +842,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun tableWithDifferentTextTypes() {
         val testTable = object : Table("different_text_column_types") {
@@ -951,6 +966,7 @@ class DDLTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateAndDropCheckConstraint() {
         val tester = object : Table("tester") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ParameterizationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ParameterizationTests.kt
@@ -2,10 +2,12 @@ package org.jetbrains.exposed.v1.tests.shared
 
 import org.jetbrains.exposed.v1.core.BooleanColumnType
 import org.jetbrains.exposed.v1.core.IntegerColumnType
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.StdOutSqlLogger
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.VarCharColumnType
 import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.addLogger
@@ -14,7 +16,6 @@ import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.junit.Assume
 import org.junit.Test
 import kotlin.test.assertNotNull
@@ -41,6 +42,7 @@ class ParameterizationTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testSingleParametersWithMultipleStatements() {
         Assume.assumeTrue(supportMultipleStatements.containsAll(TestDB.enabledDialects()))
@@ -91,6 +93,7 @@ class ParameterizationTests : DatabaseTestsBase() {
         TransactionManager.closeAndUnregister(db)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testMultipleParametersWithMultipleStatements() {
         Assume.assumeTrue(supportMultipleStatements.containsAll(TestDB.enabledDialects()))

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/TransactionExecTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/TransactionExecTests.kt
@@ -1,14 +1,15 @@
 package org.jetbrains.exposed.v1.tests.shared
 
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.autoIncColumnType
 import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.junit.Assume
 import org.junit.Test
 import kotlin.test.assertNotNull
@@ -21,6 +22,7 @@ class TransactionExecTests : DatabaseTestsBase() {
         override val primaryKey = PrimaryKey(id)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExecWithSingleStatementQuery() {
         withTables(ExecTable) {
@@ -84,6 +86,7 @@ class TransactionExecTests : DatabaseTestsBase() {
         TransactionManager.closeAndUnregister(db)
     }
 
+    @OptIn(InternalApi::class)
     private fun JdbcTransaction.testInsertAndSelectInSingleExec(testDb: TestDB) {
         ExecTable.insert {
             it[amount] = 99
@@ -130,6 +133,7 @@ class TransactionExecTests : DatabaseTestsBase() {
         assertEquals(2, result)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExecWithNullableAndEmptyResultSets() {
         val tester = object : Table("tester") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -1,25 +1,20 @@
 package org.jetbrains.exposed.v1.tests.shared.ddl
 
-import org.jetbrains.exposed.v1.core.Column
-import org.jetbrains.exposed.v1.core.ReferenceOption
-import org.jetbrains.exposed.v1.core.Schema
+import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.isNull
-import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
-import org.jetbrains.exposed.v1.core.doubleLiteral
-import org.jetbrains.exposed.v1.core.floatLiteral
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.PrimaryKeyMetadata
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentDialectMetadataTest
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
@@ -46,9 +41,9 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withTables(excludeSettings = listOf(TestDB.H2_V2_MYSQL), tables = arrayOf(testTable)) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(testTable)
+            SchemaUtils.createMissingTablesAndColumns(testTable)
             assertTrue(testTable.exists())
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(testTable)
+            SchemaUtils.drop(testTable)
         }
     }
 
@@ -65,12 +60,12 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withDb {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(testTable)
+            SchemaUtils.createMissingTablesAndColumns(testTable)
             assertTrue(testTable.exists())
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(testTable)
+                SchemaUtils.createMissingTablesAndColumns(testTable)
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(testTable)
+                SchemaUtils.drop(testTable)
             }
         }
     }
@@ -86,25 +81,25 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withDb(excludeSettings = listOf(TestDB.SQLITE)) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+            SchemaUtils.createMissingTablesAndColumns(t1)
             t1.insert { it[foo] = "ABC" }
             assertFailAndRollback("Can't insert to not-null column") {
                 t2.insert { it[foo] = null }
             }
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t2)
+            SchemaUtils.createMissingTablesAndColumns(t2)
             t2.insert { it[foo] = null }
             assertFailAndRollback("Can't make column non-null while has null value") {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+                SchemaUtils.createMissingTablesAndColumns(t1)
             }
 
             t2.deleteWhere { t2.foo.isNull() }
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+            SchemaUtils.createMissingTablesAndColumns(t1)
             assertFailAndRollback("Can't insert to nullable column") {
                 t2.insert { it[foo] = null }
             }
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t1)
+            SchemaUtils.drop(t1)
         }
     }
 
@@ -125,10 +120,10 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withDb(db = listOf(TestDB.H2_V2)) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+            SchemaUtils.createMissingTablesAndColumns(t1)
             t1.insert { it[foo] = "ABC" }
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t2)
+            SchemaUtils.createMissingTablesAndColumns(t2)
             assertFailAndRollback("Can't insert without primaryKey value") {
                 t2.insert { it[foo] = "ABC" }
             }
@@ -138,7 +133,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                 it[foo] = "ABC"
             }
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t1)
+            SchemaUtils.drop(t1)
         }
     }
 
@@ -158,7 +153,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
         withDb {
             if (db.supportsAlterTableWithAddColumn) {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+                SchemaUtils.createMissingTablesAndColumns(t1)
 
                 val missingStatements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.addMissingColumnsStatements(t2)
 
@@ -176,7 +171,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
                 assertEquals(expected, missingStatements.firstOrNull())
 
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t1)
+                SchemaUtils.drop(t1)
             }
         }
     }
@@ -196,13 +191,13 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withDb {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+            SchemaUtils.createMissingTablesAndColumns(t1)
 
             val missingStatements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.addMissingColumnsStatements(t2)
 
             assertEqualCollections(missingStatements, emptyList())
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t1)
+            SchemaUtils.drop(t1)
         }
     }
 
@@ -221,13 +216,13 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withDb {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+            SchemaUtils.createMissingTablesAndColumns(t1)
 
             val missingStatements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.addMissingColumnsStatements(t2)
 
             assertEqualCollections(missingStatements, emptyList())
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t1)
+            SchemaUtils.drop(t1)
         }
     }
 
@@ -246,10 +241,11 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withTables(fooTable, barTable1) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(barTable2)
+            SchemaUtils.createMissingTablesAndColumns(barTable2)
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun addAutoPrimaryKey() {
         val tableName = "Foo"
@@ -261,11 +257,12 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         withTables(excludeSettings = TestDB.ALL_H2 + TestDB.SQLITE, tables = arrayOf(initialTable)) {
             assertEquals("ALTER TABLE ${tableName.inProperCase()} ADD ${"id".inProperCase()} ${t.id.columnType.sqlType()} PRIMARY KEY", t.id.ddl)
             assertEquals(1, currentDialectMetadataTest.tableColumns(t)[t]!!.size)
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t)
+            SchemaUtils.createMissingTablesAndColumns(t)
             assertEquals(2, currentDialectMetadataTest.tableColumns(t)[t]!!.size)
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testAddNewPrimaryKeyOnExistingColumn() {
         val tableName = "tester"
@@ -280,20 +277,20 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withDb(excludeSettings = listOf(TestDB.SQLITE)) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(noPKTable)
+            SchemaUtils.createMissingTablesAndColumns(noPKTable)
             var primaryKey: PrimaryKeyMetadata? = currentDialectMetadataTest.existingPrimaryKeys(singlePKTable)[singlePKTable]
             assertNull(primaryKey)
 
             val expected = "ALTER TABLE ${tableName.inProperCase()} ADD PRIMARY KEY (${noPKTable.bar.nameInDatabaseCase()})"
-            val statements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(singlePKTable)
+            val statements = SchemaUtils.statementsRequiredToActualizeScheme(singlePKTable)
             assertEquals(expected, statements.single())
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(singlePKTable)
+            SchemaUtils.createMissingTablesAndColumns(singlePKTable)
             primaryKey = currentDialectMetadataTest.existingPrimaryKeys(singlePKTable)[singlePKTable]
             assertNotNull(primaryKey)
             assertEquals("bar".inProperCase(), primaryKey.columnNames.single())
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(noPKTable)
+            SchemaUtils.drop(noPKTable)
         }
     }
 
@@ -315,10 +312,10 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                 }
 
                 org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(table)
-                val actual = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(table)
+                val actual = SchemaUtils.statementsRequiredToActualizeScheme(table)
                 assertEqualLists(emptyList(), actual)
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(table)
+                SchemaUtils.drop(table)
             }
         }
     }
@@ -363,7 +360,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                         }.single()[whiteSpaceTable.column]
                     )
 
-                    val actual = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(emptyTable)
+                    val actual = SchemaUtils.statementsRequiredToActualizeScheme(emptyTable)
                     val expected = if (testDb == TestDB.SQLSERVER) 2 else 1
                     assertEquals(expected, actual.size)
 
@@ -372,7 +369,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                         // Apply changes
                         actual.forEach { exec(it) }
                     } else {
-                        org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(whiteSpaceTable)
+                        SchemaUtils.drop(whiteSpaceTable)
                         org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(emptyTable)
                     }
 
@@ -389,7 +386,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                         emptyTable.selectAll().where { emptyTable.id eq emptyId }.single()[emptyTable.column]
                     )
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(whiteSpaceTable, emptyTable)
+                    SchemaUtils.drop(whiteSpaceTable, emptyTable)
                 }
             }
         }
@@ -418,7 +415,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         val complexAlterTable = TestDB.ALL_POSTGRES_LIKE + TestDB.ORACLE + TestDB.SQLSERVER
         withDb(excludeSettings = excludeSettings) { testDb ->
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t1)
+                SchemaUtils.createMissingTablesAndColumns(t1)
 
                 val missingStatements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.addMissingColumnsStatements(t2)
 
@@ -441,13 +438,13 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                     exec(it)
                 }
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t1)
+                SchemaUtils.drop(t1)
             }
         }
 
         withDb(excludeSettings = excludeSettings) { testDb ->
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(t2)
+                SchemaUtils.createMissingTablesAndColumns(t2)
 
                 val missingStatements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.addMissingColumnsStatements(t1)
 
@@ -470,7 +467,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                     exec(it)
                 }
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(t2)
+                SchemaUtils.drop(t2)
             }
         }
     }
@@ -495,7 +492,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                 org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(table)
                 assertEqualLists(emptyList(), SchemaUtils.statementsRequiredToActualizeScheme(table))
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(table)
+                SchemaUtils.drop(table)
             }
         }
     }
@@ -504,9 +501,9 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     fun createTableWithMultipleIndexes() {
         withDb {
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(MultipleIndexesTable)
+                SchemaUtils.createMissingTablesAndColumns(MultipleIndexesTable)
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(MultipleIndexesTable)
+                SchemaUtils.drop(MultipleIndexesTable)
             }
         }
     }
@@ -519,10 +516,10 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
 
         withDb {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(usersTable, spacesTable)
+            SchemaUtils.createMissingTablesAndColumns(usersTable, spacesTable)
             assertTrue(usersTable.exists())
             assertTrue(spacesTable.exists())
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(usersTable, spacesTable)
+            SchemaUtils.drop(usersTable, spacesTable)
         }
     }
 
@@ -537,10 +534,10 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
         // Oracle metadata only returns foreign keys that reference primary keys
         withDb(excludeSettings = listOf(TestDB.ORACLE)) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(ordersTable, receiptsTable)
+            SchemaUtils.createMissingTablesAndColumns(ordersTable, receiptsTable)
             assertTrue(ordersTable.exists())
             assertTrue(receiptsTable.exists())
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(ordersTable, receiptsTable)
+            SchemaUtils.drop(ordersTable, receiptsTable)
         }
     }
 
@@ -557,8 +554,8 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     @Test
     fun testCreateTableWithReferenceMultipleTimes() {
         withTables(PlayerTable, SessionsTable) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(PlayerTable, SessionsTable)
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(PlayerTable, SessionsTable)
+            SchemaUtils.createMissingTablesAndColumns(PlayerTable, SessionsTable)
+            SchemaUtils.createMissingTablesAndColumns(PlayerTable, SessionsTable)
         }
     }
 
@@ -573,13 +570,13 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     @Test
     fun createTableWithReservedIdentifierInColumnName() {
         withDb(TestDB.MYSQL_V5) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(T1, T2)
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(T1, T2)
+            SchemaUtils.createMissingTablesAndColumns(T1, T2)
+            SchemaUtils.createMissingTablesAndColumns(T1, T2)
 
             assertTrue(T1.exists())
             assertTrue(T2.exists())
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(T1, T2)
+            SchemaUtils.drop(T1, T2)
         }
     }
 
@@ -617,10 +614,10 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
         withDb {
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(usersTable)
+                SchemaUtils.createMissingTablesAndColumns(usersTable)
                 assertTrue(usersTable.exists())
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(usersTable)
+                SchemaUtils.drop(usersTable)
             }
         }
     }
@@ -643,9 +640,9 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     @Test
     fun testCreateCompositePrimaryKeyTableAndCompositeForeignKeyTableMultipleTimes() {
         withTables(CompositePrimaryKeyTable, CompositeForeignKeyTable) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
-            val statements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            val statements = SchemaUtils.statementsRequiredToActualizeScheme(CompositePrimaryKeyTable, CompositeForeignKeyTable)
             assertTrue(statements.isEmpty())
         }
     }
@@ -659,13 +656,13 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
         withDb {
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(quotedTable)
+                SchemaUtils.createMissingTablesAndColumns(quotedTable)
                 assertTrue(quotedTable.exists())
 
-                val statements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(quotedTable)
+                val statements = SchemaUtils.statementsRequiredToActualizeScheme(quotedTable)
                 assertTrue(statements.isEmpty())
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(quotedTable)
+                SchemaUtils.drop(quotedTable)
             }
         }
     }
@@ -673,16 +670,16 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
     @Test
     fun testCreateCompositePrimaryKeyTableAndCompositeForeignKeyInVariousOrder() {
         withTables(CompositeForeignKeyTable, CompositePrimaryKeyTable) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
         }
         withTables(CompositeForeignKeyTable, CompositePrimaryKeyTable) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(CompositeForeignKeyTable, CompositePrimaryKeyTable)
+            SchemaUtils.createMissingTablesAndColumns(CompositeForeignKeyTable, CompositePrimaryKeyTable)
         }
         withTables(CompositePrimaryKeyTable, CompositeForeignKeyTable) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
+            SchemaUtils.createMissingTablesAndColumns(CompositePrimaryKeyTable, CompositeForeignKeyTable)
         }
         withTables(CompositePrimaryKeyTable, CompositeForeignKeyTable) {
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(CompositeForeignKeyTable, CompositePrimaryKeyTable)
+            SchemaUtils.createMissingTablesAndColumns(CompositeForeignKeyTable, CompositePrimaryKeyTable)
         }
     }
 
@@ -713,23 +710,23 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
             try {
                 // Try in different schema
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
+                SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
                 assertTrue(parentTable.exists())
                 assertTrue(childTable.exists())
 
                 // Try in the same schema
                 if (testDb != TestDB.ORACLE) {
                     org.jetbrains.exposed.v1.jdbc.SchemaUtils.setSchema(schema)
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
+                    SchemaUtils.createMissingTablesAndColumns(parentTable, childTable)
                     assertTrue(parentTable.exists())
                     assertTrue(childTable.exists())
                 }
             } finally {
                 if (testDb == TestDB.SQLSERVER) {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(childTable, parentTable)
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.dropSchema(schema)
+                    SchemaUtils.drop(childTable, parentTable)
+                    SchemaUtils.dropSchema(schema)
                 } else {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.dropSchema(schema, cascade = true)
+                    SchemaUtils.dropSchema(schema, cascade = true)
                 }
             }
         }
@@ -762,7 +759,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             testerWithoutDefaults to testerWithoutDefaults
         ).forEach { (existingTable, definedTable) ->
             withTables(existingTable) {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(definedTable).also {
+                SchemaUtils.statementsRequiredToActualizeScheme(definedTable).also {
                     assertTrue(it.isEmpty())
                 }
             }
@@ -788,7 +785,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             testerWithoutDefaults to testerWithDefaults,
         ).forEach { (existingTable, definedTable) ->
             withTables(excludeSettings = listOf(TestDB.SQLITE), existingTable) {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(definedTable).also {
+                SchemaUtils.statementsRequiredToActualizeScheme(definedTable).also {
                     assertTrue(it.isNotEmpty())
                 }
             }
@@ -799,7 +796,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
             testerWithoutDefaults to testerWithoutDefaults
         ).forEach { (existingTable, definedTable) ->
             withTables(excludeSettings = listOf(TestDB.SQLITE), existingTable) {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(definedTable).also {
+                SchemaUtils.statementsRequiredToActualizeScheme(definedTable).also {
                     assertTrue(it.isEmpty())
                 }
             }
@@ -841,7 +838,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
 
         // SQLite doesn't support alter table with add column, so it doesn't generate alter statements
         withTables(excludeSettings = listOf(TestDB.SQLITE), originalTable) { testDb ->
-            assertTrue(org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(originalTable, withLogs = false).isEmpty())
+            assertTrue(SchemaUtils.statementsRequiredToActualizeScheme(originalTable, withLogs = false).isEmpty())
 
             expectException<IllegalArgumentException> {
                 originalTable.insert {
@@ -852,7 +849,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
                 }
             }
 
-            val alterStatements = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(newTable, withLogs = false)
+            val alterStatements = SchemaUtils.statementsRequiredToActualizeScheme(newTable, withLogs = false)
             val expectedSize = if (testDb in TestDB.ALL_POSTGRES_LIKE) {
                 3
             } else {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateTableTests.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.v1.tests.shared.ddl
 
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.v1.core.Table
@@ -11,12 +12,12 @@ import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.shared.Category
 import org.jetbrains.exposed.v1.tests.shared.Item
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
@@ -46,6 +47,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateIdTableWithPrimaryKeyByEntityID() {
         val testTable = object : IdTable<String>("test_table") {
@@ -68,6 +70,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateIdTableWithPrimaryKeyByColumn() {
         val testTable = object : IdTable<String>("test_table") {
@@ -90,6 +93,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateIdTableWithNamedPrimaryKeyByColumn() {
         val pkConstraintName = "PK_Constraint_name"
@@ -113,6 +117,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateTableWithSingleColumnPrimaryKey() {
         val stringPKTable = object : Table("string_pk_table") {
@@ -152,6 +157,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun primaryKeyCreateTableTest() {
         val account = object : Table("Account") {
@@ -181,6 +187,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun primaryKeyWithConstraintNameCreateTableTest() {
         val pkConstraintName = "PKConstraintName"
@@ -227,6 +234,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun addCompositePrimaryKeyToTableTest() {
         withDb { testDb ->
@@ -259,6 +267,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun addOneColumnPrimaryKeyToTableTest() {
         withTables(Book) { testDb ->
@@ -312,6 +321,7 @@ class CreateTableTests : DatabaseTestsBase() {
         val reference = reference("id", TableWithDuplicatedColumn.id1)
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName1() {
         val fkName = "MyForeignKey1"
@@ -345,6 +355,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithQuotes() {
         val parent = object : LongIdTable("\"Parent\"") {}
@@ -372,6 +383,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithSingleQuotes() {
         val parent = object : LongIdTable("'Parent2'") {}
@@ -399,6 +411,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName2() {
         val fkName = "MyForeignKey2"
@@ -434,6 +447,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName3() {
         val fkName = "MyForeignKey3"
@@ -467,6 +481,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitForeignKeyName4() {
         val fkName = "MyForeignKey4"
@@ -503,6 +518,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitCompositeForeignKeyName1() {
         val fkName = "MyForeignKey1"
@@ -548,6 +564,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithExplicitCompositeForeignKeyName2() {
         val fkName = "MyForeignKey2"
@@ -593,6 +610,7 @@ class CreateTableTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun createTableWithOnDeleteSetDefault() {
         withDb(excludeSettings = TestDB.ALL_MYSQL + TestDB.ALL_MARIADB + listOf(TestDB.ORACLE)) { testDb ->

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -13,6 +13,7 @@ import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.PrimaryKeyMetadata
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.datetime.*
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -25,7 +26,6 @@ import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentDialectMetadataTest
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
@@ -151,6 +151,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testCreateStatementsGeneratedForTablesThatDoNotExist() {
         val tester = object : Table("tester") {
@@ -207,6 +208,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testAddNewPrimaryKeyOnExistingColumn() {
         val tableName = "tester"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/SequencesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/SequencesTests.kt
@@ -1,17 +1,13 @@
 package org.jetbrains.exposed.v1.tests.shared.ddl
 
-import org.jetbrains.exposed.v1.core.Column
-import org.jetbrains.exposed.v1.core.Sequence
-import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.core.autoIncColumnType
+import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
-import org.jetbrains.exposed.v1.core.nextIntVal
-import org.jetbrains.exposed.v1.core.nextLongVal
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.dao.UUIDEntity
 import org.jetbrains.exposed.v1.dao.UUIDEntityClass
 import org.jetbrains.exposed.v1.jdbc.*
@@ -20,7 +16,6 @@ import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentDialectMetadataTest
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.assertFalse
 import org.jetbrains.exposed.v1.tests.shared.assertTrue
@@ -71,7 +66,7 @@ class SequencesTests : DatabaseTestsBase() {
 
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, developerId.toLong())
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
@@ -103,7 +98,7 @@ class SequencesTests : DatabaseTestsBase() {
 
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, testerId.toLong())
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(tester)
+                    SchemaUtils.drop(tester)
                     assertFalse(myseq.exists())
                 }
             }
@@ -130,7 +125,7 @@ class SequencesTests : DatabaseTestsBase() {
                     }
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, developerId.value)
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
@@ -162,7 +157,7 @@ class SequencesTests : DatabaseTestsBase() {
 
                     assertEquals(myseq.startWith!! + myseq.incrementBy!!, testerId.value)
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(tester)
+                    SchemaUtils.drop(tester)
                     assertFalse(myseq.exists())
                 }
             }
@@ -186,7 +181,7 @@ class SequencesTests : DatabaseTestsBase() {
                     }
                     assertEquals(developerId.value + 1, developerId2.value)
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(DeveloperWithAutoIncrementBySequence)
+                    SchemaUtils.drop(DeveloperWithAutoIncrementBySequence)
                 }
             }
         }
@@ -213,7 +208,7 @@ class SequencesTests : DatabaseTestsBase() {
                     val expSecondValue = expFirstValue + myseq.incrementBy!!
                     assertEquals(expSecondValue, secondValue.toLong())
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
@@ -228,12 +223,13 @@ class SequencesTests : DatabaseTestsBase() {
 
                     assertTrue(myseq.exists())
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.dropSequence(myseq)
+                    SchemaUtils.dropSequence(myseq)
                 }
             }
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExistingSequencesForAutoIncrementWithCustomSequence() {
         val tableWithExplicitSequenceName = object : IdTable<Long>() {
@@ -250,12 +246,13 @@ class SequencesTests : DatabaseTestsBase() {
                     assertTrue(sequences.isNotEmpty())
                     assertTrue(sequences.any { it == myseq.name.inProperCase() })
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(tableWithExplicitSequenceName)
+                    SchemaUtils.drop(tableWithExplicitSequenceName)
                 }
             }
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExistingSequencesForAutoIncrementWithExplicitSequenceName() {
         val sequenceName = "id_seq"
@@ -273,12 +270,13 @@ class SequencesTests : DatabaseTestsBase() {
                     assertTrue(sequences.isNotEmpty())
                     assertTrue(sequences.any { it == sequenceName.inProperCase() })
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(tableWithExplicitSequenceName)
+                    SchemaUtils.drop(tableWithExplicitSequenceName)
                 }
             }
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testExistingSequencesForAutoIncrementWithoutExplicitSequenceName() {
         val tableWithoutExplicitSequenceName = object : IdTable<Long>() {
@@ -297,7 +295,7 @@ class SequencesTests : DatabaseTestsBase() {
                     val expected = tableWithoutExplicitSequenceName.id.autoIncColumnType!!.autoincSeq!!
                     assertTrue(sequences.any { it == if (testDb == TestDB.ORACLE) expected.inProperCase() else expected })
                 } finally {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(tableWithoutExplicitSequenceName)
+                    SchemaUtils.drop(tableWithoutExplicitSequenceName)
                 }
             }
         }
@@ -325,7 +323,7 @@ class SequencesTests : DatabaseTestsBase() {
 
                 // Clean up: create table and drop it for removing sequence
                 SchemaUtils.create(DeveloperWithAutoIncrementBySequence)
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(DeveloperWithAutoIncrementBySequence)
+                SchemaUtils.drop(DeveloperWithAutoIncrementBySequence)
             }
         }
     }
@@ -342,7 +340,7 @@ class SequencesTests : DatabaseTestsBase() {
                 assertNotNull(foundSequence)
                 assertEquals(identityTable.sequences.single().identifier, foundSequence.identifier)
             } finally {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(identityTable)
+                SchemaUtils.drop(identityTable)
             }
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
@@ -19,7 +20,6 @@ import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTrans
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentTestDB
-import org.jetbrains.exposed.v1.tests.inProperCase
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.assertFailAndRollback
@@ -650,6 +650,7 @@ class InsertTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testInsertIntoNullableGeneratedColumn() {
         withDb(excludeSettings = TestDB.ALL_H2_V1) { testDb ->


### PR DESCRIPTION
#### Description

One `inProperCase()` for all. Remove duplications of `inProperCase()`, mark as `@InternalApi` the one in `core` module
