### PR TITLE
chore: Replace use of thread local in R2DBC transaction manager

### DIFF
--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/MultiDatabaseTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/h2/MultiDatabaseTest.kt
@@ -112,77 +112,77 @@ class MultiDatabaseTest {
         }
     }
 
-//    @Test
-//    fun testEmbeddedInsertsInDifferentDatabase() = runTest {
-//        suspendTransaction(db1) {
-//            SchemaUtils.create(DMLTestsData.Cities)
-//            assertTrue(DMLTestsData.Cities.selectAll().empty())
-//            DMLTestsData.Cities.insert {
-//                it[DMLTestsData.Cities.name] = "city1"
-//            }
-//
-//            suspendTransaction(db2) {
-//                assertFalse(DMLTestsData.Cities.exists())
-//                SchemaUtils.create(DMLTestsData.Cities)
-//                DMLTestsData.Cities.insert {
-//                    it[DMLTestsData.Cities.name] = "city2"
-//                }
-//                DMLTestsData.Cities.insert {
-//                    it[DMLTestsData.Cities.name] = "city3"
-//                }
-//                assertEquals(2L, DMLTestsData.Cities.selectAll().count())
-//                assertEquals("city3", DMLTestsData.Cities.selectAll().last()[DMLTestsData.Cities.name])
-//                SchemaUtils.drop(DMLTestsData.Cities)
-//            }
-//
-//            assertEquals(1L, DMLTestsData.Cities.selectAll().count())
-//            assertEquals("city1", DMLTestsData.Cities.selectAll().single()[DMLTestsData.Cities.name])
-//            SchemaUtils.drop(DMLTestsData.Cities)
-//        }
-//    }
-//
-//    @Test
-//    fun testEmbeddedInsertsInDifferentDatabaseDepth2() = runTest {
-//        suspendTransaction(db1) {
-//            SchemaUtils.create(DMLTestsData.Cities)
-//            assertTrue(DMLTestsData.Cities.selectAll().empty())
-//            DMLTestsData.Cities.insert {
-//                it[DMLTestsData.Cities.name] = "city1"
-//            }
-//
-//            suspendTransaction(db2) {
-//                assertFalse(DMLTestsData.Cities.exists())
-//                SchemaUtils.create(DMLTestsData.Cities)
-//                DMLTestsData.Cities.insert {
-//                    it[DMLTestsData.Cities.name] = "city2"
-//                }
-//                DMLTestsData.Cities.insert {
-//                    it[DMLTestsData.Cities.name] = "city3"
-//                }
-//                assertEquals(2L, DMLTestsData.Cities.selectAll().count())
-//                assertEquals("city3", DMLTestsData.Cities.selectAll().last()[DMLTestsData.Cities.name])
-//
-//                suspendTransaction(db1) {
-//                    assertEquals(1L, DMLTestsData.Cities.selectAll().count())
-//                    DMLTestsData.Cities.insert {
-//                        it[DMLTestsData.Cities.name] = "city4"
-//                    }
-//                    DMLTestsData.Cities.insert {
-//                        it[DMLTestsData.Cities.name] = "city5"
-//                    }
-//                    assertEquals(3L, DMLTestsData.Cities.selectAll().count())
-//                }
-//
-//                assertEquals(2L, DMLTestsData.Cities.selectAll().count())
-//                assertEquals("city3", DMLTestsData.Cities.selectAll().last()[DMLTestsData.Cities.name])
-//                SchemaUtils.drop(DMLTestsData.Cities)
-//            }
-//
-//            assertEquals(3L, DMLTestsData.Cities.selectAll().count())
-//            assertEqualLists(listOf("city1", "city4", "city5"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
-//            SchemaUtils.drop(DMLTestsData.Cities)
-//        }
-//    }
+    @Test
+    fun testEmbeddedInsertsInDifferentDatabase() = runTest {
+        suspendTransaction(db1) {
+            SchemaUtils.create(DMLTestsData.Cities)
+            assertTrue(DMLTestsData.Cities.selectAll().empty())
+            DMLTestsData.Cities.insert {
+                it[DMLTestsData.Cities.name] = "city1"
+            }
+
+            suspendTransaction(db2) {
+                assertFalse(DMLTestsData.Cities.exists())
+                SchemaUtils.create(DMLTestsData.Cities)
+                DMLTestsData.Cities.insert {
+                    it[DMLTestsData.Cities.name] = "city2"
+                }
+                DMLTestsData.Cities.insert {
+                    it[DMLTestsData.Cities.name] = "city3"
+                }
+                assertEquals(2L, DMLTestsData.Cities.selectAll().count())
+                assertEquals("city3", DMLTestsData.Cities.selectAll().last()[DMLTestsData.Cities.name])
+                SchemaUtils.drop(DMLTestsData.Cities)
+            }
+
+            assertEquals(1L, DMLTestsData.Cities.selectAll().count())
+            assertEquals("city1", DMLTestsData.Cities.selectAll().single()[DMLTestsData.Cities.name])
+            SchemaUtils.drop(DMLTestsData.Cities)
+        }
+    }
+
+    @Test
+    fun testEmbeddedInsertsInDifferentDatabaseDepth2() = runTest {
+        suspendTransaction(db1) {
+            SchemaUtils.create(DMLTestsData.Cities)
+            assertTrue(DMLTestsData.Cities.selectAll().empty())
+            DMLTestsData.Cities.insert {
+                it[DMLTestsData.Cities.name] = "city1"
+            }
+
+            suspendTransaction(db2) {
+                assertFalse(DMLTestsData.Cities.exists())
+                SchemaUtils.create(DMLTestsData.Cities)
+                DMLTestsData.Cities.insert {
+                    it[DMLTestsData.Cities.name] = "city2"
+                }
+                DMLTestsData.Cities.insert {
+                    it[DMLTestsData.Cities.name] = "city3"
+                }
+                assertEquals(2L, DMLTestsData.Cities.selectAll().count())
+                assertEquals("city3", DMLTestsData.Cities.selectAll().last()[DMLTestsData.Cities.name])
+
+                suspendTransaction(db1) {
+                    assertEquals(1L, DMLTestsData.Cities.selectAll().count())
+                    DMLTestsData.Cities.insert {
+                        it[DMLTestsData.Cities.name] = "city4"
+                    }
+                    DMLTestsData.Cities.insert {
+                        it[DMLTestsData.Cities.name] = "city5"
+                    }
+                    assertEquals(3L, DMLTestsData.Cities.selectAll().count())
+                }
+
+                assertEquals(2L, DMLTestsData.Cities.selectAll().count())
+                assertEquals("city3", DMLTestsData.Cities.selectAll().last()[DMLTestsData.Cities.name])
+                SchemaUtils.drop(DMLTestsData.Cities)
+            }
+
+            assertEquals(3L, DMLTestsData.Cities.selectAll().count())
+            assertEqualLists(listOf("city1", "city4", "city5"), DMLTestsData.Cities.selectAll().map { it[DMLTestsData.Cities.name] })
+            SchemaUtils.drop(DMLTestsData.Cities)
+        }
+    }
 
     @Test
     fun testCoroutinesWithMultiDb() = runTest {

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -997,7 +997,6 @@ public final class org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManage
 	public fun getDefaultMaxRetryDelay ()J
 	public fun getDefaultMinRetryDelay ()J
 	public fun getDefaultReadOnly ()Z
-	public final fun getThreadLocal ()Ljava/lang/ThreadLocal;
 	public final fun newTransaction (Lio/r2dbc/spi/IsolationLevel;ZLorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;
 	public static synthetic fun newTransaction$default (Lorg/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager;Lio/r2dbc/spi/IsolationLevel;ZLorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;
 	public final fun setDefaultIsolationLevel (Lio/r2dbc/spi/IsolationLevel;)V

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
@@ -4,7 +4,9 @@ import io.r2dbc.spi.IsolationLevel
 import io.r2dbc.spi.R2dbcException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.SqlLogger
 import org.jetbrains.exposed.v1.core.Transaction
@@ -45,8 +47,18 @@ class TransactionManager(
 
     override var defaultReadOnly: Boolean = db.config.defaultReadOnly
 
-    /** A thread local variable storing the current transaction. */
-    val threadLocal = ThreadLocal<R2dbcTransaction>()
+    /** A unique key for storing coroutine context elements, as [TransactionContextHolder]. */
+    private val contextKey = object : CoroutineContext.Key<TransactionContextHolder> {}
+
+    private var transactionLocal: R2dbcTransaction? = null
+
+    internal suspend fun getContextFromTransaction(transaction: R2dbcTransaction?): CoroutineContext {
+        val currentTransaction = transaction
+            ?: currentCoroutineContext()[contextKey]?.transaction
+        transactionLocal = currentTransaction
+        MappedTransactionContext.setTransaction(currentTransaction)
+        return TransactionContextHolder(currentTransaction, contextKey)
+    }
 
     override fun toString(): String {
         return "R2dbcTransactionManager[${hashCode()}](db=$db)"
@@ -65,12 +77,12 @@ class TransactionManager(
     ): R2dbcTransaction {
         val transaction = outerTransaction?.takeIf { !db.useNestedTransactions }
             ?: R2dbcTransaction(
-                R2dbcThreadLocalTransaction(
+                R2dbcLocalTransaction(
                     db = db,
                     readOnly = outerTransaction?.readOnly ?: readOnly,
                     transactionIsolation = outerTransaction?.transactionIsolation ?: isolation,
                     setupTxConnection = setupTxConnection,
-                    threadLocal = threadLocal,
+                    setTransactionLocal = { transactionLocal = it },
                     outerTransaction = outerTransaction,
                 ),
             )
@@ -79,15 +91,16 @@ class TransactionManager(
     }
 
     override fun currentOrNull(): R2dbcTransaction? {
-        return threadLocal.get() ?: MappedTransactionContext.getTransactionOrNull()
+        return transactionLocal
+            ?: MappedTransactionContext.getTransactionOrNull()?.takeIf { it.db == this.db }
     }
 
     override fun bindTransactionToThread(transaction: Transaction?) {
         if (transaction != null) {
-            threadLocal.set(transaction as R2dbcTransaction)
+            transactionLocal = transaction as R2dbcTransaction
             MappedTransactionContext.setTransaction(transaction)
         } else {
-            threadLocal.remove()
+            transactionLocal = null
             MappedTransactionContext.clean()
         }
     }
@@ -171,13 +184,13 @@ class TransactionManager(
         }
     }
 
-    private class R2dbcThreadLocalTransaction(
+    private class R2dbcLocalTransaction(
         override val db: R2dbcDatabase,
         private val setupTxConnection:
         ((R2dbcExposedConnection<*>, R2dbcTransactionInterface) -> Unit)?,
         override val transactionIsolation: IsolationLevel,
         override val readOnly: Boolean,
-        val threadLocal: ThreadLocal<R2dbcTransaction>,
+        private val setTransactionLocal: ((R2dbcTransaction?) -> Unit),
         override val outerTransaction: R2dbcTransaction?,
     ) : R2dbcTransactionInterface {
 
@@ -192,9 +205,9 @@ class TransactionManager(
             ?: db.connector().apply {
                 @Suppress("TooGenericExceptionCaught")
                 try {
-                    setupTxConnection?.invoke(this, this@R2dbcThreadLocalTransaction) ?: run {
-                        setTransactionIsolation(this@R2dbcThreadLocalTransaction.transactionIsolation)
-                        setReadOnly(this@R2dbcThreadLocalTransaction.readOnly)
+                    setupTxConnection?.invoke(this, this@R2dbcLocalTransaction) ?: run {
+                        setTransactionIsolation(this@R2dbcLocalTransaction.transactionIsolation)
+                        setReadOnly(this@R2dbcLocalTransaction.readOnly)
                         // potentially redundant if R2dbcConnectionImpl calls beginTransaction(), which disables autoCommit
                         setAutoCommit(false)
                     }
@@ -247,7 +260,7 @@ class TransactionManager(
                     }
                 }
             } finally {
-                threadLocal.set(outerTransaction)
+                setTransactionLocal(outerTransaction)
                 MappedTransactionContext.setTransaction(outerTransaction)
             }
         }
@@ -266,6 +279,15 @@ class TransactionManager(
             }
     }
 }
+
+/**
+ * Singleton coroutine context element storing its associated transaction
+ * & the unique key for its [TransactionManager.transactionLocal].
+ */
+private data class TransactionContextHolder(
+    val transaction: R2dbcTransaction?,
+    override val key: CoroutineContext.Key<*>
+) : CoroutineContext.Element
 
 @Deprecated(
     message = "This method overload will be removed in release 1.0.0. It should be replaced with either overload" +
@@ -346,24 +368,16 @@ suspend fun <T> suspendTransaction(
         val outerManager = outer.db.transactionManager
 
         val transaction = outerManager.newTransaction(transactionIsolation, readOnly, outer)
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            transaction.statement().also {
-                if (outer.db.useNestedTransactions) {
-                    transaction.commit()
+        val context = outerManager.getContextFromTransaction(transaction)
+        withContext(context) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                transaction.statement().also {
+                    if (outer.db.useNestedTransactions) {
+                        transaction.commit()
+                    }
                 }
-            }
-        } catch (cause: R2dbcException) {
-            val currentStatement = transaction.currentStatement
-            transaction.rollbackLoggingException {
-                exposedLogger.warn(
-                    "Transaction rollback failed: ${it.message}. Statement: $currentStatement",
-                    it
-                )
-            }
-            throw cause
-        } catch (cause: Throwable) {
-            if (outer.db.useNestedTransactions) {
+            } catch (cause: R2dbcException) {
                 val currentStatement = transaction.currentStatement
                 transaction.rollbackLoggingException {
                     exposedLogger.warn(
@@ -371,24 +385,38 @@ suspend fun <T> suspendTransaction(
                         it
                     )
                 }
+                throw cause
+            } catch (cause: Throwable) {
+                if (outer.db.useNestedTransactions) {
+                    val currentStatement = transaction.currentStatement
+                    transaction.rollbackLoggingException {
+                        exposedLogger.warn(
+                            "Transaction rollback failed: ${it.message}. Statement: $currentStatement",
+                            it
+                        )
+                    }
+                }
+                throw cause
+            } finally {
+                TransactionManager.resetCurrent(outerManager)
             }
-            throw cause
-        } finally {
-            TransactionManager.resetCurrent(outerManager)
         }
     } else {
         val existingForDb = db?.transactionManager
         existingForDb?.currentOrNull()?.let { transaction ->
             val currentManager = outer?.db.transactionManager
-            try {
-                TransactionManager.resetCurrent(existingForDb)
-                transaction.statement().also {
-                    if (db.useNestedTransactions) {
-                        transaction.commit()
+            val context = existingForDb.getContextFromTransaction(transaction)
+            withContext(context) {
+                try {
+                    TransactionManager.resetCurrent(existingForDb)
+                    transaction.statement().also {
+                        if (db.useNestedTransactions) {
+                            transaction.commit()
+                        }
                     }
+                } finally {
+                    TransactionManager.resetCurrent(currentManager)
                 }
-            } finally {
-                TransactionManager.resetCurrent(currentManager)
             }
         } ?: inTopLevelSuspendTransaction(
             transactionIsolation,
@@ -429,12 +457,16 @@ suspend fun <T> inTopLevelSuspendTransaction(
         while (true) {
             db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
             val transaction = db.transactionManager.newTransaction(transactionIsolation, readOnly, outerTransaction)
+            val context = db.transactionManager.getContextFromTransaction(transaction)
 
             @Suppress("TooGenericExceptionCaught")
             try {
-                transaction.db.config.defaultSchema?.let { SchemaUtils.setSchema(it) }
-                val answer = transaction.statement()
-                transaction.commit()
+                var answer: T
+                withContext(context) {
+                    transaction.db.config.defaultSchema?.let { SchemaUtils.setSchema(it) }
+                    answer = transaction.statement()
+                    transaction.commit()
+                }
                 return answer
             } catch (cause: R2dbcException) {
                 handleR2dbcException(cause, transaction, attempts)

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
@@ -50,12 +50,12 @@ class TransactionManager(
     /** A unique key for storing coroutine context elements, as [TransactionContextHolder]. */
     private val contextKey = object : CoroutineContext.Key<TransactionContextHolder> {}
 
-    private var transactionLocal: R2dbcTransaction? = null
+    internal suspend fun getCurrentContextTransaction(): R2dbcTransaction? {
+        return currentCoroutineContext()[contextKey]?.transaction
+    }
 
-    internal suspend fun getContextFromTransaction(transaction: R2dbcTransaction?): CoroutineContext {
-        val currentTransaction = transaction
-            ?: currentCoroutineContext()[contextKey]?.transaction
-        transactionLocal = currentTransaction
+    internal suspend fun createTransactionContext(transaction: R2dbcTransaction?): CoroutineContext {
+        val currentTransaction = transaction ?: getCurrentContextTransaction()
         MappedTransactionContext.setTransaction(currentTransaction)
         return TransactionContextHolder(currentTransaction, contextKey)
     }
@@ -82,7 +82,6 @@ class TransactionManager(
                     readOnly = outerTransaction?.readOnly ?: readOnly,
                     transactionIsolation = outerTransaction?.transactionIsolation ?: isolation,
                     setupTxConnection = setupTxConnection,
-                    setTransactionLocal = { transactionLocal = it },
                     outerTransaction = outerTransaction,
                 ),
             )
@@ -91,15 +90,13 @@ class TransactionManager(
     }
 
     override fun currentOrNull(): R2dbcTransaction? {
-        return transactionLocal ?: MappedTransactionContext.getTransactionOrNull()
+        return MappedTransactionContext.getTransactionOrNull()
     }
 
     override fun bindTransactionToThread(transaction: Transaction?) {
         if (transaction != null) {
-            transactionLocal = transaction as R2dbcTransaction
-            MappedTransactionContext.setTransaction(transaction)
+            MappedTransactionContext.setTransaction(transaction as R2dbcTransaction)
         } else {
-            transactionLocal = null
             MappedTransactionContext.clean()
         }
     }
@@ -189,7 +186,6 @@ class TransactionManager(
         ((R2dbcExposedConnection<*>, R2dbcTransactionInterface) -> Unit)?,
         override val transactionIsolation: IsolationLevel,
         override val readOnly: Boolean,
-        private val setTransactionLocal: ((R2dbcTransaction?) -> Unit),
         override val outerTransaction: R2dbcTransaction?,
     ) : R2dbcTransactionInterface {
 
@@ -259,7 +255,6 @@ class TransactionManager(
                     }
                 }
             } finally {
-                setTransactionLocal(outerTransaction)
                 MappedTransactionContext.setTransaction(outerTransaction)
             }
         }
@@ -367,8 +362,7 @@ suspend fun <T> suspendTransaction(
         val outerManager = outer.db.transactionManager
 
         val transaction = outerManager.newTransaction(transactionIsolation, readOnly, outer)
-        val context = outerManager.getContextFromTransaction(transaction)
-        withContext(context) {
+        withTransactionContext(transaction) {
             @Suppress("TooGenericExceptionCaught")
             try {
                 transaction.statement().also {
@@ -396,34 +390,25 @@ suspend fun <T> suspendTransaction(
                     }
                 }
                 throw cause
-            } finally {
-                TransactionManager.resetCurrent(outerManager)
             }
         }
     } else {
-        val existingForDb = db?.transactionManager
-        existingForDb?.currentOrNull()?.let { transaction ->
-            val currentManager = outer?.db.transactionManager
-            val context = existingForDb.getContextFromTransaction(transaction)
-            withContext(context) {
-                try {
-                    TransactionManager.resetCurrent(existingForDb)
-                    transaction.statement().also {
-                        if (db.useNestedTransactions) {
-                            transaction.commit()
-                        }
+        db?.transactionManager?.getCurrentContextTransaction()?.let { transaction ->
+            withTransactionContext(transaction) {
+                transaction.statement().also {
+                    if (transaction.db.useNestedTransactions) {
+                        transaction.commit()
                     }
-                } finally {
-                    TransactionManager.resetCurrent(currentManager)
                 }
             }
-        } ?: inTopLevelSuspendTransaction(
-            transactionIsolation,
-            readOnly,
-            db,
-            null,
-            statement
-        )
+        }
+            ?: inTopLevelSuspendTransaction(
+                transactionIsolation,
+                readOnly,
+                db,
+                null,
+                statement
+            )
     }
 }
 
@@ -456,11 +441,11 @@ suspend fun <T> inTopLevelSuspendTransaction(
         while (true) {
             db?.let { db.transactionManager.let { m -> TransactionManager.resetCurrent(m) } }
             val transaction = db.transactionManager.newTransaction(transactionIsolation, readOnly, outerTransaction)
-            val context = db.transactionManager.getContextFromTransaction(transaction)
+            val context = db.transactionManager.createTransactionContext(transaction)
 
             @Suppress("TooGenericExceptionCaught")
             try {
-                var answer: T
+                val answer: T
                 withContext(context) {
                     transaction.db.config.defaultSchema?.let { SchemaUtils.setSchema(it) }
                     answer = transaction.statement()
@@ -554,5 +539,31 @@ internal suspend fun closeStatementsAndConnection(transaction: R2dbcTransaction)
     }
     transaction.closeLoggingException {
         exposedLogger.warn("Transaction close failed: ${it.message}. Statement: $currentStatement", it)
+    }
+}
+
+/**
+ * The method creates context with provided transaction and runs code block within that context.
+ *
+ * @param transaction The transaction to be used in the context.
+ * @param body The code block to be executed in the context.
+ * @return The result of executing the code block.
+ */
+internal suspend fun <T> withTransactionContext(transaction: R2dbcTransaction, body: suspend () -> T): T {
+    val outerTransaction = transaction.outerTransaction
+
+    val context = transaction.db.transactionManager.createTransactionContext(transaction)
+
+    return try {
+        TransactionManager.resetCurrent(transaction.db.transactionManager)
+        MappedTransactionContext.setTransaction(transaction)
+        withContext(context) {
+            body()
+        }
+    } finally {
+        outerTransaction?.let { MappedTransactionContext.setTransaction(it) }
+            ?: MappedTransactionContext.clean()
+
+        TransactionManager.resetCurrent(outerTransaction?.db.transactionManager)
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/transactions/TransactionManager.kt
@@ -91,8 +91,7 @@ class TransactionManager(
     }
 
     override fun currentOrNull(): R2dbcTransaction? {
-        return transactionLocal
-            ?: MappedTransactionContext.getTransactionOrNull()?.takeIf { it.db == this.db }
+        return transactionLocal ?: MappedTransactionContext.getTransactionOrNull()
     }
 
     override fun bindTransactionToThread(transaction: Transaction?) {


### PR DESCRIPTION
#### Description

**Summary of the change**: Replace thread local variable usage in R2DBC `TransactionManager` with `CoroutineContext.Key` + `Element`.

**Description:**

- **How:**
    - Introduce internal data holder `TransactionContextHolder` that can be used to pass around transaction & its coroutine context key reference.
    - Replace all usages of `ThreadLocal` in `TransactionManager`.
    - Pass context holder to `withContext()` in `suspendTransaction()`.

---

There are 2 other uses of `ThreadLocal` in the library:

1. `exposed-core/CoreTransactionManager` - private variable for transaction manager storage
2. `exposed-core/DatabaseDialect` - private variable for explicit dialect storage

I'm not sure if either is worth refactoring currently, but I have wondered if # 1 is potentially related to these issues.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - Refactor

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs