### PR TITLE
fix: EXPOSED-790 Connection leak when coroutine is cancelled during JDBC suspendTransaction

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/JdbcTransactionInterface.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/JdbcTransactionInterface.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.exposed.v1.jdbc.transactions
 
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.core.transactions.TransactionInterface
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
@@ -41,6 +43,13 @@ internal fun JdbcTransactionInterface.rollbackLoggingException(log: (Exception) 
         rollback()
     } catch (e: Exception) {
         log(e)
+    }
+}
+
+@Suppress("TooGenericExceptionCaught")
+internal suspend fun JdbcTransactionInterface.rollbackSuspendLoggingException(log: (Exception) -> Unit) {
+    withContext(NonCancellable) {
+        this@rollbackSuspendLoggingException.rollbackLoggingException(log)
     }
 }
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/Transactions.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/transactions/Transactions.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.exposed.v1.jdbc.transactions
 
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.SqlLogger
 import org.jetbrains.exposed.v1.core.exposedLogger
@@ -9,6 +11,7 @@ import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import org.jetbrains.exposed.v1.jdbc.withTransactionContext
 import java.sql.SQLException
 import java.util.concurrent.ThreadLocalRandom
@@ -28,10 +31,11 @@ import java.util.concurrent.ThreadLocalRandom
  * @throws Throwable If any other error occurs during execution (after attempting rollback)
  */
 @Suppress("TooGenericExceptionCaught")
-private inline fun <T> executeTransactionWithErrorHandling(
+private inline fun <T> executeBaseTransactionWithErrorHandling(
     transaction: JdbcTransaction,
     shouldCommit: Boolean,
-    block: () -> T
+    block: () -> T,
+    errorBlock: (JdbcPreparedStatementApi?) -> Unit,
 ): T {
     return try {
         block().also {
@@ -41,24 +45,44 @@ private inline fun <T> executeTransactionWithErrorHandling(
         }
     } catch (cause: SQLException) {
         val currentStatement = transaction.currentStatement
-        transaction.rollbackLoggingException {
-            exposedLogger.warn(
-                "Transaction rollback failed: ${it.message}. Statement: $currentStatement",
-                it
-            )
-        }
+        errorBlock(currentStatement)
         throw cause
     } catch (cause: Throwable) {
         if (shouldCommit) {
             val currentStatement = transaction.currentStatement
-            transaction.rollbackLoggingException {
-                exposedLogger.warn(
-                    "Transaction rollback failed: ${it.message}. Statement: $currentStatement",
-                    it
-                )
-            }
+            errorBlock(currentStatement)
         }
         throw cause
+    }
+}
+
+private inline fun <T> executeTransactionWithErrorHandling(
+    transaction: JdbcTransaction,
+    shouldCommit: Boolean,
+    block: () -> T,
+): T {
+    return executeBaseTransactionWithErrorHandling(transaction, shouldCommit, block) { errorStatement ->
+        transaction.rollbackLoggingException {
+            exposedLogger.warn(
+                "Transaction rollback failed: ${it.message}. Statement: $errorStatement",
+                it
+            )
+        }
+    }
+}
+
+private suspend inline fun <T> executeSuspendTransactionWithErrorHandling(
+    transaction: JdbcTransaction,
+    shouldCommit: Boolean,
+    block: () -> T,
+): T {
+    return executeBaseTransactionWithErrorHandling(transaction, shouldCommit, block) { errorStatement ->
+        transaction.rollbackSuspendLoggingException {
+            exposedLogger.warn(
+                "Transaction rollback failed: ${it.message}. Statement: $errorStatement",
+                it
+            )
+        }
     }
 }
 
@@ -193,7 +217,10 @@ fun <T> inTopLevelTransaction(
                         transaction.statement()
                     }
                 } catch (cause: SQLException) {
-                    handleSQLException(cause, transaction, attempts)
+                    logSQLException(cause, transaction, attempts)
+                    transaction.rollbackLoggingException {
+                        exposedLogger.debug("Transaction rollback failed: ${it.message}. See previous log line for statement", it)
+                    }
                     throw cause
                 }
             }
