### PR TITLE
fix: Unify database connect functions between r2dbc and jdbc

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -644,6 +644,25 @@ public final class org/jetbrains/exposed/v1/core/DatabaseConfig$Companion {
 	public static synthetic fun invoke$default (Lorg/jetbrains/exposed/v1/core/DatabaseConfig$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/DatabaseConfig;
 }
 
+public class org/jetbrains/exposed/v1/core/DatabaseConfigImpl : org/jetbrains/exposed/v1/core/DatabaseConfig {
+	public fun <init> (Lorg/jetbrains/exposed/v1/core/DatabaseConfig$Builder;)V
+	public fun getDefaultFetchSize ()Ljava/lang/Integer;
+	public fun getDefaultIsolationLevel ()I
+	public fun getDefaultMaxAttempts ()I
+	public fun getDefaultMaxRetryDelay ()J
+	public fun getDefaultMinRetryDelay ()J
+	public fun getDefaultReadOnly ()Z
+	public fun getDefaultSchema ()Lorg/jetbrains/exposed/v1/core/Schema;
+	public fun getExplicitDialect ()Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;
+	public fun getKeepLoadedReferencesOutOfTransaction ()Z
+	public fun getLogTooMuchResultSetsThreshold ()I
+	public fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public fun getPreserveKeywordCasing ()Z
+	public fun getSqlLogger ()Lorg/jetbrains/exposed/v1/core/SqlLogger;
+	public fun getUseNestedTransactions ()Z
+	public fun getWarnLongQueriesDuration ()Ljava/lang/Long;
+}
+
 public abstract interface class org/jetbrains/exposed/v1/core/DdlAware {
 	public abstract fun createStatement ()Ljava/util/List;
 	public abstract fun dropStatement ()Ljava/util/List;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
@@ -140,45 +140,48 @@ interface DatabaseConfig {
     }
 
     companion object {
-        // TODO make sure R2dbcDatabaseConfig has constructor function so that it is compatible with JDBC
         operator fun invoke(body: Builder.() -> Unit = {}): DatabaseConfig {
             val builder = Builder().apply(body)
             require(builder.defaultMaxAttempts > 0) { "defaultMaxAttempts must be set to perform at least 1 attempt." }
 
-            return object : DatabaseConfig {
-                override val sqlLogger: SqlLogger
-                    get() = builder.sqlLogger ?: Slf4jSqlDebugLogger
-                override val useNestedTransactions: Boolean
-                    get() = builder.useNestedTransactions
-                override val defaultFetchSize: Int?
-                    get() = builder.defaultFetchSize
-                override val defaultIsolationLevel: Int
-                    get() = builder.defaultIsolationLevel
-                override val defaultMaxAttempts: Int
-                    get() = builder.defaultMaxAttempts
-                override val defaultMinRetryDelay: Long
-                    get() = builder.defaultMinRetryDelay
-                override val defaultMaxRetryDelay: Long
-                    get() = builder.defaultMaxRetryDelay
-                override val defaultReadOnly: Boolean
-                    get() = builder.defaultReadOnly
-                override val warnLongQueriesDuration: Long?
-                    get() = builder.warnLongQueriesDuration
-                override val maxEntitiesToStoreInCachePerEntity: Int
-                    get() = builder.maxEntitiesToStoreInCachePerEntity
-                override val keepLoadedReferencesOutOfTransaction: Boolean
-                    get() = builder.keepLoadedReferencesOutOfTransaction
-                override val explicitDialect: DatabaseDialect?
-                    get() = builder.explicitDialect
-                override val defaultSchema: Schema?
-                    get() = builder.defaultSchema
-                override val logTooMuchResultSetsThreshold: Int
-                    get() = builder.logTooMuchResultSetsThreshold
-
-                @OptIn(ExperimentalKeywordApi::class)
-                override val preserveKeywordCasing: Boolean
-                    get() = builder.preserveKeywordCasing
-            }
+            @OptIn(InternalApi::class)
+            return DatabaseConfigImpl(builder)
         }
     }
+}
+
+@InternalApi
+open class DatabaseConfigImpl(private val builder: DatabaseConfig.Builder) : DatabaseConfig {
+    override val sqlLogger: SqlLogger
+        get() = builder.sqlLogger ?: Slf4jSqlDebugLogger
+    override val useNestedTransactions: Boolean
+        get() = builder.useNestedTransactions
+    override val defaultFetchSize: Int?
+        get() = builder.defaultFetchSize
+    override val defaultIsolationLevel: Int
+        get() = builder.defaultIsolationLevel
+    override val defaultMaxAttempts: Int
+        get() = builder.defaultMaxAttempts
+    override val defaultMinRetryDelay: Long
+        get() = builder.defaultMinRetryDelay
+    override val defaultMaxRetryDelay: Long
+        get() = builder.defaultMaxRetryDelay
+    override val defaultReadOnly: Boolean
+        get() = builder.defaultReadOnly
+    override val warnLongQueriesDuration: Long?
+        get() = builder.warnLongQueriesDuration
+    override val maxEntitiesToStoreInCachePerEntity: Int
+        get() = builder.maxEntitiesToStoreInCachePerEntity
+    override val keepLoadedReferencesOutOfTransaction: Boolean
+        get() = builder.keepLoadedReferencesOutOfTransaction
+    override val explicitDialect: DatabaseDialect?
+        get() = builder.explicitDialect
+    override val defaultSchema: Schema?
+        get() = builder.defaultSchema
+    override val logTooMuchResultSetsThreshold: Int
+        get() = builder.logTooMuchResultSetsThreshold
+
+    @OptIn(ExperimentalKeywordApi::class)
+    override val preserveKeywordCasing: Boolean
+        get() = builder.preserveKeywordCasing
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
@@ -919,7 +919,7 @@ private fun QueryBuilder.addClausesToMergeStatement(transaction: Transaction, ta
         val defaultValuesStatementSupported = currentDialect !is H2Dialect
         when (clause.action) {
             MergeStatement.ClauseAction.INSERT -> {
-                val nextValExpression = autoIncColumn?.autoIncColumnType?.nextValExpression?.takeIf { autoIncColumn !in clause.arguments.map { it.first } }
+                val nextValExpression = autoIncColumn?.autoIncColumnType?.nextValExpression?.takeIf { autoIncColumn !in clause.arguments.map { (key, _) -> key } }
 
                 val extraArg = if (nextValExpression != null) listOf(autoIncColumn to nextValExpression) else emptyList()
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/MultiDatabaseTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/MultiDatabaseTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.invoke
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import org.jetbrains.exposed.v1.r2dbc.exists
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -39,7 +40,7 @@ class MultiDatabaseTest {
     private val db1 by lazy {
         R2dbcDatabase.connect(
             "r2dbc:h2:mem:///db1;USER=root;DB_CLOSE_DELAY=-1;",
-            databaseConfig = {
+            databaseConfig = R2dbcDatabaseConfig {
                 defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
             }
         )
@@ -47,7 +48,7 @@ class MultiDatabaseTest {
     private val db2 by lazy {
         R2dbcDatabase.connect(
             "r2dbc:h2:mem:///db2;USER=root;DB_CLOSE_DELAY=-1;",
-            databaseConfig = {
+            databaseConfig = R2dbcDatabaseConfig {
                 defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
             }
         )

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
@@ -108,7 +108,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
     private val keywordFlagDB by lazy {
         R2dbcDatabase.connect(
             url = "r2dbc:h2:mem:///flagtest;DB_CLOSE_DELAY=-1;",
-            databaseConfig = {
+            databaseConfig = R2dbcDatabaseConfig {
                 @OptIn(ExperimentalKeywordApi::class)
                 preserveKeywordCasing = false
             }

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -237,13 +237,15 @@ public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabase : org/jetbrains/
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion {
-	public final fun connect (Lio/r2dbc/spi/ConnectionFactory;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
-	public final fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
+	public final fun connect (Lio/r2dbc/spi/ConnectionFactory;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
+	public final fun connect (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
 	public final fun connect (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
+	public final fun connect (Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
 	public final fun connect (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
-	public static synthetic fun connect$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion;Lio/r2dbc/spi/ConnectionFactory;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
-	public static synthetic fun connect$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
+	public static synthetic fun connect$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion;Lio/r2dbc/spi/ConnectionFactory;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
+	public static synthetic fun connect$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
+	public static synthetic fun connect$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
 	public static synthetic fun connect$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase$Companion;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;
 	public final fun getDefaultIsolationLevel (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabase;)Lio/r2dbc/spi/IsolationLevel;
 	public final fun registerDialectMetadata (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
@@ -275,8 +277,31 @@ public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder : 
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Companion {
-	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig;
-	public static synthetic fun invoke$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig;
+	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;
+	public static synthetic fun invoke$default (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfigImpl : org/jetbrains/exposed/v1/core/DatabaseConfig, org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig {
+	public fun <init> (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig$Builder;)V
+	public fun getConnectionFactoryOptions ()Lio/r2dbc/spi/ConnectionFactoryOptions;
+	public fun getDefaultFetchSize ()Ljava/lang/Integer;
+	public fun getDefaultIsolationLevel ()I
+	public fun getDefaultMaxAttempts ()I
+	public fun getDefaultMaxRetryDelay ()J
+	public fun getDefaultMinRetryDelay ()J
+	public fun getDefaultR2dbcIsolationLevel ()Lio/r2dbc/spi/IsolationLevel;
+	public fun getDefaultReadOnly ()Z
+	public fun getDefaultSchema ()Lorg/jetbrains/exposed/v1/core/Schema;
+	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public fun getExplicitDialect ()Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;
+	public fun getKeepLoadedReferencesOutOfTransaction ()Z
+	public fun getLogTooMuchResultSetsThreshold ()I
+	public fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public fun getPreserveKeywordCasing ()Z
+	public fun getSqlLogger ()Lorg/jetbrains/exposed/v1/core/SqlLogger;
+	public fun getTypeMapping ()Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;
+	public fun getUseNestedTransactions ()Z
+	public fun getWarnLongQueriesDuration ()Ljava/lang/Long;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseKt {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfig.kt
@@ -5,11 +5,8 @@ import io.r2dbc.spi.IsolationLevel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.exposed.v1.core.DatabaseConfig
-import org.jetbrains.exposed.v1.core.ExperimentalKeywordApi
-import org.jetbrains.exposed.v1.core.Schema
-import org.jetbrains.exposed.v1.core.Slf4jSqlDebugLogger
-import org.jetbrains.exposed.v1.core.SqlLogger
-import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
+import org.jetbrains.exposed.v1.core.DatabaseConfigImpl
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.r2dbc.mappers.R2dbcRegistryTypeMapping
 import org.jetbrains.exposed.v1.r2dbc.mappers.R2dbcTypeMapping
 import org.jetbrains.exposed.v1.r2dbc.statements.asInt
@@ -119,53 +116,26 @@ interface R2dbcDatabaseConfig : DatabaseConfig {
         }
 
         fun build(): R2dbcDatabaseConfig {
-            return object : R2dbcDatabaseConfig {
-                override val sqlLogger: SqlLogger
-                    get() = this@Builder.sqlLogger ?: Slf4jSqlDebugLogger
-                override val useNestedTransactions: Boolean
-                    get() = this@Builder.useNestedTransactions
-                override val defaultFetchSize: Int?
-                    get() = this@Builder.defaultFetchSize
-                override val defaultIsolationLevel: Int
-                    get() = this@Builder.defaultIsolationLevel
-                override val defaultMaxAttempts: Int
-                    get() = this@Builder.defaultMaxAttempts
-                override val defaultMinRetryDelay: Long
-                    get() = this@Builder.defaultMinRetryDelay
-                override val defaultMaxRetryDelay: Long
-                    get() = this@Builder.defaultMaxRetryDelay
-                override val defaultReadOnly: Boolean
-                    get() = this@Builder.defaultReadOnly
-                override val warnLongQueriesDuration: Long?
-                    get() = this@Builder.warnLongQueriesDuration
-                override val maxEntitiesToStoreInCachePerEntity: Int
-                    get() = this@Builder.maxEntitiesToStoreInCachePerEntity
-                override val keepLoadedReferencesOutOfTransaction: Boolean
-                    get() = this@Builder.keepLoadedReferencesOutOfTransaction
-                override val explicitDialect: DatabaseDialect?
-                    get() = this@Builder.explicitDialect
-                override val defaultSchema: Schema?
-                    get() = this@Builder.defaultSchema
-                override val logTooMuchResultSetsThreshold: Int
-                    get() = this@Builder.logTooMuchResultSetsThreshold
-
-                @OptIn(ExperimentalKeywordApi::class)
-                override val preserveKeywordCasing: Boolean
-                    get() = this@Builder.preserveKeywordCasing
-
-                override val dispatcher: CoroutineDispatcher
-                    get() = this@Builder.dispatcher
-                override val connectionFactoryOptions: ConnectionFactoryOptions
-                    get() = this@Builder.connectionFactoryOptions
-                override val typeMapping: R2dbcTypeMapping
-                    get() = this@Builder.typeMapping
-                override val defaultR2dbcIsolationLevel: IsolationLevel?
-                    get() = this@Builder.defaultR2dbcIsolationLevel
-            }
+            @OptIn(InternalApi::class)
+            return R2dbcDatabaseConfigImpl(this)
         }
     }
 
     companion object {
-        operator fun invoke(body: Builder.() -> Unit = {}): R2dbcDatabaseConfig = Builder().apply(body).build()
+        operator fun invoke(body: Builder.() -> Unit = {}): Builder = Builder().apply(body)
     }
+}
+
+@InternalApi
+class R2dbcDatabaseConfigImpl(
+    private val builder: R2dbcDatabaseConfig.Builder
+) : R2dbcDatabaseConfig, DatabaseConfig by DatabaseConfigImpl(builder) {
+    override val dispatcher: CoroutineDispatcher
+        get() = builder.dispatcher
+    override val connectionFactoryOptions: ConnectionFactoryOptions
+        get() = builder.connectionFactoryOptions
+    override val typeMapping: R2dbcTypeMapping
+        get() = builder.typeMapping
+    override val defaultR2dbcIsolationLevel: IsolationLevel?
+        get() = builder.defaultR2dbcIsolationLevel
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Allow using new r2dbc connect functions the same way we're using them with jdbc. It also permits calling connect just with the block (a more idiomatic way)


---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
