### PR TITLE
feat!: EXPOSED-882 Add StatementInterceptor that allows suspend operations

### DIFF
--- a/documentation-website/Writerside/topics/Breaking-Changes.md
+++ b/documentation-website/Writerside/topics/Breaking-Changes.md
@@ -1,5 +1,11 @@
 # Breaking Changes
 
+## 1.0.0-rc-2
+
+* `R2dbcTransaction.globalInterceptors` property now stores a collection of `GlobalSuspendStatementInterceptor` instances.
+  Any loaded `GlobalStatementInterceptor` implementations are automatically wrapped to be compatible with the new interceptor
+  type, so no changes need to be made to how any existing custom interceptors are declared in the `resources` folder.
+
 ## 1.0.0-rc-1
 
 * `exposed-migration` artifact has been replaced with `exposed-migration-core` to hold core common schema migration functionality across both available drivers.

--- a/documentation-website/Writerside/topics/Statement-Interceptors.md
+++ b/documentation-website/Writerside/topics/Statement-Interceptors.md
@@ -18,3 +18,22 @@ In this situation, a new file should be created in the *resources* folder named:
 META-INF/services/org.jetbrains.exposed.v1.core.statements.GlobalStatementInterceptor
 ```
 The contents of this file should be the fully qualified class names of all custom implementations.
+
+## Suspend operations
+
+<tldr>
+    <p>
+        <b>Required dependencies</b>: <code>org.jetbrains.exposed:exposed-r2dbc</code>
+    </p>
+    <include from="lib.topic" element-id="r2dbc-supported"/>
+</tldr>
+
+Exposed additionally provides both
+the [`SuspendStatementInterceptor`](https://jetbrains.github.io/Exposed/api/exposed-r2dbc/org.jetbrains.exposed.v1.r2dbc.statements/-suspend-statement-interceptor/index.html)
+and [`GlobalSuspendStatementInterceptor`](https://jetbrains.github.io/Exposed/api/exposed-r2dbc/org.jetbrains.exposed.v1.r2dbc.statements/-global-suspend-statement-interceptor/index.html)
+interfaces.
+
+As in the previous section, these interfaces allow you to implement your own logic at the same points in a statement's lifecycle,
+but their methods allow the use of suspending functions and database operation methods specific to R2DBC suspend transactions.
+
+These custom suspend interceptors can be enabled and disabled in the same way as the core statement interceptors.

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/StatementInterceptorTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/StatementInterceptorTests.kt
@@ -1,0 +1,132 @@
+package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared
+
+import kotlinx.coroutines.flow.single
+import nl.altindag.log.LogCaptor
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.count
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.exposedLogger
+import org.jetbrains.exposed.v1.core.statements.StatementContext
+import org.jetbrains.exposed.v1.core.statements.StatementInterceptor
+import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.deleteWhere
+import org.jetbrains.exposed.v1.r2dbc.insert
+import org.jetbrains.exposed.v1.r2dbc.select
+import org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.DMLTestsData
+import org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.withCitiesAndUsers
+import org.jetbrains.exposed.v1.r2dbc.statements.SuspendStatementInterceptor
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.Test
+
+private class DeleteWarningInterceptor : StatementInterceptor {
+    override fun beforeExecution(transaction: Transaction, context: StatementContext) {
+        if (context.statement.type == StatementType.DELETE) {
+            exposedLogger.warn(DELETE_WARNING)
+        }
+    }
+
+    companion object {
+        const val DELETE_WARNING = "Delete operation detected"
+    }
+}
+
+private class RollbackCheckInterceptor(
+    private val query: String
+) : SuspendStatementInterceptor {
+    override suspend fun afterRollback(transaction: R2dbcTransaction) {
+        val recordCount = transaction.exec(query) {
+            it.get(0)
+        }?.single()
+        exposedLogger.info("$ROLLBACK_CHECK$recordCount")
+    }
+
+    companion object {
+        const val ROLLBACK_CHECK = "Querying state post-rollback : "
+    }
+}
+
+class StatementInterceptorTests : R2dbcDatabaseTestsBase() {
+    @Test
+    fun testInterceptorWithOnlyLogs() {
+        withCitiesAndUsers { cities, _, _ ->
+            val logCaptor = LogCaptor.forName(exposedLogger.name)
+
+            val testDeleteInterceptor = DeleteWarningInterceptor()
+
+            registerInterceptor(testDeleteInterceptor).also {
+                assertTrue(it)
+            }
+
+            val belgradeId = cities.insert { it[name] = "Belgrade" } get cities.id
+            val amsterdamId = cities.insert { it[name] = "Amsterdam" } get cities.id
+
+            assertTrue(logCaptor.warnLogs.isEmpty())
+
+            cities.deleteWhere { cities.id eq belgradeId }
+
+            assertTrue(logCaptor.warnLogs.single() == DeleteWarningInterceptor.DELETE_WARNING)
+            logCaptor.clearLogs()
+
+            unregisterInterceptor(testDeleteInterceptor).also {
+                assertTrue(it)
+            }
+
+            cities.deleteWhere { cities.id eq amsterdamId }
+
+            assertTrue(logCaptor.warnLogs.isEmpty())
+
+            logCaptor.clearLogs()
+            logCaptor.close()
+        }
+    }
+
+    @Test
+    fun testInterceptorWithOperations() {
+        val cities = DMLTestsData.Cities
+        withTables(cities, configure = { useNestedTransactions = true }) {
+            val logCaptor = LogCaptor.forName(exposedLogger.name)
+
+            val cityCount = cities.select(cities.id.count())
+            val testRollbackInterceptor = RollbackCheckInterceptor(
+                query = cityCount.prepareSQL(this)
+            )
+
+            cities.insert { it[name] = "Munich" }
+
+            val originalCount = cityCount.single()[cities.id.count()]
+            assertEquals(1, originalCount)
+
+            suspendTransaction {
+                registerInterceptor(testRollbackInterceptor).also {
+                    assertTrue(it)
+                }
+
+                cities.insert { it[name] = "Belgrade" }
+                cities.insert { it[name] = "Amsterdam" }
+
+                assertEquals(originalCount + 2, cityCount.single()[cities.id.count()])
+                assertTrue(logCaptor.infoLogs.isEmpty())
+
+                rollback()
+
+                unregisterInterceptor(testRollbackInterceptor).also {
+                    assertTrue(it)
+                }
+            }
+
+            val loggedInfo = logCaptor.infoLogs.single()
+            assertTrue(loggedInfo.startsWith(RollbackCheckInterceptor.ROLLBACK_CHECK))
+            assertEquals(
+                originalCount,
+                loggedInfo.substringAfter(RollbackCheckInterceptor.ROLLBACK_CHECK).toLong()
+            )
+
+            logCaptor.clearLogs()
+            logCaptor.close()
+        }
+    }
+}

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -336,12 +336,14 @@ public class org/jetbrains/exposed/v1/r2dbc/R2dbcTransaction : org/jetbrains/exp
 	public fun getReadOnly ()Z
 	public fun getTransactionIsolation ()Lio/r2dbc/spi/IsolationLevel;
 	public final fun registerInterceptor (Lorg/jetbrains/exposed/v1/core/statements/StatementInterceptor;)Z
+	public final fun registerInterceptor (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;)Z
 	public fun rollback (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setCurrentStatement (Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi;)V
 	public final fun setMaxAttempts (I)V
 	public final fun setMaxRetryDelay (J)V
 	public final fun setMinRetryDelay (J)V
 	public final fun unregisterInterceptor (Lorg/jetbrains/exposed/v1/core/statements/StatementInterceptor;)Z
+	public final fun unregisterInterceptor (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;)Z
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/R2dbcTransaction$Companion {
@@ -668,6 +670,20 @@ public class org/jetbrains/exposed/v1/r2dbc/statements/DeleteSuspendExecutable :
 	public fun prepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class org/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor : org/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor {
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor$DefaultImpls {
+	public static fun afterCommit (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun afterExecution (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/util/List;Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun afterRollback (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun afterStatementPrepared (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun beforeCommit (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun beforeExecution (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lorg/jetbrains/exposed/v1/core/statements/StatementContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun beforeRollback (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun keepUserDataInTransactionStoreOnCommit (Lorg/jetbrains/exposed/v1/r2dbc/statements/GlobalSuspendStatementInterceptor;Ljava/util/Map;)Ljava/util/Map;
+}
+
 public class org/jetbrains/exposed/v1/r2dbc/statements/InsertSelectSuspendExecutable : org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable {
 	public fun <init> (Lorg/jetbrains/exposed/v1/core/statements/InsertSelectStatement;)V
 	public fun execute (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -787,6 +803,28 @@ public final class org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable$D
 
 public final class org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutableKt {
 	public static final fun toExecutable (Lorg/jetbrains/exposed/v1/core/statements/Statement;)Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable;
+}
+
+public abstract interface class org/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor {
+	public abstract fun afterCommit (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun afterExecution (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/util/List;Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun afterRollback (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun afterStatementPrepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun beforeCommit (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun beforeExecution (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lorg/jetbrains/exposed/v1/core/statements/StatementContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun beforeRollback (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun keepUserDataInTransactionStoreOnCommit (Ljava/util/Map;)Ljava/util/Map;
+}
+
+public final class org/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor$DefaultImpls {
+	public static fun afterCommit (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun afterExecution (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/util/List;Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun afterRollback (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun afterStatementPrepared (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lorg/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcPreparedStatementApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun beforeCommit (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun beforeExecution (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lorg/jetbrains/exposed/v1/core/statements/StatementContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun beforeRollback (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun keepUserDataInTransactionStoreOnCommit (Lorg/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor;Ljava/util/Map;)Ljava/util/Map;
 }
 
 public class org/jetbrains/exposed/v1/r2dbc/statements/UpdateSuspendExecutable : org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor.kt
@@ -100,36 +100,7 @@ internal class StatementInterceptorWrapper(
  * so they can be processed together using a single `R2dbcTransaction.globalInterceptors` property.
  */
 internal class GlobalStatementInterceptorWrapper(
-    internal val originalInterceptor: GlobalStatementInterceptor
-) : GlobalSuspendStatementInterceptor {
-    override suspend fun beforeExecution(transaction: R2dbcTransaction, context: StatementContext) {
-        originalInterceptor.beforeExecution(transaction, context)
-    }
-
-    override suspend fun afterStatementPrepared(
-        transaction: R2dbcTransaction,
-        preparedStatement: R2dbcPreparedStatementApi
-    ) {
-        originalInterceptor.afterStatementPrepared(transaction, preparedStatement)
-    }
-
-    override suspend fun afterExecution(
-        transaction: R2dbcTransaction,
-        contexts: List<StatementContext>,
-        executedStatement: R2dbcPreparedStatementApi
-    ) {
-        originalInterceptor.afterExecution(transaction, contexts, executedStatement)
-    }
-
-    override suspend fun beforeCommit(transaction: R2dbcTransaction) { originalInterceptor.beforeCommit(transaction) }
-
-    override suspend fun afterCommit(transaction: R2dbcTransaction) { originalInterceptor.afterCommit(transaction) }
-
-    override suspend fun beforeRollback(transaction: R2dbcTransaction) { originalInterceptor.beforeRollback(transaction) }
-
-    override suspend fun afterRollback(transaction: R2dbcTransaction) { originalInterceptor.afterRollback(transaction) }
-
-    override fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> {
-        return originalInterceptor.keepUserDataInTransactionStoreOnCommit(userData)
-    }
+    private val wrapper: StatementInterceptorWrapper,
+) : GlobalSuspendStatementInterceptor, SuspendStatementInterceptor by wrapper {
+    constructor(originalInterceptor: GlobalStatementInterceptor) : this(StatementInterceptorWrapper(originalInterceptor))
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendStatementInterceptor.kt
@@ -1,0 +1,135 @@
+package org.jetbrains.exposed.v1.r2dbc.statements
+
+import org.jetbrains.exposed.v1.core.Key
+import org.jetbrains.exposed.v1.core.statements.GlobalStatementInterceptor
+import org.jetbrains.exposed.v1.core.statements.StatementContext
+import org.jetbrains.exposed.v1.core.statements.StatementInterceptor
+import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcPreparedStatementApi
+
+/**
+ * Represents the processes that should be performed during a statement's lifecycle events in a suspend transaction.
+ *
+ * In general, statement execution flow works in the following way:
+ * 1) [beforeExecution] of the statement
+ * 2) Creation of the prepared statement
+ * 3) [afterStatementPrepared] using the prepared statement from step 2
+ * 4) Execution of the SQL query
+ * 5) [afterExecution]
+ */
+interface SuspendStatementInterceptor {
+    /** Performs steps before a statement, from the provided [context], is executed in a [transaction]. */
+    suspend fun beforeExecution(transaction: R2dbcTransaction, context: StatementContext) {}
+
+    /**
+     * Performs steps after [preparedStatement] has been created in a [transaction], but before the statement
+     * has been executed.
+     **/
+    suspend fun afterStatementPrepared(transaction: R2dbcTransaction, preparedStatement: R2dbcPreparedStatementApi) {}
+
+    /** Performs steps after an [executedStatement], from the provided [contexts], is complete in [transaction]. */
+    suspend fun afterExecution(
+        transaction: R2dbcTransaction,
+        contexts: List<StatementContext>,
+        executedStatement: R2dbcPreparedStatementApi
+    ) {}
+
+    /** Performs steps before a [transaction] is committed. */
+    suspend fun beforeCommit(transaction: R2dbcTransaction) {}
+
+    /** Performs steps after a [transaction] is committed. */
+    suspend fun afterCommit(transaction: R2dbcTransaction) {}
+
+    /** Performs steps before a rollback operation is issued on a [transaction]. */
+    suspend fun beforeRollback(transaction: R2dbcTransaction) {}
+
+    /** Performs steps after a rollback operation is issued on a [transaction]. */
+    suspend fun afterRollback(transaction: R2dbcTransaction) {}
+
+    /**
+     * Returns a mapping of [userData] that ensures required information is not lost from the transaction scope
+     * once the transaction is committed.
+     */
+    fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> = emptyMap()
+}
+
+/** Represents a [SuspendStatementInterceptor] that is loaded whenever a [R2dbcTransaction] instance is initialized. */
+interface GlobalSuspendStatementInterceptor : SuspendStatementInterceptor
+
+/**
+ * Wrapper class to consolidate usage of core [StatementInterceptor] with R2DBC-specific [SuspendStatementInterceptor],
+ * so they can be processed together using a single `R2dbcTransaction.interceptors` property.
+ */
+internal class StatementInterceptorWrapper(
+    internal val originalInterceptor: StatementInterceptor
+) : SuspendStatementInterceptor {
+    override suspend fun beforeExecution(transaction: R2dbcTransaction, context: StatementContext) {
+        originalInterceptor.beforeExecution(transaction, context)
+    }
+
+    override suspend fun afterStatementPrepared(
+        transaction: R2dbcTransaction,
+        preparedStatement: R2dbcPreparedStatementApi
+    ) {
+        originalInterceptor.afterStatementPrepared(transaction, preparedStatement)
+    }
+
+    override suspend fun afterExecution(
+        transaction: R2dbcTransaction,
+        contexts: List<StatementContext>,
+        executedStatement: R2dbcPreparedStatementApi
+    ) {
+        originalInterceptor.afterExecution(transaction, contexts, executedStatement)
+    }
+
+    override suspend fun beforeCommit(transaction: R2dbcTransaction) { originalInterceptor.beforeCommit(transaction) }
+
+    override suspend fun afterCommit(transaction: R2dbcTransaction) { originalInterceptor.afterCommit(transaction) }
+
+    override suspend fun beforeRollback(transaction: R2dbcTransaction) { originalInterceptor.beforeRollback(transaction) }
+
+    override suspend fun afterRollback(transaction: R2dbcTransaction) { originalInterceptor.afterRollback(transaction) }
+
+    override fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> {
+        return originalInterceptor.keepUserDataInTransactionStoreOnCommit(userData)
+    }
+}
+
+/**
+ * Wrapper class to consolidate usage of core [GlobalStatementInterceptor] with R2DBC-specific [GlobalSuspendStatementInterceptor],
+ * so they can be processed together using a single `R2dbcTransaction.globalInterceptors` property.
+ */
+internal class GlobalStatementInterceptorWrapper(
+    internal val originalInterceptor: GlobalStatementInterceptor
+) : GlobalSuspendStatementInterceptor {
+    override suspend fun beforeExecution(transaction: R2dbcTransaction, context: StatementContext) {
+        originalInterceptor.beforeExecution(transaction, context)
+    }
+
+    override suspend fun afterStatementPrepared(
+        transaction: R2dbcTransaction,
+        preparedStatement: R2dbcPreparedStatementApi
+    ) {
+        originalInterceptor.afterStatementPrepared(transaction, preparedStatement)
+    }
+
+    override suspend fun afterExecution(
+        transaction: R2dbcTransaction,
+        contexts: List<StatementContext>,
+        executedStatement: R2dbcPreparedStatementApi
+    ) {
+        originalInterceptor.afterExecution(transaction, contexts, executedStatement)
+    }
+
+    override suspend fun beforeCommit(transaction: R2dbcTransaction) { originalInterceptor.beforeCommit(transaction) }
+
+    override suspend fun afterCommit(transaction: R2dbcTransaction) { originalInterceptor.afterCommit(transaction) }
+
+    override suspend fun beforeRollback(transaction: R2dbcTransaction) { originalInterceptor.beforeRollback(transaction) }
+
+    override suspend fun afterRollback(transaction: R2dbcTransaction) { originalInterceptor.afterRollback(transaction) }
+
+    override fun keepUserDataInTransactionStoreOnCommit(userData: Map<Key<*>, Any?>): Map<Key<*>, Any?> {
+        return originalInterceptor.keepUserDataInTransactionStoreOnCommit(userData)
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/StatementInterceptorTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/StatementInterceptorTests.kt
@@ -1,0 +1,130 @@
+package org.jetbrains.exposed.v1.tests.shared
+
+import nl.altindag.log.LogCaptor
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.count
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.exposedLogger
+import org.jetbrains.exposed.v1.core.statements.StatementContext
+import org.jetbrains.exposed.v1.core.statements.StatementInterceptor
+import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import org.jetbrains.exposed.v1.tests.shared.dml.DMLTestsData
+import org.jetbrains.exposed.v1.tests.shared.dml.withCitiesAndUsers
+import org.junit.Test
+
+private class DeleteWarningInterceptor : StatementInterceptor {
+    override fun beforeExecution(transaction: Transaction, context: StatementContext) {
+        if (context.statement.type == StatementType.DELETE) {
+            exposedLogger.warn(DELETE_WARNING)
+        }
+    }
+
+    companion object {
+        const val DELETE_WARNING = "Delete operation detected"
+    }
+}
+
+private class RollbackCheckInterceptor(
+    private val query: String
+) : StatementInterceptor {
+    override fun afterRollback(transaction: Transaction) {
+        transaction as JdbcTransaction
+        val recordCount = transaction.exec(query) {
+            it.next()
+            it.getObject(1)
+        }
+        exposedLogger.info("$ROLLBACK_CHECK$recordCount")
+    }
+
+    companion object {
+        const val ROLLBACK_CHECK = "Querying state post-rollback : "
+    }
+}
+
+class StatementInterceptorTests : DatabaseTestsBase() {
+    @Test
+    fun testInterceptorWithOnlyLogs() {
+        withCitiesAndUsers { cities, _, _ ->
+            val logCaptor = LogCaptor.forName(exposedLogger.name)
+
+            val testDeleteInterceptor = DeleteWarningInterceptor()
+
+            registerInterceptor(testDeleteInterceptor).also {
+                assertTrue(it)
+            }
+
+            val belgradeId = cities.insert { it[name] = "Belgrade" } get cities.id
+            val amsterdamId = cities.insert { it[name] = "Amsterdam" } get cities.id
+
+            assertTrue(logCaptor.warnLogs.isEmpty())
+
+            cities.deleteWhere { cities.id eq belgradeId }
+
+            assertTrue(logCaptor.warnLogs.single() == DeleteWarningInterceptor.DELETE_WARNING)
+            logCaptor.clearLogs()
+
+            unregisterInterceptor(testDeleteInterceptor).also {
+                assertTrue(it)
+            }
+
+            cities.deleteWhere { cities.id eq amsterdamId }
+
+            assertTrue(logCaptor.warnLogs.isEmpty())
+
+            logCaptor.clearLogs()
+            logCaptor.close()
+        }
+    }
+
+    @Test
+    fun testInterceptorWithOperations() {
+        val cities = DMLTestsData.Cities
+        withTables(cities, configure = { useNestedTransactions = true }) {
+            val logCaptor = LogCaptor.forName(exposedLogger.name)
+
+            val cityCount = cities.select(cities.id.count())
+            val testRollbackInterceptor = RollbackCheckInterceptor(
+                query = cityCount.prepareSQL(this)
+            )
+
+            cities.insert { it[name] = "Munich" }
+
+            val originalCount = cityCount.single()[cities.id.count()]
+            assertEquals(1, originalCount)
+
+            transaction {
+                registerInterceptor(testRollbackInterceptor).also {
+                    assertTrue(it)
+                }
+
+                cities.insert { it[name] = "Belgrade" }
+                cities.insert { it[name] = "Amsterdam" }
+
+                assertEquals(originalCount + 2, cityCount.single()[cities.id.count()])
+                assertTrue(logCaptor.infoLogs.isEmpty())
+
+                rollback()
+
+                unregisterInterceptor(testRollbackInterceptor).also {
+                    assertTrue(it)
+                }
+            }
+
+            val loggedInfo = logCaptor.infoLogs.single()
+            assertTrue(loggedInfo.startsWith(RollbackCheckInterceptor.ROLLBACK_CHECK))
+            assertEquals(
+                originalCount,
+                loggedInfo.substringAfter(RollbackCheckInterceptor.ROLLBACK_CHECK).toLong()
+            )
+
+            logCaptor.clearLogs()
+            logCaptor.close()
+        }
+    }
+}


### PR DESCRIPTION
#### Description

**Summary of the change**: Add statement interceptor to `exposed-r2dbc` that uses suspend methods, so that suspend db operations can potentially be called by them.

**Detailed description**:
- **Why**: `StatementInterceptor` + `GlobalStatementInterceptor` were left in `exposed-core` after V1 refactoring. In the event suspend db operations need to be run in custom interceptor overrides, this would not be possible without the methods themselves suspending.

An example of this is in our own `EntityLifecycleInterceptor` -> If DAO was made to be compatible with R2DBC, `beforeExecution()` would need to suspend.

- **What**:
    - No changes have been made to `StatementInterceptor` or JDBC usage
    - R2DBC user could continue to rely solely on core's `StatementInterceptor`, if it suites their needs
    - If they need to run suspend methods in the overrides, they can instead switch to new `SuspendStatementInterceptor` or `GlobalSuspendStatementInterceptor`.
        - Internally, `R2dbcTransaction` treats all interceptors as suspend versions, by wrapping core interceptors before storing. 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Updates/remove existing public API methods:
- [X] Is breaking change

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-882](https://youtrack.jetbrains.com/issue/EXPOSED-882/Assess-StatementInterceptor-use-case-with-suspend-operations)