### PR TITLE
build: Include api(exposed-jdbc) dependency with spring-transaction

### DIFF
--- a/exposed-spring-boot-starter/build.gradle.kts
+++ b/exposed-spring-boot-starter/build.gradle.kts
@@ -21,9 +21,6 @@ dependencies {
     api(project(":exposed-core"))
     api(project(":exposed-dao"))
     api(project(":spring-transaction"))
-    // TODO how to avoid this
-    //  Should we create r2dbc-spring-boot-starter module?
-    compileOnly(project(":exposed-jdbc"))
     api(libs.spring.boot.starter.jdbc)
     api(libs.spring.boot.autoconfigure)
     compileOnly(libs.spring.boot.configuration.processor)

--- a/spring-transaction/build.gradle.kts
+++ b/spring-transaction/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
 
 dependencies {
     api(project(":exposed-core"))
-    implementation(project(":exposed-jdbc"))
+    api(project(":exposed-jdbc"))
     api(libs.spring.jdbc)
     api(libs.spring.context)
     implementation(libs.kotlinx.coroutines)


### PR DESCRIPTION
#### Description

**Summary of the change**: Expose the jdbc module with dependencies on `spring-transaction`.

**Detailed description**:
- **Why**: After many core classes were extracted to `exposed-jdbc`, a `compileOnly()` dependency was included in both  `spring-transaction` and `exposed-spring-boot-starter` to allow them to work. More than likely, a dependency on these modules will still require the user to add a dependency on `exposed-jdbc` to get other aspects of previously core code to work. So the dependency has been switched to `api()` in `spring-transaction`, on which `exposed-spring-boot-starter` already has a full dependency.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Dependency change

---

#### Related Issues
[EXPOSED-818](https://youtrack.jetbrains.com/issue/EXPOSED-818/Add-SpringTransactionManager-and-autoconfiguration-compatible-with-R2DBC)
[EXPOSED-840](https://youtrack.jetbrains.com/issue/EXPOSED-840/Enable-spring-boot-starter-that-does-not-rely-on-JDBC)