### PR TITLE
fix: EXPOSED-731 Timestamp support for SQLite is broken

### DIFF
--- a/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/v1/jodatime/DateColumnType.kt
+++ b/exposed-jodatime/src/main/kotlin/org/jetbrains/exposed/v1/jodatime/DateColumnType.kt
@@ -60,9 +60,12 @@ private val ORACLE_TIME_STRING_FORMATTER by lazy {
     DateTimeFormat.forPattern("1970-01-01 HH:mm:ss").withLocale(Locale.ROOT).withZone(DateTimeZone.UTC)
 }
 
-private val DEFAULT_TIME_STRING_FORMATTER by lazy {
-    DateTimeFormat.forPattern("HH:mm:ss").withLocale(Locale.ROOT).withZone(DateTimeZone.getDefault())
+private val DEFAULT_TIME_STRING_FORMATTER_NOTZ by lazy {
+    DateTimeFormat.forPattern("HH:mm:ss").withLocale(Locale.ROOT)
 }
+
+private val DEFAULT_TIME_STRING_FORMATTER
+    get() = DEFAULT_TIME_STRING_FORMATTER_NOTZ.withZone(DateTimeZone.getDefault())
 
 private fun formatterForDateTimeString(date: String) = dateTimeWithFractionFormat(
     date.substringAfterLast('.', "").length

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/KotlinTimeTests.kt
@@ -48,12 +48,18 @@ class KotlinTimeTests : DatabaseTestsBase() {
                 it[local_time] = now
             }
 
-            val insertedYear = CitiesTime.select(CitiesTime.local_time.year()).where { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.year()]
-            val insertedMonth = CitiesTime.select(CitiesTime.local_time.month()).where { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.month()]
-            val insertedDay = CitiesTime.select(CitiesTime.local_time.day()).where { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.day()]
-            val insertedHour = CitiesTime.select(CitiesTime.local_time.hour()).where { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.hour()]
-            val insertedMinute = CitiesTime.select(CitiesTime.local_time.minute()).where { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.minute()]
-            val insertedSecond = CitiesTime.select(CitiesTime.local_time.second()).where { CitiesTime.id.eq(cityID) }.single()[CitiesTime.local_time.second()]
+            val insertedYear = CitiesTime.select(CitiesTime.local_time.year()).where { CitiesTime.id.eq(cityID) }
+                .single()[CitiesTime.local_time.year()]
+            val insertedMonth = CitiesTime.select(CitiesTime.local_time.month()).where { CitiesTime.id.eq(cityID) }
+                .single()[CitiesTime.local_time.month()]
+            val insertedDay = CitiesTime.select(CitiesTime.local_time.day()).where { CitiesTime.id.eq(cityID) }
+                .single()[CitiesTime.local_time.day()]
+            val insertedHour = CitiesTime.select(CitiesTime.local_time.hour()).where { CitiesTime.id.eq(cityID) }
+                .single()[CitiesTime.local_time.hour()]
+            val insertedMinute = CitiesTime.select(CitiesTime.local_time.minute()).where { CitiesTime.id.eq(cityID) }
+                .single()[CitiesTime.local_time.minute()]
+            val insertedSecond = CitiesTime.select(CitiesTime.local_time.second()).where { CitiesTime.id.eq(cityID) }
+                .single()[CitiesTime.local_time.second()]
 
             assertEquals(now.year, insertedYear)
             assertEquals(now.month.number, insertedMonth)
@@ -291,7 +297,8 @@ class KotlinTimeTests : DatabaseTestsBase() {
             assertEquals(1, sameDateResult.size)
             assertEquals(mayTheFourth, sameDateResult.single()[testTable.deleted])
 
-            val sameMonthResult = testTable.selectAll().where { testTable.created.month() eq testTable.deleted.month() }.toList()
+            val sameMonthResult =
+                testTable.selectAll().where { testTable.created.month() eq testTable.deleted.month() }.toList()
             assertEquals(2, sameMonthResult.size)
 
             val year2023 = if (currentDialectTest is PostgreSQLDialect) {
@@ -326,7 +333,8 @@ class KotlinTimeTests : DatabaseTestsBase() {
             }
 
             // these DB take the nanosecond value 871_130_789 and round up to default precision (e.g. in Oracle: 871_131)
-            val requiresExplicitDTCast = listOf(TestDB.ORACLE, TestDB.H2_V2_ORACLE, TestDB.H2_V2_PSQL, TestDB.H2_V2_SQLSERVER)
+            val requiresExplicitDTCast =
+                listOf(TestDB.ORACLE, TestDB.H2_V2_ORACLE, TestDB.H2_V2_PSQL, TestDB.H2_V2_SQLSERVER)
             val dateTime = when (testDb) {
                 in requiresExplicitDTCast -> Cast(dateTimeParam(mayTheFourthDT), KotlinLocalDateTimeColumnType())
                 else -> dateTimeParam(mayTheFourthDT)
@@ -334,10 +342,12 @@ class KotlinTimeTests : DatabaseTestsBase() {
             val createdMayFourth = testTableDT.selectAll().where { testTableDT.created eq dateTime }.count()
             assertEquals(2, createdMayFourth)
 
-            val modifiedAtSameDT = testTableDT.selectAll().where { testTableDT.modified eq testTableDT.created }.single()
+            val modifiedAtSameDT =
+                testTableDT.selectAll().where { testTableDT.modified eq testTableDT.created }.single()
             assertEquals(id1, modifiedAtSameDT[testTableDT.id])
 
-            val modifiedAtLaterDT = testTableDT.selectAll().where { testTableDT.modified greater testTableDT.created }.single()
+            val modifiedAtLaterDT =
+                testTableDT.selectAll().where { testTableDT.modified greater testTableDT.created }.single()
             assertEquals(id2, modifiedAtLaterDT[testTableDT.id])
         }
     }
@@ -498,6 +508,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
                     TestDB.MYSQL_V8, TestDB.SQLSERVER,
                     in TestDB.ALL_ORACLE_LIKE,
                     in TestDB.ALL_POSTGRES_LIKE -> OffsetDateTime.parse("2023-05-04T05:04:01.123123+00:00")
+
                     else -> now
                 }.toLocalTime().toKotlinLocalTime()
             assertEquals(
@@ -644,13 +655,14 @@ class KotlinTimeTests : DatabaseTestsBase() {
 
     @Test
     fun testXTimestampAlwaysSavedInUTC() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+
         val tester = object : Table("tester") {
             val x_timestamp_col = xTimestamp("timestamp_col")
         }
 
         withTables(tester) {
             // Cairo time zone
-            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
             assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
 
             val instant = Clock.System.now()
@@ -668,13 +680,14 @@ class KotlinTimeTests : DatabaseTestsBase() {
 
     @Test
     fun testTimestampAlwaysSavedInUTC() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+
         val tester = object : Table("tester") {
             val timestamp_col = timestamp("timestamp_col")
         }
 
         withTables(tester) {
             // Cairo time zone
-            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
             assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
 
             val instant = Clock.System.now()
@@ -687,6 +700,42 @@ class KotlinTimeTests : DatabaseTestsBase() {
                 instant,
                 tester.selectAll().single()[tester.timestamp_col]
             )
+        }
+    }
+
+    @Test
+    fun testInsertAndReadWithNonUtcTimezone() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+
+        val tester = object : Table("testInsertAndReadWithNonUtcTimezone") {
+            val ts = timestamp("ts")
+        }
+
+        val testerText = object : Table("testInsertAndReadWithNonUtcTimezone") {
+            val ts = text("ts")
+        }
+
+        withTables(tester) {
+            val now = Clock.System.now()
+
+            tester.insert {
+                it[tester.ts] = now
+            }
+
+            // It gives HH:MM:SS format in local time zone
+            val nowTimeString = now.toLocalDateTime(TimeZone.currentSystemDefault()).time.toString().trim('0')
+
+            // This check validates that the value on database has local time (instead of UTC)
+            // It should prevent from the case when we convert value to UTC on insert, and back from UTC to local on reading
+            testerText.selectAll().first()[testerText.ts].let { valueAsText ->
+                kotlin.test.assertTrue(
+                    valueAsText.contains(nowTimeString),
+                    "Timestamp as text from database must contain the time in local time zone. Timestamp: $valueAsText, timeString: $nowTimeString"
+                )
+            }
+
+            val valueFromDb = tester.selectAll().first()[tester.ts]
+            assertEquals(now, valueFromDb)
         }
     }
 }
@@ -702,6 +751,7 @@ fun <T> assertEqualDateTime(d1: T?, d2: T?) {
                 assertEqualFractionalPart(d1.nanosecond, d2.nanosecond)
             }
         }
+
         d1 is LocalDateTime && d2 is LocalDateTime -> {
             assertEquals(
                 d1.toJavaLocalDateTime().toEpochSecond(ZoneOffset.UTC),
@@ -710,14 +760,20 @@ fun <T> assertEqualDateTime(d1: T?, d2: T?) {
             )
             assertEqualFractionalPart(d1.nanosecond, d2.nanosecond)
         }
+
         d1 is Instant && d2 is Instant -> {
             assertEquals(d1.epochSeconds, d2.epochSeconds, "Failed on epoch seconds ${currentDialectTest.name}")
             assertEqualFractionalPart(d1.nanosecondsOfSecond, d2.nanosecondsOfSecond)
         }
+
         d1 is OffsetDateTime && d2 is OffsetDateTime -> {
-            assertEqualDateTime(d1.toLocalDateTime().toKotlinLocalDateTime(), d2.toLocalDateTime().toKotlinLocalDateTime())
+            assertEqualDateTime(
+                d1.toLocalDateTime().toKotlinLocalDateTime(),
+                d2.toLocalDateTime().toKotlinLocalDateTime()
+            )
             assertEquals(d1.offset, d2.offset)
         }
+
         else -> assertEquals(d1, d2, "Failed on ${currentDialectTest.name}")
     }
 }
@@ -732,19 +788,23 @@ private fun assertEqualFractionalPart(nano1: Int, nano2: Int) {
         // microseconds
         is MariaDBDialect ->
             assertEquals(floorToMicro(nano1), floorToMicro(nano2), "Failed on microseconds $db")
+
         is H2Dialect, is PostgreSQLDialect, is MysqlDialect -> {
             when ((dialect as? MysqlDialect)?.isFractionDateTimeSupported()) {
                 null, true -> {
                     assertEquals(roundToMicro(nano1), roundToMicro(nano2), "Failed on microseconds $db")
                 }
+
                 else -> {} // don't compare fractional part
             }
         }
         // milliseconds
         is OracleDialect ->
             assertEquals(roundToMilli(nano1), roundToMilli(nano2), "Failed on milliseconds $db")
+
         is SQLiteDialect ->
             assertEquals(floorToMilli(nano1), floorToMilli(nano2), "Failed on milliseconds $db")
+
         else -> fail("Unknown dialect $db")
     }
 }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/DefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/DefaultsTest.kt
@@ -9,17 +9,12 @@ import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
 import org.jetbrains.exposed.v1.core.vendors.*
 import org.jetbrains.exposed.v1.javatime.*
-import org.jetbrains.exposed.v1.r2dbc.batchInsert
-import org.jetbrains.exposed.v1.r2dbc.insert
-import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
-import org.jetbrains.exposed.v1.r2dbc.selectAll
+import org.jetbrains.exposed.v1.r2dbc.*
 import org.jetbrains.exposed.v1.r2dbc.tests.*
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.expectException
-import org.jetbrains.exposed.v1.r2dbc.tests.sorted
-import org.jetbrains.exposed.v1.r2dbc.update
 import org.junit.Test
 import java.time.*
 import java.time.temporal.ChronoUnit
@@ -53,8 +48,15 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         val returnedDefault = table.clientDefault.defaultValueFun?.invoke()
 
         assertTrue(table.clientDefault.columnType.nullable, "Expected clientDefault columnType to be nullable")
-        assertNotNull(table.clientDefault.defaultValueFun, "Expected clientDefault column to have a default value fun, but was null")
-        assertEquals(defaultValue, returnedDefault, "Expected clientDefault to return $defaultValue, but was $returnedDefault")
+        assertNotNull(
+            table.clientDefault.defaultValueFun,
+            "Expected clientDefault column to have a default value fun, but was null"
+        )
+        assertEquals(
+            defaultValue,
+            returnedDefault,
+            "Expected clientDefault to return $defaultValue, but was $returnedDefault"
+        )
     }
 
     @Test
