### PR TITLE
chore: Remove more obsolete TODOs

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3507,7 +3507,7 @@ public abstract class org/jetbrains/exposed/v1/core/statements/api/ExposedDataba
 	public final fun getDatabase ()Ljava/lang/String;
 	public abstract fun getIdentifierManager ()Lorg/jetbrains/exposed/v1/core/statements/api/IdentifierManagerApi;
 	public abstract fun resetCurrentScheme ()V
-	public abstract fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/ReferenceOption;
+	protected abstract fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/ReferenceOption;
 }
 
 public final class org/jetbrains/exposed/v1/core/statements/api/ExposedMetadataUtils {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedDatabaseMetadata.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.v1.core.statements.api
 
-import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ReferenceOption
 
 /**
@@ -11,14 +10,11 @@ abstract class ExposedDatabaseMetadata(val database: String) {
     /** Clears and resets any stored information about the database's current schema to default values. */
     abstract fun resetCurrentScheme()
 
-    @Suppress("ForbiddenComment")
-    // TODO: THIS should become protected after the usage in DatabaseDialect is fully deprecated
     /**
      * Returns the corresponding [ReferenceOption] for the specified [refOption] result,
      * or `null` if the database result is an invalid string without a corresponding match.
      */
-    @InternalApi
-    abstract fun resolveReferenceOption(refOption: String): ReferenceOption?
+    protected abstract fun resolveReferenceOption(refOption: String): ReferenceOption?
 
     /** Clears any cached values. */
     abstract fun cleanCache()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
@@ -268,14 +268,6 @@ internal object OracleFunctionProvider : FunctionProvider() {
             expression to ((expression as? ExpressionWithColumnType<*>)?.alias("c$index") ?: expression.alias("c$index"))
         }.toMap()
 
-        // TODO check if it could be replaced with buildStatement
-        // TODO The old version:
-        // TODO val subQuery = targets.select(columnsToSelect.values.toList())
-        // TODO        where?.let {
-        // TODO            subQuery.adjustWhere { it }
-        // TODO        }
-        // TODO        subQuery.prepareSQL(this)
-        // TODO        +") x"
         +"SELECT "
         columnsToSelect.values.appendTo { +it }
         +" FROM "
@@ -362,7 +354,6 @@ internal object OracleFunctionProvider : FunctionProvider() {
             )
         targets.checkJoinTypes(StatementType.DELETE)
 
-        // TODO the same as above
         @OptIn(InternalApi::class)
         return with(QueryBuilder(true)) {
             +"DELETE (SELECT "

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -690,7 +690,6 @@ public final class org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMet
 	public fun getUrl ()Ljava/lang/String;
 	public fun getVersion ()Ljava/math/BigDecimal;
 	public fun resetCurrentScheme ()V
-	public fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/ReferenceOption;
 	public fun sequences ()Ljava/util/List;
 	public fun supportsLimitWithUpdateOrDelete ()Z
 	public fun tableConstraints (Ljava/util/List;)Ljava/util/Map;

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Database.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Database.kt
@@ -5,7 +5,6 @@ import org.jetbrains.exposed.v1.core.DatabaseConfig
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Version
 import org.jetbrains.exposed.v1.core.statements.api.IdentifierManagerApi
-import org.jetbrains.exposed.v1.core.transactions.CoreTransactionManager
 import org.jetbrains.exposed.v1.core.transactions.TransactionManagerApi
 import org.jetbrains.exposed.v1.core.vendors.*
 import org.jetbrains.exposed.v1.jdbc.statements.api.ExposedConnection
@@ -174,9 +173,7 @@ class Database private constructor(
             return Database(explicitVendor, config ?: DatabaseConfig.invoke()) {
                 connectionAutoRegistration(getNewConnection().apply { setupConnection(this) })
             }.apply {
-                CoreTransactionManager.registerDatabaseManager(this, manager(this))
-                // TODO ABOVE should be replaced with BELOW when ThreadLocalTransactionManager is fully deprecated
-                // TransactionManager.registerManager(this, manager(this))
+                TransactionManager.registerManager(this, manager(this))
             }
         }
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -520,7 +520,6 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         )
     }
 
-    @OptIn(InternalApi::class)
     override fun resolveReferenceOption(refOption: String): ReferenceOption? {
         val dialect = currentDialect
 

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -815,7 +815,6 @@ public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMe
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getVersion ()Lorg/jetbrains/exposed/v1/core/Version;
 	public fun resetCurrentScheme ()V
-	public fun resolveReferenceOption (Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/ReferenceOption;
 	public fun schemaNames (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun sequences (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun tableConstraints (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl.kt
@@ -404,7 +404,6 @@ class R2dbcDatabaseMetadataImpl(
         )
     }
 
-    @OptIn(InternalApi::class)
     override fun resolveReferenceOption(refOption: String): ReferenceOption? {
         val refOptionInt = refOption.toIntOrNull() ?: return null
 

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/R2dbcTransactionInterface.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/R2dbcTransactionInterface.kt
@@ -15,7 +15,6 @@ interface R2dbcTransactionInterface : TransactionInterface {
     /** The transaction isolation level of the transaction, which may differ from the set database level. */
     val transactionIsolation: IsolationLevel
 
-    // TODO Remove from interface & make suspend function
     /** The database connection used by the transaction. */
     val connection: R2dbcExposedConnection<*>
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Remove some of the existing TODOs based on most recent planning discussion

**Detailed description**:
- **Why**: These TODOs fall into 1 of 2 categories:
    - Agreed to be obsolete or no longer worth pursuing
    - Further steps or refactorings may be addressed post-V1 & YT tickets have been created

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - TODOs