### PR TITLE
fix: [EXPOSED-1010] Multiple duplicate calls to metadata retrieval methods during migration

### DIFF
--- a/documentation-website/Writerside/topics/Migrations.md
+++ b/documentation-website/Writerside/topics/Migrations.md
@@ -131,6 +131,44 @@ To generate a migration script based on schema differences between your database
 This method allows you to see what the migration script will look like before applying the migration. If a migration script with the same name already exists,
 its content will be overwritten.
 
+### Reset metadata caches
+
+<tldr>
+    <p>API references:
+        <a href="https://jetbrains.github.io/Exposed/api/exposed-jdbc/org.jetbrains.exposed.v1.jdbc.vendors/-database-dialect-metadata/reset-caches.html">
+            <code>resetCaches</code> (JDBC)
+        </a>,
+        <a href="https://jetbrains.github.io/Exposed/api/exposed-r2dbc/org.jetbrains.exposed.v1.r2dbc.vendors/-database-dialect-metadata/reset-caches.html">
+            <code>resetCaches</code> (R2DBC)
+        </a>
+    </p>
+</tldr>
+
+Some schema alignment methods rely on database metadata queries that could be potentially run multiple times for all tables being migrated.
+Exposed uses a number of metadata caches internally to avoid these unecessary and redundant query calls. In order to ensure accurate metadata retrieval,
+these caches are automatically cleared and reset whenever a schema-altering method is invoked, like `SchemaUtils.create()`, `SchemaUtils.drop()`,
+or `SchemaUtils.setSchema()`. The caches are also reset at the termination of a transaction block.
+
+Simply generating the required SQL statements to align your schema will not trigger a cache reset.
+This means that if you manually execute SQL statements, then attempt, for example, a schema validation method within the same transaction,
+the result may be inaccurate due to a stale cache. It is suggested that running schema-altering SQL statements should be done in a separate
+transaction block from any methods that may later use metadata caches. Otherwise, a manual call to `.resetCaches()` should be immediately made
+to ensure that updated database metadata will be later retrieved:
+
+```Kotlin
+transaction(db) {
+    println(UsersTable.exists()) // true
+
+    val statements: List<String> = UsersTable.dropStatement()
+    execInBatch(statements)
+    db.dialectMetadata.resetCaches()
+
+    println(UsersTable.exists()) // false
+}
+```
+
+In the example above, there would be no need to call `.resetCaches()` if `SchemaUtils.drop(UsersTable)` is used instead.
+
 ## Validating the database schema
 
 Before applying any migrations, it's useful to validate that your Exposed schema definitions match the actual state of the database. While the primary use of

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -2045,6 +2045,7 @@ public abstract class org/jetbrains/exposed/v1/core/SchemaUtilityApi {
 	protected final fun createDdl (Lorg/jetbrains/exposed/v1/core/ForeignKeyConstraint;)Ljava/util/List;
 	protected final fun filterAndLogExcessConstraints (Ljava/util/Map;Z)Ljava/util/List;
 	protected final fun filterAndLogExcessIndices (Ljava/util/Map;Z)Ljava/util/List;
+	protected final fun filterAndLogMissingAndUnmappedCheckConstraints (Ljava/util/Map;Z[Lorg/jetbrains/exposed/v1/core/Table;)Lkotlin/Pair;
 	protected final fun filterAndLogMissingAndUnmappedIndices (Ljava/util/Map;Ljava/util/Set;ZZ[Lorg/jetbrains/exposed/v1/core/Table;)Lkotlin/Pair;
 	protected final fun hasCycle (Ljava/util/List;)Z
 	protected final fun log (Ljava/util/Collection;Ljava/lang/String;Z)V

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
@@ -276,6 +276,45 @@ abstract class SchemaUtilityApi {
     }
 
     /**
+     * Filters all table check constraints that are either missing from the database
+     * or exist in the database but are not mapped in a table object.
+     * If [withLogs] is `true`, the corresponding statements for these check constraints will also be logged.
+     *
+     * @return Pair of missing [CheckConstraint] list and unmapped [CheckConstraint] list.
+     * @suppress
+     */
+    @InternalApi
+    protected fun Map<Table, List<CheckConstraint>>.filterAndLogMissingAndUnmappedCheckConstraints(
+        withLogs: Boolean,
+        vararg tables: Table
+    ): Pair<List<CheckConstraint>, List<CheckConstraint>> {
+        if (this.isEmpty()) return Pair(emptyList(), emptyList())
+
+        val missingCheckConstraints = mutableListOf<CheckConstraint>()
+        val unmappedCheckConstraints = mutableListOf<CheckConstraint>()
+
+        tables.forEach { table ->
+            val mappedCheckConstraints = table.checkConstraints()
+            val existingCheckConstraints = this[table].orEmpty()
+
+            val existingCheckConstraintsNames = existingCheckConstraints.map { it.checkName.uppercase() }.toSet()
+            missingCheckConstraints.addAll(
+                mappedCheckConstraints.filterNot { it.checkName.uppercase() in existingCheckConstraintsNames }
+            )
+
+            val mappedCheckConstraintsNames = mappedCheckConstraints.map { it.checkName.uppercase() }.toSet()
+            unmappedCheckConstraints.addAll(
+                existingCheckConstraints.filterNot { it.checkName.uppercase() in mappedCheckConstraintsNames }
+            )
+        }
+
+        missingCheckConstraints.log("CHECK constraints missed from database (will be created):", withLogs)
+        unmappedCheckConstraints.log("CHECK constraints exist in database and not mapped in code:", withLogs)
+
+        return missingCheckConstraints to unmappedCheckConstraints
+    }
+
+    /**
      * If [withLogs] is `true`, this logs every item in this collection, prefixed by [mainMessage].
      * @suppress
      */

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt
@@ -508,11 +508,15 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
         }
     }
 
+    private val existingSequenceNameCache = ConcurrentHashMap.newKeySet<String>()
+
     @Suppress("MagicNumber")
     override fun sequences(): List<String> {
+        if (existingSequenceNameCache.isNotEmpty()) return existingSequenceNameCache.toList()
+
         val dialect = currentDialect
         val fieldName = "SEQUENCE_NAME"
-        return when (dialect) {
+        val sequenceNames = when (dialect) {
             is OracleDialect -> metadata.connection.executeSQL("SELECT $fieldName FROM USER_SEQUENCES") { rs ->
                 rs.iterate {
                     val seqName = getString(fieldName)
@@ -538,6 +542,10 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
                 getString(3)
             }
         } ?: emptyList()
+
+        existingSequenceNameCache.addAll(sequenceNames)
+
+        return sequenceNames
     }
 
     @Synchronized
@@ -675,6 +683,7 @@ class JdbcDatabaseMetadataImpl(database: String, val metadata: DatabaseMetaData)
     @Synchronized
     override fun cleanCache() {
         existingIndicesCache.clear()
+        existingSequenceNameCache.clear()
     }
 
     private fun <T> lazyMetadata(body: DatabaseMetaData.() -> T) = lazy { metadata.body() }

--- a/exposed-migration-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/jdbc/MigrationUtils.kt
+++ b/exposed-migration-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/jdbc/MigrationUtils.kt
@@ -237,24 +237,35 @@ object MigrationUtils : MigrationUtilityApi() {
      * from the database will be checked, potentially returning SQL statements to drop any sequences that are unlinked
      * or unrelated to [tables].
      */
+    @OptIn(InternalApi::class)
     private fun mappingConsistenceRequiredStatements(vararg tables: Table, withLogs: Boolean = true): List<String> {
         val foreignKeyConstraints = currentDialectMetadata.columnConstraints(*tables)
         val existingIndices = currentDialectMetadata.existingIndices(*tables)
+        val existingCheckConstraints = if (currentDialect.supportsAlterCheckConstraint) {
+            // as long as 'tables' is not empty, this method always returns a non-empty map;
+            // even if no tables have a check constraint, each table will still have a key with an empty list value.
+            currentDialectMetadata.existingCheckConstraints(*tables)
+        } else {
+            emptyMap()
+        }
 
-        @OptIn(InternalApi::class)
         val filteredIndices = existingIndices.filterAndLogMissingAndUnmappedIndices(
             foreignKeyConstraints.keys, withDropIndices = true, withLogs, tables = tables
         )
         val (createMissing, dropUnmapped) = filteredIndices
 
-        @OptIn(InternalApi::class)
+        val (createMissingChecks, dropUnmappedChecks) = existingCheckConstraints.filterAndLogMissingAndUnmappedCheckConstraints(
+            withLogs = withLogs,
+            tables = tables
+        )
+
         return createMissing.flatMap { it.createStatement() } +
             dropUnmapped.flatMap { it.dropStatement() } +
             foreignKeyConstraints.filterAndLogExcessConstraints(withLogs).flatMap { it.dropStatement() } +
             existingIndices.filterAndLogExcessIndices(withLogs).flatMap { it.dropStatement() } +
             checkUnmappedSequences(tables = tables, withLogs).flatMap { it.dropStatement() } +
-            checkMissingCheckConstraints(tables = tables, withLogs).flatMap { it.createStatement() } +
-            checkUnmappedCheckConstraints(tables = tables, withLogs).flatMap { it.dropStatement() }
+            createMissingChecks.flatMap { it.createStatement() } +
+            dropUnmappedChecks.flatMap { it.dropStatement() }
     }
 
     /**
@@ -301,53 +312,5 @@ object MigrationUtils : MigrationUtilityApi() {
         return existingSequencesNames.filterUnmappedSequences(tables = tables).also {
             it.log("Sequences exist in database and not mapped in code:", withLogs)
         }
-    }
-
-    /**
-     * Checks all [tables] for any that have CHECK constraints that are missing in the database but are defined in the code.
-     * If found, this function also logs the CHECK constraints that will be created.
-     *
-     * @return List of CHECK constraints that are missing and can be created.
-     */
-    @OptIn(InternalApi::class)
-    private fun checkMissingCheckConstraints(vararg tables: Table, withLogs: Boolean): List<CheckConstraint> {
-        if (!currentDialect.supportsAlterCheckConstraint) {
-            return emptyList()
-        }
-
-        val missingCheckConstraints = mutableListOf<CheckConstraint>()
-        tables.forEach { table ->
-            val mappedCheckConstraints = table.checkConstraints()
-            val existingCheckConstraints = currentDialectMetadata.existingCheckConstraints(*tables)[table].orEmpty()
-            val existingCheckConstraintsNames = existingCheckConstraints.map { it.checkName.uppercase() }.toSet()
-
-            missingCheckConstraints.addAll(mappedCheckConstraints.filterNot { it.checkName.uppercase() in existingCheckConstraintsNames })
-        }
-        missingCheckConstraints.log("CHECK constraints missed from database (will be created):", withLogs)
-        return missingCheckConstraints
-    }
-
-    /**
-     * Checks all [tables] for any that have CHECK constraints that exist in the database but are not mapped in the code.
-     * If found, this function also logs the CHECK constraints that will be dropped.
-     *
-     * @return List of CHECK constraints that are unmapped and can be dropped.
-     */
-    @OptIn(InternalApi::class)
-    private fun checkUnmappedCheckConstraints(vararg tables: Table, withLogs: Boolean): List<CheckConstraint> {
-        if (!currentDialect.supportsAlterCheckConstraint) {
-            return emptyList()
-        }
-
-        val unmappedCheckConstraints = mutableListOf<CheckConstraint>()
-        tables.forEach { table ->
-            val mappedCheckConstraints = table.checkConstraints()
-            val existingCheckConstraints = currentDialectMetadata.existingCheckConstraints(*tables)[table].orEmpty()
-            val mappedCheckConstraintsNames = mappedCheckConstraints.map { it.checkName.uppercase() }.toSet()
-
-            unmappedCheckConstraints.addAll(existingCheckConstraints.filterNot { it.checkName.uppercase() in mappedCheckConstraintsNames })
-        }
-        unmappedCheckConstraints.log("CHECK constraints exist in database and not mapped in code:", withLogs)
-        return unmappedCheckConstraints
     }
 }

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/SequenceAutoIncrementTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/SequenceAutoIncrementTests.kt
@@ -500,6 +500,8 @@ class SequenceAutoIncrementTests : DatabaseTestsBase() {
                 assertEquals(expectedDropSequenceStatement("test_table_auto_id_seq"), statements[1])
 
                 statements.forEach { exec(it) }
+                db.dialectMetadata.resetCaches()
+
                 assertFalse(autoSeq.exists())
                 assertTrue(MigrationTestsData.customSequence.exists())
                 assertTrue(implicitSeq.exists())

--- a/exposed-migration-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/MigrationUtils.kt
+++ b/exposed-migration-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/MigrationUtils.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.exposed.v1.migration.r2dbc
 
-import org.jetbrains.exposed.v1.core.CheckConstraint
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ExperimentalDatabaseMigrationApi
 import org.jetbrains.exposed.v1.core.InternalApi
@@ -237,24 +236,35 @@ object MigrationUtils : MigrationUtilityApi() {
      * from the database will be checked, potentially returning SQL statements to drop any sequences that are unlinked
      * or unrelated to [tables].
      */
+    @OptIn(InternalApi::class)
     private suspend fun mappingConsistenceRequiredStatements(vararg tables: Table, withLogs: Boolean = true): List<String> {
         val foreignKeyConstraints = currentDialectMetadata.columnConstraints(*tables)
         val existingIndices = currentDialectMetadata.existingIndices(*tables)
+        val existingCheckConstraints = if (currentDialect.supportsAlterCheckConstraint) {
+            // as long as 'tables' is not empty, this method always returns a non-empty map;
+            // even if no tables have a check constraint, each table will still have a key with an empty list value.
+            currentDialectMetadata.existingCheckConstraints(*tables)
+        } else {
+            emptyMap()
+        }
 
-        @OptIn(InternalApi::class)
         val filteredIndices = existingIndices.filterAndLogMissingAndUnmappedIndices(
             foreignKeyConstraints.keys, withDropIndices = true, withLogs, tables = tables
         )
         val (createMissing, dropUnmapped) = filteredIndices
 
-        @OptIn(InternalApi::class)
+        val (createMissingChecks, dropUnmappedChecks) = existingCheckConstraints.filterAndLogMissingAndUnmappedCheckConstraints(
+            withLogs = withLogs,
+            tables = tables
+        )
+
         return createMissing.flatMap { it.createStatement() } +
             dropUnmapped.flatMap { it.dropStatement() } +
             foreignKeyConstraints.filterAndLogExcessConstraints(withLogs).flatMap { it.dropStatement() } +
             existingIndices.filterAndLogExcessIndices(withLogs).flatMap { it.dropStatement() } +
             checkUnmappedSequences(tables = tables, withLogs).flatMap { it.dropStatement() } +
-            checkMissingCheckConstraints(tables = tables, withLogs).flatMap { it.createStatement() } +
-            checkUnmappedCheckConstraints(tables = tables, withLogs).flatMap { it.dropStatement() }
+            createMissingChecks.flatMap { it.createStatement() } +
+            dropUnmappedChecks.flatMap { it.dropStatement() }
     }
 
     /**
@@ -301,53 +311,5 @@ object MigrationUtils : MigrationUtilityApi() {
         return existingSequencesNames.filterUnmappedSequences(tables = tables).also {
             it.log("Sequences exist in database and not mapped in code:", withLogs)
         }
-    }
-
-    /**
-     * Checks all [tables] for any that have CHECK constraints that are missing in the database but are defined in the code.
-     * If found, this function also logs the CHECK constraints that will be created.
-     *
-     * @return List of CHECK constraints that are missing and can be created.
-     */
-    @OptIn(InternalApi::class)
-    private suspend fun checkMissingCheckConstraints(vararg tables: Table, withLogs: Boolean): List<CheckConstraint> {
-        if (!currentDialect.supportsAlterCheckConstraint) {
-            return emptyList()
-        }
-
-        val missingCheckConstraints = mutableListOf<CheckConstraint>()
-        tables.forEach { table ->
-            val mappedCheckConstraints = table.checkConstraints()
-            val existingCheckConstraints = currentDialectMetadata.existingCheckConstraints(*tables)[table].orEmpty()
-            val existingCheckConstraintsNames = existingCheckConstraints.map { it.checkName.uppercase() }.toSet()
-
-            missingCheckConstraints.addAll(mappedCheckConstraints.filterNot { it.checkName.uppercase() in existingCheckConstraintsNames })
-        }
-        missingCheckConstraints.log("CHECK constraints missed from database (will be created):", withLogs)
-        return missingCheckConstraints
-    }
-
-    /**
-     * Checks all [tables] for any that have CHECK constraints that exist in the database but are not mapped in the code.
-     * If found, this function also logs the CHECK constraints that will be dropped.
-     *
-     * @return List of CHECK constraints that are unmapped and can be dropped.
-     */
-    @OptIn(InternalApi::class)
-    private suspend fun checkUnmappedCheckConstraints(vararg tables: Table, withLogs: Boolean): List<CheckConstraint> {
-        if (!currentDialect.supportsAlterCheckConstraint) {
-            return emptyList()
-        }
-
-        val unmappedCheckConstraints = mutableListOf<CheckConstraint>()
-        tables.forEach { table ->
-            val mappedCheckConstraints = table.checkConstraints()
-            val existingCheckConstraints = currentDialectMetadata.existingCheckConstraints(*tables)[table].orEmpty()
-            val mappedCheckConstraintsNames = mappedCheckConstraints.map { it.checkName.uppercase() }.toSet()
-
-            unmappedCheckConstraints.addAll(existingCheckConstraints.filterNot { it.checkName.uppercase() in mappedCheckConstraintsNames })
-        }
-        unmappedCheckConstraints.log("CHECK constraints exist in database and not mapped in code:", withLogs)
-        return unmappedCheckConstraints
     }
 }

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/SequenceAutoIncrementTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/SequenceAutoIncrementTests.kt
@@ -493,6 +493,8 @@ class SequenceAutoIncrementTests : R2dbcDatabaseTestsBase() {
                 assertEquals(expectedDropSequenceStatement("test_table_auto_id_seq"), statements[1])
 
                 statements.forEach { exec(it) }
+                db.dialectMetadata.resetCaches()
+
                 assertFalse(autoSeq.exists())
                 assertTrue(MigrationTestsData.customSequence.exists())
                 assertTrue(implicitSeq.exists())

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcDatabaseMetadataImpl.kt
@@ -7,6 +7,8 @@ import io.r2dbc.spi.Row
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.collect
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.statements.api.ExposedMetadataUtils
 import org.jetbrains.exposed.v1.core.statements.api.IdentifierManagerApi
@@ -320,17 +322,28 @@ class R2dbcDatabaseMetadataImpl(
         }
     }
 
+    private val sequenceNameCacheLock = Mutex()
+    private val existingSequenceNameCache = mutableSetOf<String>()
+
     override suspend fun sequences(): List<String> {
+        if (existingSequenceNameCache.isNotEmpty()) return existingSequenceNameCache.toList()
+
         val results = connection.executeSQL(metadataProvider.getAllSequences()) { row, _ ->
             row.getString("SEQUENCE_NAME")!!
         }.orEmpty()
 
         val dialect = currentDialect
-        return if (dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
+        val processedNames = if (dialect is OracleDialect || dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle) {
             results.map { if (identifierManager.isDotPrefixedAndUnquoted(it)) "\"$it\"" else it }
         } else {
             results
         }
+
+        sequenceNameCacheLock.withLock {
+            existingSequenceNameCache.addAll(processedNames)
+        }
+
+        return processedNames
     }
 
     override suspend fun tableConstraints(tables: List<Table>): Map<String, List<ForeignKeyConstraint>> {
@@ -387,6 +400,7 @@ class R2dbcDatabaseMetadataImpl(
 
     override fun cleanCache() {
         existingIndicesCache.clear()
+        existingSequenceNameCache.clear()
     }
 
     private suspend fun tableCatalogAndSchema(table: Table): Pair<String, String> {


### PR DESCRIPTION
#### Description

**Summary of the change**: Reduce duplicate metadata query calls by consolidating where possible and by adding a new internal cache (for sequences).

**Detailed description**:
- **Why**: The following shows the actual **METADATA** queries triggered by a **single** `MigrationUtils.statementsRequiredForDatabaseMigration(tables)`:

LET'S ASSUME 5 TABLES ARE BEING MIGRATED:

`Table.exists()` _for each table_
└── **METADATA** `getTables()` [CALL 5x] -- CACHED after 1st call ✅

ASSUME ALL 5 TABLES _DO NOT_ EXIST:

`SchemaUtils.createStatements()`
├── `Table.exists()` _for each table_
├───└──  **METADATA** `getTables()` [CALL 5x] -- USES CACHE from start ✅ 
├── `sequences()` _for each table with auto-incrementing sequence_ (even though it applies to all user tables in db)
├───└──  **METADATA** custom query [MAX CALL 5x] ❗  

`checkMissingSequences()` _if dialects supports creating sequences_
├── `sequences()` _only once_
├───└──  **METADATA** custom query [MAX CALL 1x] ❗ 

❗ Worst case: Same sequence metadata, with same results, is called N + 1 times

ASSUME ALL 5 TABLES _DO_ EXIST:

`addMissingAndDropUnmappedColumns()`
├── `columns()` _for each table_
├───└──  **METADATA** `getColumns()` [CALL 5x] -- NO CACHE but not called again ⚠️ 
├───└──  **METADATA** custom query _if dialect is Oracle_ [CALL 1x] -- to retrieve column comments only ⚠️
├── `existingPrimaryKeys()` _for each table_
├───└──  **METADATA** `getPrimaryKeys()` [CALL 5x] ⚠️
├──  `tableConstraints()` _for each table_
├───└──  **METADATA** custom query or `getImportedKeys()` [CALL 5x] -- CACHED ✅ 

`mappingConsistenceRequiredStatements()`
├── `tableConstraints()` _for each table_
├───└──  **METADATA** custom query or `getImportedKeys()`  [CALL 5x] -- USES CACHE from start ✅ 
├── `existingIndices()` _for each table_
├───└──  **METADATA** `getPrimaryKeys()` [CALL 5x] ⚠️
├───└──  **METADATA** `getIndexInfo()` [CALL 5x] -- CACHED ✅ 
├── `existingSequences()`
├───└──  **METADATA** custom query _for each table_ (PostgreSQL) or custom query _only once_ [CALL 1x] ✅ 
├── `existingCheckConstraints()` _for each table_
├───└──  **METADATA** custom query [MAX CALL 5x] ❗  
├── `existingCheckConstraints()` _for each table_
├───└──  **METADATA** custom query [MAX CALL 5x] ❗ 

❗ Worst case: Same check constraint metadata, with same results, is called 2N times
⚠️ Ok case: Oracle column metadata now uses 2 queries instead of 1. This could be reduced by writing a single custom query or by temporarily altering connection via [setRemarksReporting](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#setRemarksReporting(boolean)). Not super urgent.
⚠️Ok case: Primary key metadata is retrieved twice, but the queries are slightly different & one is tightly coupled to `getIndexInfo()` logic. It wouldn't be impossible to refactor, but this would be more work.

------------

- **How**:
    - In both `MigrationUtils`, replace duplicate back-to-back calls to `existingCheckConstraints()` with a single call
        - Extract common (JDBC + R2DBC) check constraint migration logic to new `@InternalApi` in `exposed-core/SchemaUtilityApi`
        - This pattern is consistent with what is done for indexes and foreign key constraints already
    - In both JDBC & R2DBC implementations, add private cache for results retrieved by `sequences()`
    - Add documentation about use of caches by `MigrationUtils` 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-1010](https://youtrack.jetbrains.com/issue/EXPOSED-1010/Multiple-duplicate-calls-to-metadata-retrieval-methods-during-migration)
[EXPOSED-1013](https://youtrack.jetbrains.com/issue/EXPOSED-1013/Slow-migration-checking-mapping-consistence)