### PR TITLE
fix: EXPOSED-801 NoClassDefFoundError when using exposed-json with pg-r2dbc dependency only

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3583,6 +3583,7 @@ public abstract interface class org/jetbrains/exposed/v1/core/statements/api/Row
 	public abstract fun getObject (Ljava/lang/String;)Ljava/lang/Object;
 	public abstract fun getObject (Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
 	public abstract fun getObject (Ljava/lang/String;Ljava/lang/Class;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
+	public abstract fun getString (I)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/v1/core/statements/api/RowApi$DefaultImpls {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ResultApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ResultApi.kt
@@ -92,4 +92,12 @@ interface RowApi {
      * @return The object converted to the specified type
      */
     fun <T> getObject(name: String, type: Class<T>, columnType: IColumnType<*>): T? = getObject(name, type)
+
+    /**
+     * Retrieves the value from the current data row at the specified [index] position as a String.
+     *
+     * @param index The first column is at position one, the second at position two, and onwards.
+     * @return The string at the specified index or `null` if SQL NULL is retrieved
+     */
+    fun getString(index: Int): String?
 }

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -736,6 +736,7 @@ public final class org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult : or
 	public fun getObject (Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
 	public fun getObject (Ljava/lang/String;Ljava/lang/Class;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
 	public final fun getResult ()Ljava/sql/ResultSet;
+	public fun getString (I)Ljava/lang/String;
 	public fun mapRows (Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
 	public final fun next ()Z
 	public final fun releaseResult ()V

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult.kt
@@ -37,6 +37,8 @@ class JdbcResult(
 
     override fun <T> getObject(name: String, type: Class<T>): T? = result.getObject(name, type)
 
+    override fun getString(index: Int): String? = result.getString(index)
+
     /**
      * Moves from the current position in the [ResultSet] to the next row and returns `true`,
      * or returns `false` if there are no more rows to move forward to.

--- a/exposed-json/api/exposed-json.api
+++ b/exposed-json/api/exposed-json.api
@@ -40,10 +40,10 @@ public class org/jetbrains/exposed/v1/json/JsonColumnType : org/jetbrains/expose
 	public final fun getDeserialize ()Lkotlin/jvm/functions/Function1;
 	public final fun getSerialize ()Lkotlin/jvm/functions/Function1;
 	public fun getUsesBinaryFormat ()Z
-	public fun nonNullValueAsDefaultString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun notNullValueToDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
+	public fun readObject (Lorg/jetbrains/exposed/v1/core/statements/api/RowApi;I)Ljava/lang/Object;
 	public fun setParameter (Lorg/jetbrains/exposed/v1/core/statements/api/PreparedStatementApi;ILjava/lang/Object;)V
 	public fun sqlType ()Ljava/lang/String;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;

--- a/exposed-json/build.gradle.kts
+++ b/exposed-json/build.gradle.kts
@@ -16,7 +16,6 @@ kotlin {
 dependencies {
     api(project(":exposed-core"))
     api(libs.kotlinx.serialization)
-    compileOnly(libs.postgre)
     testImplementation(project(":exposed-dao"))
     testImplementation(project(":exposed-tests"))
     testImplementation(project(":exposed-jdbc"))

--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/v1/json/JsonConditions.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/v1/json/JsonConditions.kt
@@ -62,7 +62,6 @@ fun ExpressionWithColumnType<*>.contains(candidate: Expression<*>, path: String?
  * @sample org.jetbrains.exposed.v1.json.JsonColumnTests.testJsonContains
  */
 fun <T> ExpressionWithColumnType<*>.contains(candidate: T, path: String? = null): Contains = when (candidate) {
-    is Iterable<*>, is Array<*> -> Contains(this, stringLiteral(asLiteral(candidate).toString()), path, columnType)
     is String -> Contains(this, stringLiteral(candidate), path, columnType)
     else -> Contains(this, asLiteral(candidate), path, columnType)
 }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
@@ -244,10 +244,10 @@ class JsonBColumnTests : DatabaseTestsBase() {
                     SchemaUtils.createMissingTablesAndColumns(defaultTester)
                 }
             } else {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(defaultTester)
+                SchemaUtils.createMissingTablesAndColumns(defaultTester)
                 assertTrue(defaultTester.exists())
                 // ensure defaults match returned metadata defaults
-                val alters = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 assertTrue(alters.isEmpty())
 
                 defaultTester.insert {}
@@ -260,7 +260,7 @@ class JsonBColumnTests : DatabaseTestsBase() {
                     assertEquals(defaultUser.team, it[defaultTester.user2].team)
                 }
 
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(defaultTester)
+                SchemaUtils.drop(defaultTester)
             }
         }
     }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonColumnTests.kt
@@ -312,10 +312,10 @@ class JsonColumnTests : DatabaseTestsBase() {
                     SchemaUtils.createMissingTablesAndColumns(defaultTester)
                 }
             } else {
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.createMissingTablesAndColumns(defaultTester)
+                SchemaUtils.createMissingTablesAndColumns(defaultTester)
                 assertTrue(defaultTester.exists())
                 // ensure defaults match returned metadata defaults
-                val alters = org.jetbrains.exposed.v1.jdbc.SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
+                val alters = SchemaUtils.statementsRequiredToActualizeScheme(defaultTester)
                 assertTrue(alters.isEmpty())
 
                 defaultTester.insert {}
@@ -328,7 +328,7 @@ class JsonColumnTests : DatabaseTestsBase() {
                     assertEquals(defaultUser.team, it[defaultTester.user2].team)
                 }
 
-                org.jetbrains.exposed.v1.jdbc.SchemaUtils.drop(defaultTester)
+                SchemaUtils.drop(defaultTester)
             }
         }
     }

--- a/exposed-r2dbc-tests/build.gradle.kts
+++ b/exposed-r2dbc-tests/build.gradle.kts
@@ -57,7 +57,6 @@ dependencies {
     testRuntimeOnly(libs.r2dbc.mysql)
     testRuntimeOnly(libs.r2dbc.oracle)
     testImplementation(libs.r2dbc.postgresql)
-    testCompileOnly(libs.postgre)
     testRuntimeOnly(libs.r2dbc.sqlserver)
 
     testImplementation(libs.logcaptor)

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -789,6 +789,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2DBCRow : org/
 	public fun getObject (Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
 	public fun getObject (Ljava/lang/String;Ljava/lang/Class;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
 	public final fun getRow ()Lio/r2dbc/spi/Row;
+	public fun getString (I)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl : org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcExposedDatabaseMetadata {

--- a/exposed-r2dbc/build.gradle.kts
+++ b/exposed-r2dbc/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
 
     implementation(libs.slf4j)
 
-    compileOnly(libs.postgre)
     compileOnly(libs.r2dbc.postgresql)
 }
 

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PostgresSpecificTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PostgresSpecificTypeMapper.kt
@@ -6,7 +6,6 @@ import io.r2dbc.spi.Statement
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
-import org.postgresql.util.PGobject
 import kotlin.reflect.KClass
 
 /**
@@ -21,8 +20,16 @@ class PostgresSpecificTypeMapper : TypeMapper {
         get() = listOf(PostgreSQLDialect::class)
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> getValue(row: Row, type: Class<T>?, index: Int, dialect: DatabaseDialect, columnType: IColumnType<*>): ValueContainer<T?> {
-        val value = type?.let { row.get(index - 1, it) } ?: row.get(index - 1) as T?
+    override fun <T> getValue(
+        row: Row,
+        type: Class<T>?,
+        index: Int,
+        dialect: DatabaseDialect,
+        columnType: IColumnType<*>
+    ): ValueContainer<T?> {
+        val value = type
+            ?.let { row.get(index - 1, it) }
+            ?: row.get(index - 1) as T?
 
         return when (value) {
             // It will return always the string, event if it doesn't match `type`
@@ -50,9 +57,6 @@ class PostgresSpecificTypeMapper : TypeMapper {
 
         if (value == null) {
             statement.bindNull(index - 1, Json::class.java)
-            return true
-        } else if (value is PGobject) {
-            statement.bind(index - 1, Json.of(value.value!!))
             return true
         } else if (value is String) {
             statement.bind(index - 1, Json.of(value))

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcResult.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcResult.kt
@@ -104,6 +104,8 @@ class R2DBCRow(val row: Row, private val typeMapping: R2dbcTypeMapping) : RowApi
     override fun <T> getObject(index: Int, type: Class<T>?, columnType: IColumnType<*>): T? {
         return typeMapping.getValue(row, type, index, currentDialect, columnType)
     }
+
+    override fun getString(index: Int): String? = row.get(index - 1, java.lang.String::class.java)?.toString()
 }
 
 /**


### PR DESCRIPTION
#### Description

**Summary of the change**: Remove all dependencies on PG-JDBC from both `exposed-json` and R2DBC modules.

**Detailed description**:
- **Why**: If a project is started with Exposed + PostgreSQL R2DBC + JSON, a runtime dependency on PostgreSQL JDBC is required; otherwise at some point most likely a `NoClassDefFoundError` for `PGobject` will be experienced. This occurs because `JsonColumnType` logic relies on JDBC `PGobject` to send and retrieve JSON values.

- **How**:
    -  All uses of `PGobject` removed from both `exposed-json` and `exposed-r2dbc`
    - `JsonColumnType` now treats JSON values directly as a String by casting `::json` when sending to the database and retrieving directly as a string when reading results.
        - Surprisingly, `ResultSet.getString(index)` is not equivalent to `ResultSet.getObject(index, java.lang.String::class.java)?.toString()`. So for JDBC to continue working, `RowApi.getString()` had to be introduced.
    - JSON strings were not originally wrapped with `''`. So taking generated SQL, like from `insert()`, was not working with `exec()`. Adding quotes was also needed for casting, so all string values now include quotes. 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All - _that support JSON/JSONB_

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-801](https://youtrack.jetbrains.com/issue/EXPOSED-801/NoClassDefFoundError-when-using-exposed-json-with-postgresql-r2dbc-dependency-only)