### PR TITLE
docs: fix: EXPOSED-853 Wrong import shown in exposed-kotlin-datetime example

### DIFF
--- a/documentation-website/Writerside/topics/Date-and-time-types.topic
+++ b/documentation-website/Writerside/topics/Date-and-time-types.topic
@@ -59,7 +59,7 @@
         import org.jetbrains.exposed.v1.core.Table
 
         // For exposed-kotlin-datetime (recommended)
-        import org.jetbrains.exposed.v1.kotlin.datetime.*
+        import org.jetbrains.exposed.v1.datetime.*
 
         // For exposed-java-time
         import org.jetbrains.exposed.v1.javatime.*


### PR DESCRIPTION
#### Type of Change

- [x] Documentation update

#### Related Issues

[EXPOSED-853](https://youtrack.jetbrains.com/issue/EXPOSED-853) Wrong import in date-and-time-types.topic
