### PR TITLE
EXPOSED-880: Fix casting nullable JSON columns

### DIFF
--- a/exposed-json/src/main/kotlin/org/jetbrains/exposed/v1/json/JsonColumnType.kt
+++ b/exposed-json/src/main/kotlin/org/jetbrains/exposed/v1/json/JsonColumnType.kt
@@ -39,7 +39,7 @@ open class JsonColumnType<T : Any>(
 
     override fun parameterMarker(value: T?): String = if (currentDialect is H2Dialect && value != null) {
         "? FORMAT JSON"
-    } else if (currentDialect is PostgreSQLDialect && value != null) {
+    } else if (currentDialect is PostgreSQLDialect) {
         val castType = if (usesBinaryFormat) "jsonb" else "json"
         "?::$castType"
     } else {


### PR DESCRIPTION
#### Description

**Summary of the change**: Fix casting nullable JSON(B) columns, under Postgres, by unconditionally casting irrespective of the column value.

**Detailed description**:
- **Why**: The `value != null` check causes Exposed to send `?` as the placeholder for a nullable JSON(B) column when the first value for the column in a batch is `null`. This causes subsequent rows in the batch to trigger a casting error on Postgres when their value is _not_ `null`, because it sees the JSON as a VARCHAR, not `json`/`jsonb`.
- **What**: Making the placeholder casting unconditional under Postgres ensures proper casting of nullable columns.
- **How**: Simply removed an unnecessary `value != null` clause.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [X] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
EXPOSED-880