### PR TITLE
chore!: Phase out support for H2 version 1.x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Similar to our mascot, Exposed can be used to mimic a variety of database engine
 
 ## Supported Databases
 
-- H2 (versions 2.x; 1.x version is deprecated and will be removed in future releases)
+- H2 (versions 2.x)
 - [![MariaDB](https://img.shields.io/badge/MariaDB-003545?style=for-the-badge&logo=mariadb&logoColor=white)](https://github.com/mariadb-corporation/mariadb-connector-j)
 - [![MySQL](https://img.shields.io/badge/mysql-4479A1.svg?style=for-the-badge&logo=mysql&logoColor=white)](https://github.com/mysql/mysql-connector-j)
 - [![Oracle](https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white)](https://www.oracle.com/ca-en/database/technologies/appdev/jdbc-downloads.html)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,15 +79,6 @@ subprojects {
         }
     }
 
-    testDb("h2_v1") {
-        withContainer = false
-        dialects("H2_V1", "H2_V1_MYSQL")
-
-        dependencies {
-            dependency(rootProject.libs.h1)
-        }
-    }
-
     testDb("sqlite") {
         withContainer = false
         dialects("SQLITE")

--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -10,6 +10,11 @@
   which contains all the original and unchanged methods. It's associated function `buildStatement()` no longer accepts the
   deprecated interface as the receiver of its `body` parameter; the parameter expects the new `StatementBuilder` instead.
   The same parameter type change applies to the function `explain()`.
+* Support for H2 versions earlier than 2.0.202 (namely 1.4.200 and earlier) has now been fully phased out. In addition,
+  `H2Dialect.H2MajorVersion.One` is now deprecated and `H2Dialect`-specific properties, like `majorVersion` and `isSecondVersion`,
+  now throw an exception if H2 version 1.x.x is detected. Moving forward, new features will no longer be tested on H2 version
+  1.0.0+, so support for those versions will not be guaranteed. Depending on the built-in support from these older H2 versions,
+  Exposed API may still mostly be compatible, but may now throw syntax or unsupported exceptions when generating certain SQL clauses.
 
 ## 1.0.0-beta-4
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Op.kt
@@ -435,19 +435,14 @@ class AndBitOp<T, S : T>(
     override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        when (val dialect = currentDialectIfAvailable) {
+        when (currentDialectIfAvailable) {
             is OracleDialect -> append("BITAND(", expr1, ", ", expr2, ")")
             is H2Dialect -> {
-                when (dialect.isSecondVersion) {
-                    false -> append("BITAND(", expr1, ", ", expr2, ")")
-                    true -> {
-                        +"BITAND("
-                        castToExpressionTypeForH2BitWiseIps(expr1, this)
-                        +", "
-                        castToExpressionTypeForH2BitWiseIps(expr2, this)
-                        +")"
-                    }
-                }
+                +"BITAND("
+                castToExpressionTypeForH2BitWiseIps(expr1, this)
+                +", "
+                castToExpressionTypeForH2BitWiseIps(expr2, this)
+                +")"
             }
             else -> append('(', expr1, " & ", expr2, ')')
         }
@@ -466,20 +461,15 @@ class OrBitOp<T, S : T>(
     override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        when (val dialect = currentDialectIfAvailable) {
+        when (currentDialectIfAvailable) {
             // Oracle doesn't natively support bitwise OR, thus emulate it with 'and'
             is OracleDialect -> append("(", expr1, "+", expr2, "-", AndBitOp(expr1, expr2, columnType), ")")
             is H2Dialect -> {
-                when (dialect.isSecondVersion) {
-                    false -> append("BITOR(", expr1, ", ", expr2, ")")
-                    true -> {
-                        +"BITOR("
-                        castToExpressionTypeForH2BitWiseIps(expr1, this)
-                        +", "
-                        castToExpressionTypeForH2BitWiseIps(expr2, this)
-                        +")"
-                    }
-                }
+                +"BITOR("
+                castToExpressionTypeForH2BitWiseIps(expr1, this)
+                +", "
+                castToExpressionTypeForH2BitWiseIps(expr2, this)
+                +")"
             }
             else -> append('(', expr1, " | ", expr2, ')')
         }
@@ -498,23 +488,18 @@ class XorBitOp<T, S : T>(
     override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
-        when (val dialect = currentDialectIfAvailable) {
+        when (currentDialectIfAvailable) {
             // Oracle and SQLite don't natively support bitwise XOR, thus emulate it with 'or' and 'and'
             is OracleDialect, is SQLiteDialect -> append(
                 "(", OrBitOp(expr1, expr2, columnType), "-", AndBitOp(expr1, expr2, columnType), ")"
             )
             is PostgreSQLDialect -> append('(', expr1, " # ", expr2, ')')
             is H2Dialect -> {
-                when (dialect.isSecondVersion) {
-                    false -> append("BITXOR(", expr1, ", ", expr2, ")")
-                    true -> {
-                        +"BITXOR("
-                        castToExpressionTypeForH2BitWiseIps(expr1, this)
-                        +", "
-                        castToExpressionTypeForH2BitWiseIps(expr2, this)
-                        +")"
-                    }
-                }
+                +"BITXOR("
+                castToExpressionTypeForH2BitWiseIps(expr1, this)
+                +", "
+                castToExpressionTypeForH2BitWiseIps(expr2, this)
+                +")"
             }
             else -> append('(', expr1, " ^ ", expr2, ')')
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedMetadataUtils.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedMetadataUtils.kt
@@ -97,8 +97,6 @@ object ExposedMetadataUtils {
      * MySql8              null       null                        "NULL"
      * MariaDB3            "NULL"     "NULL"                      "'NULL'"
      * MariaDB2            "NULL"     "NULL"                      "'NULL'"
-     * H2V1                null       "NULL"                      "'NULL'"
-     * H2V1 (MySql)        null       "NULL"                      "'NULL'"
      * H2V2                null       "NULL"                      "'NULL'"
      * H2V2 (MySql)        null       "NULL"                      "'NULL'"
      * H2V2 (MariaDB)      null       "NULL"                      "'NULL'"

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
@@ -229,8 +229,11 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         }
     }
 
-    /** Indicates whether the H2 Database Engine version is greater than or equal to 2.0. */
-    // Adding a note to discuss keeping, as this will only ever be true now (otherwise throws)
+    /**
+     * Indicates whether the H2 Database Engine version is greater than or equal to 2.0.
+     *
+     * @throws IllegalStateException If the major version is not 2.x.x.
+     */
     val isSecondVersion: Boolean get() = majorVersion == H2MajorVersion.Two
 
     private fun exactH2Version(transaction: Transaction): String = transaction.db.version.toString()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
@@ -32,10 +32,10 @@ internal object H2FunctionProvider : FunctionProvider() {
     override fun nextVal(seq: Sequence, builder: QueryBuilder) =
         @OptIn(InternalApi::class)
         when ((CoreTransactionManager.currentTransaction().db.dialect as H2Dialect).majorVersion) {
-            H2Dialect.H2MajorVersion.One -> super.nextVal(seq, builder)
             H2Dialect.H2MajorVersion.Two -> builder {
                 append("NEXT VALUE FOR ${seq.identifier}")
             }
+            else -> error("Unsupported H2 version")
         }
 
     override fun <T> arraySlice(expression: Expression<T>, lower: Int?, upper: Int?, queryBuilder: QueryBuilder) {
@@ -200,8 +200,16 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
 
     override fun toString(): String = "H2Dialect[$dialectName, $h2Mode]"
 
+    /** Represents the major version number x.0.0 of the H2 Database. */
     enum class H2MajorVersion {
-        One, Two
+        @Deprecated(
+            message = "This H2 database version is no longer supported and will be removed in future releases.",
+            level = DeprecationLevel.WARNING
+        )
+        One,
+
+        /** H2 database version 2.0.0+. */
+        Two,
     }
 
     @OptIn(InternalApi::class)
@@ -209,16 +217,21 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
         exactH2Version(CoreTransactionManager.currentTransaction())
     }
 
+    /**
+     * Returns the [H2MajorVersion] for the current H2 database being used.
+     *
+     * @throws IllegalStateException If the major version is not 2.x.x.
+     */
     val majorVersion: H2MajorVersion by lazy {
         when {
-            version.startsWith("1.") -> H2MajorVersion.One
             version.startsWith("2.") -> H2MajorVersion.Two
             else -> error("Unsupported H2 version: $version")
         }
     }
 
     /** Indicates whether the H2 Database Engine version is greater than or equal to 2.0. */
-    val isSecondVersion get() = majorVersion == H2MajorVersion.Two
+    // Adding a note to discuss keeping, as this will only ever be true now (otherwise throws)
+    val isSecondVersion: Boolean get() = majorVersion == H2MajorVersion.Two
 
     private fun exactH2Version(transaction: Transaction): String = transaction.db.version.toString()
 
@@ -303,14 +316,14 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
     override val supportsDualTableConcept: Boolean by lazy { resolveDelegatedDialect()?.supportsDualTableConcept ?: super.supportsDualTableConcept }
     override val supportsOrderByNullsFirstLast: Boolean by lazy { resolveDelegatedDialect()?.supportsOrderByNullsFirstLast ?: super.supportsOrderByNullsFirstLast }
     override val supportsWindowFrameGroupsMode: Boolean by lazy { resolveDelegatedDialect()?.supportsWindowFrameGroupsMode ?: super.supportsWindowFrameGroupsMode }
-    override val supportsColumnTypeChange: Boolean get() = isSecondVersion
-    override val supportsSelectForUpdate: Boolean get() = isSecondVersion
+    override val supportsColumnTypeChange: Boolean get() = true
+    override val supportsSelectForUpdate: Boolean get() = true
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true
 
     override fun createIndex(index: Index): String {
         if (
-            (majorVersion == H2MajorVersion.One || h2Mode == H2CompatibilityMode.Oracle) &&
+            h2Mode == H2CompatibilityMode.Oracle &&
             index.columns.any { it.columnType is TextColumnType }
         ) {
             exposedLogger.warn("Index on ${index.table.tableName} for ${index.columns.joinToString { it.name }} can't be created on CLOB in H2")

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DefaultsTest.kt
@@ -585,7 +585,7 @@ class DefaultsTest : DatabaseTestsBase() {
 
     @Test
     fun testCustomDefaultTimestampFunctionWithEntity() {
-        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES - TestDB.MYSQL_V8 - TestDB.ALL_H2, DefaultTimestampTable) {
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES - TestDB.MYSQL_V8 - TestDB.ALL_H2_V2, DefaultTimestampTable) {
             val entity = DefaultTimestampEntity.new {}
 
             val timestamp = DefaultTimestampTable.selectAll().first()[DefaultTimestampTable.timestamp]

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/JavaTimeTests.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/JavaTimeTests.kt
@@ -332,7 +332,7 @@ class JavaTimeTests : DatabaseTestsBase() {
             val modified = jsonb<ModifierData>("modified", Json.Default)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
+        withTables(excludeSettings = TestDB.ALL_H2_V2 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
             val dateTimeNow = LocalDateTime.now()
             tester.insert {
                 it[created] = dateTimeNow.minusYears(1)
@@ -455,7 +455,7 @@ class JavaTimeTests : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB + TestDB.ALL_H2_V1, testTable) { testDb ->
+        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB, testTable) { testDb ->
             // UTC time zone
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
             assertEquals("UTC", ZoneId.systemDefault().id)
@@ -521,7 +521,7 @@ class JavaTimeTests : DatabaseTestsBase() {
     fun testCurrentDateTimeFunction() {
         val fakeTestTable = object : IntIdTable("fakeTable") {}
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) {
+        withTables(fakeTestTable) {
             fun currentDbDateTime(): LocalDateTime {
                 return fakeTestTable.select(CurrentDateTime).first()[CurrentDateTime]
             }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -63,8 +63,8 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         if (dialect !is H2Dialect) null
 
         val (settingNameField, settingValueField) = when ((dialect as H2Dialect).majorVersion) {
-            H2Dialect.H2MajorVersion.One -> "NAME" to "VALUE"
             H2Dialect.H2MajorVersion.Two -> "SETTING_NAME" to "SETTING_VALUE"
+            else -> error("Unsupported H2 version")
         }
 
         @Language("H2")

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeDefaultsTest.kt
@@ -529,7 +529,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
 
     @Test
     fun testCustomDefaultTimestampFunctionWithEntity() {
-        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES - TestDB.MYSQL_V8 - TestDB.ALL_H2, DefaultTimestampTable) {
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES - TestDB.MYSQL_V8 - TestDB.ALL_H2_V2, DefaultTimestampTable) {
             val entity = DefaultTimestampEntity.new {}
 
             val timestamp = DefaultTimestampTable.selectAll().first()[DefaultTimestampTable.timestamp]

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeTests.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeTests.kt
@@ -248,7 +248,7 @@ class JodaTimeTests : DatabaseTestsBase() {
             val modified = jsonb<ModifierData>("modified", Json.Default)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
+        withTables(excludeSettings = TestDB.ALL_H2_V2 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
             val dateTimeNow = DateTime.now()
             tester.insert {
                 it[created] = dateTimeNow.minusYears(1)
@@ -367,7 +367,7 @@ class JodaTimeTests : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB + TestDB.ALL_H2_V1, testTable) {
+        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB, testTable) {
             // UTC time zone
             DateTimeZone.setDefault(DateTimeZone.UTC)
             assertEquals("UTC", DateTimeZone.getDefault().id)
@@ -395,7 +395,7 @@ class JodaTimeTests : DatabaseTestsBase() {
     fun testCurrentDateTimeFunction() {
         val fakeTestTable = object : IntIdTable("fakeTable") {}
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) {
+        withTables(fakeTestTable) {
             fun currentDbDateTime(): DateTime {
                 return fakeTestTable.select(CurrentDateTime).first()[CurrentDateTime]
             }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
@@ -55,7 +55,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWithSliceExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, user1, data1, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, user1, data1, _ ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
             val isActive = JsonTestsData.JsonBTable.jsonBColumn.extract<Boolean>("${pathPrefix}active", toScalar = false)
             val result1 = tester.select(isActive).singleOrNull()
@@ -74,7 +74,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWhereWithExtract() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, data1, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, data1, _ ->
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(logins = 1000)
             }
@@ -97,7 +97,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
         val dataTable = JsonTestsData.JsonBTable
         val dataEntity = JsonTestsData.JsonBEntity
 
-        withTables(excludeSettings = binaryJsonNotSupportedDB + TestDB.ALL_H2_V1, dataTable) { testDb ->
+        withTables(excludeSettings = binaryJsonNotSupportedDB, dataTable) { testDb ->
             val dataA = DataHolder(User("Admin", "Alpha"), 10, true, null)
             val newUser = dataEntity.new {
                 jsonBColumn = dataA
@@ -127,7 +127,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonContains() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, user1, data1, testDb ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, user1, data1, testDb ->
             val alphaTeamUser = user1.copy(team = "Alpha")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = data1.copy(user = alphaTeamUser)
@@ -151,7 +151,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExists() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2) { tester, _, data1, testDb ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, _, data1, testDb ->
             val maximumLogins = 1000
             val teamA = "A"
             val newId = tester.insertAndGetId {
@@ -322,7 +322,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonBWithUpsert() {
-        withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V1) { tester, _, _, _ ->
+        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, _, _ ->
             val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
             val newId = tester.insertAndGetId {
                 it[jsonBColumn] = newData

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonColumnTests.kt
@@ -58,7 +58,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWithSliceExtract() {
-        withJsonTable(exclude = TestDB.ALL_H2) { tester, user1, data1, _ ->
+        withJsonTable(exclude = TestDB.ALL_H2_V2) { tester, user1, data1, _ ->
             val pathPrefix = if (currentDialectTest is PostgreSQLDialect) "" else "."
             // SQLServer & Oracle return null if extracted JSON is not scalar
             val requiresScalar = currentDialectTest is SQLServerDialect || currentDialectTest is OracleDialect
@@ -79,7 +79,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testSelectWhereWithExtract() {
-        withJsonTable(exclude = TestDB.ALL_H2) { tester, _, data1, _ ->
+        withJsonTable(exclude = TestDB.ALL_H2_V2) { tester, _, data1, _ ->
             val newId = tester.insertAndGetId {
                 it[jsonColumn] = data1.copy(logins = 1000)
             }
@@ -132,7 +132,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
             assertEquals(updatedUser, dataEntity.all().single().jsonColumn)
 
-            if (testDb !in TestDB.ALL_H2) {
+            if (testDb !in TestDB.ALL_H2_V2) {
                 dataEntity.new { jsonColumn = dataA }
                 val path = if (currentDialectTest is PostgreSQLDialect) {
                     arrayOf("user", "team")
@@ -177,7 +177,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExists() {
-        withJsonTable(exclude = TestDB.ALL_H2 + TestDB.SQLSERVER) { tester, _, data1, testDb ->
+        withJsonTable(exclude = TestDB.ALL_H2_V2 + TestDB.SQLSERVER) { tester, _, data1, testDb ->
             val maximumLogins = 1000
             val teamA = "A"
             val newId = tester.insertAndGetId {
@@ -222,7 +222,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExtractWithArrays() {
-        withJsonArrays(exclude = TestDB.ALL_H2) { tester, singleId, _, testDb ->
+        withJsonArrays(exclude = TestDB.ALL_H2_V2) { tester, singleId, _, testDb ->
             val path1 = if (currentDialectTest is PostgreSQLDialect) {
                 arrayOf("users", "0", "team")
             } else {
@@ -254,7 +254,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonExistsWithArrays() {
-        withJsonArrays(exclude = TestDB.ALL_H2 + TestDB.SQLSERVER) { tester, _, tripleId, testDb ->
+        withJsonArrays(exclude = TestDB.ALL_H2_V2 + TestDB.SQLSERVER) { tester, _, tripleId, testDb ->
             val optional = if (testDb in TestDB.ALL_MYSQL_LIKE) "one" else null
 
             val hasMultipleUsers = JsonTestsData.JsonArrays.groups.exists(".users[1]", optional = optional)
@@ -390,7 +390,7 @@ class JsonColumnTests : DatabaseTestsBase() {
 
     @Test
     fun testJsonWithUpsert() {
-        withJsonTable(exclude = TestDB.ALL_H2_V1) { tester, _, _, _ ->
+        withJsonTable { tester, _, _, _ ->
             val newData = DataHolder(User("Pro", "Alpha"), 999, true, "A")
             val newId = tester.insertAndGetId {
                 it[jsonColumn] = newData

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonTestsData.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonTestsData.kt
@@ -92,7 +92,7 @@ fun DatabaseTestsBase.withJsonArrays(
 ) {
     val tester = JsonTestsData.JsonArrays
 
-    withTables(excludeSettings = withH2V1(exclude), tester) { testDb ->
+    withTables(excludeSettings = exclude, tester) { testDb ->
         val singleId = tester.insertAndGetId {
             it[groups] = UserGroup(listOf(User("A", "Team A")))
             it[numbers] = intArrayOf(100)
@@ -117,7 +117,7 @@ fun DatabaseTestsBase.withJsonBArrays(
 ) {
     val tester = JsonTestsData.JsonBArrays
 
-    withTables(excludeSettings = withH2V1(exclude), tester) { testDb ->
+    withTables(excludeSettings = exclude, tester) { testDb ->
         val singleId = tester.insertAndGetId {
             it[groups] = UserGroup(listOf(User("A", "Team A")))
             it[numbers] = intArrayOf(100)

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
@@ -651,7 +651,7 @@ class DefaultsTest : DatabaseTestsBase() {
 
     @Test
     fun testCustomDefaultTimestampFunctionWithEntity() {
-        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES - TestDB.MYSQL_V8 - TestDB.ALL_H2, DefaultTimestampTable) {
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES - TestDB.MYSQL_V8 - TestDB.ALL_H2_V2, DefaultTimestampTable) {
             val entity = DefaultTimestampEntity.new {}
 
             val timestamp = DefaultTimestampTable.selectAll().first()[DefaultTimestampTable.timestamp]

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/KotlinTimeTests.kt
@@ -349,7 +349,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
             val modified = jsonb<ModifierData>("modified", Json.Default)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
+        withTables(excludeSettings = TestDB.ALL_H2_V2 + TestDB.SQLITE + TestDB.SQLSERVER + TestDB.ORACLE, tester) {
             val dateTimeNow = now()
             tester.insert {
                 it[created] = dateTimeNow.date.minus(1, DateTimeUnit.YEAR).atTime(0, 0, 0)
@@ -476,7 +476,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
             val timestampWithTimeZone = timestampWithTimeZone("timestamptz-column")
         }
 
-        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB + TestDB.ALL_H2_V1, testTable) { testDb ->
+        withTables(excludeSettings = timestampWithTimeZoneUnsupportedDB, testTable) { testDb ->
             // UTC time zone
             java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone(ZoneOffset.UTC))
             assertEquals("UTC", ZoneId.systemDefault().id)
@@ -548,7 +548,7 @@ class KotlinTimeTests : DatabaseTestsBase() {
     fun testCurrentDateTimeFunction() {
         val fakeTestTable = object : IntIdTable("fakeTable") {}
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, fakeTestTable) {
+        withTables(fakeTestTable) {
             fun currentDbDateTime(): LocalDateTime {
                 return fakeTestTable.select(CurrentDateTime).first()[CurrentDateTime]
             }

--- a/exposed-migration/src/main/kotlin/org/jetbrains/exposed/v1/migration/MigrationUtils.kt
+++ b/exposed-migration/src/main/kotlin/org/jetbrains/exposed/v1/migration/MigrationUtils.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.v1.migration
 
 import org.jetbrains.exposed.v1.core.*
-import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.jdbc.exists
@@ -280,7 +279,7 @@ object MigrationUtils : MigrationUtilityApi() {
      * @return List of sequences that are unmapped and can be dropped.
      */
     private fun checkUnmappedSequences(vararg tables: Table, withLogs: Boolean): List<Sequence> {
-        if (!currentDialect.supportsCreateSequence || (currentDialect as? H2Dialect)?.majorVersion == H2Dialect.H2MajorVersion.One) {
+        if (!currentDialect.supportsCreateSequence) {
             return emptyList()
         }
 

--- a/exposed-r2dbc-tests/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/tests/TestDB.kt
+++ b/exposed-r2dbc-tests/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/tests/TestDB.kt
@@ -115,7 +115,6 @@ enum class TestDB(
 
     companion object {
         val ALL_H2_V2 = setOf(H2_V2, H2_V2_MYSQL, H2_V2_PSQL, H2_V2_MARIADB, H2_V2_ORACLE, H2_V2_SQLSERVER)
-        val ALL_H2 = ALL_H2_V2
         val ALL_MYSQL = setOf(MYSQL_V5, MYSQL_V8)
         val ALL_MARIADB = setOf(MARIADB)
         val ALL_MYSQL_MARIADB = ALL_MYSQL + ALL_MARIADB

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/H2Tests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/H2Tests.kt
@@ -4,17 +4,14 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.single
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.core.avg
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.transactions.CoreTransactionManager
 import org.jetbrains.exposed.v1.core.transactions.TransactionManagerApi
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
-import org.jetbrains.exposed.v1.r2dbc.batchInsert
 import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.replace
-import org.jetbrains.exposed.v1.r2dbc.select
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
@@ -39,13 +36,10 @@ class H2Tests : R2dbcDatabaseTestsBase() {
                     it.getString(1)
                 }?.first()
 
-                assertTrue(systemTestName == "h2_v2" || systemTestName == "h2_v1")
+                assertTrue(systemTestName == "h2_v2")
                 if (systemTestName == "h2_v2") {
                     assertNotEquals("2.1.214", version)
                     assertEquals("2", version?.first()?.toString())
-                }
-                if (systemTestName == "h2_v1") {
-                    assertEquals("1", version?.first()?.toString())
                 }
             }
         }
@@ -119,23 +113,6 @@ class H2Tests : R2dbcDatabaseTestsBase() {
             } finally {
                 org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(t)
             }
-        }
-    }
-
-    @Test
-    fun testH2V1WithBigDecimalFunctionThatReturnsShort() {
-        val testTable = object : Table("test_table") {
-            val number = short("number")
-        }
-
-        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_H2, testTable) {
-            testTable.batchInsert(listOf<Short>(2, 4, 6, 8, 10)) { n ->
-                this[testTable.number] = n
-            }
-
-            val average = testTable.number.avg()
-            val result = testTable.select(average).single()[average]
-            assertEquals("6.00".toBigDecimal(), result)
         }
     }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/CoroutineTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/CoroutineTests.kt
@@ -236,7 +236,7 @@ class CoroutineTests : R2dbcDatabaseTestsBase() {
     @Test
     @RepeatableTest(10)
     fun nestedSuspendAsyncTxTest() {
-        withTables(TestDB.ALL_H2, Testing) {
+        withTables(TestDB.ALL_H2_V2, Testing) {
             val mainJob = GlobalScope.async {
                 val job = launch(Dispatchers.IO) {
                     suspendTransaction(db = db) {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
@@ -127,7 +127,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         withDb { testDb ->
             assertTrue(db.config.preserveKeywordCasing)
 
-            org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(keywordTable)
+            SchemaUtils.create(keywordTable)
             assertTrue(keywordTable.exists())
 
             val (tableName, publicName, dataName, constraintName) = keywords.map {
@@ -158,10 +158,10 @@ class DDLTests : R2dbcDatabaseTestsBase() {
             }
 
             // check that identifiers match with returned jdbc metadata
-            val statements = org.jetbrains.exposed.v1.r2dbc.SchemaUtils.statementsRequiredToActualizeScheme(keywordTable, withLogs = false)
+            val statements = SchemaUtils.statementsRequiredToActualizeScheme(keywordTable, withLogs = false)
             assertTrue(statements.isEmpty())
 
-            org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(keywordTable)
+            SchemaUtils.drop(keywordTable)
         }
     }
 
@@ -324,10 +324,10 @@ class DDLTests : R2dbcDatabaseTestsBase() {
 
             assertTrue(singleColumnDescription.contains("PRIMARY KEY"))
 
-            if (h2Dialect.isSecondVersion && !isOracleMode) {
+            if (!isOracleMode) {
                 expect(Unit) {
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(testTable)
-                    org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(testTable)
+                    SchemaUtils.create(testTable)
+                    SchemaUtils.drop(testTable)
                 }
             } else {
                 expectException<ExposedR2dbcException> {
@@ -406,7 +406,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
                 "CREATE TABLE " + addIfNotExistsIfSupported() + tableProperName + " (" + testTable.columns.single().descriptionDdl(false) + ")", testTable.ddl
             )
 
-            if (h2Dialect.isSecondVersion && !isOracleMode) {
+            if (!isOracleMode) {
                 assertEquals(
                     "CREATE INDEX $indexProperName ON $tableProperName ($columnProperName)", indexStatement
                 )
@@ -813,7 +813,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
     fun testDeleteMissingTable() {
         val missingTable = Table("missingTable")
         withDb {
-            org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(missingTable)
+            SchemaUtils.drop(missingTable)
         }
     }
 
@@ -970,13 +970,13 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         val one = prepareSchemaForTest("one")
         val two = prepareSchemaForTest("two")
         withSchemas(two, one) {
-            org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(TableFromSchemeOne)
+            SchemaUtils.create(TableFromSchemeOne)
 
             if (currentDialectTest is OracleDialect) {
                 exec("GRANT REFERENCES ON ${TableFromSchemeOne.tableName} to TWO")
             }
 
-            org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(TableFromSchemeTwo)
+            SchemaUtils.create(TableFromSchemeTwo)
             val idFromOne = TableFromSchemeOne.insertAndGetId { }
 
             TableFromSchemeTwo.insert {
@@ -987,7 +987,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
             assertEquals(1L, TableFromSchemeTwo.selectAll().count())
 
             if (currentDialectTest is SQLServerDialect) {
-                org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(TableFromSchemeTwo, TableFromSchemeOne)
+                SchemaUtils.drop(TableFromSchemeTwo, TableFromSchemeOne)
             }
         }
     }
@@ -1156,7 +1156,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         }
 
         withSchemas(one) {
-            org.jetbrains.exposed.v1.r2dbc.SchemaUtils.create(tableA, tableB)
+            SchemaUtils.create(tableA, tableB)
             tableA.insert {
                 it[idA] = 1
                 it[idB] = 1
@@ -1170,7 +1170,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
             assertEquals(1, tableB.selectAll().count())
 
             if (currentDialectTest is SQLServerDialect) {
-                org.jetbrains.exposed.v1.r2dbc.SchemaUtils.drop(tableA, tableB)
+                SchemaUtils.drop(tableA, tableB)
             }
         }
     }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/ColumnDefinitionTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/ColumnDefinitionTests.kt
@@ -37,7 +37,7 @@ class ColumnDefinitionTests : R2dbcDatabaseTestsBase() {
             val amount = integer("amount").withDefinition("COMMENT", stringLiteral(comment))
         }
 
-        val columnCommentSupportedDB = TestDB.ALL_H2 + TestDB.ALL_MYSQL_MARIADB
+        val columnCommentSupportedDB = TestDB.ALL_H2_V2 + TestDB.ALL_MYSQL_MARIADB
 
         withTables(excludeSettings = TestDB.ALL - columnCommentSupportedDB, tester) { testDb ->
             assertTrue { org.jetbrains.exposed.v1.r2dbc.SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
@@ -171,7 +171,7 @@ class ColumnDefinitionTests : R2dbcDatabaseTestsBase() {
 
         fun FieldSet.selectImplicitAll(): Query = ImplicitQuery(this, null)
 
-        val invisibilitySupportedDB = TestDB.ALL_H2 + TestDB.ALL_MARIADB + TestDB.MYSQL_V8 + TestDB.ORACLE
+        val invisibilitySupportedDB = TestDB.ALL_H2_V2 + TestDB.ALL_MARIADB + TestDB.MYSQL_V8 + TestDB.ORACLE
 
         withTables(excludeSettings = TestDB.ALL - invisibilitySupportedDB, tester) { testDb ->
             if (testDb == TestDB.MYSQL_V8 || testDb == TestDB.ORACLE) {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/CreateIndexTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/CreateIndexTests.kt
@@ -265,7 +265,7 @@ class CreateIndexTests : R2dbcDatabaseTestsBase() {
             }
         }
 
-        val functionsNotSupported = TestDB.ALL_MARIADB + TestDB.ALL_H2 + TestDB.SQLSERVER + TestDB.MYSQL_V5
+        val functionsNotSupported = TestDB.ALL_MARIADB + TestDB.ALL_H2_V2 + TestDB.SQLSERVER + TestDB.MYSQL_V5
         withTables(excludeSettings = functionsNotSupported, tester) {
             org.jetbrains.exposed.v1.r2dbc.SchemaUtils.createMissingTablesAndColumns()
             assertTrue(tester.exists())

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/UnionTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/UnionTests.kt
@@ -97,8 +97,7 @@ class UnionTests : R2dbcDatabaseTestsBase() {
             val sergeyQuery = users.selectAll().where { users.id eq "sergey" }
             val expectedUsers = usersQuery.map { it[users.id] }.toList() + "sergey"
             val intersectAppliedFirst = when (currentDialect) {
-                is PostgreSQLDialect, is SQLServerDialect, is MariaDBDialect -> true
-                is H2Dialect -> (currentDialect as H2Dialect).isSecondVersion
+                is PostgreSQLDialect, is SQLServerDialect, is MariaDBDialect, is H2Dialect -> true
                 else -> false
             }
             usersQuery.unionAll(usersQuery).intersect(sergeyQuery).map { it[users.id] }.toList().apply {

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/DatabaseTestsBase.kt
@@ -200,8 +200,6 @@ abstract class DatabaseTestsBase {
         ""
     }
 
-    fun withH2V1(testDB: Collection<TestDB>) = (testDB + TestDB.ALL_H2_V1).toSet()
-
     protected fun prepareSchemaForTest(schemaName: String): Schema = Schema(
         schemaName,
         defaultTablespace = "USERS",

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/TestDB.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/TestDB.kt
@@ -19,20 +19,20 @@ enum class TestDB(
     val afterTestFinished: () -> Unit = {},
     val dbConfig: DatabaseConfig.Builder.() -> Unit = {}
 ) {
-    H2_V1({ "jdbc:h2:mem:regular;DB_CLOSE_DELAY=-1;" }, "org.h2.Driver", dbConfig = {
-        defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED
-    }),
-    H2_V1_MYSQL({ "jdbc:h2:mem:mysql;MODE=MySQL;DB_CLOSE_DELAY=-1" }, "org.h2.Driver", beforeConnection = {
-        Mode::class.declaredMemberProperties.firstOrNull { it.name == "convertInsertNullToZero" }?.let { field ->
-            val mode = Mode.getInstance("MySQL")
-            @Suppress("UNCHECKED_CAST")
-            (field as KMutableProperty1<Mode, Boolean>).set(mode, false)
-        }
-    }),
     H2_V2({ "jdbc:h2:mem:regular;DB_CLOSE_DELAY=-1;" }, "org.h2.Driver", dbConfig = {
         defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED
     }),
-    H2_V2_MYSQL({ "jdbc:h2:mem:mysql;MODE=MySQL;DB_CLOSE_DELAY=-1" }, "org.h2.Driver", beforeConnection = H2_V1_MYSQL.beforeConnection),
+    H2_V2_MYSQL(
+        { "jdbc:h2:mem:mysql;MODE=MySQL;DB_CLOSE_DELAY=-1" },
+        "org.h2.Driver",
+        beforeConnection = {
+            Mode::class.declaredMemberProperties.firstOrNull { it.name == "convertInsertNullToZero" }?.let { field ->
+                val mode = Mode.getInstance("MySQL")
+                @Suppress("UNCHECKED_CAST")
+                (field as KMutableProperty1<Mode, Boolean>).set(mode, false)
+            }
+        }
+    ),
     H2_V2_MARIADB(
         { "jdbc:h2:mem:mariadb;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1" },
         "org.h2.Driver",
@@ -135,13 +135,11 @@ enum class TestDB(
     }
 
     companion object {
-        val ALL_H2_V1 = setOf(H2_V1, H2_V1_MYSQL)
         val ALL_H2_V2 = setOf(H2_V2, H2_V2_MYSQL, H2_V2_PSQL, H2_V2_MARIADB, H2_V2_ORACLE, H2_V2_SQLSERVER)
-        val ALL_H2 = ALL_H2_V1 + ALL_H2_V2
         val ALL_MYSQL = setOf(MYSQL_V5, MYSQL_V8)
         val ALL_MARIADB = setOf(MARIADB)
         val ALL_MYSQL_MARIADB = ALL_MYSQL + ALL_MARIADB
-        val ALL_MYSQL_LIKE = ALL_MYSQL_MARIADB + setOf(H2_V2_MYSQL, H2_V2_MARIADB, H2_V1_MYSQL)
+        val ALL_MYSQL_LIKE = ALL_MYSQL_MARIADB + setOf(H2_V2_MYSQL, H2_V2_MARIADB)
         val ALL_POSTGRES = setOf(POSTGRESQL, POSTGRESQLNG)
         val ALL_POSTGRES_LIKE = ALL_POSTGRES + setOf(H2_V2_PSQL)
         val ALL_ORACLE_LIKE = setOf(ORACLE, H2_V2_ORACLE)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ThreadLocalManagerTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ThreadLocalManagerTest.kt
@@ -95,4 +95,4 @@ object RollbackTable : IntIdTable("rollbackTable") {
 // Explanation: MariaDB driver never set readonly to true, MSSQL silently ignores the call, SQLite does not
 // promise anything, H2 has very limited functionality
 private val READ_ONLY_EXCLUDED_VENDORS =
-    TestDB.ALL_H2 + TestDB.ALL_MARIADB + listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)
+    TestDB.ALL_H2_V2 + TestDB.ALL_MARIADB + listOf(TestDB.SQLITE, TestDB.SQLSERVER, TestDB.ORACLE)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/TransactionExecTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/TransactionExecTests.kt
@@ -58,7 +58,7 @@ class TransactionExecTests : DatabaseTestsBase() {
         // Both SQLite and H2 drivers allow multiple but only return the result of the first statement:
         // SQLite issue tracker: https://github.com/xerial/sqlite-jdbc/issues/277
         // H2 issue tracker: https://github.com/h2database/h2database/issues/3704
-        val toExclude = TestDB.ALL_H2 + TestDB.ALL_MYSQL_LIKE + listOf(TestDB.SQLITE, TestDB.POSTGRESQLNG)
+        val toExclude = TestDB.ALL_H2_V2 + TestDB.ALL_MYSQL_LIKE + listOf(TestDB.SQLITE, TestDB.POSTGRESQLNG)
 
         withTables(excludeSettings = toExclude, ExecTable) { testDb ->
             testInsertAndSelectInSingleExec(testDb)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/TransactionExecTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/TransactionExecTests.kt
@@ -183,9 +183,7 @@ class TransactionExecTests : DatabaseTestsBase() {
 
     @Test
     fun testExecWithBuildStatement() {
-        withCitiesAndUsers(
-            exclude = TestDB.ALL_H2_V1
-        ) { cities, users, userData ->
+        withCitiesAndUsers { cities, users, userData ->
             val initialCityCount = cities.selectAll().count()
             val initialUserDataCount = userData.selectAll().count()
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/ColumnDefinitionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/ColumnDefinitionTests.kt
@@ -29,7 +29,7 @@ class ColumnDefinitionTests : DatabaseTestsBase() {
             val amount = integer("amount").withDefinition("COMMENT", stringLiteral(comment))
         }
 
-        val columnCommentSupportedDB = TestDB.ALL_H2 + TestDB.ALL_MYSQL_MARIADB + TestDB.SQLITE
+        val columnCommentSupportedDB = TestDB.ALL_H2_V2 + TestDB.ALL_MYSQL_MARIADB + TestDB.SQLITE
 
         withTables(excludeSettings = TestDB.ALL - columnCommentSupportedDB, tester) { testDb ->
             assertTrue { org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(tester).isEmpty() }
@@ -166,7 +166,7 @@ class ColumnDefinitionTests : DatabaseTestsBase() {
 
         fun FieldSet.selectImplicitAll(): Query = ImplicitQuery(this, null)
 
-        val invisibilitySupportedDB = TestDB.ALL_H2 + TestDB.ALL_MARIADB + TestDB.MYSQL_V8 + TestDB.ORACLE
+        val invisibilitySupportedDB = TestDB.ALL_H2_V2 + TestDB.ALL_MARIADB + TestDB.MYSQL_V8 + TestDB.ORACLE
 
         withTables(excludeSettings = TestDB.ALL - invisibilitySupportedDB, tester) { testDb ->
             if (testDb == TestDB.MYSQL_V8 || testDb == TestDB.ORACLE) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateIndexTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateIndexTests.kt
@@ -271,7 +271,7 @@ class CreateIndexTests : DatabaseTestsBase() {
             }
         }
 
-        val functionsNotSupported = TestDB.ALL_MARIADB + TestDB.ALL_H2 + TestDB.SQLSERVER + TestDB.MYSQL_V5
+        val functionsNotSupported = TestDB.ALL_MARIADB + TestDB.ALL_H2_V2 + TestDB.SQLSERVER + TestDB.MYSQL_V5
         withTables(excludeSettings = functionsNotSupported, tester) {
             org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns()
             assertTrue(tester.exists())

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateMissingTablesAndColumnsTests.kt
@@ -254,7 +254,7 @@ class CreateMissingTablesAndColumnsTests : DatabaseTestsBase() {
         }
         val t = IntIdTable(tableName)
 
-        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.SQLITE, tables = arrayOf(initialTable)) {
+        withTables(excludeSettings = TestDB.ALL_H2_V2 + TestDB.SQLITE, tables = arrayOf(initialTable)) {
             assertEquals("ALTER TABLE ${tableName.inProperCase()} ADD ${"id".inProperCase()} ${t.id.columnType.sqlType()} PRIMARY KEY", t.id.ddl)
             assertEquals(1, currentDialectMetadataTest.tableColumns(t)[t]!!.size)
             SchemaUtils.createMissingTablesAndColumns(t)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateTableTests.kt
@@ -250,7 +250,7 @@ class CreateTableTests : DatabaseTestsBase() {
             assertEquals("ALTER TABLE $tableProperName ADD ${Person.id1.descriptionDdl(false)}", ddlId1.first())
 
             when (testDb) {
-                in TestDB.ALL_H2, TestDB.ORACLE -> {
+                in TestDB.ALL_H2_V2, TestDB.ORACLE -> {
                     assertEquals(2, ddlId2.size)
                     assertEquals("ALTER TABLE $tableProperName ADD $id2ProperName ${Person.id2.columnType.sqlType()}", ddlId2.first())
                     assertEquals("ALTER TABLE $tableProperName ADD CONSTRAINT $pkConstraintName PRIMARY KEY ($id1ProperName, $id2ProperName)", Person.id2.ddl.last())
@@ -278,7 +278,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
             when (testDb) {
                 TestDB.SQLITE -> assertEquals("ALTER TABLE $tableProperName ADD ${Book.id.descriptionDdl(false)}", ddlId1.first())
-                in TestDB.ALL_H2, TestDB.ORACLE -> assertEqualCollections(
+                in TestDB.ALL_H2_V2, TestDB.ORACLE -> assertEqualCollections(
                     listOf(
                         "ALTER TABLE $tableProperName ADD ${Book.id.descriptionDdl(false)}",
                         "ALTER TABLE $tableProperName ADD CONSTRAINT $pkConstraintName PRIMARY KEY ($id1ProperName)"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/DatabaseMigrationTests.kt
@@ -516,9 +516,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
                     val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false)
                     when (testDb) {
-                        TestDB.H2_V1 -> {
-                            assertEquals(0, statements.size)
-                        }
                         in TestDB.ALL_POSTGRES -> {
                             // previous sequence used by column is altered but no longer dropped as not linked
                             assertEquals(0, statements.size)
@@ -565,10 +562,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                             assertEquals(expectedCreateSequenceStatement("test_table_id_seq"), statements[0])
                             assertTrue(statements[1].equals(expectedDropSequenceStatement(sequenceName), ignoreCase = true))
                         }
-                        TestDB.H2_V1 -> {
-                            assertEquals(1, statements.size)
-                            assertEquals("ALTER TABLE TEST_TABLE ALTER COLUMN ID BIGINT AUTO_INCREMENT NOT NULL", statements[0])
-                        }
                         TestDB.MARIADB -> {
                             assertEquals(2, statements.size)
                             assertEquals("ALTER TABLE test_table MODIFY COLUMN id BIGINT AUTO_INCREMENT NOT NULL", statements[0])
@@ -598,10 +591,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
                     val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementCustomSequence, withLogs = false)
                     when (testDb) {
-                        TestDB.H2_V1 -> {
-                            assertEquals(1, statements.size)
-                            assertEquals(expectedCreateSequenceStatement(sequence.name), statements[0])
-                        }
                         in TestDB.ALL_POSTGRES -> {
                             // previous sequence used by column is altered but no longer dropped as not linked
                             assertEquals(1, statements.size)
@@ -631,7 +620,7 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
                     val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithoutAutoIncrement, withLogs = false)
                     when (testDb) {
-                        TestDB.H2_V1, in TestDB.ALL_POSTGRES -> {
+                        in TestDB.ALL_POSTGRES -> {
                             // previous sequence used by column is altered but no longer dropped as not linked
                             assertEquals(0, statements.size)
                         }
@@ -677,10 +666,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                             assertEquals(expectedCreateSequenceStatement("test_table_id_seq"), statements[0])
                             assertTrue(statements[1].equals(expectedDropSequenceStatement(sequence.name), ignoreCase = true))
                         }
-                        TestDB.H2_V1 -> {
-                            assertEquals(1, statements.size)
-                            assertEquals("ALTER TABLE TEST_TABLE ALTER COLUMN ID BIGINT AUTO_INCREMENT NOT NULL", statements[0])
-                        }
                         TestDB.MARIADB -> {
                             assertEquals(2, statements.size)
                             assertEquals("ALTER TABLE test_table MODIFY COLUMN id BIGINT AUTO_INCREMENT NOT NULL", statements[0])
@@ -710,10 +695,6 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
                     val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tableWithAutoIncrementSequenceName, withLogs = false)
                     when (testDb) {
-                        TestDB.H2_V1 -> {
-                            assertEquals(1, statements.size)
-                            assertEquals(expectedCreateSequenceStatement(sequenceName), statements[0])
-                        }
                         in TestDB.ALL_POSTGRES -> {
                             // previous sequence used by column is altered but no longer dropped as not linked
                             assertEquals(1, statements.size)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/DeleteTests.kt
@@ -110,7 +110,7 @@ class DeleteTests : DatabaseTestsBase() {
 
     @Test
     fun testDeleteWithMultipleAliasJoins() {
-        withCitiesAndUsers(exclude = listOf(TestDB.SQLITE)) { cities, users, userData ->
+        withCitiesAndUsers(exclude = TestDB.ALL_H2_V2 + TestDB.SQLITE) { cities, users, userData ->
             val towns = cities.alias("towns")
             val people = users.alias("people")
             val stats = userData.alias("stats")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/DeleteTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/DeleteTests.kt
@@ -110,7 +110,7 @@ class DeleteTests : DatabaseTestsBase() {
 
     @Test
     fun testDeleteWithMultipleAliasJoins() {
-        withCitiesAndUsers(exclude = TestDB.ALL_H2 + TestDB.SQLITE) { cities, users, userData ->
+        withCitiesAndUsers(exclude = listOf(TestDB.SQLITE)) { cities, users, userData ->
             val towns = cities.alias("towns")
             val people = users.alias("people")
             val stats = userData.alias("stats")
@@ -127,7 +127,7 @@ class DeleteTests : DatabaseTestsBase() {
 
     @Test
     fun testDeleteWithJoinQuery() {
-        withCitiesAndUsers(exclude = TestDB.ALL_H2_V1 + TestDB.SQLITE) { _, users, userData ->
+        withCitiesAndUsers(exclude = listOf(TestDB.SQLITE)) { _, users, userData ->
             val singleJoinQuery = userData.joinQuery(
                 on = { userData.user_id eq it[users.id] },
                 joinPart = { users.selectAll().where { users.cityId eq 2 } }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/DistinctOnTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/DistinctOnTests.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertNull
 
 class DistinctOnTests : DatabaseTestsBase() {
 
-    private val distinctOnSupportedDb = TestDB.ALL_POSTGRES + TestDB.ALL_H2
+    private val distinctOnSupportedDb = TestDB.ALL_POSTGRES + TestDB.ALL_H2_V2
 
     @Test
     fun testDistinctOn() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/ExplainTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/ExplainTests.kt
@@ -60,7 +60,7 @@ class ExplainTests : DatabaseTestsBase() {
             explainCount++
         }
 
-        withCitiesAndUsers(exclude = withH2V1(explainUnsupportedDb)) { cities, users, userData ->
+        withCitiesAndUsers(exclude = explainUnsupportedDb) { cities, users, userData ->
             val testDb = currentDialectTest
             debug = true
             statementCount = 0

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -407,7 +407,7 @@ class InsertTests : DatabaseTestsBase() {
         }
         val emojis = "\uD83D\uDC68\uD83C\uDFFF\u200D\uD83D\uDC69\uD83C\uDFFF\u200D\uD83D\uDC67\uD83C\uDFFF\u200D\uD83D\uDC66\uD83C\uDFFF"
 
-        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.SQLSERVER, table) { testDb ->
+        withTables(excludeSettings = TestDB.ALL_H2_V2 + TestDB.SQLSERVER, table) { testDb ->
             if (testDb == TestDB.MYSQL_V5) {
                 exec("ALTER TABLE ${table.nameInDatabaseCase()} DEFAULT CHARSET utf8mb4, MODIFY emoji VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")
             }
@@ -655,7 +655,7 @@ class InsertTests : DatabaseTestsBase() {
     @OptIn(InternalApi::class)
     @Test
     fun testInsertIntoNullableGeneratedColumn() {
-        withDb(excludeSettings = TestDB.ALL_H2_V1) { testDb ->
+        withDb { testDb ->
             val generatedTable = object : IntIdTable("generated_table") {
                 val amount = integer("amount").nullable()
                 val computedAmount = integer("computed_amount").nullable().databaseGenerated().apply {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/MergeBaseTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/MergeBaseTest.kt
@@ -14,7 +14,7 @@ val TEST_DEFAULT_DATE_TIME = LocalDateTime(2000, 1, 1, 0, 0, 0, 0)
 abstract class MergeBaseTest : DatabaseTestsBase() {
     protected fun allDbExcept(includeSettings: Collection<TestDB>) = TestDB.ALL - includeSettings.toSet()
 
-    protected val defaultExcludeSettings = TestDB.ALL_MARIADB + TestDB.ALL_MYSQL + TestDB.SQLITE + TestDB.ALL_H2_V1
+    protected val defaultExcludeSettings = TestDB.ALL_MARIADB + TestDB.ALL_MYSQL + TestDB.SQLITE
 
     protected fun withMergeTestTables(
         excludeSettings: Collection<TestDB> = emptyList(),

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/ReplaceTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/ReplaceTests.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertContentEquals
 
 class ReplaceTests : DatabaseTestsBase() {
 
-    private val replaceNotSupported = TestDB.ALL - TestDB.ALL_MYSQL_LIKE - TestDB.SQLITE + TestDB.ALL_H2_V1
+    private val replaceNotSupported = TestDB.ALL - TestDB.ALL_MYSQL_LIKE - TestDB.SQLITE
 
     private object NewAuth : Table("new_auth") {
         val username = varchar("username", 16)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/SelectTests.kt
@@ -339,7 +339,7 @@ class SelectTests : DatabaseTestsBase() {
         }
     }
 
-    private val inAnyAllFromTablesNotSupported = TestDB.ALL - (TestDB.ALL_POSTGRES + TestDB.ALL_H2 + TestDB.MYSQL_V8).toSet()
+    private val inAnyAllFromTablesNotSupported = TestDB.ALL - (TestDB.ALL_POSTGRES + TestDB.ALL_H2_V2 + TestDB.MYSQL_V8).toSet()
 
     @Test
     fun testInTable() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UnionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UnionTests.kt
@@ -86,8 +86,7 @@ class UnionTests : DatabaseTestsBase() {
             val sergeyQuery = users.selectAll().where { users.id eq "sergey" }
             val expectedUsers = usersQuery.map { it[users.id] } + "sergey"
             val intersectAppliedFirst = when (currentDialect) {
-                is PostgreSQLDialect, is SQLServerDialect, is MariaDBDialect -> true
-                is H2Dialect -> (currentDialect as H2Dialect).isSecondVersion
+                is PostgreSQLDialect, is SQLServerDialect, is MariaDBDialect, is H2Dialect -> true
                 else -> false
             }
             usersQuery.unionAll(usersQuery).intersect(sergeyQuery).map { it[users.id] }.apply {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpdateTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpdateTests.kt
@@ -107,7 +107,7 @@ class UpdateTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdateWithMultipleJoins() {
-        withCitiesAndUsers(exclude = TestDB.ALL_H2 + TestDB.SQLITE) { cities, users, userData ->
+        withCitiesAndUsers(exclude = TestDB.ALL_H2_V2 + TestDB.SQLITE) { cities, users, userData ->
             val join = cities.innerJoin(users).innerJoin(userData)
             join.update {
                 it[userData.comment] = users.name
@@ -131,7 +131,7 @@ class UpdateTests : DatabaseTestsBase() {
             val tableAId = reference("table_a_id", tableA)
         }
 
-        val supportWhere = TestDB.entries - TestDB.ALL_H2.toSet() - TestDB.SQLITE + TestDB.H2_V2_ORACLE
+        val supportWhere = TestDB.entries - TestDB.ALL_H2_V2.toSet() - TestDB.SQLITE + TestDB.H2_V2_ORACLE
 
         withTables(tableA, tableB) { testingDb ->
             val aId = tableA.insertAndGetId { it[foo] = "foo" }
@@ -167,7 +167,7 @@ class UpdateTests : DatabaseTestsBase() {
 
     @Test
     fun testUpdateWithJoinQuery() {
-        withCitiesAndUsers(exclude = TestDB.ALL_H2_V1 + TestDB.SQLITE) { _, users, userData ->
+        withCitiesAndUsers(exclude = listOf(TestDB.SQLITE)) { _, users, userData ->
             // single join query using join()
             val userAlias = users.selectAll().where { users.cityId neq 1 }.alias("u2")
             val joinWithSubQuery = userData.innerJoin(userAlias, { userData.user_id }, { userAlias[users.id] })
@@ -179,7 +179,7 @@ class UpdateTests : DatabaseTestsBase() {
                 assertEquals(123, it[userData.value])
             }
 
-            if (currentTestDB !in TestDB.ALL_H2) { // does not support either multi-table joins or update(where)
+            if (currentTestDB !in TestDB.ALL_H2_V2) { // does not support either multi-table joins or update(where)
                 // single join query using join() with update(where)
                 joinWithSubQuery.update({ userData.comment like "Comment%" }) {
                     it[userData.value] = 0

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
@@ -41,11 +41,11 @@ import kotlin.test.assertNotNull
 @Suppress("LargeClass")
 class UpsertTests : DatabaseTestsBase() {
     // these DB require key columns from ON clause to be included in the derived source table (USING clause)
-    private val upsertViaMergeDB = TestDB.ALL_H2 + TestDB.SQLSERVER + TestDB.ORACLE
+    private val upsertViaMergeDB = TestDB.ALL_H2_V2 + TestDB.SQLSERVER + TestDB.ORACLE
 
     @Test
     fun testUpsertWithPKConflict() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, AutoIncTable) { testDb ->
+        withTables(AutoIncTable) { testDb ->
             val id1 = AutoIncTable.insert {
                 it[name] = "A"
             } get AutoIncTable.id
@@ -75,7 +75,7 @@ class UpsertTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(idA, idB)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
+        withTables(tester) {
             val insertStmt = tester.insert {
                 it[idA] = 1
                 it[idB] = 1
@@ -119,7 +119,7 @@ class UpsertTests : DatabaseTestsBase() {
             }
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) { testDb ->
+        withTables(tester) { testDb ->
             val primaryKeyValues = Pair("User A", "Key A")
             // insert new row
             upsertOnlyKeyColumns(primaryKeyValues)
@@ -136,7 +136,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertWithUniqueIndexConflict() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
+        withTables(Words) {
             val wordA = Words.upsert {
                 it[word] = "A"
                 it[count] = 10
@@ -164,7 +164,7 @@ class UpsertTests : DatabaseTestsBase() {
             val name = varchar("name", 64)
         }
 
-        withTables(excludeSettings = TestDB.ALL_MYSQL_LIKE + TestDB.ALL_H2_V1, tester) { testDb ->
+        withTables(excludeSettings = TestDB.ALL_MYSQL_LIKE, tester) { testDb ->
             val oldIdA = tester.insert {
                 it[idA] = 1
                 it[idB] = 1
@@ -210,7 +210,7 @@ class UpsertTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(id)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
+        withTables(tester) {
             val uuid1 = tester.upsert {
                 it[title] = "A"
             } get tester.id
@@ -233,7 +233,7 @@ class UpsertTests : DatabaseTestsBase() {
 
         val okWithNoUniquenessDB = TestDB.ALL_MYSQL_LIKE + TestDB.SQLITE
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) { testDb ->
+        withTables(tester) { testDb ->
             if (testDb in okWithNoUniquenessDB) {
                 tester.upsert {
                     it[name] = "A"
@@ -251,7 +251,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testUpsertWithManualUpdateAssignment() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
+        withTables(Words) {
             val testWord = "Test"
 
             repeat(3) {
@@ -284,7 +284,7 @@ class UpsertTests : DatabaseTestsBase() {
             statement[tester.losses] = tester.losses - insertValue(tester.amount)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
+        withTables(tester) {
             val itemA = tester.upsert {
                 it[item] = "Item A"
             } get tester.item
@@ -325,7 +325,7 @@ class UpsertTests : DatabaseTestsBase() {
             val phrase = varchar("phrase", 256).defaultExpression(stringParam(defaultPhrase))
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
+        withTables(tester) {
             val testWord = "Test"
             tester.upsert { // default expression in insert
                 it[word] = testWord
@@ -368,7 +368,7 @@ class UpsertTests : DatabaseTestsBase() {
             val count = integer("count").default(1)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
+        withTables(tester) {
             tester.insert {
                 it[id] = 1
                 it[word] = "Word A"
@@ -420,7 +420,7 @@ class UpsertTests : DatabaseTestsBase() {
             val losses = integer("losses")
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester, configure = { useNestedTransactions = true }) {
+        withTables(tester, configure = { useNestedTransactions = true }) {
             val itemA = "Item A"
             tester.upsert {
                 it[item] = itemA
@@ -547,7 +547,7 @@ class UpsertTests : DatabaseTestsBase() {
             val name = varchar("name", 32)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester1, tester2) { testDb ->
+        withTables(tester1, tester2) { testDb ->
             val id1 = tester1.insertAndGetId {
                 it[name] = "foo"
             }
@@ -573,7 +573,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testBatchUpsertWithNoConflict() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
+        withTables(Words) {
             val amountOfWords = 10
             val allWords = List(amountOfWords) { i -> "Word ${'A' + i}" to amountOfWords * i + amountOfWords }
 
@@ -589,7 +589,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testBatchUpsertWithConflict() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
+        withTables(Words) {
             val vowels = listOf("A", "E", "I", "O", "U")
             val alphabet = ('A'..'Z').map { it.toString() }
             val lettersWithDuplicates = alphabet + vowels
@@ -611,7 +611,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testBatchUpsertWithSequence() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
+        withTables(Words) {
             val amountOfWords = 25
             val allWords = List(amountOfWords) { UUID.randomUUID().toString() }.asSequence()
             Words.batchUpsert(allWords) { word -> this[Words.word] = word }
@@ -624,7 +624,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testBatchUpsertWithEmptySequence() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Words) {
+        withTables(Words) {
             val allWords = emptySequence<String>()
             Words.batchUpsert(allWords) { word -> this[Words.word] = word }
 
@@ -663,7 +663,7 @@ class UpsertTests : DatabaseTestsBase() {
 
     @Test
     fun testInsertedCountWithBatchUpsert() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, AutoIncTable) { testDb ->
+        withTables(AutoIncTable) { testDb ->
             // SQL Server requires statements to be executed before results can be obtained
             val isNotSqlServer = testDb != TestDB.SQLSERVER
             val data = listOf(1 to "A", 2 to "B", 3 to "C")
@@ -765,7 +765,7 @@ class UpsertTests : DatabaseTestsBase() {
             override val primaryKey = PrimaryKey(myTableId)
         }
 
-        withTables(excludeSettings = TestDB.ALL_H2_V1, tester) {
+        withTables(tester) {
             tester.upsert {
                 it[myTableId] = 1
                 it[myTableValue] = "Hello"
@@ -809,7 +809,7 @@ class UpsertTests : DatabaseTestsBase() {
             val databaseGenerated = integer("databaseGenerated").default(-1)
         }
 
-        withTables(excludeSettings = listOf(TestDB.H2_V1), tester) {
+        withTables(tester) {
             testerWithFakeDefaults.batchUpsert(listOf(1, 2, 3)) {
                 this[testerWithFakeDefaults.number] = 10
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/CompositeIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/CompositeIdTableEntityTest.kt
@@ -256,7 +256,7 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
             }
             val found2 = Publisher.find { Publishers.isbn eq isbn }.single()
             assertEquals(p2.id, found2.id)
-            val expectedNextVal1 = if (currentTestDB in TestDB.ALL_MYSQL_LIKE || currentTestDB == TestDB.H2_V1) 579 else 1
+            val expectedNextVal1 = if (currentTestDB in TestDB.ALL_MYSQL_LIKE) 579 else 1
             assertEquals(expectedNextVal1, found2.id.value[Publishers.pubId].value)
         }
     }
@@ -300,7 +300,7 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
             val id2: EntityID<CompositeID> = Publishers.insertAndGetId {
                 it[name] = "Publisher B"
             }
-            val expectedNextVal1 = if (currentTestDB in TestDB.ALL_MYSQL_LIKE || currentTestDB == TestDB.H2_V1) 726 else 1
+            val expectedNextVal1 = if (currentTestDB in TestDB.ALL_MYSQL_LIKE) 726 else 1
             assertEquals(expectedNextVal1, id2.value[Publishers.pubId].value)
 
             // insert as composite ID
@@ -342,7 +342,7 @@ class CompositeIdTableEntityTest : DatabaseTestsBase() {
                 }
                 it[name] = "Publisher C"
             }
-            val expectedNextVal2 = if (currentTestDB in TestDB.ALL_MYSQL_LIKE || currentTestDB == TestDB.H2_V1) 1002 else 2
+            val expectedNextVal2 = if (currentTestDB in TestDB.ALL_MYSQL_LIKE) 1002 else 2
             assertEquals(expectedNextVal2, id6.value[Publishers.pubId].value)
         }
     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityTests.kt
@@ -375,7 +375,7 @@ class EntityTests : DatabaseTestsBase() {
 
     @Test
     fun testCacheInvalidatedOnDSLUpsert() {
-        withTables(excludeSettings = TestDB.ALL_H2_V1, Items) { testDb ->
+        withTables(Items) { testDb ->
             val oldPrice = 20.0
             val itemA = Item.new {
                 name = "Item A"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/functions/MathFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/functions/MathFunctionTests.kt
@@ -137,7 +137,7 @@ class MathFunctionTests : FunctionsTestBase() {
                 in (TestDB.ALL_MYSQL_MARIADB + TestDB.SQLITE) -> {
                     assertExpressionEqual(null, SqrtFunction(intLiteral(-100)))
                 }
-                in (TestDB.ALL_H2) -> {
+                in (TestDB.ALL_H2_V2) -> {
                     expectException<IllegalStateException> {
                         assertExpressionEqual(null, SqrtFunction(intLiteral(-100)))
                     }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/functions/WindowFunctionsTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/functions/WindowFunctionsTests.kt
@@ -26,7 +26,7 @@ import java.math.RoundingMode
 
 class WindowFunctionsTests : DatabaseTestsBase() {
 
-    private val supportsCountDistinctAsWindowFunction = TestDB.ALL_H2 + TestDB.ORACLE
+    private val supportsCountDistinctAsWindowFunction = TestDB.ALL_H2_V2 + TestDB.ORACLE
     private val supportsStatisticsAggregateFunctions = TestDB.ALL - listOf(TestDB.SQLSERVER, TestDB.SQLITE)
     private val supportsNthValueFunction = TestDB.ALL - TestDB.SQLSERVER
     private val supportsExpressionsInWindowFunctionArguments = TestDB.ALL - TestDB.ALL_MYSQL

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/CharColumnType.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/CharColumnType.kt
@@ -44,7 +44,7 @@ class CharColumnType : DatabaseTestsBase() {
         // H2 only allows collation for the entire database using SET COLLATION
         // Oracle only allows collation if MAX_STRING_SIZE=EXTENDED, which can only be set in upgrade mode
         // Oracle -> https://docs.oracle.com/en/database/oracle/oracle-database/12.2/refrn/MAX_STRING_SIZE.html#
-        withTables(excludeSettings = TestDB.ALL_H2 + TestDB.ORACLE, tester) {
+        withTables(excludeSettings = TestDB.ALL_H2_V2 + TestDB.ORACLE, tester) {
             val letters = listOf("a", "A", "b", "B")
             tester.batchInsert(letters) { ch ->
                 this[tester.letter] = ch

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -75,7 +75,7 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
     @Test
     fun testPreviousUByteColumnTypeWorksWithNewSmallIntType() {
         // MySQL and MariaDB type hasn't changed, and PostgreSQL and Oracle never supported TINYINT
-        withDb(TestDB.ALL_H2 - TestDB.H2_V2_PSQL + TestDB.SQLITE) { testDb ->
+        withDb(TestDB.ALL_H2_V2 - TestDB.H2_V2_PSQL + TestDB.SQLITE) { testDb ->
             try {
                 val tableName = UByteTable.nameInDatabaseCase()
                 val columnName = UByteTable.unsignedByte.nameInDatabaseCase()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ kotlinxSerialization = "1.9.0"
 slf4j = "2.0.9"
 log4j2 = "2.24.3"
 
-h2 = "1.4.200"
 h2_v2 = "2.2.224"
 mariaDB_v2 = "2.7.9"
 mariaDB_v3 = "3.3.1"
@@ -74,7 +73,6 @@ spring-context = { group = "org.springframework", name = "spring-context", versi
 spring-test = { group = "org.springframework", name = "spring-test", version.ref = "springFramework" }
 
 h2 = { group = "com.h2database", name = "h2", version.ref = "h2_v2" }
-h1 = { group = "com.h2database", name = "h2", version.ref = "h2" }
 
 log4j-slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version.ref = "log4j2" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j2" }


### PR DESCRIPTION
#### Description

**Summary of the change**: Drop support for H2 V1 in tests and where applicable in source-code

**Detailed description**:
- **Why**: Phased-out support for H2 version 1 has been documented since Exposed's initial release 0.42.0. Most new features implemented since then have not included support for or testing on this version. As a technical and db-support breaking change, 1.0.0 is a good candidate to officially drop support. Full details in [EXPOSED-30](https://youtrack.jetbrains.com/issue/EXPOSED-30/Phase-Out-Support-for-H2-Version-1.x).

- **How**:
    - Remove gradle dependencies on older H2 version
    - Remove gradle test task for `h2_v1` and `TestDB.H2_V1`
    - Remove any associated test classes or functions for older version
    - Deprecate `H2MajorVersion.One` in `H2Dialect`
    - Refactor `H2Dialect.majorVersion` so that it only returns `Two`; any other detected version throws
    - Replace all usages of `H2Dialect.isSecondVersion()`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Task

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] H2

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-30](https://youtrack.jetbrains.com/issue/EXPOSED-30/Phase-Out-Support-for-H2-Version-1.x)
