### PR TITLE
fix: EXPOSED-1015 [MariaDB] Internal check constraint on JSON column triggers DROP statement

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
@@ -290,6 +290,14 @@ abstract class SchemaUtilityApi {
     ): Pair<List<CheckConstraint>, List<CheckConstraint>> {
         if (this.isEmpty()) return Pair(emptyList(), emptyList())
 
+        // MariaDB: unmapped check constraints on JSON(B) columns are db-generated for internal validation use
+        fun CheckConstraint.isInternalConstraint(): Boolean {
+            // generated constraint name always matches the column name;
+            // but doing a further column-name or -type check here would overlook the case when a JSON column has been dropped,
+            // resulting in an invalid DROP constraint due to an unmapped column to check
+            return currentDialect is MariaDBDialect && checkOp.startsWith("json_valid(", ignoreCase = true)
+        }
+
         val missingCheckConstraints = mutableListOf<CheckConstraint>()
         val unmappedCheckConstraints = mutableListOf<CheckConstraint>()
 
@@ -304,7 +312,9 @@ abstract class SchemaUtilityApi {
 
             val mappedCheckConstraintsNames = mappedCheckConstraints.map { it.checkName.uppercase() }.toSet()
             unmappedCheckConstraints.addAll(
-                existingCheckConstraints.filterNot { it.checkName.uppercase() in mappedCheckConstraintsNames }
+                existingCheckConstraints.filterNot {
+                    it.checkName.uppercase() in mappedCheckConstraintsNames || it.isInternalConstraint()
+                }
             )
         }
 

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
@@ -37,9 +37,9 @@ import kotlin.test.assertNull
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlin.uuid.toKotlinUuid
+import java.util.UUID as JavaUUID
 import org.jetbrains.exposed.v1.datetime.date as kotlinDatetimeDate
 import org.jetbrains.exposed.v1.javatime.date as javatimeDate
-import java.util.UUID as JavaUUID
 
 class DatabaseMigrationTests : DatabaseTestsBase() {
     private val columnTypeChangeUnsupportedDb = TestDB.ALL - TestDB.ALL_H2_V2

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.*
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.vendors.PrimaryKeyMetadata
 import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
@@ -15,6 +16,7 @@ import org.jetbrains.exposed.v1.jdbc.batchInsert
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.json.json
 import org.jetbrains.exposed.v1.json.jsonb
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.TestDB
@@ -503,6 +505,58 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
                 it[secondaryId] = Uuid.random()
             }
             assertEquals(convertedIdPairs.size + 1L, updatedTable.selectAll().count())
+        }
+    }
+
+    @Test
+    fun testJsonGeneratedCheckConstraintNotDroppedByRepeatedMigrations() {
+        val testerOG = object : Table("tester") {
+            val numbers = json<IntArray>("numbers", Json.Default)
+            val names = json<List<String>>("names", Json.Default).check { it.isNotNull() }
+        }
+        val testerNew = object : Table("tester") {
+            val letters = jsonb<CharArray>("letters", Json.Default)
+            val names = json<List<String>>("names", Json.Default).check { it.isNotNull() }
+        }
+
+        // MariaDB JSON type is actually an alias for LONGTEXT + an automatic check constraint with checkOp=json_valid(`numbers`);
+        // MariaDB is the only db so far that backs up a JSON column with a constraint, which should be ignored by schema diffs.
+        withDb { testDb ->
+            try {
+                SchemaUtils.create(testerOG)
+
+                var alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerOG, withLogs = false)
+                // neither db-generated nor mapped user-defined check constraints should be dropped
+                assertTrue(alterStatements.isEmpty())
+
+                val jsonBUnsupportedDb = listOf(TestDB.ORACLE, TestDB.SQLSERVER)
+                if (testDb !in jsonBUnsupportedDb) {
+                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
+                    // column should be dropped without attempting to drop db-generated constraint
+                    assertEquals(2, alterStatements.size)
+                    assertTrue(
+                        alterStatements.first()
+                            .startsWith("ALTER TABLE ${testerNew.nameInDatabaseCase()} ADD ${testerNew.letters.nameInDatabaseCase()}")
+                    )
+                    assertEquals(
+                        alterStatements.last(),
+                        testerOG.numbers.dropStatement().single()
+                    )
+
+                    if (testDb == TestDB.SQLITE) {
+                        // SQLite ALTER TABLE ADD returns results, so must use executeQuery()
+                        exec(alterStatements.first(), explicitStatementType = StatementType.EXEC)
+                        exec(alterStatements.last(), explicitStatementType = StatementType.ALTER)
+                    } else {
+                        alterStatements.forEach(::exec)
+                    }
+
+                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
+                    assertTrue(alterStatements.isEmpty())
+                }
+            } finally {
+                SchemaUtils.drop(testerOG)
+            }
         }
     }
 }

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
@@ -4,7 +4,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.v1.core.*
-import org.jetbrains.exposed.v1.core.dao.id.*
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.core.dao.id.UIntIdTable
+import org.jetbrains.exposed.v1.core.dao.id.ULongIdTable
+import org.jetbrains.exposed.v1.core.dao.id.UuidTable
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.statements.StatementType
@@ -32,9 +37,9 @@ import kotlin.test.assertNull
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlin.uuid.toKotlinUuid
-import java.util.UUID as JavaUUID
 import org.jetbrains.exposed.v1.datetime.date as kotlinDatetimeDate
 import org.jetbrains.exposed.v1.javatime.date as javatimeDate
