### PR TITLE
feat: EXPOSED-826 Extend MigrationUtils with dropUnmappedIndices and dropUnmappedSequence

### DIFF
--- a/documentation-website/Writerside/topics/Migrations.md
+++ b/documentation-website/Writerside/topics/Migrations.md
@@ -124,6 +124,7 @@ function helps identify columns that are no longer present in your current table
 ```
 {src="exposed-migrations/src/main/kotlin/org/example/App.kt" include-symbol="dropStatements"}
 
+For indices and sequences, there are similar methods: `MigrationUtils.dropUnmappedIndices()` and `MigrationUtils.dropUnmappedSequences()`.
 
 ## Logging
 

--- a/exposed-migration/api/exposed-migration.api
+++ b/exposed-migration/api/exposed-migration.api
@@ -10,6 +10,10 @@ public final class org/jetbrains/exposed/v1/migration/MigrationUtils : org/jetbr
 	public static final field INSTANCE Lorg/jetbrains/exposed/v1/migration/MigrationUtils;
 	public final fun dropUnmappedColumnsStatements ([Lorg/jetbrains/exposed/v1/core/Table;Z)Ljava/util/List;
 	public static synthetic fun dropUnmappedColumnsStatements$default (Lorg/jetbrains/exposed/v1/migration/MigrationUtils;[Lorg/jetbrains/exposed/v1/core/Table;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun dropUnmappedIndices ([Lorg/jetbrains/exposed/v1/core/Table;Z)Ljava/util/List;
+	public static synthetic fun dropUnmappedIndices$default (Lorg/jetbrains/exposed/v1/migration/MigrationUtils;[Lorg/jetbrains/exposed/v1/core/Table;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun dropUnmappedSequences ([Lorg/jetbrains/exposed/v1/core/Table;Z)Ljava/util/List;
+	public static synthetic fun dropUnmappedSequences$default (Lorg/jetbrains/exposed/v1/migration/MigrationUtils;[Lorg/jetbrains/exposed/v1/core/Table;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun generateMigrationScript ([Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/String;Ljava/lang/String;Z)Ljava/io/File;
 	public static synthetic fun generateMigrationScript$default (Lorg/jetbrains/exposed/v1/migration/MigrationUtils;[Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ljava/io/File;
 	public final fun statementsRequiredForDatabaseMigration ([Lorg/jetbrains/exposed/v1/core/Table;Z)Ljava/util/List;

--- a/exposed-migration/src/main/kotlin/org/jetbrains/exposed/v1/migration/MigrationUtilityApi.kt
+++ b/exposed-migration/src/main/kotlin/org/jetbrains/exposed/v1/migration/MigrationUtilityApi.kt
@@ -65,8 +65,13 @@ abstract class MigrationUtilityApi : SchemaUtilityApi() {
     @InternalApi
     protected fun Set<String>.filterUnmappedSequences(vararg tables: Table): List<Sequence> {
         val unmappedSequences = mutableSetOf<Sequence>()
-        val mappedSequencesNames = tables.flatMap { table -> table.sequences.map { it.identifier.inProperCase() } }.toSet()
-        unmappedSequences.addAll(subtract(mappedSequencesNames).map { Sequence(it) })
+        val mappedSequencesNames = tables.flatMap { table ->
+            table.sequences.map {
+                it.identifier.inProperCase()
+            }
+        }.toSet()
+
+        unmappedSequences.addAll(filter { !mappedSequencesNames.contains(it.inProperCase()) }.map { Sequence(it) })
         return unmappedSequences.toList()
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -1236,7 +1236,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
         }
 
         // It doesn't look like Sequence metadata works stable for all databases. For some databases it can't find existing sequences
-        withTables(excludeSettings = TestDB.ALL - TestDB.POSTGRESQL, dbTable, configure = { sqlLogger = StdOutSqlLogger }) {
+        withTables(excludeSettings = TestDB.ALL - TestDB.POSTGRESQL, dbTable) {
             val statements = MigrationUtils.dropUnmappedSequences(tester)
 
             assertEquals(2, statements.size)


### PR DESCRIPTION
#### Description

Migration utils already had a method `dropUnmappedColumnsStatements` to get the statements to drop columns that exist in database but not defined in the code. 

With these PR two new methods `dropUnmappedIndices` and `dropUnmappedSequences` would be added. These methods allow to get statements to drop unmapped indices and sequences respectively

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

Affected databases:
- [X] All

---

#### Related Issues

[EXPOSED-826](https://youtrack.jetbrains.com/issue/EXPOSED-826) Extend MigrationUtils with dropUnmappedIndices and dropUnmappedSequence