@@ -271,7 +298,7 @@ suspend fun <T> suspendTransaction(
 
         @OptIn(InternalApi::class)
         withTransactionContext(transaction) {
-            executeTransactionWithErrorHandling(
+            executeSuspendTransactionWithErrorHandling(
                 transaction,
                 shouldCommit = outer.db.useNestedTransactions
             ) {
@@ -335,12 +362,15 @@ suspend fun <T> inTopLevelSuspendTransaction(
             @OptIn(InternalApi::class)
             return withTransactionContext(transaction) {
                 try {
-                    executeTransactionWithErrorHandling(transaction, shouldCommit = true) {
+                    executeSuspendTransactionWithErrorHandling(transaction, shouldCommit = true) {
                         transaction.db.config.defaultSchema?.let { SchemaUtils.setSchema(it) }
                         transaction.statement()
                     }
                 } catch (cause: SQLException) {
-                    handleSQLException(cause, transaction, attempts)
+                    logSQLException(cause, transaction, attempts)
+                    transaction.rollbackSuspendLoggingException {
+                        exposedLogger.debug("Transaction rollback failed: ${it.message}. See previous log line for statement", it)
+                    }
                     throw cause
                 }
             }
@@ -374,24 +404,29 @@ suspend fun <T> inTopLevelSuspendTransaction(
             }
         } finally {
             @OptIn(InternalApi::class)
-            withTransactionContext(transaction) {
-                closeStatementsAndConnection(transaction)
+            withContext(NonCancellable) {
+                withTransactionContext(transaction) {
+                    closeStatementsAndConnection(transaction)
+                }
             }
         }
     }
 }
 
 /**
- * Handles SQL exceptions that occur during transaction execution.
+ * Logs SQL exceptions that occur during execution of a suspended transaction.
  *
- * This function logs the exception details, including the queries that caused the exception,
- * and attempts to roll back the transaction.
+ * This function logs the exception details, including the queries that caused the exception.
  *
  * @param cause The SQLException that occurred.
  * @param transaction The transaction in which the exception occurred.
  * @param attempts The number of transaction attempts made so far.
  */
-internal fun handleSQLException(cause: SQLException, transaction: JdbcTransaction, attempts: Int) {
+private fun logSQLException(
+    cause: SQLException,
+    transaction: JdbcTransaction,
+    attempts: Int,
+) {
     val exposedSQLException = cause as? ExposedSQLException
     val queriesToLog = exposedSQLException?.causedByQueries()?.joinToString(";\n") ?: "${transaction.currentStatement}"
     val message = "Transaction attempt #$attempts failed: ${cause.message}. Statement(s): $queriesToLog"
@@ -401,9 +436,6 @@ internal fun handleSQLException(cause: SQLException, transaction: JdbcTransactio
         }
     }
     exposedLogger.debug(message, cause)
-    transaction.rollbackLoggingException {
-        exposedLogger.debug("Transaction rollback failed: ${it.message}. See previous log line for statement", it)
-    }
 }
 
 /**

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ConnectionTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ConnectionTests.kt
@@ -43,6 +43,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class ConnectionTests : R2dbcDatabaseTestsBase() {
 
@@ -324,21 +325,29 @@ class ConnectionTests : R2dbcDatabaseTestsBase() {
         Assumptions.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
         val initialCount = getIdleInTransactionCount()
 
+        suspendTransaction(dialect.db) {
+            SchemaUtils.create(People)
+        }
+
         repeat(30) { i ->
             val job = launch {
                 suspendTransaction(dialect.db) {
                     People.insert {
                         it[People.firstName] = "test-$i"
                     }
-                    delay(5000) // Cancellation happens here
+                    delay(5000.milliseconds) // Cancellation happens here
                 }
             }
-            delay(100)
+            delay(100.milliseconds)
             job.cancelAndJoin()
 
             val finalCount = getIdleInTransactionCount()
             val leaked = finalCount - initialCount
-            assertEquals(0, leaked, "Connection was leaked due to transdaction cancellation")
+            assertEquals(0, leaked, "Connection was leaked due to transaction cancellation")
+        }
+
+        suspendTransaction(dialect.db) {
+            SchemaUtils.drop(People)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ConnectionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ConnectionTests.kt
@@ -1,12 +1,19 @@
 package org.jetbrains.exposed.v1.tests.shared
 
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.v1.core.StdOutSqlLogger
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.core.vendors.ColumnMetadata
 import org.jetbrains.exposed.v1.core.vendors.H2Dialect
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.name
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
@@ -15,6 +22,8 @@ import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 import java.sql.Types
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
 
 class ConnectionTests : DatabaseTestsBase() {
 
@@ -136,6 +145,59 @@ class ConnectionTests : DatabaseTestsBase() {
         } catch (cause: Exception) {
             assertTrue(cause.message != null)
             assertContains(cause.message!!, "Table \"TESTER\" not found")
+        }
+    }
+
+    @Test
+    fun testNoConnectionLeakOnCancellation() = runTest {
+        Assumptions.assumeTrue(TestDB.POSTGRESQL in TestDB.enabledDialects())
+        val initialCount = getIdleInTransactionCount()
+
+        transaction(dialect.db) {
+            SchemaUtils.create(People)
+        }
+
+        repeat(30) { i ->
+            val job = launch {
+                suspendTransaction(dialect.db) {
+                    People.insert {
+                        it[People.firstName] = "test-$i"
+                    }
+                    delay(5000.milliseconds) // Cancellation happens here
+                }
+            }
+            delay(100.milliseconds)
+            job.cancelAndJoin()
+
+            val finalCount = getIdleInTransactionCount()
+            val leaked = finalCount - initialCount
+            assertEquals(0, leaked, "Connection was leaked due to transaction cancellation")
+        }
+
+        transaction(dialect.db) {
+            SchemaUtils.drop(People)
+        }
+    }
+
+    private suspend fun getIdleInTransactionCount(): Int {
+        if (dialect.db == null) {
+            dialect.db = dialect.connect()
+        }
+
+        return suspendTransaction(dialect.db!!) {
+            maxAttempts = 1
+            exec(
+                """
+              SELECT COUNT(*) as count
+              FROM pg_stat_activity
+              WHERE state is not null
+              AND datname = current_database()
+              AND pid != pg_backend_pid()
+                """.trimIndent()
+            ) { rs ->
+                rs.next()
+                rs.getInt(1)
+            } ?: 0
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Fixed connection leak in JDBC when coroutines are cancelled during `suspendTransaction` by wrapping cleanup operations in `withContext(NonCancellable)`.

**Detailed description**:
- **Why**: Issues similar to #2738 have been reported for JDBC suspend transactions. Test for the original R2DBC fix was reproducible with minor changes, and fixed by the same fix.

- **How**:
    - Introduce suspend versions of cleanup methods
    - Wrap them all in `withContext(NonCancellable)`

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs

---

#### Related Issues

[EXPOSED-790](https://youtrack.jetbrains.com/issue/EXPOSED-790/Cancelled-Coroutine-Keeps-Executing-Statements)
[EXPOSED-1008](https://youtrack.jetbrains.com/issue/EXPOSED-1008/Connection-leak-when-coroutine-is-cancelled-during-suspendTransaction)