### PR TITLE
docs: EXPOSED-865 Sample projects not compiling with beta versions

### DIFF
--- a/samples/exposed-ktor-r2dbc/build.gradle.kts
+++ b/samples/exposed-ktor-r2dbc/build.gradle.kts
@@ -33,7 +33,11 @@ dependencies {
     implementation(libs.postgresql.r2dbc)
     runtimeOnly(libs.postgresql)
 
-    implementation(libs.kotlinx.datetime)
-
     implementation(libs.logback.classic)
+}
+
+kotlin {
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+    }
 }

--- a/samples/exposed-ktor-r2dbc/gradle/libs.versions.toml
+++ b/samples/exposed-ktor-r2dbc/gradle/libs.versions.toml
@@ -1,10 +1,9 @@
 [versions]
-kotlin-version = "2.1.21"
-ktor-version = "3.2.0"
-exposed-version = "1.0.0-beta-2"
+kotlin-version = "2.2.0"
+ktor-version = "3.2.3"
+exposed-version = "1.0.0-beta-5"
 postgresql-r2dbc-version = "1.0.7.RELEASE"
 postgresql-version = "42.7.5"
-kotlinx-datetime = "0.6.2"
 logback-version = "1.5.18"
 
 [libraries]
@@ -24,8 +23,6 @@ exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "e
 
 postgresql-r2dbc = { group = "org.postgresql", name = "r2dbc-postgresql", version.ref = "postgresql-r2dbc-version" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql-version" }
-
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-version" }
 

--- a/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/comment/Comment.kt
+++ b/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/comment/Comment.kt
@@ -2,10 +2,10 @@
 
 package org.jetbrains.exposed.samples.r2dbc.domain.comment
 
-import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.samples.r2dbc.domain.project.ProjectId
 import org.jetbrains.exposed.samples.r2dbc.domain.user.UserId
+import kotlin.time.Instant
 
 @JvmInline
 @Serializable

--- a/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/issue/Issue.kt
+++ b/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/issue/Issue.kt
@@ -2,11 +2,11 @@
 
 package org.jetbrains.exposed.samples.r2dbc.domain.issue
 
-import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.samples.r2dbc.domain.comment.Comment
 import org.jetbrains.exposed.samples.r2dbc.domain.project.ProjectId
 import org.jetbrains.exposed.samples.r2dbc.domain.user.UserId
+import kotlin.time.Instant
 
 @Serializable
 data class Issue(

--- a/samples/exposed-ktor/build.gradle.kts
+++ b/samples/exposed-ktor/build.gradle.kts
@@ -5,9 +5,9 @@ val exposedVersion: String by project
 val h2Version: String by project
 
 plugins {
-    kotlin("jvm") version "2.0.0"
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0"
-    id("io.ktor.plugin") version "2.3.4"
+    kotlin("jvm") version "2.2.0"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.2.0"
+    id("io.ktor.plugin") version "3.2.3"
 }
 
 group = "org.jetbrains.exposed.samples.ktor"

--- a/samples/exposed-ktor/gradle.properties
+++ b/samples/exposed-ktor/gradle.properties
@@ -1,6 +1,6 @@
-ktorVersion=2.3.12
-kotlinVersion=2.0.0
-logbackVersion=1.4.12
+ktorVersion=3.2.3
+kotlinVersion=2.2.0
+logbackVersion=1.5.18
 kotlin.code.style=official
 exposedVersion=1.0.0-beta-5
 h2Version=2.1.214

--- a/samples/exposed-ktor/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/exposed-ktor/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/exposed-ktor/src/main/kotlin/plugins/Databases.kt
+++ b/samples/exposed-ktor/src/main/kotlin/plugins/Databases.kt
@@ -7,7 +7,7 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import org.jetbrains.exposed.v1.*
+import org.jetbrains.exposed.v1.jdbc.Database
 
 fun Application.configureDatabases() {
     val database = Database.connect(

--- a/samples/exposed-ktor/src/main/kotlin/plugins/UsersSchema.kt
+++ b/samples/exposed-ktor/src/main/kotlin/plugins/UsersSchema.kt
@@ -4,10 +4,11 @@ package org.jetbrains.exposed.samples.ktor
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.Serializable
-import org.jetbrains.exposed.v1.*
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.v1.transactions.experimental.newSuspendedTransaction
-import org.jetbrains.exposed.v1.transactions.transaction
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.*
+import org.jetbrains.exposed.v1.jdbc.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 @Serializable
 data class ExposedUser(val name: String, val age: Int)

--- a/samples/exposed-migration/build.gradle.kts
+++ b/samples/exposed-migration/build.gradle.kts
@@ -4,7 +4,7 @@ val flywayVersion: String by project
 
 plugins {
     id("application")
-    kotlin("jvm") version "2.0.0"
+    kotlin("jvm") version "2.2.0"
 }
 
 group = "org.jetbrains.exposed.samples.migration"

--- a/samples/exposed-migration/src/main/kotlin/Application.kt
+++ b/samples/exposed-migration/src/main/kotlin/Application.kt
@@ -1,7 +1,7 @@
 import org.flywaydb.core.Flyway
-import org.jetbrains.exposed.v1.core.vendors.currentDialect
-import org.jetbrains.exposed.v1.insert
-import org.jetbrains.exposed.v1.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.vendors.currentDialectMetadata
 import java.util.*
 
 fun main() {
@@ -15,7 +15,7 @@ fun main() {
 
     transaction(database) {
         println("*** Before migration ***")
-        println("Primary key: ${currentDialect.existingPrimaryKeys(Users)[Users]}")
+        println("Primary key: ${currentDialectMetadata.existingPrimaryKeys(Users)[Users]}")
 
         generateMigrationScript()
     }
@@ -27,7 +27,7 @@ fun main() {
 
     transaction(database) {
         println("*** After migration ***")
-        println("Primary key: ${currentDialect.existingPrimaryKeys(Users)[Users]}")
+        println("Primary key: ${currentDialectMetadata.existingPrimaryKeys(Users)[Users]}")
 
         Users.insert {
             it[id] = UUID.randomUUID()

--- a/samples/exposed-migration/src/main/kotlin/GenerateMigrationScript.kt
+++ b/samples/exposed-migration/src/main/kotlin/GenerateMigrationScript.kt
@@ -1,8 +1,9 @@
 @file:OptIn(ExperimentalDatabaseMigrationApi::class)
 
-import org.jetbrains.exposed.v1.Database
-import org.jetbrains.exposed.v1.ExperimentalDatabaseMigrationApi
-import org.jetbrains.exposed.v1.transactions.transaction
+import org.jetbrains.exposed.v1.core.ExperimentalDatabaseMigrationApi
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.migration.MigrationUtils
 
 const val URL = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
 const val USER = "root"

--- a/samples/exposed-spring/build.gradle.kts
+++ b/samples/exposed-spring/build.gradle.kts
@@ -5,8 +5,8 @@ val exposedVersion: String by project
 plugins {
     id("org.springframework.boot") version "3.3.2"
     id("io.spring.dependency-management") version "1.1.6"
-    kotlin("jvm") version "2.0.0"
-    kotlin("plugin.spring") version "2.0.0"
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.spring") version "2.2.0"
 }
 
 group = "org.jetbrains.exposed"
@@ -31,6 +31,7 @@ dependencies {
 
     implementation("com.h2database:h2")
     implementation("org.jetbrains.exposed:exposed-spring-boot-starter:$exposedVersion")
+    implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/samples/exposed-spring/gradle.properties
+++ b/samples/exposed-spring/gradle.properties
@@ -1,2 +1,2 @@
 exposedVersion=1.0.0-beta-5
-kotlinVersion=2.0.0
+kotlinVersion=2.2.0

--- a/samples/exposed-spring/src/main/kotlin/SpringApplication.kt
+++ b/samples/exposed-spring/src/main/kotlin/SpringApplication.kt
@@ -2,7 +2,7 @@
 
 package org.jetbrains.exposed.samples.spring
 
-import org.jetbrains.exposed.v1.spring.autoconfigure.ExposedAutoConfiguration
+import org.jetbrains.exposed.v1.spring.boot.autoconfigure.ExposedAutoConfiguration
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/samples/exposed-spring/src/main/kotlin/controller/UserController.kt
+++ b/samples/exposed-spring/src/main/kotlin/controller/UserController.kt
@@ -2,10 +2,10 @@
 
 package org.jetbrains.exposed.samples.spring.controller
 
-import org.jetbrains.exposed.v1.samples.spring.domain.UserId
-import org.jetbrains.exposed.v1.samples.spring.service.UserCreateRequest
-import org.jetbrains.exposed.v1.samples.spring.service.UserService
-import org.jetbrains.exposed.v1.samples.spring.service.UserUpdateRequest
+import org.jetbrains.exposed.samples.spring.domain.UserId
+import org.jetbrains.exposed.samples.spring.service.UserCreateRequest
+import org.jetbrains.exposed.samples.spring.service.UserService
+import org.jetbrains.exposed.samples.spring.service.UserUpdateRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping

--- a/samples/exposed-spring/src/main/kotlin/domain/UserEntity.kt
+++ b/samples/exposed-spring/src/main/kotlin/domain/UserEntity.kt
@@ -2,7 +2,7 @@
 
 package org.jetbrains.exposed.samples.spring.domain
 
-import org.jetbrains.exposed.v1.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 
 object UserEntity : LongIdTable() {
     val name = varchar("name", length = 50)

--- a/samples/exposed-spring/src/main/kotlin/service/UserService.kt
+++ b/samples/exposed-spring/src/main/kotlin/service/UserService.kt
@@ -2,14 +2,14 @@
 
 package org.jetbrains.exposed.samples.spring.service
 
+import org.jetbrains.exposed.samples.spring.domain.User
+import org.jetbrains.exposed.samples.spring.domain.UserEntity
+import org.jetbrains.exposed.samples.spring.domain.UserId
 import org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.v1.deleteWhere
-import org.jetbrains.exposed.v1.insertAndGetId
-import org.jetbrains.exposed.v1.samples.spring.domain.User
-import org.jetbrains.exposed.v1.samples.spring.domain.UserEntity
-import org.jetbrains.exposed.v1.samples.spring.domain.UserId
-import org.jetbrains.exposed.v1.selectAll
-import org.jetbrains.exposed.v1.update
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 

--- a/samples/exposed-spring/src/main/kotlin/support/SchemaInitialize.kt
+++ b/samples/exposed-spring/src/main/kotlin/support/SchemaInitialize.kt
@@ -2,8 +2,8 @@
 
 package org.jetbrains.exposed.samples.spring.support
 
-import org.jetbrains.exposed.v1.SchemaUtils
-import org.jetbrains.exposed.v1.samples.spring.domain.UserEntity
+import org.jetbrains.exposed.samples.spring.domain.UserEntity
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.stereotype.Component


### PR DESCRIPTION
#### Description

**Summary of the change**: Update all 4 sample projects so that they compile and run on latest version 1.0.0-beta-5.

**Detailed description**:
- **Why**: When Exposed version is bumped as part of release process, all sample project versions are bumped. Unfortunately, these projects are not set up as part of the automatic CI/CD to ensure compilation and compatibility with the new version. This means a number of issues have popped up in the projects that have been overlooked, with the majority relating to invalid import statements or other missed migration steps.

- **How**:
    - Fix all broken imports to match new package paths
    - Bump Kotlin version to 2.2.0, as well as any other older peripherals like Ktor
    - Fix issue with experimental `kotlin.time` packaged with `exposed-kotlin-datetime` dependency
    - Replace `currentDialect...` with `currentDialectMetadata...`
    - Add dependency on `exposed-jdbc` to spring boot project

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

#### Checklist

- [X] The build is green (including the Detekt check)

---

#### Related Issues

[EXPOSED-865](https://youtrack.jetbrains.com/issue/EXPOSED-865)