### PR TITLE
chore: Update sample projects to work with version 1.0.0-rc-1

### DIFF
--- a/samples/exposed-ktor-r2dbc/build.gradle.kts
+++ b/samples/exposed-ktor-r2dbc/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(libs.exposed.json)
 
     implementation(libs.postgresql.r2dbc)
-    runtimeOnly(libs.postgresql)
 
     implementation(libs.logback.classic)
 }

--- a/samples/exposed-ktor-r2dbc/gradle/libs.versions.toml
+++ b/samples/exposed-ktor-r2dbc/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ kotlin-version = "2.2.0"
 ktor-version = "3.2.3"
 exposed-version = "1.0.0-rc-1"
 postgresql-r2dbc-version = "1.0.7.RELEASE"
-postgresql-version = "42.7.5"
 logback-version = "1.5.18"
 
 [libraries]
@@ -22,7 +21,6 @@ exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datet
 exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed-version" }
 
 postgresql-r2dbc = { group = "org.postgresql", name = "r2dbc-postgresql", version.ref = "postgresql-r2dbc-version" }
-postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql-version" }
 
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-version" }
 

--- a/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/BaseRepository.kt
+++ b/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/BaseRepository.kt
@@ -3,6 +3,7 @@
 package org.jetbrains.exposed.samples.r2dbc.domain
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.samples.r2dbc.domain.issue.Issues
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
@@ -13,8 +14,10 @@ import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 interface BaseRepository {
     suspend fun <T> dbQuery(
         block: suspend R2dbcTransaction.() -> T
-    ): T = suspendTransaction(Dispatchers.IO) {
-        block()
+    ): T = withContext(Dispatchers.IO) {
+        suspendTransaction {
+            block()
+        }
     }
 
     fun issueProjectMatches(id: Int): Op<Boolean> = Issues.projectId eq id

--- a/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/comment/CommentRepository.kt
+++ b/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/comment/CommentRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.singleOrNull
 import org.jetbrains.exposed.samples.r2dbc.domain.BaseRepository
 import org.jetbrains.exposed.samples.r2dbc.domain.issue.Issues
 import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
 import org.jetbrains.exposed.v1.r2dbc.deleteReturning
 import org.jetbrains.exposed.v1.r2dbc.insertReturning

--- a/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/project/ProjectsTable.kt
+++ b/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/project/ProjectsTable.kt
@@ -4,6 +4,7 @@ package org.jetbrains.exposed.samples.r2dbc.domain.project
 
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.between
 import org.jetbrains.exposed.v1.core.charLength
 
 object Projects : Table("projects") {

--- a/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/user/UserRepository.kt
+++ b/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/user/UserRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.samples.r2dbc.domain.BaseRepository
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.update

--- a/samples/exposed-ktor/src/main/kotlin/Application.kt
+++ b/samples/exposed-ktor/src/main/kotlin/Application.kt
@@ -9,5 +9,6 @@ fun main(args: Array<String>): Unit =
 
 @Suppress("unused") // application.conf references the main function. This annotation prevents the IDE from marking it as unused.
 fun Application.module() {
+    configureSerialization()
     configureDatabases()
 }

--- a/samples/exposed-ktor/src/main/kotlin/plugins/Serialization.kt
+++ b/samples/exposed-ktor/src/main/kotlin/plugins/Serialization.kt
@@ -1,0 +1,13 @@
+@file:Suppress("InvalidPackageDeclaration")
+
+package org.jetbrains.exposed.samples.ktor
+
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.contentnegotiation.*
+
+fun Application.configureSerialization() {
+    install(ContentNegotiation) {
+        json()
+    }
+}

--- a/samples/exposed-migration/README.md
+++ b/samples/exposed-migration/README.md
@@ -18,7 +18,8 @@ The function `MigrationUtils.generateMigrationScript` generates a SQL migration 
 In this sample project, the migration script will be generated inside a directory called `migrations`.
 
 ```kotlin
-implementation("org.jetbrains.exposed:exposed-migration:$exposedVersion")
+implementation("org.jetbrains.exposed:exposed-migration-core:$exposedVersion")
+implementation("org.jetbrains.exposed:exposed-migration-jdbc:$exposedVersion")
 ```
 
 The generated migration script can also be edited manually before applying a migration.


### PR DESCRIPTION
#### Description

**Summary of the change**: Fix any sample projects that no longer compiled following version bump to 1.0.0-rc-1, or that were missing some details.

**Detailed description**:
**How**:

- **exposed-ktor-r2dbc**
    - Remove dependency on PostgreSQL-JDBC (no longer needed following fix in  PR #2579 )
    - Replace deprecated `suspendTransaction(context)`
    - Add missing imports (following PR #2600 )

- **exposed-ktor**
    -  Install content negotiation plugin for JSON (de)-/serialization; otherwise if user attempts to have paths respond at, for example, http://127.0.0.1:8000/users/# it sends back `Error code: 406 Not Acceptable`

- **exposed-migration**
    -   Change to dependency code block was missed from docs changes in PR #2604 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other _- Sample project update_

#### Checklist

- [X] The build is green (including the Detekt check)
