### PR TITLE
fix: JDBC TransactionScope is not cleared on completion

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/experimental/Suspended.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/experimental/Suspended.kt
@@ -165,7 +165,11 @@ private suspend fun <T> withTransactionScope(
 
         val newContext = context ?: coroutineContext
 
-        return TransactionScope(tx, newContext + element).body()
+        return try {
+            TransactionScope(tx, newContext + element).body()
+        } finally {
+            manager.bindTransactionToThread(null) // remove the transaction from the ThreadLocal
+        }
     }
 
     val sameTransaction = currentScope?.holdsSameTransaction(currentTransaction) == true


### PR DESCRIPTION

#### Description

**Summary of the change**: Clear the Transaction from the `TransactionManager`'s `ThreadLocal` after completion in order to prevent retrieving closed Transactions through `TransactionManager#currentOrNull`

**Detailed description**:
Since JDBC Transactions are not cleared from the TransactionManager's ThreadLocal after completion, future calls to `TransactionManager#currentOrNull` from the same Thread results in a closed transaction being returned, leading to leaking transactions, which ultimately clears the entire thread pool of usable connections, rendering the entire application unable to make **any** Database calls.

I've created [SIMULATAN/ktor-exposed-leak-reproducer](https://github.com/SIMULATAN/ktor-exposed-leak-reproducer/tree/fe3c02a172a7ea2940c1e59700a3f501571b9918) to demonstrate the issue. Instructions can be found in the README.

The R2DBC equivalent to the `withTransactionScope` function [correctly cleans the context up](https://github.com/JetBrains/Exposed/blob/c8833d60902550f5528d8ecc87b343d1e4dc6e63/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt#L385). My patch aligns the JDBC implementation with the R2DBC one.

This issue originally surfaced through [KTOR-8747](https://youtrack.jetbrains.com/issue/KTOR-8747). The change made in this PR fixes that issue, although I'd label the new persistence of ThreadLocals between requests as a regression, therefore prompting further investigation on the Ktor side to prevent additional side effects.

---

#### Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
https://youtrack.jetbrains.com/issue/KTOR-8747/Netty-Exposed-suspending-transactions-leak-since-3.2.0