### PR TITLE
chore!: Drop return value of R2dbcPreparedStatementApi.executeUpdate()

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,12 @@
 # Breaking Changes
 
+## 1.0.0-beta-6 <!--- temp name; potential RC -->
+
+* `R2dbcPreparedStatementApi.executeUpdate()` no longer returns a value. It was previously defined as returning an integer of the affected row count,
+  as per the JDBC variant, but it always returned a value of zero due to the nature of R2DBC result processing. If you wish to still retrieve the affected
+  row count manually after calling `executeUpdate()` (and have no further need of the statement results after), this can be achieved by calling
+  `R2dbcPreparedStatementApi.getResultRow()?.rowsUpdated()?.singleOrNull()`.
+
 ## 1.0.0-beta-5
 
 * Migration of kotlinx-datetime from version 6 to version 7. The only package affected is `exposed-kotlin-datetime`. `KotlinInstantColumnType`, and

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcPreparedStatementImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcPreparedStatementImpl.kt
@@ -59,13 +59,10 @@ class R2dbcPreparedStatementImpl(
 
     override suspend fun executeQuery(): R2dbcResult = R2dbcResult(statement.execute(), typeMapping)
 
-    override suspend fun executeUpdate(): Int {
+    override suspend fun executeUpdate() {
         val result = statement.execute()
         val r2dbcResult = R2dbcResult(result, typeMapping)
         resultRow = r2dbcResult
-
-        // Todo discuss if a return value is even necessary (since never used)
-        return 0
     }
 
     override suspend fun executeMultiple(): List<StatementResult> {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi.kt
@@ -25,11 +25,8 @@ interface R2dbcPreparedStatementApi : PreparedStatementApi {
 
     /**
      * Executes an SQL statement stored in an [io.r2dbc.spi.Statement].
-     *
-     * @return The affected row count if the executed statement is a DML type;
-     * otherwise, 0 if the statement returns nothing.
      */
-    suspend fun executeUpdate(): Int
+    suspend fun executeUpdate()
 
     /**
      * Executes multiple SQL statements stored in a single [io.r2dbc.spi.Statement].


### PR DESCRIPTION
#### Description

**Summary of the change**: Remove the `Int` return type of `R2dbcPreparedStatementApi.executeUpdate()`

**Detailed description**:
- **Why**: The R2DBC method was initially introduced to be an exact mimic of JDBC's `executeUpdate()`, which returns the affected row count easily after statement execution.

With R2DBC, the SPI firstly only has the method `execute()`.
Secondly, statement execution does not so easily return both affected row count and generated result values, which needs to be kept open as an option for every subclass of `InsertStatement`.
So `executeUpdate()` was never being used to check the affected row count and always returned a value of 0.
Instead, when it is certain what the results will be consumed for, `getResultRow()?.rowsUpdated()?.singleOrNull()` is called instead.
If the latter was directly called inside `executeUpdate()`, any further processing of the execution result would not be possible, due to this SPI logic:

> After emitting the update count, a Result object gets invalidated and rows from the same Result object can no longer be consumed.

[reference](https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/)

Example in [UpdateSuspendExecutable](https://github.com/JetBrains/Exposed/blob/main/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/UpdateSuspendExecutable.kt#L12)

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Refactor

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date