### PR TITLE
chore!: EXPOSED-813 When is the plan to migrate kotlinx.datetime.Instant to kotlin.time.Instant?

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -4,7 +4,9 @@
 
 * Migration of kotlinx-datetime from version 6 to version 7. The only package affected is `exposed-kotlin-datetime`. `KotlinInstantColumnType`, and
   `Table.timestamp(name: String)` are parametrized with `kotlin.time.Instant` class now. If you need to use `kotlinx.datetime.Instant` with Exposed, you have to
-  replace usages of `KotlinInstantColumnType` and `Table.timestamp(name: String)` with `XKotlinInstantColumnType` and `Table.xTimestamp(name: String)` respectively.
+  replace usages of `KotlinInstantColumnType` and `Table.timestamp(name: String)` with `XKotlinInstantColumnType` and `Table.xTimestamp(name: String)` respectively,
+  also the `CurrentTimestamp` constant should be changed with `XCurrentTimestamp`, `CustomTimeStampFunction` with `XCustomTimeStampFunction`. 
+  
 
 ## 1.0.0-beta-4
 

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,11 @@
 # Breaking Changes
 
+## 1.0.0-beta-5
+
+* Migration of kotlinx-datetime from version 6 to version 7. The only package affected is `exposed-kotlin-datetime`. `KotlinInstantColumnType`, and
+  `Table.timestamp(name: String)` are parametrized with `kotlin.time.Instant` class now. If you need to use `kotlinx.datetime.Instant` with Exposed, you have to
+  replace usages of `KotlinInstantColumnType` and `Table.timestamp(name: String)` with `XKotlinInstantColumnType` and `Table.xTimestamp(name: String)` respectively.
+
 ## 1.0.0-beta-4
 
 * `ThreadLocalMap` has been restricted to internal use, based on its current limited usage in already internal classes.

