### PR TITLE
chore!: Rename R2DBCRow to R2dbcRow

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -18,6 +18,7 @@
   and [higher-order functions](https://www.jetbrains.com/help/exposed/migration-guide-1-0-0.html#sql-expression-builder-lambda).
 * Parameter `supportsSelectForUpdate` from `DatabaseDialect` was deprecated and should not be used. The parameter was moved to `JdbcExposedDatabaseMetadata`/
   `R2dbcExposedDatabaseMetadata` classes. It could be used with call `TransactionManager.current().connection.metadata { supportsSelectForUpdate }` now.
+* `R2DBCRow`, which is the R2DBC implementation of `RowApi` meant to wrap elements of a statement's result, has been renamed to `R2dbcRow`.
 
 ## 1.0.0-beta-5
 

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -806,18 +806,6 @@ public class org/jetbrains/exposed/v1/r2dbc/statements/UpsertSuspendExecutable :
 	public fun prepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2DBCRow : org/jetbrains/exposed/v1/core/statements/api/RowApi {
-	public fun <init> (Lio/r2dbc/spi/Row;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;)V
-	public fun getObject (I)Ljava/lang/Object;
-	public fun getObject (ILjava/lang/Class;)Ljava/lang/Object;
-	public fun getObject (ILjava/lang/Class;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
-	public fun getObject (Ljava/lang/String;)Ljava/lang/Object;
-	public fun getObject (Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
-	public fun getObject (Ljava/lang/String;Ljava/lang/Class;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
-	public final fun getRow ()Lio/r2dbc/spi/Row;
-	public fun getString (I)Ljava/lang/String;
-}
-
 public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl : org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcExposedDatabaseMetadata {
 	public static final field Companion Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl$Companion;
 	public fun <init> (Ljava/lang/String;Lio/r2dbc/spi/Connection;Ljava/lang/String;)V
@@ -935,6 +923,18 @@ public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcResultKt {
 	public static final fun getMetadata (Lorg/jetbrains/exposed/v1/core/statements/api/RowApi;)Lio/r2dbc/spi/RowMetadata;
 	public static final fun getOrigin (Lorg/jetbrains/exposed/v1/core/statements/api/RowApi;)Lio/r2dbc/spi/Row;
 	public static final fun rowsCount (Lorg/jetbrains/exposed/v1/core/statements/api/ResultApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcRow : org/jetbrains/exposed/v1/core/statements/api/RowApi {
+	public fun <init> (Lio/r2dbc/spi/Row;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;)V
+	public fun getObject (I)Ljava/lang/Object;
+	public fun getObject (ILjava/lang/Class;)Ljava/lang/Object;
+	public fun getObject (ILjava/lang/Class;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
+	public fun getObject (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getObject (Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
+	public fun getObject (Ljava/lang/String;Ljava/lang/Class;Lorg/jetbrains/exposed/v1/core/IColumnType;)Ljava/lang/Object;
+	public final fun getRow ()Lio/r2dbc/spi/Row;
+	public fun getString (I)Ljava/lang/String;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcSavepoint : org/jetbrains/exposed/v1/core/statements/api/ExposedSavepoint {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/InsertSuspendExecutable.kt
@@ -10,9 +10,9 @@ import org.jetbrains.exposed.v1.core.statements.InsertStatement
 import org.jetbrains.exposed.v1.core.statements.ReplaceStatement
 import org.jetbrains.exposed.v1.core.vendors.*
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
-import org.jetbrains.exposed.v1.r2dbc.statements.api.R2DBCRow
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcPreparedStatementApi
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcResult
+import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcRow
 import org.jetbrains.exposed.v1.r2dbc.statements.api.metadata
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 
@@ -154,7 +154,7 @@ open class InsertSuspendExecutable<Key : Any, S : InsertStatement<Key>>(
             if (segment is Result.RowSegment && !isSQLServerLastRowId(segment, isSqlServerBatchInsert, dialect)) {
                 isSqlServerBatchInsert = isSqlServerBatchInsert || isSQLServerBatchSegment(segment, dialect)
 
-                val row = R2DBCRow(segment.row(), typeMapping)
+                val row = R2dbcRow(segment.row(), typeMapping)
 
                 if (columnIndexesInResultSet == null) {
                     columnIndexesInResultSet = row.metadata.returnedColumns()

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl.kt
@@ -196,7 +196,7 @@ class R2dbcDatabaseMetadataImpl(
                 val columns = connection.executeSQL(query) { row, _ ->
                     // Unlike JdbcResult, R2dbcResult is split apart for ResultApi vs RowApi, so a 2nd arg placeholder has to be used
                     with(ExposedMetadataUtils) {
-                        R2DBCRow(row, R2dbcRegistryTypeMappingImpl()).asColumnMetadata(prefetchedColumnTypes)
+                        R2dbcRow(row, R2dbcRegistryTypeMappingImpl()).asColumnMetadata(prefetchedColumnTypes)
                     }
                 }.orEmpty()
                 check(columns.isNotEmpty())

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcResult.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcResult.kt
@@ -36,7 +36,7 @@ class R2dbcResult internal constructor(
         return flow {
             resultPublisher.collect { result ->
                 result.map { row, rm ->
-                    Optional.ofNullable(block(R2DBCRow(row, typeMapping)))
+                    Optional.ofNullable(block(R2dbcRow(row, typeMapping)))
                 }.collect { emit(it.getOrNull()) }
             }
         }
@@ -87,7 +87,7 @@ class R2dbcResult internal constructor(
  * @param row The actual underlying wrapped [Row] that is being accessed.
  * @param typeMapping The type mapper logic being used to get values from a [Row].
  */
-class R2DBCRow(val row: Row, private val typeMapping: R2dbcTypeMapping) : RowApi {
+class R2dbcRow(val row: Row, private val typeMapping: R2dbcTypeMapping) : RowApi {
     override fun getObject(index: Int): Any? {
         return row.get(index - 1)
     }
@@ -116,7 +116,7 @@ class R2DBCRow(val row: Row, private val typeMapping: R2dbcTypeMapping) : RowApi
 suspend fun ResultApi.rowsCount(): Int = mapRows { }.count()
 
 /** Returns the actual underlying [Row] at the current position in this result [RowApi]. */
-val RowApi.origin: Row get() = (this as R2DBCRow).row
+val RowApi.origin: Row get() = (this as R2dbcRow).row
 
 /** Returns the actual [RowMetadata] for the current row in this result [RowApi]. */
-val RowApi.metadata: RowMetadata get() = (this as R2DBCRow).row.metadata
+val RowApi.metadata: RowMetadata get() = (this as R2dbcRow).row.metadata


### PR DESCRIPTION
#### Description

**Summary of the change**: Rename new `R2DBCRow` to `R2dbcRow` to match convention of all other R2DBC-specific API and all existing JDBC-specific API.

**Detailed description**:
- **Why**: To keep naming convention (related to acronyms/abbreviations) as consistent as possible, especially with all newly implemented API.

- **What**:
    - `R2DBCRow` -> `R2dbcRow`
    - Updated breaking changes even though class has only been available since 1.0.0-beta-1

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Refactor

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date