### PR TITLE
fix: EXPOSED-815 Resolving an aliased field on a query alias doesn't work

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
@@ -194,7 +194,7 @@ class QueryAlias(val query: AbstractQuery<*>, val alias: String) : ColumnSet() {
             ?: error("Column not found in original table")
 
     operator fun <T : Any?> get(original: Expression<T>): Expression<T> {
-        val aliases = query.set.fields.filterIsInstance<ExpressionAlias<T>>()
+        val aliases = query.set.fields.filterIsInstance<IExpressionAlias<T>>()
         return aliases.find { it == original }?.let {
             it.delegate.alias("$alias.${it.alias}").aliasOnlyExpression()
         } ?: aliases.find { it.delegate == original }?.aliasOnlyExpression()

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/AliasesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/AliasesTests.kt
@@ -342,4 +342,23 @@ class AliasesTests : DatabaseTestsBase() {
             )
         }
     }
+
+    @Test
+    fun testAliasCastedToExpression() {
+        val tester = object : IntIdTable("Test") {
+            val weight = integer("weight")
+        }
+
+        val expression = tester.weight.sum()
+        val alias: Expression<Int?> = expression.alias("task_weight")
+        val query: QueryAlias = tester.select(alias).alias("all_weight")
+
+        // EXPOSED-815 Resolving an aliased field on a query alias doesn't work
+        // Reading `query[alias]` crashed before the fix
+        val aliasExpressionString = QueryBuilder(true).also {
+            query[alias].toQueryBuilder(it)
+        }.toString()
+
+        assertEquals("all_weight.task_weight", aliasExpressionString)
+    }
 }


### PR DESCRIPTION
#### Description

**Detailed description**:
- **What**: Getting `alias` from `query alias` fails, if the `alias` has not type `ExpressionWithColumnTypeAlias` but has `IExpressionAlias`.
- **Why**: `QueryAlias::get()` filters for `ExpressionAlias` to get aliases
- **How**: Change filtering to `IExpressionAlias`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
Affected databases:
- [X] ALL
---

#### Related Issues

[EXPOSED-815](https://youtrack.jetbrains.com/issue/EXPOSED-815) Resolving an aliased field on a query alias doesn't work