@@ -66,8 +68,15 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         val returnedDefault = table.clientDefault.defaultValueFun?.invoke()
 
         assertTrue(table.clientDefault.columnType.nullable, "Expected clientDefault columnType to be nullable")
-        assertNotNull(table.clientDefault.defaultValueFun, "Expected clientDefault column to have a default value fun, but was null")
-        assertEquals(defaultValue, returnedDefault, "Expected clientDefault to return $defaultValue, but was $returnedDefault")
+        assertNotNull(
+            table.clientDefault.defaultValueFun,
+            "Expected clientDefault column to have a default value fun, but was null"
+        )
+        assertEquals(
+            defaultValue,
+            returnedDefault,
+            "Expected clientDefault to return $defaultValue, but was $returnedDefault"
+        )
     }
 
     private val initBatch = listOf<(BatchInsertStatement) -> Unit>(
@@ -159,6 +168,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         fun Expression<*>.itOrNull() = when {
             currentDialectTest.isAllowedAsColumnDefault(this) ->
                 "DEFAULT ${currentDialectTest.dataTypeProvider.processForDefaultValue(this)} NOT NULL"
+
             else -> "NULL"
         }
 
@@ -193,15 +203,20 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
                     TestDB.ORACLE ->
                         ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
                             ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+
                     else -> ""
                 } +
                 ")"
 
