### PR TITLE
fix: Refactor use of runBlocking to be conditional for metadata properties

### DIFF
--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -694,6 +694,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl
 	public fun getSchema (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getTransactionIsolation (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun isClosed (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun localMetadata (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun metadata (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prepareStatement (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prepareStatement (Ljava/lang/String;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -840,6 +841,7 @@ public abstract interface class org/jetbrains/exposed/v1/r2dbc/statements/api/R2
 	public abstract fun getSchema (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getTransactionIsolation (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun isClosed (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun localMetadata (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun metadata (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun prepareStatement (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun prepareStatement (Ljava/lang/String;[Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactive.collect
+import kotlinx.coroutines.runBlocking
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.statements.api.ExposedSavepoint
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
@@ -209,6 +210,18 @@ class R2dbcConnectionImpl(
             metadataImpl = R2dbcDatabaseMetadataImpl(getCatalog(), this, vendorDialect)
         }
         metadataImpl!!.body()
+    }
+
+    override fun <T> localMetadata(body: R2dbcExposedDatabaseMetadata.() -> T): T {
+        if (metadataImpl == null) {
+            metadataImpl = runBlocking {
+                withConnection {
+                    R2dbcDatabaseMetadataImpl(getCatalog(), this, vendorDialect)
+                }
+            }
+        }
+
+        return metadataImpl!!.body()
     }
 
     private var localConnection: Connection? = null

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcExposedConnection.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcExposedConnection.kt
@@ -73,6 +73,13 @@ interface R2dbcExposedConnection<OriginalConnection : Any> {
      */
     suspend fun <T> metadata(body: suspend R2dbcExposedDatabaseMetadata.() -> T): T
 
+    /**
+     * Calls the specified function [body] with an [R2dbcExposedDatabaseMetadata] implementation as its receiver and
+     * returns the data retrieved from either a local [org.jetbrains.exposed.v1.r2dbc.vendors.metadata.MetadataProvider]
+     * or the current transaction's connection metadata as a result.
+     */
+    fun <T> localMetadata(body: R2dbcExposedDatabaseMetadata.() -> T): T
+
     /** Sets and returns a new savepoint with the specified [name]. */
     suspend fun setSavepoint(name: String): ExposedSavepoint
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Replace `runBlocking()` use in some database metadata properties with a `localMetadata()` call that only blocks conditionally, in the event a metadata implementation has not already been instantiated.

**Detailed description**:
- **How**: Introduce `localMetadata()` to connection implementation, which does not suspend.

**With JdbcDatabaseMetadataImpl, there are 2 types of metadata checks:**

1. (Very common) Methods and properties called directly on provided `java.sql.DatabaseMetaData`
    - There is even a `DatabaseMetaData.connection` property that allows access to the underlying `Connection` and its metadata via a single access point.
2. (Less common) SQL query strings executed using `exec()`

**With R2dbcDatabaseMetadataImpl, there are 3 types of metadata checks:**
1. (Very common) SQL query strings (provided by our `MetadataProvider`) executed directly on the provided `Connection` **- Needs an instance of the class, a connection, and to suspend**
2. (Less common) Calls to `Connection.metadata` directly **- Needs an instance of the class & a connection**
3. (Uncommon) Getters for hard-coded property values provided by our `MetadataProvider` **- Needs only MetadataProvider**

---

4 of the `runBlocking()` usages could be solved by relying directly on `metadataProvider` property, instead of `R2dbcDatabaseMetadataImpl` instance. But this would mean the user no longer has easy access to these properties, unlike with JDBC.

The current solution feels like a band-aid. It simply pulls down the `runBlocking()` to the lowest common level and ensures it's only reached if a metadata implementation has not already been instantiated (or if the metadata check is attempted outside a transaction).

An alternative solution might be to have a different metadata implementation, like `R2dbcLocalMetadataImpl`, but this seems excessive for 4 properties and doesn't solve the issue of metadata|connection checks like `getVersion()`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix | Refactor

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs