### PR TITLE
fix: EXPOSED-811 argument "where" in "batchUpsert" have no way to use it

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2975,13 +2975,6 @@ public class org/jetbrains/exposed/v1/core/statements/InsertStatement : org/jetb
 	public static synthetic fun valuesAndDefaults$default (Lorg/jetbrains/exposed/v1/core/statements/InsertStatement;Ljava/util/Map;ILjava/lang/Object;)Ljava/util/Map;
 }
 
-public final class org/jetbrains/exposed/v1/core/statements/InsertValue : org/jetbrains/exposed/v1/core/ExpressionWithColumnType {
-	public fun <init> (Lorg/jetbrains/exposed/v1/core/Column;Lorg/jetbrains/exposed/v1/core/IColumnType;)V
-	public final fun getColumn ()Lorg/jetbrains/exposed/v1/core/Column;
-	public fun getColumnType ()Lorg/jetbrains/exposed/v1/core/IColumnType;
-	public fun toQueryBuilder (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
-}
-
 public class org/jetbrains/exposed/v1/core/statements/MergeSelectStatement : org/jetbrains/exposed/v1/core/statements/MergeStatement {
 	public fun <init> (Lorg/jetbrains/exposed/v1/core/Table;Lorg/jetbrains/exposed/v1/core/QueryAlias;Lorg/jetbrains/exposed/v1/core/Op;)V
 	public fun arguments ()Ljava/lang/Iterable;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2975,6 +2975,13 @@ public class org/jetbrains/exposed/v1/core/statements/InsertStatement : org/jetb
 	public static synthetic fun valuesAndDefaults$default (Lorg/jetbrains/exposed/v1/core/statements/InsertStatement;Ljava/util/Map;ILjava/lang/Object;)Ljava/util/Map;
 }
 
+public final class org/jetbrains/exposed/v1/core/statements/InsertValue : org/jetbrains/exposed/v1/core/ExpressionWithColumnType {
+	public fun <init> (Lorg/jetbrains/exposed/v1/core/Column;Lorg/jetbrains/exposed/v1/core/IColumnType;)V
+	public final fun getColumn ()Lorg/jetbrains/exposed/v1/core/Column;
+	public fun getColumnType ()Lorg/jetbrains/exposed/v1/core/IColumnType;
+	public fun toQueryBuilder (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
+}
+
 public class org/jetbrains/exposed/v1/core/statements/MergeSelectStatement : org/jetbrains/exposed/v1/core/statements/MergeStatement {
 	public fun <init> (Lorg/jetbrains/exposed/v1/core/Table;Lorg/jetbrains/exposed/v1/core/QueryAlias;Lorg/jetbrains/exposed/v1/core/Op;)V
 	public fun arguments ()Ljava/lang/Iterable;
@@ -3213,6 +3220,148 @@ public final class org/jetbrains/exposed/v1/core/statements/UpsertBuilder$Compan
 public final class org/jetbrains/exposed/v1/core/statements/UpsertBuilder$DefaultImpls {
 	public static fun insertValue (Lorg/jetbrains/exposed/v1/core/statements/UpsertBuilder;Lorg/jetbrains/exposed/v1/core/Column;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
 	public static fun storeUpdateValues (Lorg/jetbrains/exposed/v1/core/statements/UpsertBuilder;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class org/jetbrains/exposed/v1/core/statements/UpsertSqlExpressionBuilder : org/jetbrains/exposed/v1/core/ISqlExpressionBuilder {
+	public static final field INSTANCE Lorg/jetbrains/exposed/v1/core/statements/UpsertSqlExpressionBuilder;
+	public fun asLiteral (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/LiteralOp;
+	public fun between (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/Between;
+	public fun between (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/Between;
+	public fun bitwiseAnd (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/AndBitOp;
+	public fun bitwiseAnd (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/AndBitOp;
+	public fun bitwiseOr (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/OrBitOp;
+	public fun bitwiseOr (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/OrBitOp;
+	public fun bitwiseXor (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/XorBitOp;
+	public fun bitwiseXor (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/XorBitOp;
+	public fun case (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Case;
+	public fun coalesce (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;[Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Coalesce;
+	public fun concat (Ljava/lang/String;Ljava/util/List;)Lorg/jetbrains/exposed/v1/core/Concat;
+	public fun concat ([Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Concat;
+	public fun cumeDist ()Lorg/jetbrains/exposed/v1/core/CumeDist;
+	public fun denseRank ()Lorg/jetbrains/exposed/v1/core/DenseRank;
+	public fun div (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/DivideOp;
+	public fun div (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/DivideOp;
+	public fun eq (Lorg/jetbrains/exposed/v1/core/CompositeColumn;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun eq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun eq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun eq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun eq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun eqEntityIDValue (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun eqSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/EqSubQueryOp;
+	public fun firstValue (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/FirstValue;
+	public fun greater (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/GreaterOp;
+	public fun greater (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/GreaterOp;
+	public fun greater (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/GreaterOp;
+	public fun greater (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/GreaterOp;
+	public fun greaterBetweenEntityIDs (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/GreaterOp;
+	public fun greaterEntityID (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/GreaterOp;
+	public fun greaterEq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/GreaterEqOp;
+	public fun greaterEq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/GreaterEqOp;
+	public fun greaterEq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/GreaterEqOp;
+	public fun greaterEq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/GreaterEqOp;
+	public fun greaterEqBetweenEntityIDs (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/GreaterEqOp;
+	public fun greaterEqEntityID (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/GreaterEqOp;
+	public fun greaterEqSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/GreaterEqSubQueryOp;
+	public fun greaterSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/GreaterSubQueryOp;
+	public fun hasFlag (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/EqOp;
+	public fun hasFlag (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/EqOp;
+	public fun inList (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun inList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun inList (Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun inList (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun inListCompositeEntityIds (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun inListCompositeIDs (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun inListIds (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun inSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/InSubQueryOp;
+	public fun inTable (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Table;)Lorg/jetbrains/exposed/v1/core/ops/InTableOp;
+	public final fun insertValue (Lorg/jetbrains/exposed/v1/core/Column;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun intToDecimal (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/NoOpConversion;
+	public fun isDistinctFrom (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/IsDistinctFromOp;
+	public fun isDistinctFrom (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/IsDistinctFromOp;
+	public fun isDistinctFrom (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/IsDistinctFromOp;
+	public fun isDistinctFrom (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/IsDistinctFromOp;
+	public fun isDistinctFromEntityID (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/IsDistinctFromOp;
+	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/IsNotDistinctFromOp;
+	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/IsNotDistinctFromOp;
+	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/IsNotDistinctFromOp;
+	public fun isNotDistinctFrom (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/IsNotDistinctFromOp;
+	public fun isNotDistinctFromEntityID (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/IsNotDistinctFromOp;
+	public fun isNotNull (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun isNull (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun isNullOrEmpty (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun lag (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/Lag;
+	public fun lastValue (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/LastValue;
+	public fun lead (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/Lead;
+	public fun less (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/LessOp;
+	public fun less (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/LessOp;
+	public fun less (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/LessOp;
+	public fun less (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/LessOp;
+	public fun lessBetweenEntityIDs (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/LessOp;
+	public fun lessEntityID (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/LessOp;
+	public fun lessEq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/LessEqOp;
+	public fun lessEq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/LessEqOp;
+	public fun lessEq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/LessEqOp;
+	public fun lessEq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/LessEqOp;
+	public fun lessEqBetweenEntityIDs (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/LessEqOp;
+	public fun lessEqEntityID (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Comparable;)Lorg/jetbrains/exposed/v1/core/LessEqOp;
+	public fun lessEqSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/LessEqSubQueryOp;
+	public fun lessSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/LessSubQueryOp;
+	public fun like (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun like (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun like (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/LikePattern;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun likeWithEntityID (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun likeWithEntityID (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/LikePattern;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun likeWithEntityIDAndExpression (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun match (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun match (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/vendors/FunctionProvider$MatchMode;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun minus (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/MinusOp;
+	public fun minus (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/MinusOp;
+	public fun mod (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Number;)Lorg/jetbrains/exposed/v1/core/ModOp;
+	public fun mod (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/ModOp;
+	public fun modWithEntityId (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Number;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun modWithEntityId2 (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun modWithEntityId3 (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun neq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun neq (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun neq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun neq (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun neqEntityIDValue (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/Op;
+	public fun notEqSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/NotEqSubQueryOp;
+	public fun notInList (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun notInList (Lkotlin/Pair;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun notInList (Lkotlin/Triple;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun notInList (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun notInListCompositeEntityIds (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun notInListCompositeIDs (Ljava/util/List;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun notInListIds (Lorg/jetbrains/exposed/v1/core/Column;Ljava/lang/Iterable;)Lorg/jetbrains/exposed/v1/core/ops/InListOrNotInListBaseOp;
+	public fun notInSubQuery (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)Lorg/jetbrains/exposed/v1/core/NotInSubQueryOp;
+	public fun notInTable (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Table;)Lorg/jetbrains/exposed/v1/core/ops/InTableOp;
+	public fun notLike (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun notLike (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun notLike (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/LikePattern;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun notLikeWithEntityID (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun notLikeWithEntityID (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/LikePattern;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun notLikeWithEntityIDAndExpression (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/LikeEscapeOp;
+	public fun nthValue (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/NthValue;
+	public fun ntile (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/Ntile;
+	public fun percentRank ()Lorg/jetbrains/exposed/v1/core/PercentRank;
+	public fun plus (Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Concat;
+	public fun plus (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/Concat;
+	public fun plus (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Concat;
+	public fun plus (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/PlusOp;
+	public fun plus (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/PlusOp;
+	public fun rank ()Lorg/jetbrains/exposed/v1/core/Rank;
+	public fun regexp (Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/RegexpOp;
+	public fun regexp (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;Z)Lorg/jetbrains/exposed/v1/core/RegexpOp;
+	public fun rem (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Number;)Lorg/jetbrains/exposed/v1/core/ModOp;
+	public fun rem (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/ModOp;
+	public fun remWithEntityId (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Number;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun remWithEntityId2 (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun remWithEntityId3 (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun rowNumber ()Lorg/jetbrains/exposed/v1/core/RowNumber;
+	public fun times (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/TimesOp;
+	public fun times (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/TimesOp;
+	public fun wrap (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;Ljava/lang/Object;)Lorg/jetbrains/exposed/v1/core/QueryParameter;
 }
 
 public class org/jetbrains/exposed/v1/core/statements/UpsertStatement : org/jetbrains/exposed/v1/core/statements/InsertStatement, org/jetbrains/exposed/v1/core/statements/UpsertBuilder {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/IStatementBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/IStatementBuilder.kt
@@ -301,14 +301,14 @@ interface IStatementBuilder {
         vararg keys: Column<*>,
         onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
         onUpdateExclude: List<Column<*>>? = null,
-        where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+        where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
         body: T.(UpsertStatement<Long>) -> Unit
     ): UpsertStatement<Long> {
         return UpsertStatement<Long>(
             table = this,
             keys = keys,
             onUpdateExclude = onUpdateExclude,
-            where = where?.let { SqlExpressionBuilder.it() }
+            where = where?.let { UpsertSqlExpressionBuilder.it() }
         ).apply {
             onUpdate?.let { storeUpdateValues(it) }
             body(this)
@@ -371,7 +371,7 @@ interface IStatementBuilder {
         onUpdateList: List<Pair<Column<*>, Any?>>? = null,
         onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
         onUpdateExclude: List<Column<*>>? = null,
-        where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+        where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
         shouldReturnGeneratedValues: Boolean = true,
         vararg keys: Column<*>,
         body: BatchUpsertStatement.(E) -> Unit
@@ -380,7 +380,7 @@ interface IStatementBuilder {
             table = this,
             keys = keys,
             onUpdateExclude = onUpdateExclude,
-            where = where?.let { SqlExpressionBuilder.it() },
+            where = where?.let { UpsertSqlExpressionBuilder.it() },
             shouldReturnGeneratedValues = shouldReturnGeneratedValues
         ).apply {
             onUpdate?.let { storeUpdateValues(it) }
@@ -425,6 +425,7 @@ interface IStatementBuilder {
     ): MergeSelectStatement {
         return MergeSelectStatement(this, selectQuery, SqlExpressionBuilder.on()).apply(body)
     }
+
     private fun Column<*>.isValidIfAutoIncrement(): Boolean =
         !columnType.isAutoInc || autoIncColumnType?.nextValExpression != null
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/UpsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/UpsertStatement.kt
@@ -88,7 +88,6 @@ sealed interface UpsertBuilder {
      *
      * @sample org.jetbrains.exposed.v1.tests.shared.dml.UpsertTests.testUpsertWithManualUpdateUsingInsertValues
      */
-    @OptIn(InternalApi::class)
     fun <T> insertValue(column: Column<T>): ExpressionWithColumnType<T> = InsertValue(column, column.columnType)
 
     companion object {
@@ -144,11 +143,11 @@ internal fun UpsertBuilder.getAdditionalArgs(
     }.args
 }
 
-@InternalApi
-class InsertValue<T>(
+internal class InsertValue<T>(
     val column: Column<T>,
     override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
+    @OptIn(InternalApi::class)
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         val transaction = CoreTransactionManager.currentTransaction()
         val functionProvider = getFunctionProvider(transaction.db.dialect)
@@ -158,6 +157,5 @@ class InsertValue<T>(
 
 /** Builder object for creating SQL expressions in UpsertStatement */
 object UpsertSqlExpressionBuilder : ISqlExpressionBuilder by SqlExpressionBuilder {
-    @OptIn(InternalApi::class)
     fun <T> insertValue(column: Column<T>): ExpressionWithColumnType<T> = InsertValue(column, column.columnType)
 }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Queries.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Queries.kt
@@ -680,7 +680,7 @@ fun <T : Table> T.upsert(
     vararg keys: Column<*>,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     body: T.(UpsertStatement<Long>) -> Unit
 ): UpsertStatement<Long> {
     val stmt = buildStatement { upsert(keys = keys, onUpdate, onUpdateExclude, where, body) }
@@ -739,7 +739,7 @@ fun <T : Table, E : Any> T.batchUpsert(
     vararg keys: Column<*>,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchUpsertStatement.(E) -> Unit
 ): List<ResultRow> {
@@ -768,7 +768,7 @@ fun <T : Table, E : Any> T.batchUpsert(
     vararg keys: Column<*>,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchUpsertStatement.(E) -> Unit
 ): List<ResultRow> {
@@ -781,7 +781,7 @@ private fun <T : Table, E> T.batchUpsert(
     onUpdateList: List<Pair<Column<*>, Any?>>? = null,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     shouldReturnGeneratedValues: Boolean = true,
     vararg keys: Column<*>,
     body: BatchUpsertStatement.(E) -> Unit

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/UpsertTests.kt
@@ -38,6 +38,7 @@ import org.junit.Test
 import java.lang.Integer.parseInt
 import java.util.*
 import kotlin.properties.Delegates
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
@@ -892,6 +893,62 @@ class UpsertTests : R2dbcDatabaseTestsBase() {
             assertEqualLists(listOf(1.1, 2.2), value[tester.doubleArray])
             assertEqualLists(listOf('a', 'b'), value[tester.charArray])
             assertEqualLists(uuidList, value[tester.uuidArray])
+        }
+    }
+
+    @Test
+    fun testExcludedValueInWhereCondition() {
+        val tester = object : Table("upsert_where_excluded") {
+            val id = integer("id")
+                .uniqueIndex()
+            val name = text("name")
+            val order = integer("order")
+        }
+
+        class TesterData(val id: Int, val name: String, val order: Int)
+
+        suspend fun testerBatchUpsert(data: List<TesterData>) {
+            tester.batchUpsert(
+                data,
+                tester.id,
+                onUpdate = {
+                    it[tester.name] = insertValue(tester.name)
+                    it[tester.order] = insertValue(tester.order)
+                },
+                where = {
+                    tester.order less insertValue(tester.order)
+                }
+            ) {
+                this[tester.id] = it.id
+                this[tester.name] = it.name
+                this[tester.order] = it.order
+            }
+        }
+
+        suspend fun assertTesterName(id: Int, name: String) {
+            assertEquals(name, tester.selectAll().where { tester.id eq id }.single()[tester.name])
+        }
+
+        withTables(excludeSettings = TestDB.ALL_MYSQL_LIKE + upsertViaMergeDB, tester) {
+            testerBatchUpsert(
+                listOf(
+                    TesterData(1, "tester1", 10),
+                    TesterData(2, "tester2", 10),
+                )
+            )
+
+            assertTesterName(1, "tester1")
+            assertTesterName(2, "tester2")
+
+            testerBatchUpsert(
+                listOf(
+                    TesterData(1, "tester1-modified", 5),
+                    TesterData(2, "tester2-modified", 20),
+                )
+            )
+
+            assertTesterName(1, "tester1")
+            assertTesterName(2, "tester2-modified")
         }
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
@@ -673,7 +673,7 @@ suspend fun <T : Table> T.upsert(
     vararg keys: Column<*>,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     body: T.(UpsertStatement<Long>) -> Unit
 ): UpsertStatement<Long> {
     val stmt = buildStatement { upsert(keys = keys, onUpdate, onUpdateExclude, where, body) }
@@ -732,7 +732,7 @@ suspend fun <T : Table, E : Any> T.batchUpsert(
     vararg keys: Column<*>,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchUpsertStatement.(E) -> Unit
 ): List<ResultRow> {
@@ -761,7 +761,7 @@ suspend fun <T : Table, E : Any> T.batchUpsert(
     vararg keys: Column<*>,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchUpsertStatement.(E) -> Unit
 ): List<ResultRow> {
@@ -774,7 +774,7 @@ private suspend fun <T : Table, E> T.batchUpsert(
     onUpdateList: List<Pair<Column<*>, Any?>>? = null,
     onUpdate: (UpsertBuilder.(UpdateStatement) -> Unit)? = null,
     onUpdateExclude: List<Column<*>>? = null,
-    where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
+    where: (UpsertSqlExpressionBuilder.() -> Op<Boolean>)? = null,
     shouldReturnGeneratedValues: Boolean = true,
     vararg keys: Column<*>,
     body: BatchUpsertStatement.(E) -> Unit

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
@@ -923,7 +923,9 @@ class UpsertTests : DatabaseTestsBase() {
             assertEquals(name, tester.selectAll().where { tester.id eq id }.single()[tester.name])
         }
 
-        // SQL seems correct, but the statement fails on POSTGRESNG
+        // SQL seems correct, but the statement fails on POSTGRESNG.
+        // It looks like POSTGRESNG driver fails if batch insert fails if the amount of result rows less
+        // than amount of statements in batch (due to `where` condition in this case)
         withTables(excludeSettings = TestDB.ALL_MYSQL_LIKE + upsertViaMergeDB + TestDB.POSTGRESQLNG, tester) {
             testerBatchUpsert(
                 listOf(

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.v1.tests.shared.dml
 
-import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.concat
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.less
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.like
@@ -8,14 +7,24 @@ import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.minus
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.neq
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.plus
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.times
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
+import org.jetbrains.exposed.v1.core.intLiteral
 import org.jetbrains.exposed.v1.core.statements.BatchUpsertStatement
 import org.jetbrains.exposed.v1.core.statements.UpdateStatement
 import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.core.stringParam
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
-import org.jetbrains.exposed.v1.jdbc.*
+import org.jetbrains.exposed.v1.jdbc.batchUpsert
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
@@ -25,6 +34,7 @@ import org.junit.Test
 import java.lang.Integer.parseInt
 import java.util.*
 import kotlin.properties.Delegates
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 
@@ -877,6 +887,63 @@ class UpsertTests : DatabaseTestsBase() {
             assertEqualLists(listOf(1.1, 2.2), value[tester.doubleArray])
             assertEqualLists(listOf('a', 'b'), value[tester.charArray])
             assertEqualLists(uuidList, value[tester.uuidArray])
+        }
+    }
+
+    @Test
+    fun testExcludedValueInWhereCondition() {
+        val tester = object : Table("upsert_where_excluded") {
+            val id = integer("id")
+                .uniqueIndex()
+            val name = text("name")
+            val order = integer("order")
+        }
+
+        class TesterData(val id: Int, val name: String, val order: Int)
+
+        fun testerBatchUpsert(data: List<TesterData>) {
+            tester.batchUpsert(
+                data,
+                tester.id,
+                onUpdate = {
+                    it[tester.name] = insertValue(tester.name)
+                    it[tester.order] = insertValue(tester.order)
+                },
+                where = {
+                    tester.order less insertValue(tester.order)
+                }
+            ) {
+                this[tester.id] = it.id
+                this[tester.name] = it.name
+                this[tester.order] = it.order
+            }
+        }
+
+        fun assertTesterName(id: Int, name: String) {
+            assertEquals(name, tester.selectAll().where { tester.id eq id }.single()[tester.name])
+        }
+
+        // SQL seems correct, but the statement fails on POSTGRESNG
+        withTables(excludeSettings = TestDB.ALL_MYSQL_LIKE + upsertViaMergeDB + TestDB.POSTGRESQLNG, tester) {
+            testerBatchUpsert(
+                listOf(
+                    TesterData(1, "tester1", 10),
+                    TesterData(2, "tester2", 10),
+                )
+            )
+
+            assertTesterName(1, "tester1")
+            assertTesterName(2, "tester2")
+
+            testerBatchUpsert(
+                listOf(
+                    TesterData(1, "tester1-modified", 5),
+                    TesterData(2, "tester2-modified", 20),
+                )
+            )
+
+            assertTesterName(1, "tester1")
+            assertTesterName(2, "tester2-modified")
         }
     }
 }


### PR DESCRIPTION
#### Description

Update `where` parameter in upsert statement to allow use `insertValue(column)` also in the `where` condition.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] Postgres
- [X] SQLite

---

#### Related Issues

[EXPOSED-811](https://youtrack.jetbrains.com/issue/EXPOSED-811) argument "where" in "batchUpsert" have no way to use it
