### PR TITLE
fix: EXPOSED-851 Not use Cached Entity when reference column defined with `.references()`

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/EntityClass.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/EntityClass.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.CompositeID
 import org.jetbrains.exposed.v1.core.dao.id.CompositeIdTable
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.EntityIDFunctionProvider
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.dao.exceptions.EntityNotFoundException
 import org.jetbrains.exposed.v1.jdbc.*
@@ -915,22 +916,50 @@ abstract class EntityClass<ID : Any, out T : Entity<ID>>(
             val findQuery = wrapRows(finalQuery)
             val entities = getEntities(forUpdate, findQuery).distinct()
 
-            entities.groupByReference(refColumn = refColumn).forEach { (id, values) ->
-                val castReferee = refColumn.referee
-                    .takeUnless { it?.columnType is EntityIDColumnType<*> && id !is EntityID<*> }
-                    ?: (refColumn.referee?.columnType as EntityIDColumnType<*>).idColumn
-                val parentEntityId: EntityID<*> = parentTable.selectAll().where { castReferee as Column<SID> eq id }
-                    .single()[parentTable.id]
+            val groupedEntities = entities.groupByReference(refColumn = refColumn)
+            val parentEntityIds = resolveParentEntityIds(groupedEntities.keys, refColumn, parentTable)
+
+            groupedEntities.forEach { (id, values) ->
+                val parentEntityId: EntityID<*> = parentEntityIds[id] ?: return@forEach
 
                 cache.getOrPutReferrers(parentEntityId, refColumn) { SizedCollection(values) }.also {
                     if (keepLoadedReferenceOutOfTransaction) {
-                        val childEntity = find { refColumn eq id }.firstOrNull()
-                        childEntity?.storeReferenceInCache(refColumn, it)
+                        values.firstOrNull()?.storeReferenceInCache(refColumn, it)
                     }
                 }
             }
             return entities
         }
+    }
+
+    /**
+     * Maps each value stored in a non-[EntityIDColumnType] [refColumn] to the [EntityID] of the parent row it points to.
+     */
+    private fun <SID> resolveParentEntityIds(
+        refereeValues: Set<SID>,
+        refColumn: Column<SID>,
+        parentTable: IdTable<*>
+    ): Map<SID, EntityID<*>> {
+        if (refereeValues.isEmpty()) return emptyMap()
+
+        val referee = refColumn.referee
+        val idColumn = (parentTable.id.columnType as EntityIDColumnType<*>).idColumn
+
+        if (referee == parentTable.id || referee == idColumn) {
+            return refereeValues.associateWith { value ->
+                val idValue = (value as? EntityID<*>)?.value ?: value
+                EntityIDFunctionProvider.createEntityID(idValue!!, parentTable as IdTable<Any>)
+            }
+        }
+
+        val castReferee = referee
+            .takeUnless { it?.columnType is EntityIDColumnType<*> && refereeValues.none { value -> value is EntityID<*> } }
+            ?: (referee?.columnType as EntityIDColumnType<*>).idColumn
+
+        return parentTable
+            .select(parentTable.id, castReferee as Column<SID>)
+            .where { castReferee inList refereeValues.toList() }
+            .associate { it[castReferee] to it[parentTable.id] }
     }
 
     internal fun warmUpCompositeIdReferences(

--- a/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/DatabaseTestsBase.kt
+++ b/exposed-tests/src/main/kotlin/org/jetbrains/exposed/v1/tests/DatabaseTestsBase.kt
@@ -4,6 +4,8 @@ import org.jetbrains.exposed.v1.core.DatabaseConfig
 import org.jetbrains.exposed.v1.core.Key
 import org.jetbrains.exposed.v1.core.Schema
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.statements.StatementContext
 import org.jetbrains.exposed.v1.core.statements.StatementInterceptor
 import org.jetbrains.exposed.v1.core.transactions.nullableTransactionScope
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -218,4 +220,30 @@ abstract class DatabaseTestsBase {
         quota = "20M",
         on = "USERS"
     )
+
+    interface Counter {
+        var count: Int
+        fun inc()
+        fun reset()
+    }
+
+    protected fun JdbcTransaction.executionsCounter(): Counter {
+        val counter = object : Counter {
+            override var count = 0
+            override fun inc() {
+                count++
+            }
+
+            override fun reset() {
+                count = 0
+            }
+        }
+        registerInterceptor(object : StatementInterceptor {
+            override fun beforeExecution(transaction: Transaction, context: StatementContext) {
+                counter.inc()
+            }
+        })
+
+        return counter
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityReferrersTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityReferrersTests.kt
@@ -1,0 +1,61 @@
+package org.jetbrains.exposed.v1.tests.shared.entities
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.dao.IntEntity
+import org.jetbrains.exposed.v1.dao.IntEntityClass
+import org.jetbrains.exposed.v1.dao.LongEntity
+import org.jetbrains.exposed.v1.dao.LongEntityClass
+import org.jetbrains.exposed.v1.dao.with
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EntityReferrersTests : DatabaseTestsBase() {
+
+    object AlertItemTable : IntIdTable("alert_item") {
+        val isAlarm = bool("is_alarm").default(true)
+    }
+
+    class AlertItemEntity(id: EntityID<Int>) : IntEntity(id) {
+        companion object : IntEntityClass<AlertItemEntity>(AlertItemTable)
+
+        val bids by ItemBidEntity.referrersOn(ItemBidTable.alertItemId, cache = true)
+    }
+
+    object ItemBidTable : LongIdTable("item_bid") {
+        val alertItemId = integer("alert_item_id").references(AlertItemTable.id, onDelete = ReferenceOption.CASCADE)
+    }
+
+    class ItemBidEntity(id: EntityID<Long>) : LongEntity(id) {
+        companion object : LongEntityClass<ItemBidEntity>(ItemBidTable)
+    }
+
+    @Test
+    fun testCacheIsUsedWithReference() {
+        withTables(AlertItemTable, ItemBidTable) {
+            repeat(3) {
+                val itemId = AlertItemTable.insertAndGetId {
+                    it[isAlarm] = true
+                }
+                repeat(5) {
+                    ItemBidTable.insertAndGetId {
+                        it[alertItemId] = itemId.value
+                    }
+                }
+            }
+
+            val counter = executionsCounter()
+
+            AlertItemEntity
+                .find { AlertItemTable.isAlarm eq true }
+                .with(AlertItemEntity::bids)
+
+            assertEquals(2, counter.count, "'find()' must execute exactly 2 statements. One to fetch items, another one to fetch all the bids")
+        }
+    }
+}


### PR DESCRIPTION
#### Description

The root problem from the issue `EXPOSED-851` is that call `Entity.find().with()` performs more sql queries than it should. 

if the columnd with reference defined as `val alertItemId = integer("alert_item_id").references(AlertItemTable.id, ...)` some extra queries on the parent entity is performed, but if it's defined via `val alertItemId = reference(...)` it doesn't happen.

For that case the signatures of these methods have the following structure:

```kotlin
fun <T : Any, S : T, C : Column<S>> C.references(
  ref: Column<EntityID<T>>,
  ...
): C

fun <T : Any, E : EntityID<T>> reference(
  name: String,
  refColumn: Column<E>,
  ...
): Column<E>
```

In the case of `reference()` the method is defined for `Column<EntityID<T>>` reference and returns `Column<E> ~ Column<EntitytID<T>>` column.

From other side the method `references()` is also defined on `Column<EntityID<T>>` reference, but returns `Column<S` column (without `EntityID`). Internally that method also doesn't register the current column as entity id column.

The solution is to align behavior of `references()` method to the `reference()` method.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All


---

#### Related Issues

[EXPOSED-851](https://youtrack.jetbrains.com/issue/EXPOSED-851) Not use Cached Entity when reference column defined with `.references()`