### PR TITLE
chore!: Move areEquivalentColumnTypes from DatabaseDialect to Exposed DatabaseMetadata

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -1859,7 +1859,7 @@ public abstract class org/jetbrains/exposed/v1/core/SchemaUtilityApi {
 	protected final fun hasCycle (Ljava/util/List;)Z
 	protected final fun log (Ljava/util/Collection;Ljava/lang/String;Z)V
 	protected final fun logTimeSpent (Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	protected final fun mapMissingColumnStatementsTo (Lorg/jetbrains/exposed/v1/core/Table;Ljava/util/Collection;Ljava/util/List;Lorg/jetbrains/exposed/v1/core/vendors/PrimaryKeyMetadata;Z)Ljava/util/Collection;
+	protected final fun mapMissingColumnStatementsTo (Lorg/jetbrains/exposed/v1/core/Table;Ljava/util/Collection;Ljava/util/List;Lorg/jetbrains/exposed/v1/core/vendors/PrimaryKeyMetadata;ZLkotlin/jvm/functions/Function2;)Ljava/util/Collection;
 	protected final fun mapMissingConstraintsTo (Ljava/util/Collection;Ljava/util/Map;[Lorg/jetbrains/exposed/v1/core/Table;)Ljava/util/Collection;
 	protected final fun sortByReferences (Ljava/lang/Iterable;)Ljava/util/List;
 	protected final fun tableDdlWithoutExistingSequence (Lorg/jetbrains/exposed/v1/core/Table;Lorg/jetbrains/exposed/v1/core/Sequence;)Lkotlin/Pair;
@@ -3503,6 +3503,7 @@ public final class org/jetbrains/exposed/v1/core/statements/api/ExposedBlob {
 
 public abstract class org/jetbrains/exposed/v1/core/statements/api/ExposedDatabaseMetadata {
 	public fun <init> (Ljava/lang/String;)V
+	public final fun areEquivalentColumnTypes (Ljava/lang/String;ILjava/lang/String;)Z
 	public abstract fun cleanCache ()V
 	public final fun getDatabase ()Ljava/lang/String;
 	public abstract fun getIdentifierManager ()Lorg/jetbrains/exposed/v1/core/statements/api/IdentifierManagerApi;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedDatabaseMetadata.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/ExposedDatabaseMetadata.kt
@@ -2,6 +2,11 @@ package org.jetbrains.exposed.v1.core.statements.api
 
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.vendors.H2Dialect
+import org.jetbrains.exposed.v1.core.vendors.H2Dialect.H2CompatibilityMode
+import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.h2Mode
+import java.sql.Types
 
 /**
  * Base class responsible for shared utility methods needed for retrieving and storing information about
@@ -25,4 +30,92 @@ abstract class ExposedDatabaseMetadata(val database: String) {
 
     /** The database-specific and metadata-reliant implementation of [IdentifierManagerApi]. */
     abstract val identifierManager: IdentifierManagerApi
+
+    fun areEquivalentColumnTypes(columnMetadataSqlType: String, columnMetadataType: Int, columnType: String): Boolean {
+        return when {
+            columnMetadataSqlType.equals(columnType, ignoreCase = true) -> true
+            currentDialect is H2Dialect -> areEquivalentColumnTypesH2(columnMetadataSqlType, columnMetadataType, columnType)
+            else -> false
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun areEquivalentColumnTypesH2(columnMetadataSqlType: String, columnMetadataJdbcType: Int, columnType: String): Boolean {
+        val dialect = currentDialect
+
+        val columnMetadataSqlType = columnMetadataSqlType.uppercase()
+        val columnType = columnType.uppercase()
+
+        if (columnMetadataJdbcType == Types.ARRAY) {
+            val baseType = columnMetadataSqlType.substringBefore(" ARRAY")
+            return areEquivalentColumnTypes(baseType, Types.OTHER, columnType.substringBefore(" ARRAY")) &&
+                areEquivalentColumnTypes(columnMetadataSqlType.replaceBefore("ARRAY", ""), Types.OTHER, columnType.replaceBefore("ARRAY", ""))
+        }
+
+        if (columnType == "TEXT" && columnMetadataSqlType == "VARCHAR") {
+            return true
+        }
+
+        if (listOf(columnMetadataSqlType, columnType).all { it.matches(Regex("VARCHAR(?:\\((?:MAX|\\d+)\\))?")) }) {
+            return true
+        }
+
+        if (listOf(columnMetadataSqlType, columnType).all { it.matches(Regex("VARBINARY(?:\\((?:MAX|\\d+)\\))?")) }) {
+            return true
+        }
+
+        return when (dialect.h2Mode) {
+            H2CompatibilityMode.PostgreSQL -> {
+                when {
+                    // Auto-increment difference is dealt with elsewhere
+                    (columnType == "SERIAL" && columnMetadataSqlType == "INT") || (columnType == "BIGSERIAL" && columnMetadataSqlType == "BIGINT") -> true
+                    else -> false
+                }
+            }
+            H2CompatibilityMode.Oracle -> {
+                when {
+                    columnType == "DATE" && columnMetadataSqlType == "TIMESTAMP(0)" -> true
+                    // Unlike Oracle, H2 Oracle mode does not distinguish between VARCHAR2(4000) and VARCHAR2(4000 CHAR).
+                    // It treats the length as a character count and does not enforce a separate byte limit.
+                    listOf(columnMetadataSqlType, columnType).all { it.matches(Regex("VARCHAR2(?:\\((?:MAX|\\d+)(?:\\s+CHAR)?\\))?")) } -> true
+                    else -> {
+                        // H2 maps NUMBER to NUMERIC
+                        val numberRegex = Regex("NUMBER(?:\\((\\d+)(?:,\\s?(\\d+))?\\))?")
+                        val numericRegex = Regex("NUMERIC(?:\\((\\d+)(?:,\\s?(\\d+))?\\))?")
+                        val numberMatch = numberRegex.find(columnType)
+                        val numericMatch = numericRegex.find(columnMetadataSqlType)
+                        if (numberMatch != null && numericMatch != null) {
+                            numberMatch.groupValues[1] == numericMatch.groupValues[1] // compare precision
+                        } else {
+                            false
+                        }
+                    }
+                }
+            }
+            H2CompatibilityMode.SQLServer ->
+                when {
+                    columnType.equals("uniqueidentifier", ignoreCase = true) && columnMetadataSqlType == "UUID" -> true
+                    // Auto-increment difference is dealt with elsewhere
+                    columnType.contains(" IDENTITY") ->
+                        areEquivalentColumnTypes(columnMetadataSqlType, columnMetadataJdbcType, columnType.substringBefore(" IDENTITY"))
+                    // H2 maps DATETIME2 to TIMESTAMP
+                    columnType.matches(Regex("DATETIME2(?:\\(\\d+\\))?")) &&
+                        columnMetadataSqlType.matches(Regex("TIMESTAMP(?:\\(\\d+\\))?")) -> true
+                    // H2 maps NVARCHAR to VARCHAR
+                    columnType.matches(Regex("NVARCHAR(?:\\((\\d+|MAX)\\))?")) &&
+                        columnMetadataSqlType.matches(Regex("VARCHAR(?:\\((\\d+|MAX)\\))?")) -> true
+                    else -> false
+                }
+            null, H2CompatibilityMode.MySQL, H2CompatibilityMode.MariaDB ->
+                when {
+                    // Auto-increment difference is dealt with elsewhere
+                    columnType.contains(" AUTO_INCREMENT") ->
+                        areEquivalentColumnTypes(columnMetadataSqlType, columnMetadataJdbcType, columnType.substringBefore(" AUTO_INCREMENT"))
+                    // H2 maps DATETIME to TIMESTAMP
+                    columnType.matches(Regex("DATETIME(?:\\(\\d+\\))?")) &&
+                        columnMetadataSqlType.matches(Regex("TIMESTAMP(?:\\(\\d+\\))?")) -> true
+                    else -> false
+                }
+        }
+    }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
@@ -130,12 +130,15 @@ interface DatabaseDialect {
         }
     }
 
-    // TODO move it to JDBC or R2DBC metadata
     /** Returns whether the [columnMetadataSqlType] type and the [columnType] are equivalent.
      *
      * [columnMetadataJdbcType], the value of which comes from [java.sql.Types], is taken into consideration if needed by a specific database.
      * @see [H2Dialect.areEquivalentColumnTypes]
      */
+    @Deprecated(
+        "This method was moved to ExposedDatabaseMetadata and should not be used anymore from here.",
+        ReplaceWith("TransactionManager.current().db.metadata { areEquivalentColumnTypes() }")
+    )
     fun areEquivalentColumnTypes(columnMetadataSqlType: String, columnMetadataJdbcType: Int, columnType: String): Boolean =
         columnMetadataSqlType.equals(columnType, ignoreCase = true)
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
@@ -359,6 +359,10 @@ open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2Function
     override fun dropDatabase(name: String) = "DROP SCHEMA IF EXISTS ${name.inProperCase()}"
 
     @Suppress("CyclomaticComplexMethod")
+    @Deprecated(
+        "This method was moved to ExposedDatabaseMetadata and should not be used anymore from here.",
+        ReplaceWith("TransactionManager.current().db.metadata { areEquivalentColumnTypes() }")
+    )
     override fun areEquivalentColumnTypes(columnMetadataSqlType: String, columnMetadataJdbcType: Int, columnType: String): Boolean {
         if (super.areEquivalentColumnTypes(columnMetadataSqlType, columnMetadataJdbcType, columnType)) {
             return true

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -13,6 +13,7 @@ public final class org/jetbrains/exposed/v1/jdbc/Database : org/jetbrains/expose
 	public fun getUrl ()Ljava/lang/String;
 	public fun getVendor ()Ljava/lang/String;
 	public fun getVersion ()Lorg/jetbrains/exposed/v1/core/Version;
+	public final fun metadata (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/v1/jdbc/Database$Companion {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Database.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Database.kt
@@ -28,7 +28,8 @@ class Database private constructor(
     config: DatabaseConfig,
     val connector: () -> ExposedConnection<*>
 ) : DatabaseApi(resolvedVendor, config) {
-    internal fun <T> metadata(body: JdbcExposedDatabaseMetadata.() -> T): T {
+    @InternalApi
+    fun <T> metadata(body: JdbcExposedDatabaseMetadata.() -> T): T {
         val transaction = TransactionManager.currentOrNull()
         return if (transaction == null) {
             val connection = connector()
@@ -42,8 +43,10 @@ class Database private constructor(
         }
     }
 
+    @OptIn(InternalApi::class)
     override val url: String by lazy { metadata { url } }
 
+    @OptIn(InternalApi::class)
     override val vendor: String by lazy {
         resolvedVendor ?: metadata { databaseDialectName }
     }
@@ -63,24 +66,31 @@ class Database private constructor(
             ?: error("No dialect metadata registered for $name. URL=$url")
     }
 
+    @OptIn(InternalApi::class)
     override val dialectMode: String? by lazy { metadata { databaseDialectMode } }
 
+    @OptIn(InternalApi::class)
     override val version: Version by lazy { metadata { Version.from(version) } }
 
+    @OptIn(InternalApi::class)
     override val fullVersion: String by lazy { metadata { databaseProductVersion } }
 
+    @OptIn(InternalApi::class)
     override val supportsAlterTableWithAddColumn: Boolean by lazy(
         LazyThreadSafetyMode.NONE
     ) { metadata { supportsAlterTableWithAddColumn } }
 
+    @OptIn(InternalApi::class)
     override val supportsAlterTableWithDropColumn: Boolean by lazy(
         LazyThreadSafetyMode.NONE
     ) { metadata { supportsAlterTableWithDropColumn } }
 
+    @OptIn(InternalApi::class)
     override val supportsMultipleResultSets: Boolean by lazy(
         LazyThreadSafetyMode.NONE
     ) { metadata { supportsMultipleResultSets } }
 
+    @OptIn(InternalApi::class)
     override val identifierManager: IdentifierManagerApi by lazy { metadata { identifierManager } }
 
     /** Whether [Database.connect] was invoked with a [DataSource] argument. */

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -2,7 +2,6 @@ package org.jetbrains.exposed.v1.jdbc.statements.jdbc
 
 import org.intellij.lang.annotations.Language
 import org.jetbrains.exposed.v1.core.*
-import org.jetbrains.exposed.v1.core.Sequence
 import org.jetbrains.exposed.v1.core.statements.api.ExposedMetadataUtils
 import org.jetbrains.exposed.v1.core.statements.api.IdentifierManagerApi
 import org.jetbrains.exposed.v1.core.utils.CachableMapWithDefault

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/DatabaseDialectMetadata.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/DatabaseDialectMetadata.kt
@@ -118,6 +118,7 @@ abstract class DatabaseDialectMetadata {
 
     protected val columnConstraintsCache: MutableMap<String, Collection<ForeignKeyConstraint>> = ConcurrentHashMap()
 
+    @OptIn(InternalApi::class)
     protected open fun fillConstraintCacheForTables(tables: List<Table>) {
         val tx = TransactionManager.current()
         columnConstraintsCache.putAll(tx.db.metadata { tableConstraints(tables) })
@@ -141,16 +142,19 @@ abstract class DatabaseDialectMetadata {
     }
 
     /** Returns a map with all the defined indices in each of the specified [tables]. */
+    @OptIn(InternalApi::class)
     open fun existingIndices(vararg tables: Table): Map<Table, List<Index>> {
         return TransactionManager.current().db.metadata { existingIndices(*tables) }
     }
 
     /** Returns a map with all the defined check constraints in each of the specified [tables]. */
+    @OptIn(InternalApi::class)
     fun existingCheckConstraints(vararg tables: Table): Map<Table, List<CheckConstraint>> {
         return TransactionManager.current().db.metadata { existingCheckConstraints(*tables) }
     }
 
     /** Returns a map with the primary key metadata in each of the specified [tables]. */
+    @OptIn(InternalApi::class)
     fun existingPrimaryKeys(vararg tables: Table): Map<Table, PrimaryKeyMetadata?> {
         return TransactionManager.current().db.metadata { existingPrimaryKeys(*tables) }
     }
@@ -165,16 +169,19 @@ abstract class DatabaseDialectMetadata {
      * as it is not necessarily bound to any particular table. Sequences that are used in a table via triggers will also
      * not be returned.
      */
+    @OptIn(InternalApi::class)
     fun existingSequences(vararg tables: Table): Map<Table, List<Sequence>> {
         return TransactionManager.current().db.metadata { existingSequences(*tables) }
     }
 
     /** Returns a list of the names of all sequences in the database. */
+    @OptIn(InternalApi::class)
     fun sequences(): List<String> {
         return TransactionManager.current().db.metadata { sequences() }
     }
 
     /** Clears any cached values. */
+    @OptIn(InternalApi::class)
     fun resetCaches() {
         _allTableNames = null
         columnConstraintsCache.clear()

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/SQLiteDialectMetadata.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/vendors/SQLiteDialectMetadata.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.exposed.v1.jdbc.vendors
 
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 
 /**
  * SQLite dialect metadata implementation.
  */
 open class SQLiteDialectMetadata : DatabaseDialectMetadata() {
+    @OptIn(InternalApi::class)
     override fun supportsLimitWithUpdateOrDelete(): Boolean {
         return TransactionManager.current().db.metadata { supportsLimitWithUpdateOrDelete() }
     }


### PR DESCRIPTION
#### Description

Move areEquivalentColumnTypes from DatabaseDialect to ExposedDatabaseMetadata

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Chore

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All JDBC

---

