### PR TITLE
docs: build: EXPOSED-850 Add configuration for feedback widget

### DIFF
--- a/documentation-website/Writerside/cfg/buildprofiles.xml
+++ b/documentation-website/Writerside/cfg/buildprofiles.xml
@@ -13,6 +13,9 @@
             exposed-logo.svg
         </custom-favicons>
         <analytics-head-script-file>google-search.html</analytics-head-script-file>
+        <feedback-url>https://forms-service.jetbrains.com/feedback</feedback-url>
+        <feedback-enabled>true</feedback-enabled>
+        <feedback-widget>true</feedback-widget>
     </variables>
     <build-profile instance="hi">
         <variables>


### PR DESCRIPTION
#### Description

This configures a feedback widget that will be displayed on the bottom of each documentation page. Users will be able to leave feedback or report issues. By doing so a new ticket will be created  in the EXPOSED project on YouTrack.

#### Type of Change

- [x] Documentation update

#### Related Issues

[EXPOSED-850](https://youtrack.jetbrains.com/issue/EXPOSED-850) Add feedback widget to Exposed docs