--- a/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
+++ b/exposed-kotlin-datetime/api/exposed-kotlin-datetime.api
@@ -27,6 +27,7 @@ public final class org/jetbrains/exposed/v1/datetime/KotlinDateColumnTypeKt {
 	public static final fun time (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/Column;
 	public static final fun timestamp (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/Column;
 	public static final fun timestampWithTimeZone (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/Column;
+	public static final fun xTimestamp (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/Column;
 }
 
 public final class org/jetbrains/exposed/v1/datetime/KotlinDateFunctionsKt {
@@ -100,6 +101,23 @@ public final class org/jetbrains/exposed/v1/datetime/KotlinDateFunctionsKt {
 	public static final fun OffsetDateTimeTimeFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
 	public static final fun OffsetDateTimeYearExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
 	public static final fun OffsetDateTimeYearFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XCustomTimeStampFunction (Ljava/lang/String;[Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/CustomFunction;
+	public static final fun XInstantDateExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantDateFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantDayExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantDayFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantHourExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantHourFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantMinuteExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantMinuteFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantMonthExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantMonthFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantSecondExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantSecondFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantTimeExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantTimeFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantYearExt (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
+	public static final fun XInstantYearFunction (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Function;
 	public static final fun dateLiteral (Lkotlinx/datetime/LocalDate;)Lorg/jetbrains/exposed/v1/core/LiteralOp;
 	public static final fun dateParam (Lkotlinx/datetime/LocalDate;)Lorg/jetbrains/exposed/v1/core/Expression;
 	public static final fun dateTimeLiteral (Lkotlinx/datetime/LocalDateTime;)Lorg/jetbrains/exposed/v1/core/LiteralOp;
@@ -108,7 +126,9 @@ public final class org/jetbrains/exposed/v1/datetime/KotlinDateFunctionsKt {
 	public static final fun durationParam-LRDsOJo (J)Lorg/jetbrains/exposed/v1/core/Expression;
 	public static final fun timeLiteral (Lkotlinx/datetime/LocalTime;)Lorg/jetbrains/exposed/v1/core/LiteralOp;
 	public static final fun timeParam (Lkotlinx/datetime/LocalTime;)Lorg/jetbrains/exposed/v1/core/Expression;
+	public static final fun timestampLiteral (Lkotlin/time/Instant;)Lorg/jetbrains/exposed/v1/core/LiteralOp;
 	public static final fun timestampLiteral (Lkotlinx/datetime/Instant;)Lorg/jetbrains/exposed/v1/core/LiteralOp;
+	public static final fun timestampParam (Lkotlin/time/Instant;)Lorg/jetbrains/exposed/v1/core/Expression;
 	public static final fun timestampParam (Lkotlinx/datetime/Instant;)Lorg/jetbrains/exposed/v1/core/Expression;
 	public static final fun timestampWithTimeZoneLiteral (Ljava/time/OffsetDateTime;)Lorg/jetbrains/exposed/v1/core/LiteralOp;
 	public static final fun timestampWithTimeZoneParam (Ljava/time/OffsetDateTime;)Lorg/jetbrains/exposed/v1/core/Expression;
@@ -134,15 +154,15 @@ public final class org/jetbrains/exposed/v1/datetime/KotlinInstantColumnType : o
 	public fun <init> ()V
 	public fun getHasTimePart ()Z
 	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueAsDefaultString (Lkotlinx/datetime/Instant;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lkotlin/time/Instant;)Ljava/lang/String;
 	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
-	public fun nonNullValueToString (Lkotlinx/datetime/Instant;)Ljava/lang/String;
+	public fun nonNullValueToString (Lkotlin/time/Instant;)Ljava/lang/String;
 	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun notNullValueToDB (Lkotlinx/datetime/Instant;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lkotlin/time/Instant;)Ljava/lang/Object;
 	public fun readObject (Lorg/jetbrains/exposed/v1/core/statements/api/RowApi;I)Ljava/lang/Object;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
-	public fun valueFromDB (Ljava/lang/Object;)Lkotlinx/datetime/Instant;
+	public fun valueFromDB (Ljava/lang/Object;)Lkotlin/time/Instant;
 }
 
 public final class org/jetbrains/exposed/v1/datetime/KotlinInstantColumnType$Companion {
@@ -222,6 +242,29 @@ public final class org/jetbrains/exposed/v1/datetime/KotlinOffsetDateTimeColumnT
 }
 
 public final class org/jetbrains/exposed/v1/datetime/KotlinOffsetDateTimeColumnType$Companion {
+}
+
+public final class org/jetbrains/exposed/v1/datetime/XCurrentTimestamp : org/jetbrains/exposed/v1/datetime/CurrentTimestampBase {
+	public static final field INSTANCE Lorg/jetbrains/exposed/v1/datetime/XCurrentTimestamp;
+}
+
+public final class org/jetbrains/exposed/v1/datetime/XKotlinInstantColumnType : org/jetbrains/exposed/v1/core/ColumnType, org/jetbrains/exposed/v1/core/IDateColumnType {
+	public static final field Companion Lorg/jetbrains/exposed/v1/datetime/XKotlinInstantColumnType$Companion;
+	public fun <init> ()V
+	public fun getHasTimePart ()Z
+	public synthetic fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueAsDefaultString (Lkotlinx/datetime/Instant;)Ljava/lang/String;
+	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
+	public fun nonNullValueToString (Lkotlinx/datetime/Instant;)Ljava/lang/String;
+	public synthetic fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun notNullValueToDB (Lkotlinx/datetime/Instant;)Ljava/lang/Object;
+	public fun readObject (Lorg/jetbrains/exposed/v1/core/statements/api/RowApi;I)Ljava/lang/Object;
+	public fun sqlType ()Ljava/lang/String;
+	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueFromDB (Ljava/lang/Object;)Lkotlinx/datetime/Instant;
+}
+
+public final class org/jetbrains/exposed/v1/datetime/XKotlinInstantColumnType$Companion {
 }
 
 public final class org/jetbrains/exposed/v1/datetime/YearInternal : org/jetbrains/exposed/v1/core/Function {

--- a/exposed-kotlin-datetime/build.gradle.kts
+++ b/exposed-kotlin-datetime/build.gradle.kts
@@ -14,6 +14,10 @@ repositories {
 
 kotlin {
     jvmToolchain(8)
+
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+    }
 }
 
 dependencies {

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/v1/datetime/KotlinDateColumnType.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/v1/datetime/KotlinDateColumnType.kt
@@ -401,6 +401,10 @@ class KotlinLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
  *
  * @sample timestamp
  */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("KotlinInstantColumnType")
+)
 class XKotlinInstantColumnType : ColumnType<xInstant>(), IDateColumnType {
     override val hasTimePart: Boolean = true
 
@@ -667,7 +671,9 @@ fun Table.time(name: String): Column<LocalTime> = registerColumn(name, KotlinLoc
  * @param name The column name
  */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("timestamp")
 )
 fun Table.xTimestamp(name: String): Column<xInstant> = registerColumn(name, XKotlinInstantColumnType())

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/v1/datetime/KotlinDateFunctions.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/v1/datetime/KotlinDateFunctions.kt
@@ -34,7 +34,9 @@ fun <T : LocalDateTime?> Date(expr: Expression<T>): Function<LocalDate> = DateIn
 
 /** Represents an SQL function that extracts the date part from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Date")
 )
 @JvmName("XInstantDateFunction")
@@ -69,7 +71,9 @@ fun <T : LocalDateTime?> Time(expr: Expression<T>): Function<LocalTime> = TimeIn
 
 /** Represents an SQL function that extracts the time part from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Time")
 )
 @JvmName("XInstantTimeFunction")
@@ -107,7 +111,9 @@ object CurrentDateTime : CurrentTimestampBase<LocalDateTime>(KotlinLocalDateTime
  * @sample org.jetbrains.exposed.v1.datetime.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
  */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("CurrentTimestamp")
 )
 object XCurrentTimestamp : CurrentTimestampBase<xInstant>(XKotlinInstantColumnType.INSTANCE)
@@ -163,7 +169,9 @@ fun <T : LocalDateTime?> Year(expr: Expression<T>): Function<Int> = YearInternal
 
 /** Represents an SQL function that extracts the year field from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Year")
 )
 @JvmName("XInstantYearFunction")
@@ -198,7 +206,9 @@ fun <T : LocalDateTime?> Month(expr: Expression<T>): Function<Int> = MonthIntern
 
 /** Represents an SQL function that extracts the month field from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Month")
 )
 @JvmName("XInstantMonthFunction")
@@ -233,7 +243,9 @@ fun <T : LocalDateTime?> Day(expr: Expression<T>): Function<Int> = DayInternal(e
 
 /** Represents an SQL function that extracts the day field from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Day")
 )
 @JvmName("XInstantDayFunction")
@@ -268,7 +280,9 @@ fun <T : LocalDateTime?> Hour(expr: Expression<T>): Function<Int> = HourInternal
 
 /** Represents an SQL function that extracts the hour field from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Hour")
 )
 @JvmName("XInstantHourFunction")
@@ -303,7 +317,9 @@ fun <T : LocalDateTime?> Minute(expr: Expression<T>): Function<Int> = MinuteInte
 
 /** Represents an SQL function that extracts the minute field from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Minute")
 )
 @JvmName("XInstantMinuteFunction")
@@ -338,7 +354,9 @@ fun <T : LocalDateTime?> Second(expr: Expression<T>): Function<Int> = SecondInte
 
 /** Represents an SQL function that extracts the second field from a given timestamp [expr]. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("Second")
 )
 @JvmName("XInstantSecondFunction")
@@ -364,7 +382,9 @@ fun <T : LocalDateTime?> Expression<T>.date() = Date(this)
 
 /** Returns the date from this timestamp expression. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("date")
 )
 @JvmName("InstantDateExt")
@@ -388,7 +408,9 @@ fun <T : LocalDateTime?> Expression<T>.time() = Time(this)
 
 /** Returns the time from this timestamp expression. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("time")
 )
 @JvmName("XInstantTimeExt")
@@ -412,7 +434,9 @@ fun <T : LocalDateTime?> Expression<T>.year() = Year(this)
 
 /** Returns the year from this timestamp expression, as an integer. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("year")
 )
 @JvmName("XInstantYearExt")
@@ -440,7 +464,9 @@ fun <T : xInstant?> Expression<T>.month() = Month(this)
 
 /** Returns the month from this timestamp expression, as an integer between 1 and 12 inclusive. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("month")
 )
 @JvmName("XInstantMonthExt")
@@ -460,7 +486,9 @@ fun <T : LocalDateTime?> Expression<T>.day() = Day(this)
 
 /** Returns the day from this timestamp expression, as an integer between 1 and 31 inclusive. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("day")
 )
 @JvmName("XInstantDayExt")
@@ -484,7 +512,9 @@ fun <T : LocalDateTime?> Expression<T>.hour() = Hour(this)
 
 /** Returns the hour from this timestamp expression, as an integer between 0 and 23 inclusive. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("hour")
 )
 @JvmName("XInstantHourExt")
@@ -508,7 +538,9 @@ fun <T : LocalDateTime?> Expression<T>.minute() = Minute(this)
 
 /** Returns the minute from this timestamp expression, as an integer between 0 and 59 inclusive. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("minute")
 )
 @JvmName("XInstantMinuteExt")
@@ -532,7 +564,9 @@ fun <T : LocalDateTime?> Expression<T>.second() = Second(this)
 
 /** Returns the second from this timestamp expression, as an integer between 0 and 59 inclusive. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("second")
 )
 @JvmName("InstantSecondExt")
@@ -560,7 +594,9 @@ fun dateTimeParam(value: LocalDateTime): Expression<LocalDateTime> = QueryParame
 
 /** Returns the specified [value] as a timestamp query parameter. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("timestampParam")
 )
 fun timestampParam(value: xInstant): Expression<xInstant> = QueryParameter(value, XKotlinInstantColumnType.INSTANCE)
@@ -586,7 +622,9 @@ fun dateTimeLiteral(value: LocalDateTime): LiteralOp<LocalDateTime> = LiteralOp(
 
 /** Returns the specified [value] as a timestamp literal. */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("timestampLiteral")
 )
 fun timestampLiteral(value: xInstant): LiteralOp<xInstant> = LiteralOp(XKotlinInstantColumnType.INSTANCE, value)
@@ -627,7 +665,9 @@ fun CustomDateTimeFunction(functionName: String, vararg params: Expression<*>): 
  * and passing [params] as its arguments.
  */
 @Deprecated(
-    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    "Deprecated due to usage of old kotlinx.datetime.Instant. " +
+        "The change caused by deprecation of Instant in the kotlinx.datetime " +
+        "(see more on https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant)",
     replaceWith = ReplaceWith("CustomTimeStampFunction")
 )
 fun XCustomTimeStampFunction(functionName: String, vararg params: Expression<*>): CustomFunction<xInstant?> =

--- a/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/v1/datetime/KotlinDateFunctions.kt
+++ b/exposed-kotlin-datetime/src/main/kotlin/org/jetbrains/exposed/v1/datetime/KotlinDateFunctions.kt
@@ -1,8 +1,7 @@
-@file:Suppress("FunctionName")
+@file:Suppress("FunctionName", "TooManyFunctions")
 
 package org.jetbrains.exposed.v1.datetime
 
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
@@ -16,6 +15,8 @@ import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.core.vendors.h2Mode
 import java.time.OffsetDateTime
 import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlinx.datetime.Instant as xInstant
 
 internal class DateInternal(val expr: Expression<*>) : Function<LocalDate>(KotlinLocalDateColumnType.INSTANCE) {
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
@@ -32,6 +33,13 @@ fun <T : LocalDate?> Date(expr: Expression<T>): Function<LocalDate> = DateIntern
 fun <T : LocalDateTime?> Date(expr: Expression<T>): Function<LocalDate> = DateInternal(expr)
 
 /** Represents an SQL function that extracts the date part from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Date")
+)
+@JvmName("XInstantDateFunction")
+fun <T : xInstant?> Date(expr: Expression<T>): Function<LocalDate> = DateInternal(expr)
+
 @JvmName("InstantDateFunction")
 fun <T : Instant?> Date(expr: Expression<T>): Function<LocalDate> = DateInternal(expr)
 
@@ -60,6 +68,13 @@ fun <T : LocalDate?> Time(expr: Expression<T>): Function<LocalTime> = TimeIntern
 fun <T : LocalDateTime?> Time(expr: Expression<T>): Function<LocalTime> = TimeInternal(expr)
 
 /** Represents an SQL function that extracts the time part from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Time")
+)
+@JvmName("XInstantTimeFunction")
+fun <T : xInstant?> Time(expr: Expression<T>): Function<LocalTime> = TimeInternal(expr)
+
 @JvmName("InstantTimeFunction")
 fun <T : Instant?> Time(expr: Expression<T>): Function<LocalTime> = TimeInternal(expr)
 
@@ -87,7 +102,18 @@ sealed class CurrentTimestampBase<T>(columnType: IColumnType<T & Any>) : Functio
 object CurrentDateTime : CurrentTimestampBase<LocalDateTime>(KotlinLocalDateTimeColumnType.INSTANCE)
 
 /**
- * Represents an SQL function that returns the current date and time, as [Instant].
+ * Represents an SQL function that returns the current date and time, as [kotlinx.datetime.Instant].
+ *
+ * @sample org.jetbrains.exposed.v1.datetime.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
+ */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("CurrentTimestamp")
+)
+object XCurrentTimestamp : CurrentTimestampBase<xInstant>(XKotlinInstantColumnType.INSTANCE)
+
+/**
+ * Represents an SQL function that returns the current date and time, as [kotlin.time.Instant].
  *
  * @sample org.jetbrains.exposed.v1.datetime.DefaultsTest.testConsistentSchemeWithFunctionAsDefaultExpression
  */
@@ -136,6 +162,14 @@ fun <T : LocalDate?> Year(expr: Expression<T>): Function<Int> = YearInternal(exp
 fun <T : LocalDateTime?> Year(expr: Expression<T>): Function<Int> = YearInternal(expr)
 
 /** Represents an SQL function that extracts the year field from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Year")
+)
+@JvmName("XInstantYearFunction")
+fun <T : xInstant?> Year(expr: Expression<T>): Function<Int> = YearInternal(expr)
+
+/** Represents an SQL function that extracts the year field from a given timestamp [expr]. */
 @JvmName("InstantYearFunction")
 fun <T : Instant?> Year(expr: Expression<T>): Function<Int> = YearInternal(expr)
 
@@ -161,6 +195,14 @@ fun <T : LocalDate?> Month(expr: Expression<T>): Function<Int> = MonthInternal(e
 /** Represents an SQL function that extracts the month field from a given datetime [expr]. */
 @JvmName("LocalDateTimeMonthFunction")
 fun <T : LocalDateTime?> Month(expr: Expression<T>): Function<Int> = MonthInternal(expr)
+
+/** Represents an SQL function that extracts the month field from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Month")
+)
+@JvmName("XInstantMonthFunction")
+fun <T : xInstant?> Month(expr: Expression<T>): Function<Int> = MonthInternal(expr)
 
 /** Represents an SQL function that extracts the month field from a given timestamp [expr]. */
 @JvmName("InstantMonthFunction")
@@ -190,6 +232,14 @@ fun <T : LocalDate?> Day(expr: Expression<T>): Function<Int> = DayInternal(expr)
 fun <T : LocalDateTime?> Day(expr: Expression<T>): Function<Int> = DayInternal(expr)
 
 /** Represents an SQL function that extracts the day field from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Day")
+)
+@JvmName("XInstantDayFunction")
+fun <T : xInstant?> Day(expr: Expression<T>): Function<Int> = DayInternal(expr)
+
+/** Represents an SQL function that extracts the day field from a given timestamp [expr]. */
 @JvmName("InstantDayFunction")
 fun <T : Instant?> Day(expr: Expression<T>): Function<Int> = DayInternal(expr)
 
@@ -215,6 +265,14 @@ fun <T : LocalDate?> Hour(expr: Expression<T>): Function<Int> = HourInternal(exp
 /** Represents an SQL function that extracts the hour field from a given datetime [expr]. */
 @JvmName("LocalDateTimeHourFunction")
 fun <T : LocalDateTime?> Hour(expr: Expression<T>): Function<Int> = HourInternal(expr)
+
+/** Represents an SQL function that extracts the hour field from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Hour")
+)
+@JvmName("XInstantHourFunction")
+fun <T : xInstant?> Hour(expr: Expression<T>): Function<Int> = HourInternal(expr)
 
 /** Represents an SQL function that extracts the hour field from a given timestamp [expr]. */
 @JvmName("InstantHourFunction")
@@ -244,6 +302,14 @@ fun <T : LocalDate?> Minute(expr: Expression<T>): Function<Int> = MinuteInternal
 fun <T : LocalDateTime?> Minute(expr: Expression<T>): Function<Int> = MinuteInternal(expr)
 
 /** Represents an SQL function that extracts the minute field from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Minute")
+)
+@JvmName("XInstantMinuteFunction")
+fun <T : xInstant?> Minute(expr: Expression<T>): Function<Int> = MinuteInternal(expr)
+
+/** Represents an SQL function that extracts the minute field from a given timestamp [expr]. */
 @JvmName("InstantMinuteFunction")
 fun <T : Instant?> Minute(expr: Expression<T>): Function<Int> = MinuteInternal(expr)
 
@@ -271,6 +337,14 @@ fun <T : LocalDate?> Second(expr: Expression<T>): Function<Int> = SecondInternal
 fun <T : LocalDateTime?> Second(expr: Expression<T>): Function<Int> = SecondInternal(expr)
 
 /** Represents an SQL function that extracts the second field from a given timestamp [expr]. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("Second")
+)
+@JvmName("XInstantSecondFunction")
+fun <T : xInstant?> Second(expr: Expression<T>): Function<Int> = SecondInternal(expr)
+
+/** Represents an SQL function that extracts the second field from a given timestamp [expr]. */
 @JvmName("InstantSecondFunction")
 fun <T : Instant?> Second(expr: Expression<T>): Function<Int> = SecondInternal(expr)
 
@@ -289,7 +363,15 @@ fun <T : LocalDate?> Expression<T>.date() = Date(this)
 fun <T : LocalDateTime?> Expression<T>.date() = Date(this)
 
 /** Returns the date from this timestamp expression. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("date")
+)
 @JvmName("InstantDateExt")
+fun <T : xInstant?> Expression<T>.date() = Date(this)
+
+/** Returns the date from this timestamp expression. */
+@JvmName("XInstantDateExt")
 fun <T : Instant?> Expression<T>.date() = Date(this)
 
 /** Returns the date from this timestampWithTimeZone expression. */
@@ -303,6 +385,14 @@ fun <T : LocalDate?> Expression<T>.time() = Time(this)
 /** Returns the time from this datetime expression. */
 @JvmName("LocalDateTimeTimeExt")
 fun <T : LocalDateTime?> Expression<T>.time() = Time(this)
+
+/** Returns the time from this timestamp expression. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("time")
+)
+@JvmName("XInstantTimeExt")
+fun <T : xInstant?> Expression<T>.time() = Time(this)
 
 /** Returns the time from this timestamp expression. */
 @JvmName("InstantTimeExt")
@@ -319,6 +409,14 @@ fun <T : LocalDate?> Expression<T>.year() = Year(this)
 /** Returns the year from this datetime expression, as an integer. */
 @JvmName("LocalDateTimeYearExt")
 fun <T : LocalDateTime?> Expression<T>.year() = Year(this)
+
+/** Returns the year from this timestamp expression, as an integer. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("year")
+)
+@JvmName("XInstantYearExt")
+fun <T : xInstant?> Expression<T>.year() = Year(this)
 
 /** Returns the year from this timestamp expression, as an integer. */
 @JvmName("InstantYearExt")
@@ -338,6 +436,14 @@ fun <T : LocalDateTime?> Expression<T>.month() = Month(this)
 
 /** Returns the month from this timestamp expression, as an integer between 1 and 12 inclusive. */
 @JvmName("InstantMonthExt")
+fun <T : xInstant?> Expression<T>.month() = Month(this)
+
+/** Returns the month from this timestamp expression, as an integer between 1 and 12 inclusive. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("month")
+)
+@JvmName("XInstantMonthExt")
 fun <T : Instant?> Expression<T>.month() = Month(this)
 
 /** Returns the month from this timestampWithTimeZone expression, as an integer between 1 and 12 inclusive. */
@@ -351,6 +457,14 @@ fun <T : LocalDate?> Expression<T>.day() = Day(this)
 /** Returns the day from this datetime expression, as an integer between 1 and 31 inclusive. */
 @JvmName("LocalDateTimeDayExt")
 fun <T : LocalDateTime?> Expression<T>.day() = Day(this)
+
+/** Returns the day from this timestamp expression, as an integer between 1 and 31 inclusive. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("day")
+)
+@JvmName("XInstantDayExt")
+fun <T : xInstant?> Expression<T>.day() = Day(this)
 
 /** Returns the day from this timestamp expression, as an integer between 1 and 31 inclusive. */
 @JvmName("InstantDayExt")
@@ -369,6 +483,14 @@ fun <T : LocalDate?> Expression<T>.hour() = Hour(this)
 fun <T : LocalDateTime?> Expression<T>.hour() = Hour(this)
 
 /** Returns the hour from this timestamp expression, as an integer between 0 and 23 inclusive. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("hour")
+)
+@JvmName("XInstantHourExt")
+fun <T : xInstant?> Expression<T>.hour() = Hour(this)
+
+/** Returns the hour from this timestamp expression, as an integer between 0 and 23 inclusive. */
 @JvmName("InstantHourExt")
 fun <T : Instant?> Expression<T>.hour() = Hour(this)
 
@@ -383,6 +505,14 @@ fun <T : LocalDate?> Expression<T>.minute() = Minute(this)
 /** Returns the minute from this datetime expression, as an integer between 0 and 59 inclusive. */
 @JvmName("LocalDateTimeMinuteExt")
 fun <T : LocalDateTime?> Expression<T>.minute() = Minute(this)
+
+/** Returns the minute from this timestamp expression, as an integer between 0 and 59 inclusive. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("minute")
+)
+@JvmName("XInstantMinuteExt")
+fun <T : xInstant?> Expression<T>.minute() = Minute(this)
 
 /** Returns the minute from this timestamp expression, as an integer between 0 and 59 inclusive. */
 @JvmName("InstantMinuteExt")
@@ -401,7 +531,15 @@ fun <T : LocalDate?> Expression<T>.second() = Second(this)
 fun <T : LocalDateTime?> Expression<T>.second() = Second(this)
 
 /** Returns the second from this timestamp expression, as an integer between 0 and 59 inclusive. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("second")
+)
 @JvmName("InstantSecondExt")
+fun <T : xInstant?> Expression<T>.second() = Second(this)
+
+/** Returns the second from this timestamp expression, as an integer between 0 and 59 inclusive. */
+@JvmName("XInstantSecondExt")
 fun <T : Instant?> Expression<T>.second() = Second(this)
 
 /** Returns the second from this timestampWithTimeZone expression, as an integer between 0 and 59 inclusive. */
@@ -421,6 +559,13 @@ fun dateTimeParam(value: LocalDateTime): Expression<LocalDateTime> = QueryParame
 )
 
 /** Returns the specified [value] as a timestamp query parameter. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("timestampParam")
+)
+fun timestampParam(value: xInstant): Expression<xInstant> = QueryParameter(value, XKotlinInstantColumnType.INSTANCE)
+
+/** Returns the specified [value] as a timestamp query parameter. */
 fun timestampParam(value: Instant): Expression<Instant> = QueryParameter(value, KotlinInstantColumnType.INSTANCE)
 
 /** Returns the specified [value] as a date with time and time zone query parameter. */
@@ -438,6 +583,13 @@ fun timeLiteral(value: LocalTime): LiteralOp<LocalTime> = LiteralOp(KotlinLocalT
 
 /** Returns the specified [value] as a date with time literal. */
 fun dateTimeLiteral(value: LocalDateTime): LiteralOp<LocalDateTime> = LiteralOp(KotlinLocalDateTimeColumnType.INSTANCE, value)
+
+/** Returns the specified [value] as a timestamp literal. */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("timestampLiteral")
+)
+fun timestampLiteral(value: xInstant): LiteralOp<xInstant> = LiteralOp(XKotlinInstantColumnType.INSTANCE, value)
 
 /** Returns the specified [value] as a timestamp literal. */
 fun timestampLiteral(value: Instant): LiteralOp<Instant> = LiteralOp(KotlinInstantColumnType.INSTANCE, value)
@@ -469,6 +621,17 @@ fun CustomTimeFunction(functionName: String, vararg params: Expression<*>): Cust
  */
 fun CustomDateTimeFunction(functionName: String, vararg params: Expression<*>): CustomFunction<LocalDateTime?> =
     CustomFunction(functionName, KotlinLocalDateTimeColumnType.INSTANCE, *params)
+
+/**
+ * Calls a custom SQL function with the specified [functionName], that returns a timestamp,
+ * and passing [params] as its arguments.
+ */
+@Deprecated(
+    "Deprecated due to usage of old kotlinx.datetime.Instant",
+    replaceWith = ReplaceWith("CustomTimeStampFunction")
+)
+fun XCustomTimeStampFunction(functionName: String, vararg params: Expression<*>): CustomFunction<xInstant?> =
+    CustomFunction(functionName, XKotlinInstantColumnType.INSTANCE, *params)
 
 /**
  * Calls a custom SQL function with the specified [functionName], that returns a timestamp,

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DateTimeLiteralTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DateTimeLiteralTest.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.v1.datetime
 
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
@@ -11,6 +10,8 @@ import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.junit.Test
 import kotlin.test.assertNotNull
+import kotlin.time.Instant
+import kotlinx.datetime.Instant as xInstant
 
 class DateTimeLiteralTest : DatabaseTestsBase() {
     private val defaultDate = LocalDate(2000, 1, 1)
@@ -25,6 +26,14 @@ class DateTimeLiteralTest : DatabaseTestsBase() {
 
     object TableWithDatetime : IntIdTable() {
         val datetime = datetime("datetime")
+    }
+
+    @Deprecated("Deprecated due to usage of old kotlinx.datetime.Instant")
+    private val xDefaultTimestamp = xInstant.parse("2000-01-01T01:00:00.00Z")
+
+    @Deprecated("Deprecated due to usage of old kotlinx.datetime.Instant")
+    object XTableWithTimestamp : IntIdTable() {
+        val timestamp = xTimestamp("timestamp")
     }
 
     private val defaultTimestamp = Instant.parse("2000-01-01T01:00:00.00Z")
@@ -76,6 +85,18 @@ class DateTimeLiteralTest : DatabaseTestsBase() {
             }
             val query = TableWithDatetime.selectAll().where { TableWithDatetime.datetime less dateTimeLiteral(futureDatetime) }
             assertNotNull(query.firstOrNull())
+        }
+    }
+
+    @Test
+    fun testSelectByXTimestampLiteralEquality() {
+        withTables(XTableWithTimestamp) {
+            XTableWithTimestamp.insert {
+                it[timestamp] = xDefaultTimestamp
+            }
+
+            val query = XTableWithTimestamp.select(XTableWithTimestamp.timestamp).where { XTableWithTimestamp.timestamp eq timestampLiteral(xDefaultTimestamp) }
+            assertEquals(xDefaultTimestamp, query.single()[XTableWithTimestamp.timestamp])
         }
     }
 

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/MiscTableTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/MiscTableTest.kt
@@ -3,11 +3,10 @@
 
 package org.jetbrains.exposed.v1.datetime
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toDeprecatedInstant
 import org.jetbrains.exposed.v1.core.Cast
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
@@ -25,9 +24,11 @@ import org.junit.Test
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 @Suppress("LargeClass")
 class MiscTableTest : DatabaseTestsBase() {
@@ -49,6 +50,7 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -92,7 +94,8 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = null
                 it[ts] = timestamp
-                it[tsn] = null
+                it[xts] = timestamp.toDeprecatedInstant()
+                it[xtsn] = null
                 it[dr] = duration
                 it[drn] = null
                 it[e] = MiscTable.E.ONE
@@ -141,7 +144,9 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[tsn] = timestamp
+                it[xtsn] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[drn] = duration
                 it[e] = MiscTable.E.ONE
@@ -187,6 +192,7 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -223,6 +229,7 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -264,6 +271,7 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -712,7 +720,9 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[tsn] = timestamp
+                it[xtsn] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[drn] = duration
                 it[e] = eOne
@@ -1076,7 +1086,9 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[tsn] = timestamp
+                it[xtsn] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[drn] = duration
                 it[e] = eOne
@@ -1098,7 +1110,7 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[dn] = null
                 it[tn] = null
                 it[dtn] = null
-                it[tsn] = null
+                it[xtsn] = null
                 it[drn] = null
                 it[en] = null
                 it[esn] = null
@@ -1166,6 +1178,7 @@ class MiscTableTest : DatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = eOne
                 it[es] = eOne
@@ -1275,6 +1288,9 @@ object Misc : MiscTable() {
     val ts = timestamp("ts")
     val tsn = timestamp("tsn").nullable()
 
+    val xts = xTimestamp("xts")
+    val xtsn = xTimestamp("xtsn").nullable()
+
     val dr = duration("dr")
     val drn = duration("drn").nullable()
 }
@@ -1335,8 +1351,8 @@ fun Misc.checkRowDates(
     assertLocalTime(tn, row[Misc.tn])
     assertEqualDateTime(dt, row[Misc.dt])
     assertEqualDateTime(dtn, row[Misc.dtn])
-    assertEqualDateTime(ts, row[Misc.ts])
-    assertEqualDateTime(tsn, row[Misc.tsn])
+    assertEqualDateTime(ts.toDeprecatedInstant(), row[Misc.xts])
+    assertEqualDateTime(tsn?.toDeprecatedInstant(), row[Misc.xtsn])
     assertEquals(dr, row[Misc.dr])
     assertEquals(drn, row[Misc.drn])
 }

--- a/exposed-r2dbc-tests/build.gradle.kts
+++ b/exposed-r2dbc-tests/build.gradle.kts
@@ -12,6 +12,10 @@ kotlin {
     // REQUIRED for exposed-crypt tests, but makes Oracle tests fail...
 //    jvmToolchain(17)
     jvmToolchain(11)
+
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+    }
 }
 
 repositories {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DateTimeLiteralTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DateTimeLiteralTest.kt
@@ -2,16 +2,10 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.kotlindatetime
 
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.single
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
-import org.jetbrains.exposed.v1.datetime.date
-import org.jetbrains.exposed.v1.datetime.dateLiteral
-import org.jetbrains.exposed.v1.datetime.dateTimeLiteral
-import org.jetbrains.exposed.v1.datetime.datetime
-import org.jetbrains.exposed.v1.datetime.timestamp
-import org.jetbrains.exposed.v1.datetime.timestampLiteral
+import org.jetbrains.exposed.v1.datetime.*
 import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.select
 import org.jetbrains.exposed.v1.r2dbc.selectAll
@@ -19,6 +13,8 @@ import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.junit.Test
 import kotlin.test.assertNotNull
+import kotlin.time.Instant
+import kotlinx.datetime.Instant as xInstant
 
 class DateTimeLiteralTest : R2dbcDatabaseTestsBase() {
     private val defaultDate = LocalDate(2000, 1, 1)
@@ -33,6 +29,14 @@ class DateTimeLiteralTest : R2dbcDatabaseTestsBase() {
 
     object TableWithDatetime : IntIdTable() {
         val datetime = datetime("datetime")
+    }
+
+    @Deprecated("Deprecated due to usage of old kotlinx.datetime.Instant")
+    private val xDefaultTimestamp = xInstant.parse("2000-01-01T01:00:00.00Z")
+
+    @Deprecated("Deprecated due to usage of old kotlinx.datetime.Instant")
+    object TableWithXTimestamp : IntIdTable() {
+        val xTimestamp = xTimestamp("xTimestamp")
     }
 
     private val defaultTimestamp = Instant.parse("2000-01-01T01:00:00.00Z")
@@ -84,6 +88,18 @@ class DateTimeLiteralTest : R2dbcDatabaseTestsBase() {
             }
             val query = TableWithDatetime.selectAll().where { TableWithDatetime.datetime less dateTimeLiteral(futureDatetime) }
             assertNotNull(query.firstOrNull())
+        }
+    }
+
+    @Test
+    fun testSelectByXTimestampLiteralEquality() {
+        withTables(TableWithXTimestamp) {
+            TableWithXTimestamp.insert {
+                it[xTimestamp] = xDefaultTimestamp
+            }
+
+            val query = TableWithXTimestamp.select(TableWithXTimestamp.xTimestamp).where { TableWithXTimestamp.xTimestamp eq timestampLiteral(xDefaultTimestamp) }
+            assertEquals(xDefaultTimestamp, query.single()[TableWithXTimestamp.xTimestamp])
         }
     }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
@@ -23,11 +23,13 @@ import java.time.ZoneOffset
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 import kotlin.time.DurationUnit
+import kotlin.time.Instant
 import kotlin.time.toDuration
 
 /** Forces [Instant] precision to be reduced to millisecond-level, for JDK8 test compatibility. */
-internal fun Clock.System.nowAsJdk8(): Instant = Instant.fromEpochMilliseconds(this.now().toEpochMilliseconds())
+internal fun Clock.nowAsJdk8(): Instant = Instant.fromEpochMilliseconds(this.now().toEpochMilliseconds())
 
 internal fun now(): LocalDateTime = Clock.System.nowAsJdk8().toLocalDateTime(TimeZone.currentSystemDefault())
 
@@ -116,6 +118,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("LongMethod")
     fun testDefaults01() {
         val currentDT = CurrentDateTime
         val nowExpression = object : Expression<LocalDateTime>() {
@@ -135,6 +138,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         val dLiteral = dateLiteral(dateConstValue)
         val dtLiteral = dateTimeLiteral(dateTimeConstValue)
         val tsConstValue = instConstValue.plus(42.toDuration(DurationUnit.SECONDS))
+        val xTsLiteral = timestampLiteral(tsConstValue.toDeprecatedInstant())
         val tsLiteral = timestampLiteral(tsConstValue)
         val durConstValue = tsConstValue.toEpochMilliseconds().toDuration((DurationUnit.MILLISECONDS))
         val durLiteral = durationLiteral(durConstValue)
@@ -150,12 +154,14 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
             val t2 = datetime("t2").defaultExpression(nowExpression)
             val t3 = datetime("t3").defaultExpression(dtLiteral)
             val t4 = date("t4").default(dateConstValue)
-            val t5 = timestamp("t5").default(tsConstValue)
-            val t6 = timestamp("t6").defaultExpression(tsLiteral)
+            val t5 = xTimestamp("t5").default(tsConstValue.toDeprecatedInstant())
+            val t6 = xTimestamp("t6").defaultExpression(xTsLiteral)
             val t7 = duration("t7").default(durConstValue)
             val t8 = duration("t8").defaultExpression(durLiteral)
             val t9 = time("t9").default(tmConstValue)
             val t10 = time("t10").defaultExpression(tLiteral)
+            val t11 = timestamp("t11").default(tsConstValue)
+            val t12 = timestamp("t12").defaultExpression(tsLiteral)
         }
 
         fun Expression<*>.itOrNull() = when {
@@ -190,7 +196,9 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
                 "${"t7".inProperCase()} $longType${testTable.t7.constraintNamePart()} ${durLiteral.itOrNull()}, " +
                 "${"t8".inProperCase()} $longType${testTable.t8.constraintNamePart()} ${durLiteral.itOrNull()}, " +
                 "${"t9".inProperCase()} $timeType${testTable.t9.constraintNamePart()} ${tLiteral.itOrNull()}, " +
-                "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}" +
+                "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}, " +
+                "${"t11".inProperCase()} $timestampType${testTable.t11.constraintNamePart()} ${tsLiteral.itOrNull()}, " +
+                "${"t12".inProperCase()} $timestampType${testTable.t12.constraintNamePart()} ${tsLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.ORACLE ->
                         ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
@@ -216,12 +224,14 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
             assertEquals('X', row1[testTable.c])
             assertEquals(dateTimeConstValue, row1[testTable.t3])
             assertEquals(dateConstValue, row1[testTable.t4])
-            assertEquals(tsConstValue, row1[testTable.t5])
-            assertEquals(tsConstValue, row1[testTable.t6])
+            assertEquals(tsConstValue.toDeprecatedInstant(), row1[testTable.t5])
+            assertEquals(tsConstValue.toDeprecatedInstant(), row1[testTable.t6])
             assertEquals(durConstValue, row1[testTable.t7])
             assertEquals(durConstValue, row1[testTable.t8])
             assertEquals(tmConstValue, row1[testTable.t9])
             assertEquals(tmConstValue, row1[testTable.t10])
+            assertEquals(tsConstValue, row1[testTable.t11])
+            assertEquals(tsConstValue, row1[testTable.t12])
         }
     }
 
@@ -311,6 +321,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
             val name = text("name")
             val defaultDate = date("default_date").defaultExpression(CurrentDate)
             val defaultDateTime = datetime("default_date_time").defaultExpression(CurrentDateTime)
+            val xDefaultTimeStamp = xTimestamp("x_default_time_stamp").defaultExpression(XCurrentTimestamp)
             val defaultTimeStamp = timestamp("default_time_stamp").defaultExpression(CurrentTimestamp)
         }
 
@@ -464,10 +475,10 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         val instant = Instant.parse("2023-05-04T05:04:00.700Z") // In UTC
 
         val tester = object : Table("tester") {
+            val xTimestampWithDefault = xTimestamp("xTimestampWithDefault").default(instant.toDeprecatedInstant())
+            val xTimestampWithDefaultExpression = xTimestamp("xTimestampWithDefaultExpression").defaultExpression(XCurrentTimestamp)
             val timestampWithDefault = timestamp("timestampWithDefault").default(instant)
-            val timestampWithDefaultExpression = timestamp("timestampWithDefaultExpression").defaultExpression(
-                CurrentTimestamp
-            )
+            val timestampWithDefaultExpression = timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp)
         }
 
         withTables(tester) {
@@ -493,6 +504,32 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
     }
 
     @Test
+    fun testColumnOnUpdateXCurrentTimestamp() {
+        val tester = object : Table("tester") {
+            val amount = integer("amount")
+            val xCreated = xTimestamp("created").defaultExpression(XCurrentTimestamp).withDefinition("ON UPDATE", XCurrentTimestamp)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_MYSQL_LIKE.toSet(), tester) {
+            assertTrue { SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
+
+            tester.insert {
+                it[amount] = 999
+            }
+            val generatedTS = tester.select(tester.xCreated).single()[tester.xCreated]
+
+            Thread.sleep(1000)
+
+            tester.update {
+                it[amount] = 111
+            }
+
+            val updatedResult = tester.selectAll().where { tester.xCreated greater generatedTS }.single()
+            assertTrue { updatedResult[tester.xCreated] > generatedTS }
+        }
+    }
+
+    @Test
     fun testColumnOnUpdateCurrentTimestamp() {
         val tester = object : Table("tester") {
             val amount = integer("amount")
@@ -500,7 +537,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         }
 
         withTables(excludeSettings = TestDB.ALL - TestDB.ALL_MYSQL_LIKE.toSet(), tester) {
-            assertTrue { org.jetbrains.exposed.v1.r2dbc.SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
+            assertTrue { SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
 
             tester.insert {
                 it[amount] = 999

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/MiscTableTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/MiscTableTest.kt
@@ -5,11 +5,10 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.kotlindatetime
 
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.single
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
+import kotlinx.datetime.toDeprecatedInstant
 import org.jetbrains.exposed.v1.core.Cast
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
@@ -28,9 +27,11 @@ import org.junit.Test
 import java.math.BigDecimal
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 @Suppress("LargeClass")
 class MiscTableTest : R2dbcDatabaseTestsBase() {
@@ -52,6 +53,7 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -95,7 +97,9 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = null
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[tsn] = null
+                it[xtsn] = null
                 it[dr] = duration
                 it[drn] = null
                 it[e] = MiscTable.E.ONE
@@ -144,7 +148,9 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[tsn] = timestamp
+                it[xtsn] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[drn] = duration
                 it[e] = MiscTable.E.ONE
@@ -190,6 +196,7 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -226,6 +233,7 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -267,6 +275,7 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = MiscTable.E.ONE
                 it[es] = MiscTable.E.ONE
@@ -715,7 +724,9 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[tsn] = timestamp
+                it[xtsn] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[drn] = duration
                 it[e] = eOne
@@ -1079,7 +1090,9 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[dt] = dateTime
                 it[dtn] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[tsn] = timestamp
+                it[xtsn] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[drn] = duration
                 it[e] = eOne
@@ -1102,6 +1115,7 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[tn] = null
                 it[dtn] = null
                 it[tsn] = null
+                it[xtsn] = null
                 it[drn] = null
                 it[en] = null
                 it[esn] = null
@@ -1169,6 +1183,7 @@ class MiscTableTest : R2dbcDatabaseTestsBase() {
                 it[t] = time
                 it[dt] = dateTime
                 it[ts] = timestamp
+                it[xts] = timestamp.toDeprecatedInstant()
                 it[dr] = duration
                 it[e] = eOne
                 it[es] = eOne
@@ -1273,6 +1288,9 @@ object Misc : MiscTable() {
     val ts = timestamp("ts")
     val tsn = timestamp("tsn").nullable()
 
+    val xts = xTimestamp("xts")
+    val xtsn = xTimestamp("xtsn").nullable()
+
     val dr = duration("dr")
     val drn = duration("drn").nullable()
 }
@@ -1335,6 +1353,8 @@ fun Misc.checkRowDates(
     assertEqualDateTime(dtn, row[this.dtn])
     assertEqualDateTime(ts, row[this.ts])
     assertEqualDateTime(tsn, row[this.tsn])
+    assertEqualDateTime(ts.toDeprecatedInstant(), row[this.xts])
+    assertEqualDateTime(tsn?.toDeprecatedInstant(), row[this.xtsn])
     assertEquals(dr, row[this.dr])
     assertEquals(drn, row[this.drn])
 }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -17,7 +17,9 @@ import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
+import org.jetbrains.exposed.v1.datetime.XCurrentTimestamp
 import org.jetbrains.exposed.v1.datetime.timestamp
+import org.jetbrains.exposed.v1.datetime.xTimestamp
 import org.jetbrains.exposed.v1.r2dbc.*
 import org.jetbrains.exposed.v1.r2dbc.statements.BatchInsertSuspendExecutable
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
@@ -646,6 +648,19 @@ class InsertTests : R2dbcDatabaseTestsBase() {
             }.single()
             assertEquals("custom-id-value", result1[tester.id].value)
             assertEquals("custom-id-value", result1[tester.customId])
+        }
+    }
+
+    @Test
+    fun testXInsertReturnsValuesFromDefaultExpression() {
+        val tester = object : Table() {
+            val xDefaultDate = xTimestamp(name = "default_date").defaultExpression(XCurrentTimestamp)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            val entry = tester.insert {}
+
+            assertNotNull(entry[tester.xDefaultDate])
         }
     }
 

--- a/exposed-tests/build.gradle.kts
+++ b/exposed-tests/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 
 kotlin {
     jvmToolchain(8)
+
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+    }
 }
 
 repositories {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -1131,6 +1131,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
             val datetime = datetime("datetime_col")
             val time = time("time_col")
             val timestamp = timestamp("timestamp_col")
+            val xTimestamp = xTimestamp("x_timestamp_col")
             val timestampWithTimeZone = timestampWithTimeZone("timestampWithTimeZone_col")
             val duration = duration("duration_col")
             val intArrayJson = json<IntArray>("json_col", Json.Default)
@@ -1166,6 +1167,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
             val datetimeArray = array("datetimeArray", KotlinLocalDateTimeColumnType(), 10)
             val timeArray = array("timeArray", KotlinLocalTimeColumnType(), 14)
             val timestampArray = array("timestampArray", KotlinInstantColumnType(), 10)
+            val xTimestampArray = array("xTimestampArray", XKotlinInstantColumnType(), 10)
             val timestampWithTimeZoneArray = array("timestampWithTimeZoneArray", KotlinOffsetDateTimeColumnType(), 10)
             val durationArray = array("durationArray", KotlinDurationColumnType(), 7)
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -13,7 +13,9 @@ import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
+import org.jetbrains.exposed.v1.datetime.XCurrentTimestamp
 import org.jetbrains.exposed.v1.datetime.timestamp
+import org.jetbrains.exposed.v1.datetime.xTimestamp
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.statements.BatchInsertBlockingExecutable
 import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
@@ -728,6 +730,19 @@ class InsertTests : DatabaseTestsBase() {
             }.single()
             assertEquals("custom-id-value", result1[tester.id].value)
             assertEquals("custom-id-value", result1[tester.customId])
+        }
+    }
+
+    @Test
+    fun testXInsertReturnsValuesFromDefaultExpression() {
+        val tester = object : Table() {
+            val xDefaultDate = xTimestamp(name = "default_date").defaultExpression(XCurrentTimestamp)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            val entry = tester.insert {}
+
+            assertNotNull(entry[tester.xDefaultDate])
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-kotlin = "2.0.0"
+kotlin = "2.1.0"
 dokka = "2.0.0"
 detekt = "1.23.8" # When upgrading, also upgrade in detekt.yml and add corresponding detekt-formatting jar file.
 binary-compatibility-validator = "0.18.0"
 docker-compose = "0.17.5"
 kotlinCoroutines = "1.10.2"
-kotlinxSerialization = "1.8.1"
+kotlinxSerialization = "1.9.0"
 
 slf4j = "2.0.9"
 log4j2 = "2.24.3"
@@ -37,7 +37,7 @@ springBoot = "3.5.3"
 spring-security-crypto = "6.2.1"
 joda-time = "2.14.0"
 junit = "4.13.2"
-kotlinx-datetime = "0.6.2"
+kotlinx-datetime = "0.7.1-0.6.x-compat"
 javax-money = "1.1"
 moneta = "1.4.5"
 hikariCP = "4.0.3"


### PR DESCRIPTION
#### Description

Migration of `kotlinx.datetime` from version 6 to version 7

---

#### Type of Change

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All


---

#### Related Issues

[EXPOSED-813](https://youtrack.jetbrains.com/issue/EXPOSED-813) When is the plan to migrate kotlinx.datetime.Instant to kotlin.time.Instant?
