### PR TITLE
fix: readObject() parameter change requires casting to keep using

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
@@ -82,8 +82,6 @@ interface IColumnType<T> {
     fun nonNullValueAsDefaultString(value: T & Any): String = nonNullValueToString(value)
 
     /** Returns the object at the specified [index] in the [rs]. */
-    // TODO Could we avoid breaking change here for users?
-    // TODO What should do the users with custom column types that override this method?
     fun readObject(rs: RowApi, index: Int): Any? = rs.getObject(index, null, this)
 
     /** Sets the [value] at the specified [index] into the [stmt]. */

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -738,6 +738,10 @@ public final class org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult : or
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResultKt {
+	public static final fun getOrigin (Lorg/jetbrains/exposed/v1/core/statements/api/RowApi;)Ljava/sql/ResultSet;
+}
+
 public final class org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcSavepoint : org/jetbrains/exposed/v1/core/statements/api/ExposedSavepoint {
 	public fun <init> (Ljava/lang/String;Ljava/sql/Savepoint;)V
 }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult.kt
@@ -55,3 +55,6 @@ class JdbcResult(
         statement?.close()
     }
 }
+
+/** Returns the actual underlying [ResultSet] at the current position in this result [RowApi]. */
+val RowApi.origin: ResultSet get() = (this as JdbcResult).result


### PR DESCRIPTION
#### Description

**Summary of the change**: Add `RowApi.origin` to `exposed-jdbc` to avoid need to cast when overriding `IColumnType.readObject()`.

**Detailed description**:
- **Why**:

Parameter type change of `readObject()` is unavoidable at this point and already documented: [Migration Guide](https://www.jetbrains.com/help/exposed/migration-guide-1-0-0.html#read-object)

If a custom column type is implemented that requires this method override, the best way to ensure common JDBC/R2DBC compatibility is to use common `RowApi.getObject()`.
**BUT,** if there is no intention to share code, or the user wants to continue to use the original JDBC `ResultSet` code, the only way to accomplish this would be to cast and access the underlying result:
```kotlin
// PRE-V1
override fun readObject(rs: ResultSet, index: Int): Any? {
    return rs.getString(index).take(MAX_CHARS)
}

// POST-V1
override fun readObject(rs: RowApi, index: Int): Any? {
    return (rs as JdbcResult).result.getString(index).take(MAX_CHARS)
}
```

`exposed-r2dbc` already has a solution for this, providing a property `RowApi.origin`, which performs the cast and accesses the wrapped result.

- **How**: Add equivalent `RowApi.origin` to `exposed-jdbc` and update migration guide.

```kotlin
override fun readObject(rs: RowApi, index: Int): Any? {
    return rs.origin.getString(index).take(MAX_CHARS)
}
```

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [X] New feature

Affected databases:
- [X] All

#### Checklist

- [ ] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date