### PR TITLE
fix: EXPOSED-815 Check types for QueryAlias.get() at runtime

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
@@ -194,6 +194,8 @@ class QueryAlias(val query: AbstractQuery<*>, val alias: String) : ColumnSet() {
             ?: error("Column not found in original table")
 
     operator fun <T : Any?> get(original: Expression<T>): Expression<T> {
+        if (original is Column<T>) return get(original)
+        if (original is ExpressionWithColumnType<T>) return get(original)
         val aliases = query.set.fields.filterIsInstance<ExpressionAlias<T>>()
         return aliases.find { it == original }?.let {
             it.delegate.alias("$alias.${it.alias}").aliasOnlyExpression()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/AliasesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/AliasesTests.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.v1.tests.shared
 
 import org.jetbrains.exposed.v1.core.*
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.core.dao.id.UUIDTable
@@ -144,6 +145,35 @@ class AliasesTests : DatabaseTestsBase() {
                 this[EntityTestsData.XTable.b1] = it
             }
             val aliasedExpression = EntityTestsData.XTable.id.max().alias("maxId")
+            val aliasedQuery = EntityTestsData.XTable
+                .select(EntityTestsData.XTable.b1, aliasedExpression)
+                .groupBy(EntityTestsData.XTable.b1)
+                .alias("maxBoolean")
+
+            val aliasedBool = aliasedQuery[EntityTestsData.XTable.b1]
+            val expressionToCheck = aliasedQuery[aliasedExpression]
+            assertEquals("maxBoolean.maxId", expressionToCheck.toString())
+
+            val resultQuery = aliasedQuery
+                .leftJoin(EntityTestsData.XTable, { this[aliasedExpression] }, { id })
+                .select(aliasedBool, expressionToCheck)
+
+            val result = resultQuery.map {
+                it[aliasedBool] to it[expressionToCheck]!!.value
+            }
+
+            assertEqualCollections(listOf(true to 4, false to 3), result)
+        }
+    }
+
+    @Test
+    fun `test aliased expression with aliased query as expression`() {
+        withTables(EntityTestsData.XTable, EntityTestsData.YTable) {
+            val dataToInsert = listOf(true, true, false, true)
+            EntityTestsData.XTable.batchInsert(dataToInsert) {
+                this[EntityTestsData.XTable.b1] = it
+            }
+            val aliasedExpression = EntityTestsData.XTable.id.max().alias("maxId") as Expression<EntityID<Int>?>
             val aliasedQuery = EntityTestsData.XTable
                 .select(EntityTestsData.XTable.b1, aliasedExpression)
                 .groupBy(EntityTestsData.XTable.b1)


### PR DESCRIPTION
#### Description

Check types for QueryAlias.get() at runtime.

Relying purely on compile time checks causes issues when trying to dynamically select fields. E.g.:

```kt
object Tasks : UUIDTable("tasks") {
    val weight = integer("weight").nullable()
}

fun main() {
    val expression = Tasks.weight.sum()
    val alias = expression.alias("task_weight")
    val query = Tasks.select(Tasks.weight, alias).alias("all_weight")
    println(query[Tasks.weight]) // works
    println(query[alias]) // works
    val type = if (Random.nextInt(0..2) == 0) Tasks.weight else alias
    println(query[type]) // doesn't work half of the time
}
```

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [x] MariaDB
- [x] Mysql5
- [x] Mysql8
- [x] Oracle
- [x] Postgres
- [x] SqlServer
- [x] H2
- [x] SQLite

#### Checklist

- [x] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
