### PR TITLE
build: Include api(exposed-jdbc) dependency with exposed-migration

### DIFF
--- a/exposed-migration/build.gradle.kts
+++ b/exposed-migration/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     api(project(":exposed-core"))
-    compileOnly(project(":exposed-jdbc"))
+    api(project(":exposed-jdbc"))
 
     testImplementation(platform("org.junit:junit-bom:5.13.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
#### Description

**Summary of the change**: Expose the jdbc module with dependencies on `exposed-migration`.

**Detailed description**:
- **Why**: After many core classes were extracted to `exposed-jdbc`, a `compileOnly()` dependency was included in `exposed-migration`.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Dependency change

---

#### Related Issues
[EXPOSED-841](https://youtrack.jetbrains.com/issue/EXPOSED-841/Enable-exposed-migration-that-does-not-rely-on-JDBC)