### PR TITLE
refactor!: Move addLogger() to exposed-core Transaction class

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -4,6 +4,9 @@
 
 * `ThreadLocalMap` has been restricted to internal use, based on its current limited usage in already internal classes.
   It, along with `MappedTransactionContext`, has been moved into the subpackage: `org.jetbrains.exposed.v1.r2dbc.transactions.mtc`.
+* `addLogger()` has been converted into a `Transaction` method (instead of an extension method of `JdbcTransaction` and `R2dbcTransaction`),
+  so its logic can remain common within `exposed-core`. Any explicit imports, like `import org.jetbrains.exposed.v1.jdbc.addLogger`,
+  will no longer compile and should be removed.
 
 ## 1.0.0-beta-3
 

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2292,6 +2292,7 @@ public final class org/jetbrains/exposed/v1/core/TimesOp : org/jetbrains/exposed
 
 public abstract class org/jetbrains/exposed/v1/core/Transaction : org/jetbrains/exposed/v1/core/UserDataHolder, org/jetbrains/exposed/v1/core/transactions/TransactionInterface {
 	public fun <init> ()V
+	public fun addLogger ([Lorg/jetbrains/exposed/v1/core/SqlLogger;)Lorg/jetbrains/exposed/v1/core/CompositeSqlLogger;
 	public final fun fullIdentity (Lorg/jetbrains/exposed/v1/core/Column;)Ljava/lang/String;
 	public final fun getDebug ()Z
 	public final fun getDuration ()J

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
@@ -101,4 +101,11 @@ abstract class Transaction : UserDataHolder(), TransactionInterface {
 
     /** Returns the string identifier of a [column], based on its [Column.name]. */
     fun identity(column: Column<*>): String = db.identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(column.name)
+
+    /** Adds one or more [SqlLogger]s to this [Transaction]. */
+    open fun addLogger(vararg logger: SqlLogger): CompositeSqlLogger {
+        return CompositeSqlLogger().apply {
+            logger.forEach { this.addLogger(it) }
+        }
+    }
 }

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -100,6 +100,7 @@ public final class org/jetbrains/exposed/v1/jdbc/IterableExKt {
 public class org/jetbrains/exposed/v1/jdbc/JdbcTransaction : org/jetbrains/exposed/v1/core/Transaction, org/jetbrains/exposed/v1/jdbc/transactions/JdbcTransactionInterface {
 	public static final field Companion Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction$Companion;
 	public fun <init> (Lorg/jetbrains/exposed/v1/jdbc/transactions/JdbcTransactionInterface;)V
+	public final fun addLogger ([Lorg/jetbrains/exposed/v1/core/SqlLogger;)Lorg/jetbrains/exposed/v1/core/CompositeSqlLogger;
 	public fun close ()V
 	public final fun closeExecutedStatements ()V
 	public fun commit ()V
@@ -132,10 +133,6 @@ public class org/jetbrains/exposed/v1/jdbc/JdbcTransaction : org/jetbrains/expos
 
 public final class org/jetbrains/exposed/v1/jdbc/JdbcTransaction$Companion {
 	public final fun getGlobalInterceptors ()Ljava/util/ArrayList;
-}
-
-public final class org/jetbrains/exposed/v1/jdbc/JdbcTransactionKt {
-	public static final fun addLogger (Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction;[Lorg/jetbrains/exposed/v1/core/SqlLogger;)Lorg/jetbrains/exposed/v1/core/CompositeSqlLogger;
 }
 
 public final class org/jetbrains/exposed/v1/jdbc/LazySizedCollection : org/jetbrains/exposed/v1/jdbc/SizedIterable {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/JdbcTransaction.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/JdbcTransaction.kt
@@ -239,6 +239,12 @@ open class JdbcTransaction(
         executedStatements.clear()
     }
 
+    final override fun addLogger(vararg logger: SqlLogger): CompositeSqlLogger {
+        return super.addLogger(*logger).apply {
+            registerInterceptor(this)
+        }
+    }
+
     internal fun getRetryInterval(): Long = if (maxAttempts > 0) {
         maxOf((maxRetryDelay - minRetryDelay) / (maxAttempts + 1), 1)
     } else {
@@ -256,13 +262,5 @@ open class JdbcTransaction(
                 globalInterceptors.add(it)
             }
         }
-    }
-}
-
-/** Adds one or more [SqlLogger]s to this [JdbcTransaction]. */
-fun JdbcTransaction.addLogger(vararg logger: SqlLogger): CompositeSqlLogger {
-    return CompositeSqlLogger().apply {
-        logger.forEach { this.addLogger(it) }
-        registerInterceptor(this)
     }
 }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ParameterizationTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ParameterizationTests.kt
@@ -9,7 +9,6 @@ import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.VarCharColumnType
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
-import org.jetbrains.exposed.v1.r2dbc.addLogger
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -286,6 +286,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseKt {
 public class org/jetbrains/exposed/v1/r2dbc/R2dbcTransaction : org/jetbrains/exposed/v1/core/Transaction, org/jetbrains/exposed/v1/r2dbc/transactions/R2dbcTransactionInterface {
 	public static final field Companion Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction$Companion;
 	public fun <init> (Lorg/jetbrains/exposed/v1/r2dbc/transactions/R2dbcTransactionInterface;)V
+	public final fun addLogger ([Lorg/jetbrains/exposed/v1/core/SqlLogger;)Lorg/jetbrains/exposed/v1/core/CompositeSqlLogger;
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun closeExecutedStatements (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun commit (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -318,10 +319,6 @@ public class org/jetbrains/exposed/v1/r2dbc/R2dbcTransaction : org/jetbrains/exp
 
 public final class org/jetbrains/exposed/v1/r2dbc/R2dbcTransaction$Companion {
 	public final fun getGlobalInterceptors ()Ljava/util/ArrayList;
-}
-
-public final class org/jetbrains/exposed/v1/r2dbc/R2dbcTransactionKt {
-	public static final fun addLogger (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;[Lorg/jetbrains/exposed/v1/core/SqlLogger;)Lorg/jetbrains/exposed/v1/core/CompositeSqlLogger;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/SchemaUtils : org/jetbrains/exposed/v1/core/SchemaUtilityApi {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcTransaction.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcTransaction.kt
@@ -240,6 +240,12 @@ open class R2dbcTransaction(
         executedStatements.clear()
     }
 
+    final override fun addLogger(vararg logger: SqlLogger): CompositeSqlLogger {
+        return super.addLogger(*logger).apply {
+            registerInterceptor(this)
+        }
+    }
+
     internal fun getRetryInterval(): Long = if (maxAttempts > 0) {
         maxOf((maxRetryDelay - minRetryDelay) / (maxAttempts + 1), 1)
     } else {
@@ -256,14 +262,5 @@ open class R2dbcTransaction(
                 globalInterceptors.add(it)
             }
         }
-    }
-}
-
-// TODO Check why separated and if could be returned to single place in core (Transaction?)
-/** Adds one or more [SqlLogger]s to this [R2dbcTransaction]. */
-fun R2dbcTransaction.addLogger(vararg logger: SqlLogger): CompositeSqlLogger {
-    return CompositeSqlLogger().apply {
-        logger.forEach { this.addLogger(it) }
-        registerInterceptor(this)
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/demo/dao/SamplesDao.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/demo/dao/SamplesDao.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
-import org.jetbrains.exposed.v1.jdbc.addLogger
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.junit.Assume

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ParameterizationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ParameterizationTests.kt
@@ -10,7 +10,6 @@ import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
-import org.jetbrains.exposed.v1.jdbc.addLogger
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction

--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring/transaction/SpringTransactionManager.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring/transaction/SpringTransactionManager.kt
@@ -5,7 +5,6 @@ import org.jetbrains.exposed.v1.core.StdOutSqlLogger
 import org.jetbrains.exposed.v1.core.exposedLogger
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
-import org.jetbrains.exposed.v1.jdbc.addLogger
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transactionManager
 import org.springframework.transaction.TransactionDefinition


### PR DESCRIPTION
#### Description

**Summary of the change**: `JdbcTransaction.addLogger()` and `R2dbcTransaction.addLogger()` replaced with class methods.

**Detailed description**:
- **Why**:

Prior to 1.0.0, `Transaction.addLogger()` existed as an extension function ins `SQLLog.kt`. Its logic called `registerInterceptor()`, which was a public `Transaction` method that relied on [an internal ArrayList](https://github.com/JetBrains/Exposed/blob/main/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/JdbcTransaction.kt#L64). This was fine because everything was together in `exposed-core`.

After 1.0.0, the original was removed and replaced with 2 extension functions, one in the jdbc and r2dbc module. This was done because the internal array list was maintained, so `registerInterceptor()` had to be removed from `exposed-core`.

- **What**: To reduce this further duplication, `addLogger()` is returned to `exposed-core`, but as a base `Transaction` method.

Both `JdbcTransaction` and `R2dbcTransaction` now have final method overrides that call `super` and additionally call their respective `registerInterceptor()` methods.

❗ **This may break any direct imports, which would no longer be necessary to call the method.**

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Refactor

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place - PRE-EXISTING
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date
