### PR TITLE
chore: Fix broken maven central badge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@
 **Summary of the change**: Provide a concise summary of this PR. Describe the changes made in a single sentence or short paragraph.
 
 **Detailed description**:
-- **What**: Detail what changes have been made in the PR.
 - **Why**: Explain the reasons behind the changes. Why were they necessary?
+- **What**: Detail what changes have been made in the PR.
 - **How**: Describe how the changes were implemented, including any key aspects of the code modified or new features added.
 
 ---

--- a/.github/workflows/commit-message-validation.yml
+++ b/.github/workflows/commit-message-validation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Validate commit messages
         run: |
           # Regex for Conventional Commits specification
-          COMMIT_REGEX="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(!)?(\([^\)]*\))?:\s?(EXPOSED-[0-9]+\s?)?.+$"
+          COMMIT_REGEX="^(build|chore|ci|deprecate|docs|feat|fix|perf|refactor|revert|style|test)(!)?(\([^\)]*\))?:\s?(EXPOSED-[0-9]+\s?)?.+$"
           
           # Get all commits in the pull request (from base to head)
           COMMITS=$(git log --format=%s --no-merges origin/main..${{ github.sha }})

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![JetBrains team project](https://jb.gg/badges/team.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 [![Slack Channel](https://img.shields.io/badge/chat-exposed-yellow.svg?logo=slack)](https://kotlinlang.slack.com/messages/exposed/)
 [![TC Build status](https://exposed.teamcity.com/app/rest/builds/buildType:id:Exposed_Build/statusIcon.svg)](https://exposed.teamcity.com/viewType.html?buildTypeId=Exposed_Build&guest=1)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jetbrains.exposed/exposed-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jetbrains.exposed/exposed-core)
+[![Maven Central](https://img.shields.io/maven-central/v/org.jetbrains.exposed/exposed-core?label=maven+central)](https://central.sonatype.com/search?namespace=org.jetbrains.exposed)
 [![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 
 </div>


### PR DESCRIPTION
#### Description

**Summary of the change**: Changed source ref and link for GH README 'Maven Central' badge to show latest release.

**Detailed description**:
- **Why**: Previous version was relying on [search.maven.org](https://search.maven.org/artifact/org.jetbrains.exposed/exposed-core/1.0.0-beta-4/jar?eh=), which only has up to version 1.0.0-beta-4 following recent changes to publishing process. Switched to rely on [central.sonatype.com](https://central.sonatype.com/namespace/org.jetbrains.exposed) instead.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update _- README badge_

#### Checklist

- [X] The build is green (including the Detekt check)
