### PR TITLE
fix: EXPOSED-827 forUpdate() query method doesn't add actual `FOR UDPATE` modifier

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3880,6 +3880,7 @@ public class org/jetbrains/exposed/v1/core/vendors/PostgreSQLDialect : org/jetbr
 	public fun getName ()Ljava/lang/String;
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsSelectForUpdate ()Z
 	public fun getSupportsSubqueryUnions ()Z
 	public fun getSupportsWindowFrameGroupsMode ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/v1/core/Expression;)Z

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
@@ -372,6 +372,8 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
 
     override val supportsWindowFrameGroupsMode: Boolean = true
 
+    override val supportsSelectForUpdate: Boolean = true
+
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
     override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> {


### PR DESCRIPTION
Override `supportsSelectForUpdate` parameter for `PostgreSQLDialect`

---

#### Type of Change

- [X] Bug fix

Affected databases:
- [X] Postgres

---

#### Related Issues

[EXPOSED-827](https://youtrack.jetbrains.com/issue/EXPOSED-827) forUpdate() query method doesn't add actual `FOR UDPATE` modifier
