### PR TITLE
fix: [H2] R2dbcDatabase.name parsing error returns all url properties

### DIFF
--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabase.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabase.kt
@@ -59,7 +59,7 @@ class R2dbcDatabase private constructor(
                 @OptIn(InternalApi::class)
                 dialects[vendor.lowercase()]?.invoke()
             }
-            ?: error("No dialect registered for $name. URL=$url")
+            ?: error("No dialect registered for the database connected using URL=$url")
     }
 
     /** The name of the database as a [DatabaseDialectMetadata]. */
@@ -251,4 +251,7 @@ class R2dbcDatabase private constructor(
 
 /** Returns the name of the database obtained from its connection URL. */
 val R2dbcDatabase.name: String
-    get() = url.substringBefore('?').substringAfterLast('/')
+    get() {
+        val propertyDelimiter = if (dialect is H2Dialect) ';' else '?'
+        return url.substringBefore(propertyDelimiter).substringAfterLast('/')
+    }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
@@ -49,7 +49,7 @@ class R2dbcConnectionImpl(
     }
 
     override suspend fun setCatalog(value: String) {
-        withConnection { executeSQL(metadataProvider.getCatalog()) }
+        withConnection { executeSQL(metadataProvider.setCatalog(value)) }
     }
 
     override suspend fun getSchema(): String = withConnection {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/vendors/metadata/OracleMetadata.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/vendors/metadata/OracleMetadata.kt
@@ -83,7 +83,12 @@ internal class OracleMetadata : MetadataProvider(OraclePropertyProvider, OracleT
 
     override fun getDatabaseMode(): String = ""
 
-    override fun getCatalog(): String = ""
+    override fun getCatalog(): String {
+        return buildString {
+            append("SELECT SYS_CONTEXT('userenv','db_name') AS TABLE_CAT ")
+            append("FROM DUAL")
+        }
+    }
 
     override fun setCatalog(value: String): String = ""
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Fix `R2dbcDatabase.name` logic to no longer return database name + all connection url property key-value pairs.

**Detailed description**:
- **Why**:

In H2 JDBC, calling `Database.name` returns the full prefix of the connection url, like `jdbc:h2:mem:regular`. It is assumed that this is the original return value because of the potential variety of H2 connection url string prefixes.
With R2DBC, calling `R2dbcDatabase.name` returns the database name, but with every single property following attached, like `regular;MODE-...;DB_CLOSE_DELAY=...`. The full prefix is not returned because h2-r2dbc urls always have a `///` delimiter, regardless of connection type.

The same parsing logic used for JDBC does not work for R2DCB because the url being used is the user-defined string obtained when `connect()` is called. Whereas JDBC relies on a metadata check that returns a truncated url string, with properties already removed.

**Additional:**
* Addressed obsolete TODO; test was just copied from jdbc incorrectly
* Fixed incorrect call to `QueryProvider.getCatalog()` inside `setCatalog()` and added unit test to cover

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] H2

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues
