### PR TITLE
chore: Remove obsolete or reprioritized Todos

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
@@ -145,7 +145,6 @@ interface DatabaseConfig {
             val builder = Builder().apply(body)
             require(builder.defaultMaxAttempts > 0) { "defaultMaxAttempts must be set to perform at least 1 attempt." }
 
-            // TODO make default implementation to simplify & call constructor func instead
             return object : DatabaseConfig {
                 override val sqlLogger: SqlLogger
                     get() = builder.sqlLogger ?: Slf4jSqlDebugLogger

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/InsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/InsertStatement.kt
@@ -47,7 +47,6 @@ open class InsertStatement<Key : Any>(
      * retrieved from the database or if the column cannot be found in the row.
      */
     fun <T> getOrNull(column: Column<T>): T? = resultedValues?.firstOrNull()?.getOrNull(column)
-    // TODO: log issue about unifying process result method for jdbc and r2dbc
 
     @OptIn(InternalApi::class)
     @Suppress("NestedBlockDepth")

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DateTimeLiteralTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DateTimeLiteralTest.kt
@@ -12,8 +12,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.test.assertNotNull
 
-// TODO think about design of datetime module packages & extracting tests to JDBC + R2DBC test modules
-
 class DateTimeLiteralTest : DatabaseTestsBase() {
     private val defaultDate = LocalDate.of(2000, 1, 1)
     private val futureDate = LocalDate.of(3000, 1, 1)

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/experimental/Suspended.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/experimental/Suspended.kt
@@ -214,7 +214,6 @@ private fun <T> TransactionScope.suspendedTransactionAsyncInternal(
                 handleSQLException(cause, transaction, attempts)
                 attempts++
                 if (attempts >= transaction.maxAttempts) {
-                    // TODO Probably we should wrap the exception to indicate attempts
                     throw cause
                 }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/FetchBatchedResultsTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/FetchBatchedResultsTests.kt
@@ -18,7 +18,6 @@ import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
 import org.junit.Test
 import java.util.*
 
-// Todo Confirm return type of fetchBatchedResults() & expected behavior on collection
 // not possible to avoid emitting an empty flow, so tests needed to be altered to remove empty flow results
 class FetchBatchedResultsTests : R2dbcDatabaseTestsBase() {
     @Test

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
@@ -713,6 +713,10 @@ fun <T : Table> T.upsertReturning(
 /**
  * Represents the SQL statement that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
  *
+ * **Note:** It is a known limitation that R2DBC drivers for H2 and MariaDB do not return a means to access both the generated
+ * values and the updated row count from a single statement execution. If the database-accurate updated row count is required,
+ * via [BatchUpsertStatement.insertedCount], then [shouldReturnGeneratedValues] should be set to false.
+ *
  * @param data Collection of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,
  * primary keys will be used. If the table does not have any primary keys, the first unique index will be attempted.
@@ -741,6 +745,10 @@ suspend fun <T : Table, E : Any> T.batchUpsert(
 
 /**
  * Represents the SQL statement that either batch inserts new rows into a table, or updates the existing rows if insertions violate unique constraints.
+ *
+ * **Note:** It is a known limitation that R2DBC drivers for H2 and MariaDB do not return a means to access both the generated
+ * values and the updated row count from a single statement execution. If the database-accurate updated row count is required,
+ * via [BatchUpsertStatement.insertedCount], then [shouldReturnGeneratedValues] should be set to false.
  *
  * @param data Sequence of values to use in batch upsert.
  * @param keys (optional) Columns to include in the condition that determines a unique constraint match. If no columns are provided,

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Query.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Query.kt
@@ -144,6 +144,11 @@ open class Query(
      *
      * This query's [FieldSet] will be ordered by the first auto-increment column.
      *
+     * **Note:** There is a possibility that the final batched sub-collection emitted may be empty, as the flow of results
+     * cannot be pre-checked before being yielded. Whether the amount of results retrieved is less than the provided batch
+     * size will not be determined until the batch is consumed on the user-end, which means the amount of results in a
+     * batch may be zero.
+     *
      * @param batchSize Size of each sub-collection to return.
      * @param sortOrder Order in which the results should be retrieved.
      * @return Retrieved results as a collection of batched [ResultRow] sub-collections.

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
@@ -209,7 +209,6 @@ open class InsertSuspendExecutable<Key : Any, S : InsertStatement<Key>>(
             // which leads to incorrect stored values in the insert statement;
             // If an insert did not occur, no generated values should be received and stored statement
             // values should be generated based on user-provided values
-            // Todo review potential edge cases not covered by tests
             count?.let { c ->
                 resultSetsCounts.add(c)
                 values.takeIf { sendsResultsOnFailure && c != 0 }?.let { resultSetsValues.add(it) }
@@ -218,8 +217,7 @@ open class InsertSuspendExecutable<Key : Any, S : InsertStatement<Key>>(
         }
 
         // Some databases, like H2 and MariaDB, aren't returning UpdateCount segments;
-        // The workaround below therefore fails for upsert operations
-        // Todo review alternatives for these dialects
+        // The workaround below therefore fails for upsert operations; documented in upsert()
         val inserted = if (resultSetsCounts.isEmpty()) {
             resultSetsValues.size
         } else {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
@@ -210,18 +210,6 @@ class R2dbcConnectionImpl(
 
     private var localConnection: Connection? = null
 
-    // TODO Recheck the reason of creating new context with `scope.coroutineContext`
-    //   It couses the issues `No transaction in context` if Exposed is used inside ktor server
-    //   To reproduce the problem it's enough to run the following script with any table Customers inside the server code
-    //   runBlocking {
-    //        val database = R2dbcDatabase.connect("r2dbc:h2:mem:///testdb;DB_CLOSE_DELAY=-1")
-    //        suspendTransaction(db = database) {
-    //            SchemaUtils.create(Customers)
-    //        }
-    //    }
-    //
-    //    Old function definition
-    //    private suspend fun <T> withConnection(body: suspend Connection.() -> T): T = withContext(scope.coroutineContext) {
     private suspend fun <T> withConnection(body: suspend Connection.() -> T): T {
         if (localConnection == null) {
             localConnection = connection.awaitFirst().also {


### PR DESCRIPTION
#### Description

**Summary of the change**: Remove some of the existing TODOs based on planning discussion

**Detailed description**:
- **Why**: These TODOs fall into 1 of 3 categories:
    - Agreed to be obsolete or no longer worth pursuing
    - Little to be done on our end, so known limitations have been documented
    - Further steps or refactorings may be addressed post-V1 & YT tickets have been created

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - TODOs