-            val expected = if (currentDialectTest is OracleDialect || currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
-                arrayListOf("CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807", baseExpression)
-            } else {
-                arrayListOf(baseExpression)
-            }
+            val expected =
+                if (currentDialectTest is OracleDialect || currentDialectTest.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+                    arrayListOf(
+                        "CREATE SEQUENCE t_id_seq START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807",
+                        baseExpression
+                    )
+                } else {
+                    arrayListOf(baseExpression)
+                }
 
             assertEqualLists(expected, testTable.ddl)
 
@@ -332,6 +347,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         fun Expression<*>.itOrNull() = when {
             currentDialectTest.isAllowedAsColumnDefault(this) ->
                 "DEFAULT ${currentDialectTest.dataTypeProvider.processForDefaultValue(this)} NOT NULL"
+
             else -> "NULL"
         }
 
@@ -349,6 +365,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
                 when (testDb) {
                     TestDB.ORACLE ->
                         ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+
                     else -> ""
                 } +
                 ")"
@@ -426,7 +443,8 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
 
         val tester = object : Table("tester") {
             val timestampWithDefault = timestamp("timestampWithDefault").default(instant)
-            val timestampWithDefaultExpression = timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp)
+            val timestampWithDefaultExpression =
+                timestamp("timestampWithDefaultExpression").defaultExpression(CurrentTimestamp)
         }
 
         withTables(tester) {
@@ -441,7 +459,8 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
 
         val tester = object : Table("tester") {
             val datetimeWithDefault = datetime("datetimeWithDefault").default(datetime)
-            val datetimeWithDefaultExpression = datetime("datetimeWithDefaultExpression").defaultExpression(CurrentDateTime)
+            val datetimeWithDefaultExpression =
+                datetime("datetimeWithDefaultExpression").defaultExpression(CurrentDateTime)
         }
 
         withTables(tester) {
@@ -469,7 +488,8 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
         val offsetDateTime = OffsetDateTime.parse("2024-02-08T20:48:04.700+09:00")
 
         val tester = object : Table("tester") {
-            val timestampWithTimeZoneWithDefault = timestampWithTimeZone("timestampWithTimeZoneWithDefault").default(offsetDateTime)
+            val timestampWithTimeZoneWithDefault =
+                timestampWithTimeZone("timestampWithTimeZoneWithDefault").default(offsetDateTime)
         }
 
         // MariaDB does not support TIMESTAMP WITH TIME ZONE column type

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/JavaTimeTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/JavaTimeTests.kt
@@ -34,6 +34,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.*
 import java.time.temporal.Temporal
+import kotlin.collections.first
 import kotlin.test.assertEquals
 
 class JavaTimeTests : R2dbcDatabaseTestsBase() {
@@ -449,14 +450,14 @@ class JavaTimeTests : R2dbcDatabaseTestsBase() {
 
     @Test
     fun testTimestampAlwaysSavedInUTC() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+
         val tester = object : Table("tester") {
             val timestamp_col = timestamp("timestamp_col")
         }
 
         // TODO MYSQL_V8 test does not work on R2DBC now. The problem is that received timestamp is shifted by timezone.
         withTables(excludeSettings = listOf(TestDB.MYSQL_V8), tester) {
-            // Cairo time zone
-            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
             assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
 
             val instant = Instant.now().asJdk8()
@@ -468,6 +469,42 @@ class JavaTimeTests : R2dbcDatabaseTestsBase() {
             assertEquals(
                 instant, tester.selectAll().single()[tester.timestamp_col]
             )
+        }
+    }
+
+    @Test
+    fun testInsertAndReadWithNonUtcTimezone() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Africa/Cairo"))
+
+        val tester = object : Table("testInsertAndReadWithNonUtcTimezone") {
+            val ts = timestamp("ts")
+        }
+
+        val testerText = object : Table("testInsertAndReadWithNonUtcTimezone") {
+            val ts = text("ts")
+        }
+
+        withTables(tester) {
+            val now = Instant.now()
+
+            tester.insert {
+                it[tester.ts] = now
+            }
+
+            // It gives HH:MM:SS format in local time zone
+            val nowTimeString = now.atZone(ZoneId.systemDefault()).toLocalTime().toString().trim('0')
+
+            // This check validates that the value on database has local time (instead of UTC)
+            // It should prevent from the case when we convert value to UTC on insert, and back from UTC to local on reading
+            testerText.selectAll().first()[testerText.ts].let { valueAsText ->
+                kotlin.test.assertTrue(
+                    valueAsText.contains(nowTimeString),
+                    "Timestamp as text from database must contain the time in local time zone. Timestamp: $valueAsText, timeString: $nowTimeString"
+                )
+            }
+
+            val valueFromDb = tester.selectAll().first()[tester.ts]
+            assertEquals(now, valueFromDb)
         }
     }
 }

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/DatabaseTestsBase.kt
@@ -132,17 +132,17 @@ abstract class DatabaseTestsBase {
 
         withDb(dialect, configure = configure) {
             try {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(*tables)
+                SchemaUtils.drop(*tables)
             } catch (_: Throwable) {
             }
 
-            org.jetbrains.exposed.v1.jdbc.SchemaUtils.create(*tables)
+            SchemaUtils.create(*tables)
             try {
                 statement(dialect)
                 commit() // Need commit to persist data before drop tables
             } finally {
                 try {
-                    org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(*tables)
+                    SchemaUtils.drop(*tables)
                     commit()
                 } catch (_: Exception) {
                     val database = dialect.db!!


### PR DESCRIPTION
#### Description

It's the fix for `timestamp()` column. That column doesn't support time zones, and should store the values in local timezones. 

But it was working different and converting values into UTC timezone. On reading that converted value was recognized as local, and shifted one more time to convert it to UTC.

After fix Exposed will store values with the value in local time zone, and expect that the value in local time zone in the moment of reading.

Tests also read the value from database as string, and check the value, to be sure that the value was not shifted to UTC in the moment of insert, and back in the moment of reading.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix


Affected databases:
- [X] Mysql5
- [X] Mysql8
- [X] SQLite

#### Checklist

---

#### Related Issues

[EXPOSED-731](https://youtrack.jetbrains.com/issue/EXPOSED-731) Timestamp support for SQLite is broken
