### PR TITLE
chore: Move logic from JavaLocalTimeColumnType to type mappers

### DIFF
--- a/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/v1/javatime/JavaDateColumnType.kt
+++ b/exposed-java-time/src/main/kotlin/org/jetbrains/exposed/v1/javatime/JavaDateColumnType.kt
@@ -11,8 +11,6 @@ import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
 import java.util.*
 
-private const val ORACLE_START_YEAR = 1970
-
 private val DEFAULT_DATE_STRING_FORMATTER by lazy {
     DateTimeFormatter.ISO_LOCAL_DATE.withLocale(Locale.ROOT).withZone(ZoneId.systemDefault())
 }
@@ -358,24 +356,10 @@ class JavaLocalTimeColumnType : ColumnType<LocalTime>(), IDateColumnType {
         else -> valueFromDB(value.toString())
     }
 
-    // TODO check if we still need it after introducing type mappers?
-    override fun notNullValueToDB(value: LocalTime): Any {
-        val dialect = currentDialect
-        return when {
-            dialect is SQLiteDialect -> {
-                DEFAULT_TIME_STRING_FORMATTER.format(value)
-            }
-
-            dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle -> {
-                // For Oracle dialect, convert LocalTime to java.sql.Timestamp with a fixed date (1970-01-01)
-                val dateTime = LocalDateTime.of(LocalDate.of(ORACLE_START_YEAR, 1, 1), value)
-                java.sql.Timestamp.valueOf(dateTime)
-            }
-
-            else -> {
-                java.sql.Time.valueOf(value)
-            }
-        }
+    override fun notNullValueToDB(value: LocalTime): Any = when {
+        currentDialect is SQLiteDialect -> DEFAULT_TIME_STRING_FORMATTER.format(value)
+        currentDialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle -> ORACLE_TIME_STRING_FORMATTER.format(value)
+        else -> java.sql.Time.valueOf(value)
     }
 
     override fun nonNullValueAsDefaultString(value: LocalTime): String = when (currentDialect) {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/JavaTimeTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/JavaTimeTests.kt
@@ -456,8 +456,7 @@ class JavaTimeTests : R2dbcDatabaseTestsBase() {
             val timestamp_col = timestamp("timestamp_col")
         }
 
-        // TODO MYSQL_V8 test does not work on R2DBC now. The problem is that received timestamp is shifted by timezone.
-        withTables(excludeSettings = listOf(TestDB.MYSQL_V8), tester) {
+        withTables(tester) {
             assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
 
             val instant = Instant.now().asJdk8()

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/KotlinTimeTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/KotlinTimeTests.kt
@@ -506,8 +506,7 @@ class KotlinTimeTests : R2dbcDatabaseTestsBase() {
             val x_timestamp_col = xTimestamp("timestamp_col")
         }
 
-        // TODO MYSQL_V8 test does not work on R2DBC now. The problem is that received timestamp is shifted by timezone.
-        withTables(excludeSettings = listOf(TestDB.MYSQL_V8), tester) {
+        withTables(tester) {
             assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
 
             val instant = Clock.System.nowAsJdk8()
@@ -531,8 +530,7 @@ class KotlinTimeTests : R2dbcDatabaseTestsBase() {
             val timestamp_col = timestamp("timestamp_col")
         }
 
-        // TODO MYSQL_V8 test does not work on R2DBC now. The problem is that received timestamp is shifted by timezone.
-        withTables(excludeSettings = listOf(TestDB.MYSQL_V8), tester) {
+        withTables(tester) {
             assertEquals("Africa/Cairo", ZoneId.systemDefault().id)
 
             val instant = Clock.System.nowAsJdk8()

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeOracleTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/DateTimeOracleTypeMapper.kt
@@ -48,6 +48,14 @@ class DateTimeOracleTypeMapper : TypeMapper {
                 }
             }
         }
+        if (value is String) {
+            when {
+                dialect is H2Dialect && dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle -> {
+                    statement.bind(index - 1, Timestamp.valueOf(value).toLocalDateTime())
+                    return true
+                }
+            }
+        }
 
         return false
     }


### PR DESCRIPTION
#### Description

Here is the solving of yet another r2dbc todo item.

The method `JavaLocalTimeColumnType::notNullValueToDB()` is slightly cleaned by extracting the logic to type mappers layer.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Chore

Affected databases:
- [X] Oracle
- [X] H2
