### PR TITLE
fix: EXPOSED-856 Add support for inserting UUID arrays in R2DBC

### DIFF
--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ArrayTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ArrayTypeMapper.kt
@@ -9,7 +9,6 @@ import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -116,7 +115,7 @@ class ArrayTypeMapper : TypeMapper {
             columnType.delegate is BinaryColumnType -> (mappedList as List<ByteArray>).toTypedArray()
             columnType.delegate is TextColumnType -> (mappedList as List<String>).toTypedArray()
             columnType.delegate is DecimalColumnType -> (mappedList as List<java.math.BigDecimal>).toTypedArray()
-            columnType.delegate is UUIDColumnType -> (mappedList as List<UUID>).toTypedArray()
+            columnType.delegate is UUIDColumnType -> (mappedList as List<java.util.UUID>).toTypedArray()
             columnType.delegate is IDateColumnType -> {
                 // For date/time types, we need to handle them specially
                 // The hasTimePart property tells us whether it's a DATE or DATETIME column

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ArrayTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/ArrayTypeMapper.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.UUID
 import kotlin.reflect.KClass
 
 /**
@@ -115,6 +116,7 @@ class ArrayTypeMapper : TypeMapper {
             columnType.delegate is BinaryColumnType -> (mappedList as List<ByteArray>).toTypedArray()
             columnType.delegate is TextColumnType -> (mappedList as List<String>).toTypedArray()
             columnType.delegate is DecimalColumnType -> (mappedList as List<java.math.BigDecimal>).toTypedArray()
+            columnType.delegate is UUIDColumnType -> (mappedList as List<UUID>).toTypedArray()
             columnType.delegate is IDateColumnType -> {
                 // For date/time types, we need to handle them specially
                 // The hasTimePart property tells us whether it's a DATE or DATETIME column


### PR DESCRIPTION
#### Description

**Summary of the change**: Add support for inserting UUID arrays in R2DBC

**Detailed description**:
- **What**: 
  - Added UUIDColumnType columnType detector to mapPgArray
- **Why**: It is a logic that supports the implementation of JDBC that is not yet supported in R2DBC.
- **How**: 

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [x] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

https://youtrack.jetbrains.com/issue/EXPOSED-856/UUID-not-supported-in-Array-R2DBC