### PR TITLE
chore: Fix R2DBC SizedIterable collect() overrides

### DIFF
--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/IterableEx.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/IterableEx.kt
@@ -2,7 +2,6 @@ package org.jetbrains.exposed.v1.r2dbc
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -102,7 +101,7 @@ class LazySizedCollection<out T>(_delegate: SizedIterable<T>) : SizedIterable<T>
     override fun offset(start: Long): SizedIterable<T> = LazySizedCollection(delegate.offset(start))
 
     override suspend fun collect(collector: FlowCollector<T>) {
-        flowOf(wrapper())
+        wrapper().forEach { collector.emit(it) }
     }
 
     override suspend fun count(): Long = _wrapper?.size?.toLong() ?: countInternal()
@@ -177,9 +176,9 @@ infix fun <T, R> SizedIterable<T>.mapLazy(f: (T) -> R): SizedIterable<R> {
 
         override suspend fun collect(collector: FlowCollector<R>) {
             if (loadedResult != null) {
-                flowOf(loadedResult)
+                loadedResult!!.forEach { collector.emit(it) }
             } else {
-                source
+                source.collect { collector.emit(f(it)) }
             }
         }
     }


### PR DESCRIPTION
#### Description

**Summary of the change**: Replace useless `SizedIterable.collect()` overrides to actually emit flow elements.

**Detailed description**:
- **Why**: `flowOf()` was initially used as a placeholder I think, but it doesn't actually emit anything. This wasn't caught because `LazySizedCollection` and `mapLazy()` are meant for DAO usage, which is not currently available with R2DBC, so they are used nowhere.

**Alternatively, it might be prudent to remove these entirely, since they are not used anywhere?**

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - _missed refactoring_