### PR TITLE
chore!: EXPOSED-844 supportsSelectForUpdate parameter from DatabaseDialect should be deprecated

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -8,6 +8,8 @@
   `R2dbcPreparedStatementApi.getResultRow()?.rowsUpdated()?.singleOrNull()`.
 * Levels of deprecated API have been bumped. See [PR #2588](https://github.com/JetBrains/Exposed/pull/2588) and
   [Migration Guide](https://www.jetbrains.com/help/exposed/migration-guide-1-0-0.html) for full details.
+* Parameter `supportsSelectForUpdate` from `DatabaseDialect` was deprecated and should not be used. The parameter was moved to `JdbcExposedDatabaseMetadata`/
+  `R2dbcExposedDatabaseMetadata` classes. It could be used with call `TransactionManager.current().connection.metadata { supportsSelectForUpdate }` now.
 
 ## 1.0.0-beta-5
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedDatabaseMetadata.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.v1.core.statements.api
 
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect.H2CompatibilityMode

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
@@ -81,6 +81,10 @@ interface DatabaseDialect {
     val supportsColumnTypeChange: Boolean get() = false
 
     /** Returns `true` if the dialect supports `SELECT FOR UPDATE` statements, `false` otherwise. */
+    @Deprecated(
+        "The parameter was moved to JdbcExposedDatabaseMetadata/R2dbcExposedDatabaseMetadata classes",
+        ReplaceWith("TransactionManager.current().connection.metadata { supportsSelectForUpdate }")
+    )
     val supportsSelectForUpdate: Boolean get() = false
 
     /** Returns `true` if the specified [e] is allowed as a default column value in the dialect, `false` otherwise. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
@@ -320,6 +320,11 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
     override val supportsOrderByNullsFirstLast: Boolean by lazy { resolveDelegatedDialect()?.supportsOrderByNullsFirstLast ?: super.supportsOrderByNullsFirstLast }
     override val supportsWindowFrameGroupsMode: Boolean by lazy { resolveDelegatedDialect()?.supportsWindowFrameGroupsMode ?: super.supportsWindowFrameGroupsMode }
     override val supportsColumnTypeChange: Boolean get() = true
+
+    @Deprecated(
+        "The parameter was moved to JdbcExposedDatabaseMetadata/R2dbcExposedDatabaseMetadata classes",
+        ReplaceWith("TransactionManager.current().connection.metadata { supportsSelectForUpdate }")
+    )
     override val supportsSelectForUpdate: Boolean get() = true
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MysqlDialect.kt
@@ -357,6 +357,10 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider.INSTA
 
     override val supportsSetDefaultReferenceOption: Boolean = false
 
+    @Deprecated(
+        "The parameter was moved to JdbcExposedDatabaseMetadata/R2dbcExposedDatabaseMetadata classes",
+        ReplaceWith("TransactionManager.current().connection.metadata { supportsSelectForUpdate }")
+    )
     override val supportsSelectForUpdate: Boolean = true
 
     /** Returns `true` if the MySQL database version is greater than or equal to 5.6. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
@@ -436,6 +436,11 @@ open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, Or
     override val supportsOrderByNullsFirstLast: Boolean = true
     override val supportsOnUpdate: Boolean = false
     override val supportsSetDefaultReferenceOption: Boolean = false
+
+    @Deprecated(
+        "The parameter was moved to JdbcExposedDatabaseMetadata/R2dbcExposedDatabaseMetadata classes",
+        ReplaceWith("TransactionManager.current().connection.metadata { supportsSelectForUpdate }")
+    )
     override val supportsSelectForUpdate: Boolean = true
 
     // Preventing the deletion of a parent row if a child row references it is the default behaviour in Oracle.

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
@@ -372,6 +372,10 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
 
     override val supportsWindowFrameGroupsMode: Boolean = true
 
+    @Deprecated(
+        "The parameter was moved to JdbcExposedDatabaseMetadata/R2dbcExposedDatabaseMetadata classes",
+        ReplaceWith("TransactionManager.current().connection.metadata { supportsSelectForUpdate }")
+    )
     override val supportsSelectForUpdate: Boolean = true
 
     override fun isAllowedAsColumnDefault(e: Expression<*>): Boolean = true

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Query.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Query.kt
@@ -6,7 +6,6 @@ import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.less
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.statements.api.ResultApi
 import org.jetbrains.exposed.v1.core.vendors.ForUpdateOption
-import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.jdbc.statements.BlockingExecutable
 import org.jetbrains.exposed.v1.jdbc.statements.StatementIterator
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
@@ -37,8 +36,9 @@ open class Query(
     }
 
     override fun forUpdate(option: ForUpdateOption): Query {
+        val supportsSelectForUpdate = TransactionManager.current().connection.metadata { supportsSelectForUpdate }
         @OptIn(InternalApi::class)
-        this.forUpdate = if (option is ForUpdateOption.NoForUpdateOption || currentDialect.supportsSelectForUpdate) {
+        this.forUpdate = if (option is ForUpdateOption.NoForUpdateOption || supportsSelectForUpdate) {
             option
         } else {
             null

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/SelectTests.kt
@@ -642,11 +642,7 @@ class SelectTests : R2dbcDatabaseTestsBase() {
             val query = cities.selectAll()
                 .forUpdate()
 
-            query.prepareSQL(TransactionManager.current())
-                .let { sql ->
-                    println(sql)
-                    assertTrue(sql.contains("FOR UPDATE"))
-                }
+            assertTrue(query.prepareSQL(TransactionManager.current()).contains("FOR UPDATE"))
         }
     }
 }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/SelectTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/SelectTests.kt
@@ -17,8 +17,10 @@ import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.forEach
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.expectException
 import org.jetbrains.exposed.v1.r2dbc.tests.sorted
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import org.junit.Test
 import kotlin.test.assertNull
 
@@ -631,6 +633,20 @@ class SelectTests : R2dbcDatabaseTestsBase() {
                 val offsetResult = alphabet.selectAll().offset(start).map { it[alphabet.letter] }
                 assertEqualLists(allLetters.drop(start.toInt()), offsetResult)
             }
+        }
+    }
+
+    @Test
+    fun testSelectForUpdate() {
+        withCitiesAndUsers(exclude = listOf(TestDB.SQLSERVER)) { cities, _, _ ->
+            val query = cities.selectAll()
+                .forUpdate()
+
+            query.prepareSQL(TransactionManager.current())
+                .let { sql ->
+                    println(sql)
+                    assertTrue(sql.contains("FOR UPDATE"))
+                }
         }
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Query.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Query.kt
@@ -43,6 +43,7 @@ open class Query(
 
     override fun forUpdate(option: ForUpdateOption): Query {
         // Should we make the whole method `forUpdate` suspend, or should we think about an option to get metadata synchronously?
+        // TODO remove runBlocking after introducing non-suspend metadata
         val supportsSelectForUpdate = runBlocking { TransactionManager.current().connection.metadata { supportsSelectForUpdate } }
         @OptIn(InternalApi::class)
         this.forUpdate = if (option is ForUpdateOption.NoForUpdateOption || supportsSelectForUpdate) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/SelectTests.kt
@@ -664,11 +664,7 @@ class SelectTests : DatabaseTestsBase() {
             val query = cities.selectAll()
                 .forUpdate()
 
-            query.prepareSQL(TransactionManager.current())
-                .let { sql ->
-                    println(sql)
-                    assertTrue(sql.contains("FOR UPDATE"))
-                }
+            assertTrue(query.prepareSQL(TransactionManager.current()).contains("FOR UPDATE"))
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/SelectTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/SelectTests.kt
@@ -1,8 +1,10 @@
 package org.jetbrains.exposed.v1.tests.shared.dml
 
+import junit.framework.TestCase.assertTrue
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.jdbc.*
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
@@ -653,6 +655,20 @@ class SelectTests : DatabaseTestsBase() {
                 val offsetResult = alphabet.selectAll().offset(start).map { it[alphabet.letter] }
                 assertEqualLists(allLetters.drop(start.toInt()), offsetResult)
             }
+        }
+    }
+
+    @Test
+    fun testSelectForUpdate() {
+        withCitiesAndUsers(exclude = listOf(TestDB.SQLSERVER, TestDB.SQLITE)) { cities, _, _ ->
+            val query = cities.selectAll()
+                .forUpdate()
+
+            query.prepareSQL(TransactionManager.current())
+                .let { sql ->
+                    println(sql)
+                    assertTrue(sql.contains("FOR UPDATE"))
+                }
         }
     }
 }


### PR DESCRIPTION
#### Description

Parameter `supportsSelectForUpdate` from `DatabaseDialect` was deprecated and should not be used. The parameter was moved to `JdbcExposedDatabaseMetadata`/`R2dbcExposedDatabaseMetadata` classes. 

It could be used with call `TransactionManager.current().connection.metadata { supportsSelectForUpdate }` now.

---

#### Type of Change

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [ ] SqlServer
- [X] H2
- [] SQLite

---

#### Related Issues

[EXPOSED-844](https://youtrack.jetbrains.com/issue/EXPOSED-844) supportsSelectForUpdate parameter from DatabaseDialect should be deprecated
