### PR TITLE
refactor!: Make ThreadLocalMap internal & move mtc package into transactions

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,10 @@
 # Breaking Changes
 
+## 1.0.0-beta-4 <!--temporary version placeholder-->
+
+* `ThreadLocalMap` has been restricted to internal use, based on its current limited usage in already internal classes.
+  It, along with `MappedTransactionContext`, has been moved into the subpackage: `org.jetbrains.exposed.v1.r2dbc.transactions.mtc`.
+
 ## 1.0.0-beta-3
 
 * `exposed-core` interface `PreparedStatementApi` has a new `set()` method that will require an override if implemented.

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -608,11 +608,6 @@ public final class org/jetbrains/exposed/v1/r2dbc/mappers/ValueTypeMapper : org/
 	public fun setValue (Lio/r2dbc/spi/Statement;Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;Lorg/jetbrains/exposed/v1/core/IColumnType;Ljava/lang/Object;I)Z
 }
 
-public final class org/jetbrains/exposed/v1/r2dbc/mtc/ThreadLocalMap : java/lang/InheritableThreadLocal {
-	public fun <init> ()V
-	public synthetic fun childValue (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
 public class org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable : org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable {
 	public fun <init> (Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;)V
 	public fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/R2dbcTransactionUtils.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/R2dbcTransactionUtils.kt
@@ -3,7 +3,7 @@ package org.jetbrains.exposed.v1.r2dbc.transactions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ThreadContextElement
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
-import org.jetbrains.exposed.v1.r2dbc.mtc.MappedTransactionContext
+import org.jetbrains.exposed.v1.r2dbc.transactions.mtc.MappedTransactionContext
 import kotlin.coroutines.CoroutineContext
 
 internal class TransactionContext(val manager: TransactionManager?, val transaction: R2dbcTransaction?)

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
@@ -18,8 +18,8 @@ import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
-import org.jetbrains.exposed.v1.r2dbc.mtc.MappedTransactionContext
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcExposedConnection
+import org.jetbrains.exposed.v1.r2dbc.transactions.mtc.MappedTransactionContext
 import java.util.concurrent.ThreadLocalRandom
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/mtc/MappedThreadContext.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/mtc/MappedThreadContext.kt
@@ -1,4 +1,4 @@
-package org.jetbrains.exposed.v1.r2dbc.mtc
+package org.jetbrains.exposed.v1.r2dbc.transactions.mtc
 
 import java.util.*
 import kotlin.concurrent.getOrSet

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/mtc/MappedTransactionContext.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/mtc/MappedTransactionContext.kt
@@ -1,4 +1,4 @@
-package org.jetbrains.exposed.v1.r2dbc.mtc
+package org.jetbrains.exposed.v1.r2dbc.transactions.mtc
 
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/mtc/ThreadLocalMap.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/mtc/ThreadLocalMap.kt
@@ -1,12 +1,10 @@
-package org.jetbrains.exposed.v1.r2dbc.mtc
+package org.jetbrains.exposed.v1.r2dbc.transactions.mtc
 
 import java.util.*
 
-// TODO make internal based on internal usage
-//  Move mtc package as sub-package in transactions package since all internal
 // Not sure that it's really needed for us,
 // because I don't expect that one thread with tx context could start another one by itself
-class ThreadLocalMap : InheritableThreadLocal<Hashtable<String, Any?>>() {
+internal class ThreadLocalMap : InheritableThreadLocal<Hashtable<String, Any?>>() {
     @Suppress("UNCHECKED_CAST")
     override fun childValue(parentValue: Hashtable<String, Any?>?): Hashtable<String, Any?>? {
         return parentValue?.clone() as Hashtable<String, Any?>?


### PR DESCRIPTION
#### Description

**Summary of the change**: Make `ThreadLocalMap` internal & move it and associated classes under `transactions` package

**Detailed description**:
- **Why**: `ThreadLocalMap` (a public class) is only used by `MappedThreadContext` (an internal object), which is only used by `MappedTransactionContext` (an internal object). These 3 objects are the only ones in the `r2dbc.mtc` package and only the latter is actually used by a single public object, `TransactionManager`.

- **What**:
    - `ThreadLocalMap` made internal
    - Now all internal objects moved to directly where they are used, as a utility subpackage: `r2dbc.transactions.mtc`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Refactor

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date