+import java.util.UUID as JavaUUID
 
 class DatabaseMigrationTests : DatabaseTestsBase() {
     private val columnTypeChangeUnsupportedDb = TestDB.ALL - TestDB.ALL_H2_V2
@@ -521,41 +526,35 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
 
         // MariaDB JSON type is actually an alias for LONGTEXT + an automatic check constraint with checkOp=json_valid(`numbers`);
         // MariaDB is the only db so far that backs up a JSON column with a constraint, which should be ignored by schema diffs.
-        withDb { testDb ->
-            try {
-                SchemaUtils.create(testerOG)
+        withTables(testerOG) { testDb ->
+            var alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerOG, withLogs = false)
+            // neither db-generated nor mapped user-defined check constraints should be dropped
+            assertTrue(alterStatements.isEmpty())
 
-                var alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerOG, withLogs = false)
-                // neither db-generated nor mapped user-defined check constraints should be dropped
-                assertTrue(alterStatements.isEmpty())
+            val jsonBUnsupportedDb = listOf(TestDB.ORACLE, TestDB.SQLSERVER)
+            if (testDb !in jsonBUnsupportedDb) {
+                alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
+                // column should be dropped without attempting to drop db-generated constraint
+                assertEquals(2, alterStatements.size)
+                assertTrue(
+                    alterStatements.first()
+                        .startsWith("ALTER TABLE ${testerNew.nameInDatabaseCase()} ADD ${testerNew.letters.nameInDatabaseCase()}")
+                )
+                assertEquals(
+                    alterStatements.last(),
+                    testerOG.numbers.dropStatement().single()
+                )
 
-                val jsonBUnsupportedDb = listOf(TestDB.ORACLE, TestDB.SQLSERVER)
-                if (testDb !in jsonBUnsupportedDb) {
-                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
-                    // column should be dropped without attempting to drop db-generated constraint
-                    assertEquals(2, alterStatements.size)
-                    assertTrue(
-                        alterStatements.first()
-                            .startsWith("ALTER TABLE ${testerNew.nameInDatabaseCase()} ADD ${testerNew.letters.nameInDatabaseCase()}")
-                    )
-                    assertEquals(
-                        alterStatements.last(),
-                        testerOG.numbers.dropStatement().single()
-                    )
-
-                    if (testDb == TestDB.SQLITE) {
-                        // SQLite ALTER TABLE ADD returns results, so must use executeQuery()
-                        exec(alterStatements.first(), explicitStatementType = StatementType.EXEC)
-                        exec(alterStatements.last(), explicitStatementType = StatementType.ALTER)
-                    } else {
-                        alterStatements.forEach(::exec)
-                    }
-
-                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
-                    assertTrue(alterStatements.isEmpty())
+                if (testDb == TestDB.SQLITE) {
+                    // SQLite ALTER TABLE ADD returns results, so must use executeQuery()
+                    exec(alterStatements.first(), explicitStatementType = StatementType.EXEC)
+                    exec(alterStatements.last(), explicitStatementType = StatementType.ALTER)
+                } else {
+                    alterStatements.forEach(::exec)
                 }
-            } finally {
-                SchemaUtils.drop(testerOG)
+
+                alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
+                assertTrue(alterStatements.isEmpty())
             }
         }
     }

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
@@ -36,9 +36,9 @@ import kotlin.test.assertNull
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlin.uuid.toKotlinUuid
+import java.util.UUID as JavaUUID
 import org.jetbrains.exposed.v1.datetime.date as kotlinDatetimeDate
 import org.jetbrains.exposed.v1.javatime.date as javatimeDate
-import java.util.UUID as JavaUUID
 
 class DatabaseMigrationTests : R2dbcDatabaseTestsBase() {
     private val columnTypeChangeUnsupportedDb = TestDB.ALL - TestDB.ALL_H2_V2

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
@@ -36,9 +36,9 @@ import kotlin.test.assertNull
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlin.uuid.toKotlinUuid
-import java.util.UUID as JavaUUID
 import org.jetbrains.exposed.v1.datetime.date as kotlinDatetimeDate
 import org.jetbrains.exposed.v1.javatime.date as javatimeDate
+import java.util.UUID as JavaUUID
 
 class DatabaseMigrationTests : R2dbcDatabaseTestsBase() {
     private val columnTypeChangeUnsupportedDb = TestDB.ALL - TestDB.ALL_H2_V2
@@ -508,35 +508,29 @@ class DatabaseMigrationTests : R2dbcDatabaseTestsBase() {
 
         // MariaDB JSON type is actually an alias for LONGTEXT + an automatic check constraint with checkOp=json_valid(`numbers`);
         // MariaDB is the only db so far that backs up a JSON column with a constraint, which should be ignored by schema diffs.
-        withDb { testDb ->
-            try {
-                SchemaUtils.create(testerOG)
+        withTables(testerOG) { testDb ->
+            var alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerOG, withLogs = false)
+            // neither db-generated nor mapped user-defined check constraints should be dropped
+            assertTrue(alterStatements.isEmpty())
 
-                var alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerOG, withLogs = false)
-                // neither db-generated nor mapped user-defined check constraints should be dropped
+            val jsonBUnsupportedDb = listOf(TestDB.ORACLE, TestDB.SQLSERVER)
+            if (testDb !in jsonBUnsupportedDb) {
+                alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
+                // column should be dropped without attempting to drop db-generated constraint
+                assertEquals(2, alterStatements.size)
+                assertTrue(
+                    alterStatements.first()
+                        .startsWith("ALTER TABLE ${testerNew.nameInDatabaseCase()} ADD ${testerNew.letters.nameInDatabaseCase()}")
+                )
+                assertEquals(
+                    alterStatements.last(),
+                    testerOG.numbers.dropStatement().single()
+                )
+
+                alterStatements.forEach { exec(it) }
+
+                alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
                 assertTrue(alterStatements.isEmpty())
-
-                val jsonBUnsupportedDb = listOf(TestDB.ORACLE, TestDB.SQLSERVER)
-                if (testDb !in jsonBUnsupportedDb) {
-                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
-                    // column should be dropped without attempting to drop db-generated constraint
-                    assertEquals(2, alterStatements.size)
-                    assertTrue(
-                        alterStatements.first()
-                            .startsWith("ALTER TABLE ${testerNew.nameInDatabaseCase()} ADD ${testerNew.letters.nameInDatabaseCase()}")
-                    )
-                    assertEquals(
-                        alterStatements.last(),
-                        testerOG.numbers.dropStatement().single()
-                    )
-
-                    alterStatements.forEach { exec(it) }
-
-                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
-                    assertTrue(alterStatements.isEmpty())
-                }
-            } finally {
-                SchemaUtils.drop(testerOG)
             }
         }
     }

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
@@ -15,6 +15,7 @@ import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.vendors.PrimaryKeyMetadata
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
+import org.jetbrains.exposed.v1.json.json
 import org.jetbrains.exposed.v1.json.jsonb
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import org.jetbrains.exposed.v1.r2dbc.batchInsert
@@ -491,6 +492,52 @@ class DatabaseMigrationTests : R2dbcDatabaseTestsBase() {
                 it[secondaryId] = Uuid.random()
             }
             assertEquals(convertedIdPairs.size + 1L, updatedTable.selectAll().count())
+        }
+    }
+
+    @Test
+    fun testJsonGeneratedCheckConstraintNotDroppedByRepeatedMigrations() {
+        val testerOG = object : Table("tester") {
+            val numbers = json<IntArray>("numbers", Json.Default)
+            val names = json<List<String>>("names", Json.Default).check { it.isNotNull() }
+        }
+        val testerNew = object : Table("tester") {
+            val letters = jsonb<CharArray>("letters", Json.Default)
+            val names = json<List<String>>("names", Json.Default).check { it.isNotNull() }
+        }
+
+        // MariaDB JSON type is actually an alias for LONGTEXT + an automatic check constraint with checkOp=json_valid(`numbers`);
+        // MariaDB is the only db so far that backs up a JSON column with a constraint, which should be ignored by schema diffs.
+        withDb { testDb ->
+            try {
+                SchemaUtils.create(testerOG)
+
+                var alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerOG, withLogs = false)
+                // neither db-generated nor mapped user-defined check constraints should be dropped
+                assertTrue(alterStatements.isEmpty())
+
+                val jsonBUnsupportedDb = listOf(TestDB.ORACLE, TestDB.SQLSERVER)
+                if (testDb !in jsonBUnsupportedDb) {
+                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
+                    // column should be dropped without attempting to drop db-generated constraint
+                    assertEquals(2, alterStatements.size)
+                    assertTrue(
+                        alterStatements.first()
+                            .startsWith("ALTER TABLE ${testerNew.nameInDatabaseCase()} ADD ${testerNew.letters.nameInDatabaseCase()}")
+                    )
+                    assertEquals(
+                        alterStatements.last(),
+                        testerOG.numbers.dropStatement().single()
+                    )
+
+                    alterStatements.forEach { exec(it) }
+
+                    alterStatements = MigrationUtils.statementsRequiredForDatabaseMigration(testerNew, withLogs = false)
+                    assertTrue(alterStatements.isEmpty())
+                }
+            } finally {
+                SchemaUtils.drop(testerOG)
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Add a check for internal JSON column check constraints when filtering detected check constraints during MariaDB migrations.

**Detailed description**:
- **Why**: With MariaDB, the JSON data type is just an alias for the LONGTEXT data type with an automatically generated check constraint, which ensures json input validity ([reference doc](https://mariadb.com/docs/server/reference/data-types/string-data-types/json)). Now that check constraints are included as part of the schema diff generation from `MigrationUtils`, any MariaDB JSON column will generate `ALTER TABLE DROP CONSTRAINT` because the internal check constraint is detected and, of course, it is not mapped in the Exposed table.

- **How**: Apply the same pattern of logic we use to check for SQLite internal indexes when filtering metadata results. When filtering the metadata check constraints, if one is found to not be mapped on the Exposed table object, it goes through a second check. If the db is MariaDB and the constraint is determined to be internal, it if filtered out of the schema diff and no statements are generated.

❗ The only consistent ways to check for internal MariaDB JSON-constraints are by checking for `JSON_VALID()` as the check operation and by checking the name (which always equals the column name). The latter is not possible though if, for example, the Exposed table object no longer holds that column (because the user intends to drop it). If the column name & type were required to confirm the internal constraint, this would result in invalid DROP CONSTRAINT statements whenever the column is dropped.

❗ There is always a possibility that a user could manually define a check constraint on a JSON column by creating their own function for 'JSON_VALID()'. So if they later drop this column, the migration methods will ignore the constraint, as if it were internal. This seems like a rare edge case and is of course worked around by just manually dropping the constraint. But it seems less troublesome than DROP statements being created for column constraints that still exist.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] MariaDB

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-1015](https://youtrack.jetbrains.com/issue/EXPOSED-1015/Invalid-DROP-CONSTRAINT-migration-generated-for-JSON-columns-with-MariaDB)