### PR TITLE
fix: fix thread-safety of IdentifierManagerApi identifier caches (#1704)

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/IdentifierManagerApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/api/IdentifierManagerApi.kt
@@ -180,7 +180,19 @@ abstract class IdentifierManagerApi {
     private fun quote(identity: String) = quotedIdentifiersCache.getOrPut(identity) { "$quoteString$identity$quoteString".trim() }
 }
 
-private class IdentifiersCache<V : Any>(initialCapacity: Int = 100, private val cacheSize: Int = 1000) :
-    java.util.LinkedHashMap<String, V>(initialCapacity) {
-    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, V>?): Boolean = size >= cacheSize
+private class IdentifiersCache<V : Any>(initialCapacity: Int = 100, private val cacheSize: Int = 1000) {
+    // A single IdentifierManagerApi instance is shared across every transaction on a Database, so
+    // these caches can be hit concurrently. A bare LinkedHashMap is not safe under concurrent
+    // structural modification (issue #1704: treeifyBin throws ClassCastException once a bucket
+    // grows past 8 entries). ConcurrentHashMap is not used because it would lose removeEldestEntry
+    // LRU eviction; instead wrap the map and make get-or-put atomic under the wrapper's monitor.
+    private val delegate: MutableMap<String, V> = java.util.Collections.synchronizedMap(
+        object : java.util.LinkedHashMap<String, V>(initialCapacity) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, V>?): Boolean = size >= cacheSize
+        }
+    )
+
+    inline fun getOrPut(key: String, defaultValue: () -> V): V = synchronized(delegate) {
+        delegate[key] ?: defaultValue().also { delegate[key] = it }
+    }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/IdentifierManagerConcurrencyTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/IdentifierManagerConcurrencyTest.kt
@@ -1,0 +1,75 @@
+package org.jetbrains.exposed.v1.tests.shared
+
+import org.jetbrains.exposed.v1.core.statements.api.IdentifierManagerApi
+import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for issue #1704.
+ *
+ * A single [IdentifierManagerApi] is shared across every transaction / coroutine on a Database,
+ * so its 5 internal identifier caches are accessed concurrently during SQL preparation. Before
+ * the fix those caches were plain [java.util.LinkedHashMap] instances and once a bucket grew past
+ * 8 entries `HashMap.treeifyBin` would throw `ClassCastException` under contention. This test
+ * pulls the live [IdentifierManagerApi] off a real database and hammers all four cache-backed
+ * entry points from a thread pool, failing if any worker sees an exception.
+ *
+ * The concurrent section runs outside any transaction, which is representative: the identifier
+ * manager is a process-wide singleton on the Database and is routinely read from background
+ * threads (DataLoader batches, async statement preparation) that don't own the current
+ * transaction thread-local.
+ */
+class IdentifierManagerConcurrencyTest : DatabaseTestsBase() {
+
+    @Test
+    fun identifierManagerCachesSurviveConcurrentResolution() {
+        withDb { testDb ->
+            val manager: IdentifierManagerApi = db.identifierManager
+            // Prime the `keywords` / `shouldPreserveKeywordCasing` lazies from this transaction so
+            // worker threads can safely read them without a transaction context.
+            manager.needQuotes("warmup")
+            manager.shouldQuoteIdentifier("warmup")
+            manager.inProperCase("warmup")
+            manager.quoteIfNecessary("warmup")
+
+            // Use unique keys per task so every worker is populating the cache (not just reading
+            // already-cached entries). A read-only workload never races on `put`, so the original
+            // LinkedHashMap-based cache would appear safe; to reliably reproduce #1704 the caches
+            // must be under constant mutation pressure.
+            val pool = Executors.newFixedThreadPool(16)
+            val errors = ConcurrentLinkedQueue<Throwable>()
+            try {
+                val futures = (0 until 2000).map { taskId ->
+                    pool.submit {
+                        try {
+                            repeat(200) { i ->
+                                val id = "col_${taskId}_$i"
+                                manager.needQuotes(id)
+                                manager.inProperCase(id)
+                                manager.quoteIfNecessary(id)
+                                manager.shouldQuoteIdentifier(id)
+                                // Tokens containing `-` are not valid unquoted identifiers, so
+                                // `quoteTokenIfNecessary` routes them through `quote(...)` and
+                                // populates `quotedIdentifiersCache` — exercise the 5th cache.
+                                manager.quoteIfNecessary("col-$taskId-$i")
+                            }
+                        } catch (t: Throwable) {
+                            errors += t
+                        }
+                    }
+                }
+                futures.forEach { it.get(120, TimeUnit.SECONDS) }
+            } finally {
+                pool.shutdownNow()
+            }
+            assertTrue(
+                errors.isEmpty(),
+                "Expected no concurrency errors on $testDb, got ${errors.size}: ${errors.firstOrNull()}"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`IdentifierManagerApi` is instantiated once per database URL (cached by `JdbcDatabaseMetadataImpl` / `R2dbcDatabaseMetadataImpl`) and therefore shared across every transaction and coroutine that runs against a given `Database`. Its five internal caches were plain `java.util.LinkedHashMap` subclasses accessed via a non-atomic `getOrPut` (extension-style `get`-then-`put`). Under concurrent SQL preparation this races on `put`, and once any bucket grows past 8 entries `HashMap.treeifyBin` throws:

```
java.lang.ClassCastException: class java.util.LinkedHashMap$Entry cannot be
  cast to class java.util.HashMap$TreeNode
    at java.util.HashMap$TreeNode.moveRootToFront
    at java.util.HashMap.treeifyBin
    at java.util.HashMap.putVal
    at org.jetbrains.exposed.v1.core.statements.api.IdentifierManagerApi.needQuotes
```

Multiple users have reproduced this on 0.41.1, 0.49.0, 0.59.0, 0.61.0, and 1.2.0. See #1704.

Closes #1704.

## Root cause

`IdentifiersCache` extended `LinkedHashMap` directly and every accessor ran `cache.getOrPut(key) { ... }` — that's a separate `get` and `put`, so two threads inserting different keys can mutate the same bucket at the same time and corrupt it during tree-ification.

## Approach

Wrap the `LinkedHashMap` with `java.util.Collections.synchronizedMap` and expose a single atomic `getOrPut` that does the lookup + insert under the wrapper's intrinsic lock.

```kotlin
private class IdentifiersCache<V : Any>(initialCapacity: Int = 100, private val cacheSize: Int = 1000) {
    private val delegate: MutableMap<String, V> = java.util.Collections.synchronizedMap(
        object : java.util.LinkedHashMap<String, V>(initialCapacity) {
            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, V>?): Boolean = size >= cacheSize
        }
    )

    inline fun getOrPut(key: String, defaultValue: () -> V): V = synchronized(delegate) {
        delegate[key] ?: defaultValue().also { delegate[key] = it }
    }
}
```

Why not `ConcurrentHashMap`: it would drop the `removeEldestEntry`-based LRU eviction (cap of 1000 entries) — a behavioral change outside the scope of this fix.

Why not a finer-grained lock: the cache is read-mostly after warm-up and `synchronized` on a ≤1000-entry map is negligible next to SQL preparation cost.

No public API changes; all 5 fields remain private.

## Test plan

New regression test: `exposed-tests/.../shared/IdentifierManagerConcurrencyTest.kt`.

- [x] Reproduces the bug on `main` — test fails with `ClassCastException` from `HashMap.treeifyBin` when the fix is reverted
- [x] Passes with the fix applied (`./gradlew :exposed-tests:test_h2_v2 --tests "*.IdentifierManagerConcurrencyTest"`)
- [x] `./gradlew :exposed-core:detekt :exposed-tests:detekt` clean
- [x] `./gradlew :exposed-core:apiCheck` clean (no public API change)

The test spawns 16 worker threads × 2000 tasks, each inserting 200 unique keys into every cache in parallel, which reliably triggers tree-ification races on the unfixed code.