### PR TITLE
feat: eager loading, many-to-many

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/QueryParameter.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/QueryParameter.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.v1.core
 
 import org.jetbrains.exposed.v1.core.dao.id.CompositeID
+import org.jetbrains.exposed.v1.core.dao.id.CompositeIdTable
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.statements.api.ExposedBlob
 import java.math.BigDecimal
@@ -14,7 +15,9 @@ class QueryParameter<T>(
     /** Returns the column type of this expression. */
     override val columnType: IColumnType<T & Any>
 ) : ExpressionWithColumnType<T>() {
-    internal val compositeValue: CompositeID? = (value as? EntityID<*>)?.value as? CompositeID
+    internal val compositeValue: CompositeID? = (value as? EntityID<*>)
+        ?.takeIf { it.table is CompositeIdTable }
+        ?.value as? CompositeID
 
     override fun toQueryBuilder(queryBuilder: QueryBuilder) {
         queryBuilder {

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityTests.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityTests.kt
@@ -2,7 +2,7 @@ package org.jetbrains.exposed.dao.r2dbc.tests.shared
 
 import io.r2dbc.spi.IsolationLevel
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
@@ -11,15 +11,18 @@ import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.r2dbc.dao.exceptions.R2dbcEntityNotFoundException
 import org.jetbrains.exposed.r2dbc.dao.flushCache
 import org.jetbrains.exposed.r2dbc.dao.relationships.backReferencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.load
 import org.jetbrains.exposed.r2dbc.dao.relationships.optionalBackReferencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.optionalReferencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.optionalReferrersOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.referrersOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.SortOrder
@@ -30,17 +33,27 @@ import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.idParam
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import org.jetbrains.exposed.v1.r2dbc.SizedIterable
 import org.jetbrains.exposed.v1.r2dbc.batchUpsert
 import org.jetbrains.exposed.v1.r2dbc.deleteAll
 import org.jetbrains.exposed.v1.r2dbc.deleteWhere
+import org.jetbrains.exposed.v1.r2dbc.insert
+import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
+import org.jetbrains.exposed.v1.r2dbc.select
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.tests.currentDialectTest
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.expectException
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.r2dbc.transactions.inTopLevelSuspendTransaction
 import org.jetbrains.exposed.v1.r2dbc.update
 import org.jetbrains.exposed.v1.r2dbc.upsert
@@ -123,6 +136,7 @@ object EntityTestsData {
     }
 }
 
+@Suppress("LargeClass")
 class R2dbcEntityTests : R2dbcDatabaseTestsBase() {
     @Test
     fun testDefaults01() {
@@ -896,6 +910,933 @@ class R2dbcEntityTests : R2dbcDatabaseTestsBase() {
                 assertEquals(region1, Region.testCache(School.testCache(school2.id)!!.readValues[Schools.region]))
                 assertEquals(region2, Region.testCache(School.testCache(school3.id)!!.readValues[Schools.region]))
             }
+        }
+    }
+
+    @Test
+    fun testIterationOverSizedIterableWithPreload() {
+        fun HashMap<String, Pair<Int, Long>>.assertEachQueryExecutedOnlyOnce() {
+            forEach { (statement, stats) ->
+                val executionCount = stats.first
+                assertEquals(1, executionCount, "Statement executed more than once: $statement")
+            }
+        }
+
+        withTables(Regions, Schools) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+            School.new {
+                name = "Eton"
+                region set region1
+            }
+            School.new {
+                name = "Harrow"
+                region set region1
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                debug = true // enables tracking of executed statements in this transaction
+
+                val allSchools = School.all().with(School::region).toList()
+
+                assertEquals(2, allSchools.size)
+                // expected: 1 query to select all School, and 1 query to select referenced Regions
+                assertEquals(2, statementCount)
+                assertEquals(statementCount, statementStats.size)
+                statementStats.assertEachQueryExecutedOnlyOnce()
+
+                // reset tracker
+                statementCount = 0
+                statementStats.clear()
+
+                val oneSchool = School.all().limit(1).with(School::region).toList()
+
+                assertEquals(1, oneSchool.size)
+                assertEquals(2, statementCount)
+                assertEquals(statementCount, statementStats.size)
+                statementStats.assertEachQueryExecutedOnlyOnce()
+
+                debug = false
+            }
+
+            // test that cached result doesn't propagate when SizedIterable query changes after loading
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                debug = true
+
+                val oneSchool = School.all().with(School::region).limit(1).toList()
+
+                assertEquals(1, oneSchool.size)
+                // expected: 1 query to select all School, 1 query to select the referenced Regions,
+                // then 1 new query to select only first School
+                assertEquals(3, statementCount)
+                assertEquals(statementCount, statementStats.size)
+                statementStats.assertEachQueryExecutedOnlyOnce()
+
+                debug = false
+            }
+        }
+    }
+
+    @Test
+    fun preloadReferencesOnAnEntity() {
+        withTables(Regions, Schools) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                School.find {
+                    Schools.id eq school1.id
+                }.first().load(School::region)
+
+                assertNotNull(School.testCache(school1.id))
+                assertEquals(region1, Region.testCache(School.testCache(school1.id)!!.readValues[Schools.region]))
+            }
+        }
+    }
+
+    @Test
+    fun preloadOptionalReferencesOnASizedIterable() {
+        withTables(Regions, Schools) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val region2 = Region.new {
+                name = "England"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+                secondaryRegion set region2
+            }.apply {
+                // otherwise Oracle provides school1.id = 0 to testCache(), which returns null
+                if (currentDialectTest is OracleDialect) flush()
+            }
+
+            val school2 = School.new {
+                name = "Harrow"
+                region set region1
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                School.all().with(School::region, School::secondaryRegion)
+                assertNotNull(School.testCache(school1.id))
+                assertNotNull(School.testCache(school2.id))
+
+                assertEquals(region1, Region.testCache(School.testCache(school1.id)!!.readValues[Schools.region]))
+                assertEquals(region2, Region.testCache(School.testCache(school1.id)!!.readValues[Schools.secondaryRegion]!!))
+                assertEquals(null, School.testCache(school2.id)!!.readValues[Schools.secondaryRegion])
+            }
+        }
+    }
+
+    @Test
+    fun preloadOptionalReferencesOnAnEntity() {
+        withTables(Regions, Schools) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+            val region2 = Region.new {
+                name = "England"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+                secondaryRegion set region2
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                val school2 = School.find {
+                    Schools.id eq school1.id
+                }.first().load(School::secondaryRegion)
+
+                assertEquals(null, Region.testCache(school2.readValues[Schools.region]))
+                assertEquals(region2, Region.testCache(school2.readValues[Schools.secondaryRegion]!!))
+            }
+        }
+    }
+
+    @Test
+    fun preloadReferrersOnASizedIterable() {
+        withTables(Regions, Schools, Students) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val region2 = Region.new {
+                name = "England"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val school2 = School.new {
+                name = "Harrow"
+                region set region1
+            }
+
+            val school3 = School.new {
+                name = "Winchester"
+                region set region2
+            }
+
+            val student1 = Student.new {
+                name = "James Smith"
+                school set school1
+            }
+
+            val student2 = Student.new {
+                name = "Jack Smith"
+                school set school2
+            }
+
+            val student3 = Student.new {
+                name = "Henry Smith"
+                school set school3
+            }
+
+            val student4 = Student.new {
+                name = "Peter Smith"
+                school set school3
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                val cache = TransactionManager.current().entityCache
+
+                School.all().with(School::students)
+
+                assertEqualCollections(cache.getReferrers<Student>(school1.id, Students.school)?.toList().orEmpty(), student1)
+                assertEqualCollections(cache.getReferrers<Student>(school2.id, Students.school)?.toList().orEmpty(), student2)
+                assertEqualCollections(cache.getReferrers<Student>(school3.id, Students.school)?.toList().orEmpty(), student3, student4)
+            }
+        }
+    }
+
+    @Test
+    fun preloadReferrersOnAnEntity() {
+        withTables(Regions, Schools, Students) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val student1 = Student.new {
+                name = "James Smith"
+                school set school1
+            }
+
+            val student2 = Student.new {
+                name = "Jack Smith"
+                school set school1
+            }
+
+            val student3 = Student.new {
+                name = "Henry Smith"
+                school set school1
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                val cache = TransactionManager.current().entityCache
+
+                School.find { Schools.id eq school1.id }.first().load(School::students)
+
+                assertEqualCollections(cache.getReferrers<Student>(school1.id, Students.school)?.toList().orEmpty(), student1, student2, student3)
+            }
+        }
+    }
+
+    @Test
+    fun preloadOptionalReferrersOnASizedIterable() {
+        withTables(Regions, Schools, Students, Detentions) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val student1 = Student.new {
+                name = "James Smith"
+                school set school1
+            }
+
+            val student2 = Student.new {
+                name = "Jack Smith"
+                school set school1
+            }
+
+            val detention1 = Detention.new {
+                reason = "Poor Behaviour"
+                student set student1
+            }
+
+            val detention2 = Detention.new {
+                reason = "Poor Behaviour"
+                student set student1
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                School.all().with(School::students, Student::detentions)
+                val cache = TransactionManager.current().entityCache
+
+                School.all().with(School::students, Student::detentions)
+
+                assertEqualCollections(cache.getReferrers<Student>(school1.id, Students.school)?.toList().orEmpty(), student1, student2)
+                assertEqualCollections(cache.getReferrers<Detention>(student1.id, Detentions.student)?.toList().orEmpty(), detention1, detention2)
+                assertEqualCollections(cache.getReferrers<Detention>(student2.id, Detentions.student)?.toList().orEmpty(), emptyList())
+            }
+        }
+    }
+
+    @Test
+    fun preloadInnerTableLinkOnASizedIterable() {
+        withTables(Regions, Schools, Holidays, SchoolHolidays) {
+            val now = System.currentTimeMillis()
+            val now10 = now + 10
+
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val region2 = Region.new {
+                name = "England"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val school2 = School.new {
+                name = "Harrow"
+                region set region1
+            }
+
+            val school3 = School.new {
+                name = "Winchester"
+                region set region2
+            }
+
+            val holiday1 = Holiday.new {
+                holidayStart = now
+                holidayEnd = now10
+            }
+
+            val holiday2 = Holiday.new {
+                holidayStart = now
+                holidayEnd = now10
+            }
+
+            val holiday3 = Holiday.new {
+                holidayStart = now
+                holidayEnd = now10
+            }
+
+            school1.holidays set listOf(holiday1, holiday2)
+            school2.holidays set listOf(holiday3)
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                School.all().with(School::holidays)
+                val cache = TransactionManager.current().entityCache
+
+                assertEqualCollections(cache.getReferrers<Holiday>(school1.id, SchoolHolidays.school)?.toList().orEmpty(), holiday1, holiday2)
+                assertEqualCollections(cache.getReferrers<Holiday>(school2.id, SchoolHolidays.school)?.toList().orEmpty(), holiday3)
+                assertEqualCollections(cache.getReferrers<Holiday>(school3.id, SchoolHolidays.school)?.toList().orEmpty(), emptyList())
+            }
+        }
+    }
+
+    @Test
+    fun preloadInnerTableLinkOnAnEntity() {
+        withTables(Regions, Schools, Holidays, SchoolHolidays) {
+            val now = System.currentTimeMillis()
+            val now10 = now + 10
+
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val holiday1 = Holiday.new {
+                holidayStart = now
+                holidayEnd = now10
+            }
+
+            val holiday2 = Holiday.new {
+                holidayStart = now
+                holidayEnd = now10
+            }
+
+            val holiday3 = Holiday.new {
+                holidayStart = now
+                holidayEnd = now10
+            }
+
+            SchoolHolidays.insert {
+                it[school] = school1.id
+                it[holiday] = holiday1.id
+            }
+
+            SchoolHolidays.insert {
+                it[school] = school1.id
+                it[holiday] = holiday2.id
+            }
+
+            SchoolHolidays.insert {
+                it[school] = school1.id
+                it[holiday] = holiday3.id
+            }
+
+            commit()
+
+            School.find {
+                Schools.id eq school1.id
+            }.first().load(School::holidays)
+
+            val cache = TransactionManager.current().entityCache
+
+            assertEquals(true, cache.getReferrers<Holiday>(school1.id, SchoolHolidays.school)?.toList()?.contains(holiday1))
+            assertEquals(true, cache.getReferrers<Holiday>(school1.id, SchoolHolidays.school)?.toList()?.contains(holiday2))
+            assertEquals(true, cache.getReferrers<Holiday>(school1.id, SchoolHolidays.school)?.toList()?.contains(holiday3))
+        }
+    }
+
+    @Test
+    fun preloadRelationAtDepth() {
+        withTables(Regions, Schools, Holidays, SchoolHolidays, Students, Notes) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val student1 = Student.new {
+                name = "James Smith"
+                school set school1
+            }
+
+            val student2 = Student.new {
+                name = "Jack Smith"
+                school set school1
+            }
+
+            val note1 = Note.new {
+                text = "Note text"
+                student set student1
+            }
+
+            val note2 = Note.new {
+                text = "Note text"
+                student set student2
+            }
+
+            School.all().with(School::students, Student::notes)
+
+            val cache = TransactionManager.current().entityCache
+
+            assertEquals(true, cache.getReferrers<Student>(school1.id, Students.school)?.toList()?.contains(student1))
+            assertEquals(true, cache.getReferrers<Student>(school1.id, Students.school)?.toList()?.contains(student2))
+            assertEquals(note1, cache.getReferrers<Note>(student1.id, Notes.student)?.first())
+            assertEquals(note2, cache.getReferrers<Note>(student2.id, Notes.student)?.first())
+        }
+    }
+
+    @Test
+    fun preloadBackReferrenceOnASizedIterable() {
+        withTables(Regions, Schools, Students, StudentBios) {
+            val region1 = Region.new {
+                name = "United States"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val student1 = Student.new {
+                name = "James Smith"
+                school set school1
+            }
+
+            val student2 = Student.new {
+                name = "John Smith"
+                school set school1
+            }
+
+            val bio1 = StudentBio.new {
+                student set student1
+                dateOfBirth = "01/01/2000"
+            }
+
+            val bio2 = StudentBio.new {
+                student set student2
+                dateOfBirth = "01/01/2002"
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                Student.all().with(Student::bio)
+                val cache = TransactionManager.current().entityCache
+
+                assertEqualCollections(cache.getReferrers<StudentBio>(student1.id, StudentBios.student)?.toList().orEmpty(), bio1)
+                assertEqualCollections(cache.getReferrers<StudentBio>(student2.id, StudentBios.student)?.toList().orEmpty(), bio2)
+            }
+        }
+    }
+
+    @Test
+    fun preloadBackReferrenceOnAnEntity() {
+        withTables(Regions, Schools, Students, StudentBios) {
+            val region1 = Region.new {
+                name = "United States"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val student1 = Student.new {
+                name = "James Smith"
+                school set school1
+            }
+
+            val student2 = Student.new {
+                name = "John Smith"
+                school set school1
+            }
+
+            val bio1 = StudentBio.new {
+                student set student1
+                dateOfBirth = "01/01/2000"
+            }
+
+            val bio2 = StudentBio.new {
+                student set student2
+                dateOfBirth = "01/01/2002"
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                Student.all().first().load(Student::bio)
+                val cache = TransactionManager.current().entityCache
+
+                assertEqualCollections(cache.getReferrers<StudentBio>(student1.id, StudentBios.student)?.toList().orEmpty(), bio1)
+            }
+        }
+    }
+
+    @Test
+    fun `test reference cache doesn't fully invalidated on set entity reference`() {
+        withTables(Regions, Schools, Students, StudentBios) {
+            val region1 = Region.new {
+                name = "United States"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val student1 = Student.new {
+                name = "James Smith"
+                school set school1
+            }
+
+            val student2 = Student.new {
+                name = "John Smith"
+                school set school1
+            }
+
+            val bio1 = StudentBio.new {
+                student set student1
+                dateOfBirth = "01/01/2000"
+            }
+
+            assertEquals(bio1, student1.bio())
+            assertEquals(bio1.student(), student1)
+        }
+    }
+
+    @Test
+    fun `test nested entity initialization`() {
+        withTables(Posts, Categories, Boards) {
+            val parent1 = Post.new {
+                board set Board.new {
+                    name = "Parent Board"
+                }
+                category set Category.new {
+                    title = "Parent Category"
+                }
+            }
+
+            val category1 = parent1.category()
+
+            val post = Post.new {
+                parent set parent1
+
+                category set Category.new {
+                    title = "Child Category"
+                }
+
+                // TODO before everything was inside `new()`, but now it requires suspend context
+
+                optCategory set category1
+            }
+
+            assertEquals("Parent Board", post.parent()?.board()?.name)
+            assertEquals("Parent Category", post.parent()?.category()?.title)
+            assertEquals("Parent Category", post.optCategory()?.title)
+            assertEquals("Child Category", post.category()?.title)
+        }
+    }
+
+    @Test
+    fun testExplicitEntityConstructor() {
+        var createBoardCalled = false
+        fun createBoard(id: EntityID<Int>): Board {
+            createBoardCalled = true
+            return Board(id)
+        }
+
+        val boardEntityClass = object : IntR2dbcEntityClass<Board>(Boards, entityCtor = ::createBoard) {}
+
+        withTables(Boards) {
+            val board = boardEntityClass.new {
+                name = "Test Board"
+            }
+
+            assertEquals("Test Board", board.name)
+            assertTrue(
+                createBoardCalled
+            )
+        }
+    }
+
+    object RequestsTable : IdTable<String>() {
+        val requestId: Column<String> = varchar("requestId", 256)
+        override val primaryKey = PrimaryKey(requestId)
+        override val id: Column<EntityID<String>> = requestId.entityId()
+    }
+
+    class Request(id: EntityID<String>) : R2dbcEntity<String>(id) {
+        companion object : R2dbcEntityClass<String, Request>(RequestsTable)
+
+        var requestId by RequestsTable.requestId
+    }
+
+    @Test
+    fun testSelectFromStringIdTableWithPrimaryKeyByColumn() {
+        withTables(RequestsTable) {
+            Request.new {
+                requestId = "123"
+            }
+
+            val count = Request.all().count()
+            assertEquals(1, count)
+        }
+    }
+
+    object CreditCards : IntIdTable("CreditCards") {
+        val number = varchar("number", 16)
+        val spendingLimit = ulong("spendingLimit").databaseGenerated()
+    }
+
+    class CreditCard(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<CreditCard>(CreditCards)
+
+        var number by CreditCards.number
+        var spendingLimit by CreditCards.spendingLimit
+    }
+
+    @Test
+    fun testDatabaseGeneratedValues() {
+        withTables(CreditCards) { testDb ->
+            when (testDb) {
+                TestDB.POSTGRESQL -> {
+                    // The value can also be set using a SQL trigger
+                    exec(
+                        """
+                        CREATE OR REPLACE FUNCTION set_spending_limit()
+                          RETURNS TRIGGER
+                          LANGUAGE PLPGSQL
+                          AS
+                        $$
+                        BEGIN
+                            NEW."spendingLimit" := 10000;
+                            RETURN NEW;
+                        END;
+                        $$;
+                        """.trimIndent()
+                    )
+                    exec(
+                        """
+                        CREATE TRIGGER set_spending_limit
+                        BEFORE INSERT
+                        ON CreditCards
+                        FOR EACH ROW
+                        EXECUTE PROCEDURE set_spending_limit();
+                        """.trimIndent()
+                    )
+                }
+                else -> {
+                    // This table is only used to get the statement that adds the DEFAULT value, and use it with exec
+                    val creditCards2 = object : IntIdTable("CreditCards") {
+                        val spendingLimit = ulong("spendingLimit").default(10000uL)
+                    }
+                    val missingStatements = SchemaUtils.addMissingColumnsStatements(creditCards2)
+                    missingStatements.forEach {
+                        exec(it)
+                    }
+                }
+            }
+
+            val creditCardId = CreditCards.insertAndGetId {
+                it[number] = "0000111122223333"
+            }.value
+            assertEquals(
+                10000uL,
+                CreditCards.selectAll().where { CreditCards.id eq creditCardId }.single()[CreditCards.spendingLimit]
+            )
+
+            val creditCard = CreditCard.new {
+                number = "0000111122223333"
+            }
+
+            // TODO Unlike JDBC, R2DBC's Column.getValue cannot synchronously flush the entity from a
+            //  non-suspend property accessor (Kotlin operators can't be `suspend`). For columns
+            //  whose value is set by the database (DEFAULT clause / trigger), R2DBC's
+            //  `flushInserts` does not necessarily get those values back through the INSERT
+            //  result row, so we call `refresh(flush = true)` — this flushes the pending insert
+            //  and then re-SELECTs the row to populate `_readValues` with all columns.
+            creditCard.refresh(flush = true)
+
+            assertEquals(10000uL, creditCard.spendingLimit)
+        }
+    }
+
+    @Test
+    fun testEntityIdParam() {
+        withTables(CreditCards) {
+            val newCard = CreditCard.new {
+                number = "0000111122223333"
+                spendingLimit = 10000uL
+            }
+            // It's also needed because of sync `new()`
+            flushCache()
+
+            val conditionalId = Case()
+                .When(CreditCards.spendingLimit less 500uL, CreditCards.id)
+                .Else(idParam(newCard.id, CreditCards.id))
+            assertEquals(newCard.id, CreditCards.select(conditionalId).single()[conditionalId])
+            assertEquals(
+                10000uL,
+                CreditCards.select(CreditCards.spendingLimit)
+                    .where { CreditCards.id eq idParam(newCard.id, CreditCards.id) }
+                    .single()[CreditCards.spendingLimit]
+            )
+        }
+    }
+
+    object Countries : IdTable<String>("Countries") {
+        override val id = varchar("id", 3).uniqueIndex().entityId()
+        var name = text("name")
+    }
+
+    class Country(id: EntityID<String>) : R2dbcEntity<String>(id) {
+        var name by Countries.name
+        val dishes by Dish referencedOnSuspend Dishes.country
+
+        companion object : R2dbcEntityClass<String, Country>(Countries)
+    }
+
+    object Dishes : IntIdTable("Dishes") {
+        var name = text("name")
+        val country = reference("country_id", Countries)
+    }
+
+    class Dish(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var name by Dishes.name
+        val country by Country referencedOnSuspend Dishes.country
+
+        companion object : IntR2dbcEntityClass<Dish>(Dishes)
+    }
+
+    @Test
+    fun testEagerLoadingWithStringParentId() {
+        withTables(Countries, Dishes, configure = { keepLoadedReferencesOutOfTransaction = true }) {
+            val lebanonId = Countries.insertAndGetId {
+                it[id] = "LB"
+                it[name] = "Lebanon"
+            }
+            val lebanon = Country.findById(lebanonId)!!
+
+            Dish.new {
+                name = "Kebbeh"
+                country set lebanon
+            }
+
+            Dish.new {
+                name = "Mjaddara"
+                country set lebanon
+            }
+
+            Dish.new {
+                name = "Fatteh"
+                country set lebanon
+            }
+
+            debug = true
+
+            Country.all().with(Country::dishes)
+
+            statementStats
+                .filterKeys { it.startsWith("SELECT ") }
+                .forEach { (_, stats) ->
+                    val (count, _) = stats
+                    assertEquals(1, count)
+                }
+
+            debug = false
+        }
+    }
+
+    object Customers : IntIdTable("Customers") {
+        val emailAddress = varchar("emailAddress", 30).uniqueIndex()
+        val fullName = text("fullName")
+    }
+
+    class Customer(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var emailAddress by Customers.emailAddress
+        var name by Customers.fullName
+
+        val orders by Order referrersOnSuspend Orders.customer
+
+        companion object : IntR2dbcEntityClass<Customer>(Customers)
+    }
+
+    object Orders : IntIdTable("Orders") {
+        var orderName = text("orderName")
+        val customer = reference("customer", Customers.emailAddress)
+    }
+
+    class Order(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var name by Orders.orderName
+        val customer by Customer referencedOnSuspend Orders.customer
+
+        companion object : IntR2dbcEntityClass<Order>(Orders)
+    }
+
+    @Test
+    fun testEagerLoadingWithReferenceDifferentFromParentId() {
+        withTables(Customers, Orders, configure = { keepLoadedReferencesOutOfTransaction = true }) {
+            val customer1 = Customer.new {
+                emailAddress = "customer1@testing.com"
+                name = "Customer1"
+            }
+
+            val order1 = Order.new {
+                name = "Order1"
+                customer set customer1
+            }
+
+            val order2 = Order.new {
+                name = "Order2"
+                customer set customer1
+            }
+
+            Customer.all().with(Customer::orders)
+
+            val cache = this.entityCache
+
+            assertEquals(true, cache.getReferrers<Order>(customer1.id, Orders.customer)?.toList()?.contains(order1))
+            assertEquals(true, cache.getReferrers<Order>(customer1.id, Orders.customer)?.toList()?.contains(order2))
+        }
+    }
+
+    object TestTable : IntIdTable("TestTable") {
+        val value = integer("value")
+    }
+
+    class TestEntityA(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by TestTable.value
+
+        companion object : IntR2dbcEntityClass<TestEntityA>(TestTable)
+    }
+
+    class TestEntityB(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by TestTable.value
+
+        companion object : IntR2dbcEntityClass<TestEntityB>(TestTable)
+    }
+
+    @Test
+    fun testDifferentEntitiesMappedToTheSameTable() {
+        withTables(TestTable) {
+            val entityA = TestEntityA.new {
+                value = 1
+            }
+            val entityB = TestEntityB.new {
+                value = 2
+            }
+
+            flushCache()
+
+            entityA.value = 3
+            entityB.value = 4
+
+            flushCache()
         }
     }
 }

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityTests.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityTests.kt
@@ -1,30 +1,58 @@
 package org.jetbrains.exposed.dao.r2dbc.tests.shared
 
+import io.r2dbc.spi.IsolationLevel
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.exceptions.R2dbcEntityNotFoundException
 import org.jetbrains.exposed.r2dbc.dao.flushCache
 import org.jetbrains.exposed.r2dbc.dao.relationships.backReferencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.optionalBackReferencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.optionalReferencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.optionalReferrersOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.referrersOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
 import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.StdOutSqlLogger
+import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.SizedIterable
+import org.jetbrains.exposed.v1.r2dbc.batchUpsert
+import org.jetbrains.exposed.v1.r2dbc.deleteAll
+import org.jetbrains.exposed.v1.r2dbc.deleteWhere
+import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.expectException
+import org.jetbrains.exposed.v1.r2dbc.transactions.inTopLevelSuspendTransaction
+import org.jetbrains.exposed.v1.r2dbc.update
+import org.jetbrains.exposed.v1.r2dbc.upsert
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertNull
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 
 object EntityTestsData {
 
@@ -192,6 +220,202 @@ class R2dbcEntityTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    object Items : IntIdTable("items") {
+        val name = varchar("name", 255).uniqueIndex()
+        val price = double("price")
+    }
+
+    class Item(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<Item>(Items)
+
+        var name by Items.name
+        var price by Items.price
+    }
+
+    @Test
+    fun testCacheInvalidatedOnDSLUpsert() {
+        withTables(Items) { testDb ->
+            val oldPrice = 20.0
+            val itemA = Item.new {
+                name = "Item A"
+                price = oldPrice
+            }
+            assertEquals(oldPrice, itemA.price)
+            assertNotNull(Item.testCache(itemA.id))
+
+            val newPrice = 50.0
+            val conflictKeys = if (testDb in TestDB.ALL_MYSQL_LIKE) emptyArray<Column<*>>() else arrayOf(Items.name)
+            Items.upsert(*conflictKeys) {
+                it[name] = itemA.name
+                it[price] = newPrice
+            }
+            assertEquals(oldPrice, itemA.price)
+            assertNull(Item.testCache(itemA.id))
+
+            itemA.refresh(flush = false)
+            assertEquals(newPrice, itemA.price)
+            assertNotNull(Item.testCache(itemA.id))
+
+            val newPricePlusExtra = 100.0
+            val newItems = List(5) { i -> "Item ${'A' + i}" to newPricePlusExtra }
+            Items.batchUpsert(newItems, *conflictKeys, shouldReturnGeneratedValues = false) { (name, price) ->
+                this[Items.name] = name
+                this[Items.price] = price
+            }
+            assertEquals(newPrice, itemA.price)
+            assertNull(Item.testCache(itemA.id))
+
+            itemA.refresh(flush = false)
+            assertEquals(newPricePlusExtra, itemA.price)
+            assertNotNull(Item.testCache(itemA.id))
+        }
+    }
+
+    @Test
+    fun testDaoFindByIdAndUpdate() {
+        withTables(Items) {
+            val oldPrice = 20.0
+            val item = Item.new {
+                name = "Item A"
+                price = oldPrice
+            }
+            assertEquals(oldPrice, item.price)
+            assertNotNull(Item.testCache(item.id))
+
+            val newPrice = 50.0
+            flushCache()
+            val updatedItem = Item.findByIdAndUpdate(item.id.value) {
+                it.price = newPrice
+            }
+
+            assertSame(updatedItem, item)
+
+            assertNotNull(updatedItem)
+            assertEquals(newPrice, updatedItem.price)
+            assertNotNull(Item.testCache(item.id))
+
+            assertEquals(newPrice, item.price)
+            item.refresh(flush = false)
+            assertEquals(oldPrice, item.price)
+            assertNotNull(Item.testCache(item.id))
+        }
+    }
+
+    @Test
+    fun testDaoFindSingleByAndUpdate() {
+        withTables(Items) {
+            val oldPrice = 20.0
+            val item = Item.new {
+                name = "Item A"
+                price = oldPrice
+            }
+            assertEquals(oldPrice, item.price)
+            assertNotNull(Item.testCache(item.id))
+
+            val newPrice = 50.0
+            val updatedItem = Item.findSingleByAndUpdate(Items.name eq "Item A") {
+                it.price = newPrice
+            }
+
+            assertSame(updatedItem, item)
+
+            assertNotNull(updatedItem)
+            assertEquals(newPrice, updatedItem.price)
+            assertNotNull(Item.testCache(item.id))
+
+            assertEquals(newPrice, item.price)
+            item.refresh(flush = false)
+            assertEquals(oldPrice, item.price)
+            assertNotNull(Item.testCache(item.id))
+        }
+    }
+
+    private object SelfReferenceTable : IntIdTable() {
+        val parentId = optReference("parent", SelfReferenceTable)
+    }
+
+    class SelfReferencedEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var parent by SelfReferenceTable.parentId
+
+        companion object : IntR2dbcEntityClass<SelfReferencedEntity>(SelfReferenceTable)
+    }
+
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    fun testSelfReferences() {
+        withTables(SelfReferenceTable) {
+            val ref1 = SelfReferencedEntity.new { }
+            ref1.parent = ref1.id
+            val refRow = SelfReferenceTable.selectAll().where { SelfReferenceTable.id eq ref1.id }.single()
+            assertEquals(ref1.id._value, refRow[SelfReferenceTable.parentId]!!.value)
+        }
+    }
+
+    @Test
+    fun testNonEntityIdReference() {
+        withTables(Posts, Boards, Categories) {
+            val category1 = Category.new {
+                title = "cat1"
+            }
+
+            val post1 = Post.new {
+                optCategory set category1
+                category set Category.new { title = "title" }
+            }
+
+            val post2 = Post.new {
+                optCategory set category1
+                parent set post1
+            }
+
+            assertEquals(2L, Post.all().count())
+            assertEquals(2, category1.posts().count())
+            assertEquals(2L, Posts.selectAll().where { Posts.optCategory eq category1.uniqueId }.count())
+        }
+    }
+
+    // https://github.com/JetBrains/Exposed/issues/439
+    @Test
+    fun callLimitOnRelationDoesntMutateTheCachedValue() {
+        withTables(Posts, Boards, Categories) {
+            addLogger(StdOutSqlLogger) // this is left in on purpose for flaky tests
+            val category1 = Category.new {
+                title = "cat1"
+            }
+
+            Post.new {
+                optCategory set category1
+                category set Category.new { title = "title" }
+            }
+
+            Post.new {
+                optCategory set category1
+            }
+            commit()
+
+            assertEquals(2, category1.posts().count())
+            assertEquals(2, category1.posts().toList().size)
+            assertEquals(1, category1.posts().limit(1).toList().size)
+            assertEquals(1L, category1.posts().limit(1).count())
+            assertEquals(2, category1.posts().count())
+            assertEquals(2, category1.posts().toList().size)
+        }
+    }
+
+    @Test
+    fun testOrderByOnEntities() {
+        withTables(Categories) {
+            Categories.deleteAll()
+            val category1 = Category.new { title = "Test1" }
+            val category3 = Category.new { title = "Test3" }
+            val category2 = Category.new { title = "Test2" }
+
+            assertEqualLists(listOf(category1, category3, category2), Category.all().toList())
+            assertEqualLists(listOf(category1, category2, category3), Category.all().orderBy(Categories.title to SortOrder.ASC).toList())
+            assertEqualLists(listOf(category3, category2, category1), Category.all().orderBy(Categories.title to SortOrder.DESC).toList())
+        }
+    }
+
     object Boards : IntIdTable(name = "board") {
         val name = varchar("name", 255).index(isUnique = true)
     }
@@ -251,6 +475,129 @@ class R2dbcEntityTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testInsertNonChildWithoutFlush() {
+        withTables(Boards, Posts, Categories) {
+            val board = Board.new { name = "irrelevant" }
+            Post.new { this.board set board } // first flush before referencing
+            // In JDBC DAO, setting a reference triggers an implicit flush of the referenced entity
+            // (via EntityID.value access). In R2DBC, set is synchronous and cannot trigger a suspend flush,
+            // so both entities remain in the insert cache.
+            assertEquals(2, flushCache().size)
+        }
+    }
+
+    @Test
+    fun testThatQueriesWithinOtherQueryIteratorWorksFine() {
+        withTables(Boards, Posts, Categories) {
+            val board1 = Board.new { name = "irrelevant" }
+            val board2 = Board.new { name = "relevant" }
+            val post1 = Post.new { this.board set board1 }
+
+            Board.all().forEach {
+                it.posts().count() to it.posts
+                Post.find { Posts.board eq it.id }.toList()
+                    .map { post -> post.board()?.name.orEmpty() }
+                    .joinToString()
+            }
+        }
+    }
+
+    @Test
+    fun testInsertChildWithFlush() {
+        withTables(Boards, Posts, Categories) {
+            val parent = Post.new { this.category set Category.new { title = "title" } }
+            flushCache()
+            assertNotNull(parent.id._value)
+            Post.new { this.parent set parent }
+            assertEquals(1, flushCache().size)
+        }
+    }
+
+    @Test
+    fun testInsertChildWithChild() {
+        withTables(Boards, Posts, Categories) {
+            val parent = Post.new { this.category set Category.new { title = "title1" } }
+            val child1 = Post.new {
+                this.parent set parent
+                this.category set Category.new { title = "title2" }
+            }
+            Post.new { this.parent set child1 }
+            flushCache()
+        }
+    }
+
+    @Test
+    fun testOptionalReferrersWithDifferentKeys() {
+        withTables(Boards, Posts, Categories) {
+            val board = Board.new { name = "irrelevant" }
+            val post1 = Post.new {
+                this.board set board
+                this.category set Category.new { title = "title" }
+            }
+            // In R2DBC, entities must be flushed before referrers queries can find them
+            flushCache()
+            assertEquals(1, board.posts().count())
+            assertEquals(post1, board.posts().single())
+
+            Post.new { this.board set board }
+            flushCache()
+            assertEquals(2, board.posts().count())
+        }
+    }
+
+    @Test
+    fun testErrorOnSetToDeletedEntity() {
+        withTables(Boards) {
+            expectException<R2dbcEntityNotFoundException> {
+                val board = Board.new { name = "irrelevant" }
+                board.delete()
+                board.name = "Cool"
+            }
+        }
+    }
+
+    @Test
+    fun testCacheInvalidatedOnDSLDelete() {
+        withTables(Boards) {
+            val board1 = Board.new { name = "irrelevant" }
+            assertNotNull(Board.testCache(board1.id))
+            board1.delete()
+            assertNull(Board.testCache(board1.id))
+
+            val board2 = Board.new { name = "irrelevant" }
+            assertNotNull(Board.testCache(board2.id))
+            // In R2DBC, entity IDs are not auto-flushed on access (unlike JDBC DaoEntityID),
+            // so we must flush before using the ID in DSL operations.
+            flushCache()
+            Boards.deleteWhere { Boards.id eq board2.id }
+            assertNull(Board.testCache(board2.id))
+        }
+    }
+
+    @Test
+    fun testCacheInvalidatedOnDSLUpdate() {
+        withTables(Boards) {
+            val board1 = Board.new { name = "irrelevant" }
+            assertNotNull(Board.testCache(board1.id))
+            board1.name = "relevant"
+            assertEquals("relevant", board1.name)
+
+            val board2 = Board.new { name = "irrelevant2" }
+            assertNotNull(Board.testCache(board2.id))
+            // In R2DBC, entity IDs are not auto-flushed on access (unlike JDBC DaoEntityID),
+            // so we must flush before using the ID in DSL operations.
+            flushCache()
+            Boards.update({ Boards.id eq board2.id }) {
+                it[name] = "relevant2"
+            }
+            assertNull(Board.testCache(board2.id))
+            board2.refresh(flush = false)
+            assertNotNull(Board.testCache(board2.id))
+            assertEquals("relevant2", board2.name)
+        }
+    }
+
     object Humans : IntIdTable("human") {
         val h = text("h", eagerLoading = true)
     }
@@ -279,4 +626,283 @@ class R2dbcEntityTests : R2dbcDatabaseTestsBase() {
         val human by Human referencedOnSuspend Users.id
         var name by Users.name
     }
+
+    @Test
+    fun testThatUpdateOfInsertedEntitiesGoesBeforeAnInsert() {
+        withTables(Categories, Posts, Boards) {
+            val category1 = Category.new {
+                title = "category1"
+            }
+
+            val category2 = Category.new {
+                title = "category2"
+            }
+
+            val post1 = Post.new {
+                category set category1
+            }
+
+            flushCache()
+            assertEquals(post1.category(), category1)
+
+            post1.category set category2
+
+            val post2 = Post.new {
+                category set category1
+            }
+
+            flushCache()
+            Post.reload(post1)
+            Post.reload(post2)
+
+            assertEquals(category2, post1.category())
+            assertEquals(category1, post2.category())
+        }
+    }
+
+    object Parents : LongIdTable() {
+        val name = varchar("name", 50)
+    }
+
+    class Parent(id: EntityID<Long>) : LongR2dbcEntity(id) {
+        companion object : LongR2dbcEntityClass<Parent>(Parents)
+
+        var name by Parents.name
+    }
+
+    object Children : LongIdTable() {
+        val companyId = reference("company_id", Parents)
+        val name = varchar("name", 80)
+    }
+
+    class Child(id: EntityID<Long>) : LongR2dbcEntity(id) {
+        companion object : LongR2dbcEntityClass<Child>(Children)
+
+        val parent by Parent referencedOnSuspend Children.companyId
+        var name by Children.name
+    }
+
+    @Test
+    fun testNewIdWithGet() {
+        // SQL Server doesn't support an explicit id for auto-increment table
+        withTables(listOf(TestDB.SQLSERVER), Parents, Children) {
+            val parentId = Parent.new {
+                name = "parent1"
+            }.also {
+                flushCache()
+            }.id.value
+
+            commit()
+
+            val parent = Parent[parentId]
+            val child = Child.new(100L) {
+                this.parent set parent
+                name = "child1"
+            }
+            child.flush()
+
+            assertEquals(100L, child.id.value)
+            assertEquals(parentId, child.parent().id.value)
+        }
+    }
+
+    @Test
+    fun `newly created entity flushed successfully`() {
+        withTables(Boards) {
+            val board = Board.new { name = "Board1" }.apply {
+                assertEquals(true, flush())
+            }
+
+            assertEquals("Board1", board.name)
+        }
+    }
+
+    private suspend fun <T> newTransaction(statement: suspend R2dbcTransaction.() -> T) =
+        inTopLevelSuspendTransaction(null, statement = statement)
+
+    @Test
+    fun sharingEntityBetweenTransactions() {
+        withTables(Humans) {
+            val human1 = newTransaction {
+                maxAttempts = 1
+                Human.new {
+                    this.h = "foo"
+                }
+            }
+            newTransaction {
+                maxAttempts = 1
+                assertEquals(null, Human.testCache(human1.id))
+                assertEquals("foo", Humans.selectAll().single()[Humans.h])
+                // Unlike JDBC, R2DBC's Column.setValue cannot suspendingly probe the DB to adopt
+                // an entity from another transaction. Explicitly attach it first.
+                Human.attach(human1)
+                human1.h = "bar"
+                assertEquals(human1, Human.testCache(human1.id))
+                assertEquals("bar", Humans.selectAll().single()[Humans.h])
+            }
+
+            newTransaction {
+                maxAttempts = 1
+                assertEquals("bar", Humans.selectAll().single()[Humans.h])
+            }
+        }
+    }
+
+    object Regions : IntIdTable(name = "region") {
+        val name = varchar("name", 255)
+    }
+
+    object Students : LongIdTable(name = "students") {
+        val name = varchar("name", 255)
+        val school = reference("school_id", Schools)
+    }
+
+    object StudentBios : LongIdTable(name = "student_bio") {
+        val student = reference("student_id", Students).uniqueIndex()
+        val dateOfBirth = varchar("date_of_birth", 25)
+    }
+
+    object Notes : LongIdTable(name = "notes") {
+        val text = varchar("text", 255)
+        val student = reference("student_id", Students)
+    }
+
+    object Detentions : LongIdTable(name = "detentions") {
+        val reason = varchar("reason", 255)
+        val student = optReference("student_id", Students)
+    }
+
+    object Holidays : LongIdTable(name = "holidays") {
+        val holidayStart = long("holiday_start")
+        val holidayEnd = long("holiday_end")
+    }
+
+    object SchoolHolidays : Table(name = "school_holidays") {
+        val school = reference("school_id", Schools, ReferenceOption.CASCADE, ReferenceOption.CASCADE)
+        val holiday = reference("holiday_id", Holidays, ReferenceOption.CASCADE, ReferenceOption.CASCADE)
+
+        override val primaryKey = PrimaryKey(school, holiday)
+    }
+
+    object Schools : IntIdTable(name = "school") {
+        val name = varchar("name", 255).index(isUnique = true)
+        val region = reference("region_id", Regions)
+        val secondaryRegion = optReference("secondary_region_id", Regions)
+    }
+
+    class Region(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<Region>(Regions)
+
+        var name by Regions.name
+
+        override fun equals(other: Any?): Boolean {
+            return (other as? Region)?.id?.equals(id) ?: false
+        }
+
+        override fun hashCode(): Int = id.hashCode()
+    }
+
+    abstract class ComparableLongEntity<T : LongR2dbcEntity>(id: EntityID<Long>) : LongR2dbcEntity(id) {
+        override fun equals(other: Any?): Boolean {
+            return (other as? T)?.id?.equals(id) ?: false
+        }
+
+        override fun hashCode(): Int = id.hashCode()
+    }
+
+    class Student(id: EntityID<Long>) : ComparableLongEntity<Student>(id) {
+        companion object : LongR2dbcEntityClass<Student>(Students)
+
+        var name by Students.name
+        val school by School referencedOnSuspend Students.school
+        val notes by Note.referrersOnSuspend(Notes.student, true)
+        val detentions by Detention.optionalReferrersOnSuspend(Detentions.student, true)
+        val bio by StudentBio.optionalBackReferencedOnSuspend(StudentBios.student)
+    }
+
+    class StudentBio(id: EntityID<Long>) : ComparableLongEntity<StudentBio>(id) {
+        companion object : LongR2dbcEntityClass<StudentBio>(StudentBios)
+
+        val student by Student.referencedOnSuspend(StudentBios.student)
+        var dateOfBirth by StudentBios.dateOfBirth
+    }
+
+    class Note(id: EntityID<Long>) : ComparableLongEntity<Note>(id) {
+        companion object : LongR2dbcEntityClass<Note>(Notes)
+
+        var text by Notes.text
+        val student by Student referencedOnSuspend Notes.student
+    }
+
+    class Detention(id: EntityID<Long>) : ComparableLongEntity<Detention>(id) {
+        companion object : LongR2dbcEntityClass<Detention>(Detentions)
+
+        var reason by Detentions.reason
+        val student by Student optionalReferencedOnSuspend Detentions.student
+    }
+
+    class Holiday(id: EntityID<Long>) : ComparableLongEntity<Holiday>(id) {
+        companion object : LongR2dbcEntityClass<Holiday>(Holidays)
+
+        var holidayStart by Holidays.holidayStart
+        var holidayEnd by Holidays.holidayEnd
+    }
+
+    class School(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<School>(Schools)
+
+        var name by Schools.name
+        val region by Region referencedOnSuspend Schools.region
+        val secondaryRegion by Region optionalReferencedOnSuspend Schools.secondaryRegion
+        val students by Student.referrersOnSuspend(Students.school, true)
+        val holidays by Holiday viaSuspend SchoolHolidays
+    }
+
+    @Test
+    fun preloadReferencesOnASizedIterable() {
+        withTables(Regions, Schools) {
+            val region1 = Region.new {
+                name = "United Kingdom"
+            }
+
+            val region2 = Region.new {
+                name = "England"
+            }
+
+            val school1 = School.new {
+                name = "Eton"
+                region set region1
+            }
+
+            val school2 = School.new {
+                name = "Harrow"
+                region set region1
+            }
+
+            val school3 = School.new {
+                name = "Winchester"
+                region set region2
+            }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                School.all().with(School::region)
+                assertNotNull(School.testCache(school1.id))
+                assertNotNull(School.testCache(school2.id))
+                assertNotNull(School.testCache(school3.id))
+
+                assertEquals(region1, Region.testCache(School.testCache(school1.id)!!.readValues[Schools.region]))
+                assertEquals(region1, Region.testCache(School.testCache(school2.id)!!.readValues[Schools.region]))
+                assertEquals(region2, Region.testCache(School.testCache(school3.id)!!.readValues[Schools.region]))
+            }
+        }
+    }
 }
+
+/**
+ * This method is used just to keep tests similar to jdbc alternatives
+ * (otherwise it's necessary to replace `forEach` with `collect` in all the tests)
+ */
+internal suspend fun <T> SizedIterable<T>.forEach(collector: FlowCollector<T>) =
+    collect(collector)

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntity.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntity.kt
@@ -1,16 +1,19 @@
 package org.jetbrains.exposed.r2dbc.dao
 
 import org.jetbrains.exposed.r2dbc.dao.exceptions.R2dbcEntityNotFoundException
+import org.jetbrains.exposed.r2dbc.dao.relationships.R2dbcInnerTableLink
 import org.jetbrains.exposed.v1.core.AutoIncColumnType
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.EntityIDColumnType
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.CompositeID
 import org.jetbrains.exposed.v1.core.dao.id.CompositeIdTable
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.deleteWhere
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.r2dbc.update
 import kotlin.collections.get
@@ -54,6 +57,7 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
     }
 
     operator fun <T> Column<T>.setValue(entity: R2dbcEntity<ID>, desc: KProperty<*>, value: T) {
+        klass.invalidateEntityInCache(entity)
         val currentValue = _readValues?.getOrNull(this)
         if (writeValues.containsKey(this as Column<out Any?>) || currentValue != value) {
             val entityCache = TransactionManager.current().entityCache
@@ -132,9 +136,11 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
 
                 @Suppress("ForbiddenComment")
                 // TODO: Implement entity change tracking when subscriptions are implemented
-                table.update({ table.id eq id }) {
-                    for ((c, v) in _writeValues) {
-                        it[c] = v
+                executeAsPartOfEntityLifecycle {
+                    table.update({ table.id eq id }) {
+                        for ((c, v) in _writeValues) {
+                            it[c] = v
+                        }
                     }
                 }
                 // TODO: Implement alertSubscribers when subscriptions are implemented
@@ -149,6 +155,21 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
             return true
         }
         return false
+    }
+
+    open suspend fun delete() {
+        val table = klass.table
+        val entityId = this.id
+        // TODO add register change like in JDBCHello.
+        // TODO should we insert before and then remove
+        //  (extra requests, but probablyt correctness could be better)
+        if (!isNewEntity()) {
+            executeAsPartOfEntityLifecycle {
+                table.deleteWhere { table.id eq entityId }
+            }
+        }
+
+        klass.removeFromCache(this)
     }
 
     internal fun hasInReferenceCache(ref: Column<*>): Boolean {
@@ -183,6 +204,40 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
         _readValues = reloaded.readValues
         db = transaction.db
     }
+
+    /**
+     * Registers an intermediate [table] as a many-to-many link between this entity's table and
+     * the target [R2dbcEntityClass]. The source and target columns are inferred from the
+     * intermediate table's foreign keys.
+     *
+     * Counterpart of JDBC's `via`. Named `viaSuspend` to match the rest of the R2DBC DAO API.
+     */
+    infix fun <TID : Any, Target : R2dbcEntity<TID>> R2dbcEntityClass<TID, Target>.viaSuspend(
+        table: Table
+    ): R2dbcInnerTableLink<ID, R2dbcEntity<ID>, TID, Target> =
+        R2dbcInnerTableLink(
+            table = table,
+            sourceTable = this@R2dbcEntity.id.table,
+            target = this@viaSuspend
+        )
+
+    /**
+     * Registers an intermediate table as a many-to-many link with explicitly specified
+     * [sourceColumn] and [targetColumn] — use this when the intermediate table has multiple
+     * references into the same entity's table and the defaults cannot be inferred.
+     */
+    // TODO similar to jdbc, but not covered with tests yet
+    fun <TID : Any, Target : R2dbcEntity<TID>> R2dbcEntityClass<TID, Target>.viaSuspend(
+        sourceColumn: Column<EntityID<ID>>,
+        targetColumn: Column<EntityID<TID>>
+    ): R2dbcInnerTableLink<ID, R2dbcEntity<ID>, TID, Target> =
+        R2dbcInnerTableLink(
+            table = sourceColumn.table,
+            sourceTable = this@R2dbcEntity.id.table,
+            target = this@viaSuspend,
+            _sourceColumn = sourceColumn,
+            _targetColumn = targetColumn
+        )
 }
 
 class R2dbcEntityBatchUpdate {

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
@@ -4,9 +4,12 @@ import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.transactions.transactionScope
+import org.jetbrains.exposed.v1.r2dbc.LazySizedCollection
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.SizedIterable
 import org.jetbrains.exposed.v1.r2dbc.insert
+import java.util.LinkedHashMap
 import java.util.concurrent.ConcurrentHashMap
 
 val R2dbcTransaction.entityCache: R2dbcEntityCache by transactionScope {
@@ -25,14 +28,45 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
 
     internal val referrers = ConcurrentHashMap<Column<*>, MutableMap<EntityID<*>, Any>>()
 
-    var maxEntitiesToStore = transaction.db.config.maxEntitiesToStoreInCachePerEntity
-
     fun <ID : Any, T : R2dbcEntity<ID>> find(entityClass: R2dbcEntityClass<ID, T>, id: EntityID<ID>): T? {
-        val map = data[entityClass.table] ?: return null
-        return map[id.value] as T?
-            ?: inserts[entityClass.table]?.firstOrNull { it.id == id } as? T
-            ?: initializingEntities.firstOrNull { it.klass == entityClass && it.id == id } as? T
+        // `id.value` can not be used, because it can't insert the entity in the case it's null
+        if (id._value == null) {
+            return inserts[entityClass.table]?.firstOrNull { it.id == id } as? T
+                ?: initializingEntities.firstOrNull { it.klass == entityClass && it.id == id } as? T
+        }
+
+        return getMap(entityClass)[id.value] as T?
     }
+
+    private fun getMap(f: R2dbcEntityClass<*, *>): MutableMap<Any, R2dbcEntity<*>> = getMap(f.table)
+
+    private fun getMap(table: IdTable<*>): MutableMap<Any, R2dbcEntity<*>> = data.getOrPut(table) {
+        LimitedHashMap()
+    }
+
+    private inner class LimitedHashMap<K, V> : LinkedHashMap<K, V>() {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean {
+            return size > maxEntitiesToStore
+        }
+    }
+
+    var maxEntitiesToStore = transaction.db.config.maxEntitiesToStoreInCachePerEntity
+        set(value) {
+            val diff = value - field
+            field = value
+            if (diff < 0) {
+                data.values.forEach { map ->
+                    val sizeExceed = map.size - value
+                    if (sizeExceed > 0) {
+                        val iterator = map.iterator()
+                        repeat(sizeExceed) {
+                            iterator.next()
+                            iterator.remove()
+                        }
+                    }
+                }
+            }
+        }
 
     fun <ID : Any> store(entity: R2dbcEntity<ID>) {
         val map = data.getOrPut(entity.klass.table) { ConcurrentHashMap() }
@@ -40,7 +74,13 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
     }
 
     fun <ID : Any> remove(table: IdTable<ID>, entity: R2dbcEntity<ID>) {
-        data[table]?.remove(entity.id.value)
+        // Same as in find(), 'entity.id.value' can not be used directly, because
+        // because the entity could not be fetched in this moment. Another option is to
+        // make 'remove()' suspend
+        if (entity.id._value != null) {
+            data[table]?.remove(entity.id._value)
+        }
+        inserts[table]?.remove(entity)
     }
 
     fun <ID : Any> scheduleUpdate(klass: R2dbcEntityClass<ID, R2dbcEntity<ID>>, entity: R2dbcEntity<ID>) {
@@ -54,10 +94,17 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
 
     private val initializingEntities = LinkedIdentityHashSet<R2dbcEntity<*>>()
 
-    val pendingInitializationLambdas = ConcurrentHashMap<R2dbcEntity<*>, MutableList<suspend (R2dbcEntity<*>) -> Unit>>()
-
     fun <ID : Any> isEntityInInitializationState(entity: R2dbcEntity<ID>): Boolean {
         return initializingEntities.contains(entity)
+    }
+
+    fun <ID : Any> isScheduledForInsert(entity: R2dbcEntity<ID>): Boolean {
+        return inserts[entity.klass.table]?.contains(entity) ?: false
+    }
+
+    fun <ID : Any> isStoredInData(entity: R2dbcEntity<ID>): Boolean {
+        val value = entity.id._value ?: return false
+        return data[entity.klass.table]?.get(value) === entity
     }
 
     fun <ID : Any> addNotInitializedEntityToQueue(entity: R2dbcEntity<ID>) {
@@ -75,13 +122,14 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
         inserts.getOrPut(klass.table) { LinkedIdentityHashSet() }.add(entity)
     }
 
-    suspend fun <ID : Any> getOrPutReferrers(
+    suspend fun <ID : Any, R : R2dbcEntity<ID>> getOrPutReferrers(
         column: Column<*>,
         sourceId: EntityID<*>,
-        refs: suspend () -> Any
-    ): Any {
+        refs: suspend () -> SizedIterable<@UnsafeVariance R>
+    ): SizedIterable<R> {
         val columnReferrers = referrers.getOrPut(column) { ConcurrentHashMap() }
-        return columnReferrers.getOrPut(sourceId) { refs() }
+        @Suppress("UNCHECKED_CAST")
+        return columnReferrers.getOrPut(sourceId) { LazySizedCollection(refs()) } as SizedIterable<R>
     }
 
     fun removeReferrer(column: Column<*>, entityId: EntityID<*>) {
@@ -154,22 +202,33 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
         val entitiesToInsert = inserts.remove(table)?.toList().orEmpty()
         if (entitiesToInsert.isEmpty()) return
 
+        // We have to handle self references in r2dbc here comparing to jdbc, because
+        // in jdbc the entity that gets self reference would be inserted in the moment
+        // of setting that self reference
+        val entitiesWithSelfRefs = mutableListOf<R2dbcEntity<*>>()
+
         for (entity in entitiesToInsert) {
             val entityId = entity.id
-            val writeValues = entity.writeValues.toMap()
+            val allWriteValues = entity.writeValues.toMap()
+
+            // Separate self-references to the same table whose target id is not yet generated.
+            // Such values cannot be included in the INSERT because the referenced id does not
+            // exist yet. They are applied as a follow-up UPDATE once the id has been generated.
+            val selfRefs = allWriteValues.filter { (key, value) ->
+                key.referee == table.id && value is EntityID<*> && value._value == null
+            }
+            val insertValues = allWriteValues - selfRefs.keys
 
             val insertStatement = table.insert {
-                for ((column, value) in writeValues) {
-                    @Suppress("UNCHECKED_CAST")
-                    it[column as Column<Any?>] = value
+                for ((column, value) in insertValues) {
+                    it[column] = value
                 }
             }
 
             val resultRow = insertStatement.resultedValues?.firstOrNull()
 
             if (resultRow != null) {
-                @Suppress("UNCHECKED_CAST")
-                val generatedId = resultRow[table.id] as EntityID<ID>
+                val generatedId = resultRow[table.id]
                 if (entityId._value == null) {
                     entityId._value = generatedId.value
                 }
@@ -177,7 +236,29 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
             }
 
             entity.writeValues.clear()
+
+            // Restore self-reference values to writeValues for a post-insert update.
+            // The referenced id is now populated, so these can be safely serialized.
+            if (selfRefs.isNotEmpty()) {
+                for ((column, value) in selfRefs) {
+                    entity.writeValues[column] = value
+                }
+                entitiesWithSelfRefs.add(entity)
+            }
+
             store(entity)
         }
+
+        for (entity in entitiesWithSelfRefs) {
+            entity.flush()
+        }
+    }
+}
+
+suspend fun R2dbcTransaction.flushCache(): List<R2dbcEntity<*>> {
+    with(entityCache) {
+        val newEntities = inserts.flatMap { it.value }
+        flush()
+        return newEntities
     }
 }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
@@ -132,6 +132,11 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
         return columnReferrers.getOrPut(sourceId) { LazySizedCollection(refs()) } as SizedIterable<R>
     }
 
+    fun <R : R2dbcEntity<*>> getReferrers(sourceId: EntityID<*>, key: Column<*>): SizedIterable<R>? {
+        @Suppress("UNCHECKED_CAST")
+        return referrers[key]?.get(sourceId) as? SizedIterable<R>
+    }
+
     fun removeReferrer(column: Column<*>, entityId: EntityID<*>) {
         referrers[column]?.remove(entityId)
     }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
@@ -55,16 +55,7 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
             val diff = value - field
             field = value
             if (diff < 0) {
-                data.values.forEach { map ->
-                    val sizeExceed = map.size - value
-                    if (sizeExceed > 0) {
-                        val iterator = map.iterator()
-                        repeat(sizeExceed) {
-                            iterator.next()
-                            iterator.remove()
-                        }
-                    }
-                }
+                data.values.forEach { it.trimToFirst(value) }
             }
         }
 
@@ -265,5 +256,23 @@ suspend fun R2dbcTransaction.flushCache(): List<R2dbcEntity<*>> {
         val newEntities = inserts.flatMap { it.value }
         flush()
         return newEntities
+    }
+}
+
+/**
+ * Drops entries from the front of this map until its [size] is at most [maxSize].
+ *
+ * Extracted from `R2dbcEntityCache.maxEntitiesToStore`'s setter so the setter reads as intent
+ * ("trim each per-table map to the new max") rather than carrying the iterator mechanics inline.
+ * Relies on insertion-order iteration of the per-table cache (see [R2dbcEntityCache.LimitedHashMap])
+ * to evict the oldest entries first.
+ */
+private fun <K, V> MutableMap<K, V>.trimToFirst(maxSize: Int) {
+    val sizeExceed = size - maxSize
+    if (sizeExceed <= 0) return
+    val iterator = iterator()
+    repeat(sizeExceed) {
+        iterator.next()
+        iterator.remove()
     }
 }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityClass.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityClass.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.r2dbc.dao
 
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.singleOrNull
 import org.jetbrains.exposed.r2dbc.dao.exceptions.R2dbcEntityNotFoundException
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ColumnSet
@@ -10,6 +11,9 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.r2dbc.Query
+import org.jetbrains.exposed.v1.r2dbc.SizedIterable
+import org.jetbrains.exposed.v1.r2dbc.mapLazy
+import org.jetbrains.exposed.v1.r2dbc.select
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import kotlin.reflect.KFunction
@@ -74,26 +78,95 @@ abstract class R2dbcEntityClass<ID : Any, out T : R2dbcEntity<ID>>(
         val cached = testCache(id)
         if (cached != null) return cached
 
-        val row = find { table.id eq id }.firstOrNull()
-        return row?.let { wrapRow(it) }
+        return find { table.id eq id }.firstOrNull()
+    }
+
+    suspend fun findByIdAndUpdate(id: ID, block: (it: T) -> Unit): T? {
+        val result = find(table.id eq R2dbcDaoEntityID(id, table)).forUpdate().firstOrNull() ?: return null
+        block(result)
+        return result
+    }
+
+    suspend fun findSingleByAndUpdate(op: Op<Boolean>, block: (it: T) -> Unit): T? {
+        val result = find(op).forUpdate().singleOrNull() ?: return null
+        block(result)
+        return result
     }
 
     fun testCache(id: EntityID<ID>): T? = warmCache().find(this, id)
 
-    open fun all(): Query {
-        warmCache()
-        return table.selectAll()
+    suspend fun reload(entity: R2dbcEntity<ID>, flush: Boolean = false): T? {
+        if (flush) {
+            if (entity.isNewEntity()) {
+                TransactionManager.current().entityCache.flushInserts(table)
+            } else {
+                entity.flush()
+            }
+        }
+        removeFromCache(entity)
+        return if (entity.id._value != null) findById(entity.id) else null
     }
 
-    fun find(op: Op<Boolean>): Query {
-        warmCache()
-        return searchQuery(op)
+    // It actually doesn't do 'invalidation', because it's suspend operation, but this method
+    // is used on setting value to the entity
+    internal open fun invalidateEntityInCache(o: R2dbcEntity<ID>) {
+        val sameDatabase = TransactionManager.current().db == o.db
+        if (!sameDatabase) return
+
+        val cache = warmCache()
+
+        // TODO could I reverse this condition in the way to check which state of entity should
+        //  throw error, rather than which should not.
+        if (cache.isEntityInInitializationState(o)) return
+        if (cache.isScheduledForInsert(o)) return
+        if (cache.isStoredInData(o)) return
+
+        // Not in any tracked state. Either the entity has been deleted in the current
+        // transaction, or it was loaded in a different transaction and has not been
+        // `attach`-ed here. Both are user bugs — fail loudly.
+        //
+        // R2DBC cannot mirror JDBC's `get(o.id)` "verify-and-adopt" shortcut because
+        // Column.setValue is not a suspend operator and cannot query the database.
+        throw R2dbcEntityNotFoundException(o.id, this)
     }
 
-    fun find(op: () -> Op<Boolean>): Query = find(op())
+    /**
+     * This method is used in r2dbc now for the case when one entity is
+     * reused between transactions. In jdbc it's not needed, because there on 'setValue'
+     * we could attach it implicitly, but in r2dbc 'setValue' on entity is non-suspendable,
+     * so we can't do that, and user must do that explicitly.
+     *
+     * I still don't like reusing entities between transactions as a pattern, probably it should
+     * be deprecated, but it sounds like a bad idea in terms of API changes (even on major versions),
+     * because it could be used by many users.
+     */
+    suspend fun attach(entity: R2dbcEntity<ID>) {
+        val cache = warmCache()
+        if (cache.find(this, entity.id) != null) return
+
+        // Verify the row still exists — also stores a fresh instance in the cache as a side effect.
+        findById(entity.id) ?: throw R2dbcEntityNotFoundException(entity.id, this)
+
+        // Overwrite the freshly-loaded instance with the caller's reference so that subsequent
+        // writes on `entity` flow through the same cache entry (mirrors JDBC's `warmCache().store(o)`).
+        cache.store(entity)
+    }
+
+    open fun all(): SizedIterable<T> = wrapRows(table.selectAll().notForUpdate())
+
+    fun find(op: Op<Boolean>): SizedIterable<T> {
+        warmCache()
+        return wrapRows(searchQuery(op))
+    }
+
+    fun find(op: () -> Op<Boolean>): SizedIterable<T> = find(op())
 
     open fun searchQuery(op: Op<Boolean>): Query =
-        dependsOnTables.selectAll().where { op }.notForUpdate()
+        dependsOnTables.select(dependsOnColumns).where { op }.notForUpdate()
+
+    fun wrapRows(rows: SizedIterable<ResultRow>): SizedIterable<T> = rows mapLazy {
+        wrapRow(it)
+    }
 
     @Suppress("MemberVisibilityCanBePrivate")
     fun wrapRow(row: ResultRow): T {

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityLifecycleInterceptor.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityLifecycleInterceptor.kt
@@ -5,9 +5,22 @@ import org.jetbrains.exposed.v1.core.Key
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.statements.*
 import org.jetbrains.exposed.v1.core.targetTables
+import org.jetbrains.exposed.v1.core.transactions.transactionScope
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.statements.GlobalSuspendStatementInterceptor
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcPreparedStatementApi
+
+private var isExecutedWithinEntityLifecycle by transactionScope { false }
+
+internal suspend fun <T> executeAsPartOfEntityLifecycle(body: suspend () -> T): T {
+    val currentExecutionState = isExecutedWithinEntityLifecycle
+    return try {
+        isExecutedWithinEntityLifecycle = true
+        body()
+    } finally {
+        isExecutedWithinEntityLifecycle = currentExecutionState
+    }
+}
 
 class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
 
@@ -31,11 +44,21 @@ class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
             is DeleteStatement -> {
                 transaction.flushCache()
                 transaction.entityCache.removeTablesReferrers(statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>())
+                if (!isExecutedWithinEntityLifecycle) {
+                    statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>().forEach {
+                        transaction.entityCache.data[it]?.clear()
+                    }
+                }
             }
 
             is UpsertStatement<*>, is BatchUpsertStatement -> {
                 transaction.flushCache()
                 transaction.entityCache.removeTablesReferrers(statement.targets.filterIsInstance<IdTable<*>>())
+                if (!isExecutedWithinEntityLifecycle) {
+                    statement.targets.filterIsInstance<IdTable<*>>().forEach {
+                        transaction.entityCache.data[it]?.clear()
+                    }
+                }
             }
 
             is InsertStatement<*> -> {
@@ -48,6 +71,11 @@ class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
             is UpdateStatement -> {
                 transaction.flushCache()
                 transaction.entityCache.removeTablesReferrers(statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>())
+                if (!isExecutedWithinEntityLifecycle) {
+                    statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>().forEach {
+                        transaction.entityCache.data[it]?.clear()
+                    }
+                }
             }
 
             else -> {
@@ -101,12 +129,4 @@ class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
         val tables = query.targets.filterIsInstance(IdTable::class.java).toSet()
         entityCache.flush(tables)
     }
-}
-
-// Extension functions for R2dbcTransaction
-suspend fun R2dbcTransaction.flushCache(): List<R2dbcEntity<*>> {
-    entityCache.flush()
-    @Suppress("ForbiddenComment")
-    // TODO: Return list of created entities when entity change tracking is implemented
-    return emptyList()
 }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/exceptions/R2dbcEntityNotFoundException.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/exceptions/R2dbcEntityNotFoundException.kt
@@ -4,4 +4,4 @@ import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 
 class R2dbcEntityNotFoundException(val id: EntityID<*>, val entity: R2dbcEntityClass<*, *>) :
-    Exception("Entity ${entity.klass.simpleName}, id=$id not found in the database")
+    Exception("Entity ${entity.klass.simpleName}, id=${id._value} not found in the database")

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcBackReference.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcBackReference.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.exposed.r2dbc.dao.relationships
 
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.singleOrNull
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.v1.core.Column

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcBackReference.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcBackReference.kt
@@ -4,8 +4,21 @@ import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import kotlin.reflect.KProperty
+
+/**
+ * Ensures the entity has a populated id before its back-reference is queried. JDBC handles
+ * this implicitly via `DaoEntityID.invokeOnNoValue` from `thisRef.id.value`; R2DBC has to do
+ * it as an explicit suspending step because R2dbcDaoEntityID can't trigger `flushInserts`
+ * (which is `suspend`) from a non-suspend getter.
+ */
+private suspend fun R2dbcEntity<*>.ensureIdFlushed() {
+    if (id._value != null) return
+    TransactionManager.current().entityCache.flush()
+}
 
 class R2dbcBackReference<ParentID : Any, out Parent : R2dbcEntity<ParentID>, ChildID : Any, in Child : R2dbcEntity<ChildID>, REF>(
     reference: Column<REF>,
@@ -18,13 +31,11 @@ class R2dbcBackReference<ParentID : Any, out Parent : R2dbcEntity<ParentID>, Chi
     )
 
     operator fun getValue(thisRef: Child, property: KProperty<*>): suspend () -> Parent {
-        thisRef.id.value
-
         val referrersLambda = delegate.getValue(thisRef, property)
 
         return suspend {
-            val referrers = referrersLambda()
-            referrers.single()
+            thisRef.ensureIdFlushed()
+            referrersLambda().single()
         }
     }
 }
@@ -40,13 +51,11 @@ class R2dbcOptionalBackReference<ParentID : Any, out Parent : R2dbcEntity<Parent
     )
 
     operator fun getValue(thisRef: Child, property: KProperty<*>): suspend () -> Parent? {
-        thisRef.id.value
-
         val referrersLambda = delegate.getValue(thisRef, property)
 
         return suspend {
-            val referrers = referrersLambda()
-            referrers.singleOrNull()
+            thisRef.ensureIdFlushed()
+            referrersLambda().singleOrNull()
         }
     }
 }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcEagerLoading.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcEagerLoading.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.r2dbc.dao.relationships
 import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.r2dbc.dao.flushCache
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.EntityIDColumnType
@@ -11,6 +12,7 @@ import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.r2dbc.LazySizedIterable
 import org.jetbrains.exposed.v1.r2dbc.SizedCollection
 import org.jetbrains.exposed.v1.r2dbc.SizedIterable
+import org.jetbrains.exposed.v1.r2dbc.select
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
@@ -56,15 +58,35 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadRelations(
     if (!nodesVisited.add(first.klass)) return
 
     val directRelations = filterRelationsForEntity(first, relations)
+    val loadedByRelation = mutableListOf<R2dbcEntity<*>>()
+
     directRelations.forEach { prop ->
-        when (val refObject = getReferenceObjectFromDelegatedProperty(first, prop)) {
-            is SuspendAccessor<*, *, *> -> preloadReference(refObject as SuspendAccessor<Any, R2dbcEntity<Any>, Any>)
+        val loaded: List<R2dbcEntity<*>> = when (val refObject = getReferenceObjectFromDelegatedProperty(first, prop)) {
+            is SuspendAccessor<*, *, *> ->
+                preloadReference(refObject as SuspendAccessor<Any, R2dbcEntity<Any>, Any>)
             is OptionalSuspendAccessor<*, *, *> ->
                 preloadOptionalReference(refObject as OptionalSuspendAccessor<Any, R2dbcEntity<Any>, Any>)
-            else -> {
-                // TODO: extend preloading to cover Referrers / BackReference / OptionalBackReference
-                //  / InnerTableLink delegates, like in JDBC's preloadRelations.
-            }
+            is R2dbcReferrers<*, *, *, *, *> ->
+                preloadReferrers(refObject as R2dbcReferrers<ID, R2dbcEntity<ID>, Any, R2dbcEntity<Any>, Any>)
+            is R2dbcInnerTableLinkAccessor<*, *, *, *> ->
+                preloadInnerTableLink(refObject as R2dbcInnerTableLinkAccessor<ID, R2dbcEntity<ID>, Any, R2dbcEntity<Any>>)
+            is R2dbcBackReference<*, *, *, *, *> ->
+                preloadReferrers(refObject.delegate as R2dbcReferrers<ID, R2dbcEntity<ID>, Any, R2dbcEntity<Any>, Any>)
+            is R2dbcOptionalBackReference<*, *, *, *, *> ->
+                preloadReferrers(refObject.delegate as R2dbcReferrers<ID, R2dbcEntity<ID>, Any, R2dbcEntity<Any>, Any>)
+            else -> emptyList()
+        }
+        loadedByRelation += loaded
+    }
+
+    // Mirrors JDBC's recursive step in `preloadRelations`.
+    if (directRelations.isNotEmpty() && relations.size != directRelations.size) {
+        val remainingRelations = (relations.toList() - directRelations.toSet()).toTypedArray()
+        loadedByRelation.groupBy { it::class }.forEach { (_, entities) ->
+            (entities as List<R2dbcEntity<Any>>).preloadRelations(
+                relations = remainingRelations,
+                nodesVisited = nodesVisited
+            )
         }
     }
 }
@@ -77,15 +99,15 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadRelations(
 @Suppress("UNCHECKED_CAST")
 private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadReference(
     accessor: SuspendAccessor<Any, R2dbcEntity<Any>, Any>
-) {
+): List<R2dbcEntity<*>> {
     val reference = accessor.reference
     val factory = accessor.factory
     val refIds = mapNotNull { entity -> entity.lookupRefValue(reference) }
-    if (refIds.isEmpty()) return
+    if (refIds.isEmpty()) return emptyList()
 
-    val referee = reference.referee ?: return
+    val referee = reference.referee ?: return emptyList()
     val condition = buildInListCondition(referee, refIds.distinct())
-    factory.find { condition }.toList()
+    return factory.find { condition }.toList()
 }
 
 /**
@@ -94,15 +116,121 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadReference(
 @Suppress("UNCHECKED_CAST")
 private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadOptionalReference(
     accessor: OptionalSuspendAccessor<Any, R2dbcEntity<Any>, Any>
-) {
+): List<R2dbcEntity<*>> {
     val reference = accessor.reference as Column<Any?>
     val factory = accessor.factory
     val refIds = mapNotNull { entity -> entity.lookupRefValue(reference) }
-    if (refIds.isEmpty()) return
+    if (refIds.isEmpty()) return emptyList()
 
-    val referee = reference.referee ?: return
+    val referee = reference.referee ?: return emptyList()
     val condition = buildInListCondition(referee, refIds.distinct())
-    factory.find { condition }.toList()
+    return factory.find { condition }.toList()
+}
+
+/**
+ * Bulk-loads child entities for a one-to-many relationship (`R2dbcReferrers`-backed property),
+ * for every parent in the receiver list. Children are grouped by their reference column value
+ * and inserted into the entity cache's referrers slot — so subsequent calls to the parent's
+ * accessor (`parent.children()`) hit the cache without issuing per-parent queries.
+ *
+ * Mirrors JDBC's `warmUpReferences` for the simple `EntityIDColumnType` case.
+ */
+private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadReferrers(
+    referrers: R2dbcReferrers<ID, R2dbcEntity<ID>, Any, R2dbcEntity<Any>, Any>
+): List<R2dbcEntity<*>> {
+    val refColumn = referrers.reference
+    val factory = referrers.factory
+
+    val referee = refColumn.referee ?: return emptyList()
+
+    val parentMappings: List<Pair<EntityID<*>, Any>> = mapNotNull { entity ->
+        if (entity.id._value == null) return@mapNotNull null
+        val refereeValue = entity.lookupRefValue(referee) ?: return@mapNotNull null
+        entity.id to refereeValue
+    }
+    if (parentMappings.isEmpty()) return emptyList()
+
+    val cache = TransactionManager.current().entityCache
+
+    val toLoadMappings = parentMappings.filter { (parentId, _) ->
+        cache.getReferrers<R2dbcEntity<Any>>(parentId, refColumn) == null
+    }
+
+    if (toLoadMappings.isEmpty()) {
+        // Already cached for every parent — return the union of cached children so
+        // transitive preloading of remaining relations still has entities to recurse on.
+        return parentMappings.flatMap { (parentId, _) ->
+            cache.getReferrers<R2dbcEntity<Any>>(parentId, refColumn)?.toList().orEmpty()
+        }
+    }
+
+    val refereeValuesToLoad = toLoadMappings.map { it.second }.distinct()
+    val condition = buildInListCondition(refColumn, refereeValuesToLoad)
+    val loadedChildren = factory.find { condition }.toList()
+
+    val grouped: Map<Any, List<R2dbcEntity<Any>>> = loadedChildren.groupBy { child ->
+        @Suppress("UNCHECKED_CAST")
+        child.lookupRefValue(refColumn as Column<Any?>) as Any
+    }
+
+    parentMappings.forEach { (parentId, refereeValue) ->
+        cache.getOrPutReferrers(refColumn, parentId) {
+            // NOTE: we deliberately use `SizedCollection(emptyList())` rather than `emptySized()`
+            // for parents with no children. R2DBC's `EmptySizedIterable.collect` throws
+            // UnsupportedOperationException, which would propagate when the cached value is
+            // later read via `.toList()` (e.g. by transitive preload or by the user).
+            SizedCollection(grouped[refereeValue] ?: emptyList())
+        }
+    }
+
+    return loadedChildren
+}
+
+private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadInnerTableLink(
+    accessor: R2dbcInnerTableLinkAccessor<ID, R2dbcEntity<ID>, Any, R2dbcEntity<Any>>
+): List<R2dbcEntity<*>> {
+    val link = accessor.link
+    val sourceColumn = link.sourceColumn
+    val target = link.target
+
+    val parentIds = mapNotNull { entity -> entity.id._value?.let { entity.id } }
+    if (parentIds.isEmpty()) return emptyList()
+
+    val distinctParentIds = parentIds.distinct()
+    val cache = TransactionManager.current().entityCache
+
+    val toLoad = distinctParentIds.filter { id ->
+        cache.getReferrers<R2dbcEntity<Any>>(id, sourceColumn) == null
+    }
+
+    if (toLoad.isEmpty()) {
+        return distinctParentIds.flatMap { id ->
+            cache.getReferrers<R2dbcEntity<Any>>(id, sourceColumn)?.toList().orEmpty()
+        }
+    }
+
+    val (columns, entityTables) = link.columnsAndTables
+
+    val rows = entityTables.select(columns).where { sourceColumn inList toLoad }
+        .toList()
+
+    val pairs: List<Pair<EntityID<ID>, R2dbcEntity<Any>>> = rows.map { row ->
+        @Suppress("UNCHECKED_CAST")
+        val parentId = row[sourceColumn] as EntityID<ID>
+        val targetEntity = target.wrapRow(row) as R2dbcEntity<Any>
+        parentId to targetEntity
+    }
+
+    val groupedBySourceId: Map<EntityID<ID>, List<R2dbcEntity<Any>>> = pairs
+        .groupBy({ it.first }, { it.second })
+
+    toLoad.forEach { id ->
+        cache.getOrPutReferrers(sourceColumn, id) {
+            SizedCollection(groupedBySourceId[id] ?: emptyList())
+        }
+    }
+
+    return pairs.map { it.second }.distinct()
 }
 
 private fun R2dbcEntity<*>.lookupRefValue(reference: Column<*>): Any? {

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcEagerLoading.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcEagerLoading.kt
@@ -1,0 +1,138 @@
+package org.jetbrains.exposed.r2dbc.dao.relationships
+
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.flushCache
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.EntityIDColumnType
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.r2dbc.LazySizedIterable
+import org.jetbrains.exposed.v1.r2dbc.SizedCollection
+import org.jetbrains.exposed.v1.r2dbc.SizedIterable
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Eager-loads the specified [relations] for all entities in this [SizedIterable]. Mirrors JDBC's
+ * `SizedIterable.with` — each direct relation is bulk-loaded via a single query instead of being
+ * fetched lazily one entity at a time.
+ *
+ * Returns this [SizedIterable] to allow chaining; the loaded list is also pinned onto any
+ * [LazySizedIterable] so subsequent iterations do not re-query the database.
+ */
+suspend fun <SRCID : Any, SRC : R2dbcEntity<SRCID>, REF : R2dbcEntity<*>, L : SizedIterable<SRC>> L.with(
+    vararg relations: KProperty1<out REF, Any?>
+): L {
+    toList().apply {
+        @Suppress("UNCHECKED_CAST")
+        (this@with as? LazySizedIterable<SRC>)?.loadedResult = this
+        if (any { it.isNewEntity() }) {
+            TransactionManager.current().flushCache()
+        }
+        preloadRelations(*relations)
+    }
+    return this
+}
+
+/**
+ * Eager-loads the specified [relations] for this entity. Mirrors JDBC's `Entity.load`.
+ */
+suspend fun <SRCID : Any, SRC : R2dbcEntity<SRCID>> SRC.load(
+    vararg relations: KProperty1<out R2dbcEntity<*>, Any?>
+): SRC = apply {
+    SizedCollection(listOf(this)).with(*relations)
+}
+
+@Suppress("UNCHECKED_CAST", "ForbiddenComment")
+private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadRelations(
+    vararg relations: KProperty1<out R2dbcEntity<*>, Any?>,
+    nodesVisited: MutableSet<R2dbcEntityClass<*, *>> = mutableSetOf()
+) {
+    val first = firstOrNull() ?: return
+    if (!nodesVisited.add(first.klass)) return
+
+    val directRelations = filterRelationsForEntity(first, relations)
+    directRelations.forEach { prop ->
+        when (val refObject = getReferenceObjectFromDelegatedProperty(first, prop)) {
+            is SuspendAccessor<*, *, *> -> preloadReference(refObject as SuspendAccessor<Any, R2dbcEntity<Any>, Any>)
+            is OptionalSuspendAccessor<*, *, *> ->
+                preloadOptionalReference(refObject as OptionalSuspendAccessor<Any, R2dbcEntity<Any>, Any>)
+            else -> {
+                // TODO: extend preloading to cover Referrers / BackReference / OptionalBackReference
+                //  / InnerTableLink delegates, like in JDBC's preloadRelations.
+            }
+        }
+    }
+}
+
+/**
+ * Bulk-loads parents referenced by a non-nullable [SuspendAccessor]-backed property, for every
+ * entity in the receiver list. Loaded parents are inserted into the entity cache by the factory's
+ * `find(...)` traversal (via `wrapRow`).
+ */
+@Suppress("UNCHECKED_CAST")
+private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadReference(
+    accessor: SuspendAccessor<Any, R2dbcEntity<Any>, Any>
+) {
+    val reference = accessor.reference
+    val factory = accessor.factory
+    val refIds = mapNotNull { entity -> entity.lookupRefValue(reference) }
+    if (refIds.isEmpty()) return
+
+    val referee = reference.referee ?: return
+    val condition = buildInListCondition(referee, refIds.distinct())
+    factory.find { condition }.toList()
+}
+
+/**
+ * Bulk-loads parents referenced by an [OptionalSuspendAccessor]-backed property.
+ */
+@Suppress("UNCHECKED_CAST")
+private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadOptionalReference(
+    accessor: OptionalSuspendAccessor<Any, R2dbcEntity<Any>, Any>
+) {
+    val reference = accessor.reference as Column<Any?>
+    val factory = accessor.factory
+    val refIds = mapNotNull { entity -> entity.lookupRefValue(reference) }
+    if (refIds.isEmpty()) return
+
+    val referee = reference.referee ?: return
+    val condition = buildInListCondition(referee, refIds.distinct())
+    factory.find { condition }.toList()
+}
+
+private fun R2dbcEntity<*>.lookupRefValue(reference: Column<*>): Any? {
+    @Suppress("UNCHECKED_CAST")
+    return writeValues[reference as Column<Any?>] ?: _readValues?.let { row -> row.getOrNull(reference) }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun buildInListCondition(referee: Column<*>, refIds: List<Any>): org.jetbrains.exposed.v1.core.Op<Boolean> {
+    // If the reference column stores a raw value while the referee is an EntityID column (or vice
+    // versa), normalise the types before building the IN (...) expression.
+    val baseColumn = referee.takeUnless {
+        it.columnType is EntityIDColumnType<*> && refIds.first() !is EntityID<*>
+    } ?: (referee.columnType as EntityIDColumnType<Any>).idColumn
+    return (baseColumn as Column<Any>) inList refIds
+}
+
+private fun <SRC : R2dbcEntity<*>> filterRelationsForEntity(
+    entity: SRC,
+    relations: Array<out KProperty1<out R2dbcEntity<*>, Any?>>
+): Collection<KProperty1<SRC, Any?>> {
+    val validMembers = entity::class.memberProperties
+    @Suppress("UNCHECKED_CAST")
+    return validMembers.filter { it in relations } as Collection<KProperty1<SRC, Any?>>
+}
+
+private fun <SRC : R2dbcEntity<*>> getReferenceObjectFromDelegatedProperty(
+    entity: SRC,
+    property: KProperty1<SRC, Any?>
+): Any? {
+    property.isAccessible = true
+    return property.getDelegate(entity)
+}

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcInnerTableLink.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcInnerTableLink.kt
@@ -1,0 +1,130 @@
+package org.jetbrains.exposed.r2dbc.dao.relationships
+
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
+import org.jetbrains.exposed.r2dbc.dao.executeAsPartOfEntityLifecycle
+import org.jetbrains.exposed.v1.core.*
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.r2dbc.SizedIterable
+import org.jetbrains.exposed.v1.r2dbc.batchInsert
+import org.jetbrains.exposed.v1.r2dbc.deleteWhere
+import org.jetbrains.exposed.v1.r2dbc.emptySized
+import org.jetbrains.exposed.v1.r2dbc.select
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import kotlin.reflect.KProperty
+
+@Suppress("UNCHECKED_CAST")
+class R2dbcInnerTableLink<SID : Any, Source : R2dbcEntity<SID>, ID : Any, Target : R2dbcEntity<ID>>(
+    val table: Table,
+    sourceTable: IdTable<SID>,
+    val target: R2dbcEntityClass<ID, Target>,
+    _sourceColumn: Column<EntityID<SID>>? = null,
+    _targetColumn: Column<EntityID<ID>>? = null,
+) {
+    private val orderByExpressions: MutableList<Pair<Expression<*>, SortOrder>> = mutableListOf()
+
+    init {
+        _targetColumn?.let {
+            requireNotNull(_sourceColumn) { "Both source and target columns should be specified" }
+            require(_targetColumn.referee?.table == target.table) {
+                "Column $_targetColumn point to wrong table, expected ${target.table.tableName}"
+            }
+            require(_targetColumn.table == _sourceColumn.table) {
+                "Both source and target columns should be from the same table"
+            }
+        }
+        _sourceColumn?.let {
+            requireNotNull(_targetColumn) { "Both source and target columns should be specified" }
+            require(_sourceColumn.referee?.table == sourceTable) {
+                "Column $_sourceColumn point to wrong table, expected ${sourceTable.tableName}"
+            }
+        }
+    }
+
+    val sourceColumn: Column<EntityID<SID>> = _sourceColumn
+        ?: table.columns.singleOrNull { it.referee == sourceTable.id } as? Column<EntityID<SID>>
+        ?: error("Table does not reference source")
+
+    val targetColumn: Column<EntityID<ID>> = _targetColumn
+        ?: table.columns.singleOrNull { it.referee == target.table.id } as? Column<EntityID<ID>>
+        ?: error("Table does not reference target")
+
+    internal val columnsAndTables by lazy {
+        val alreadyInJoin = (target.dependsOnTables as? Join)?.alreadyInJoin(table) ?: false
+        val entityTables = if (alreadyInJoin) {
+            target.dependsOnTables
+        } else {
+            target.dependsOnTables.join(table, JoinType.INNER, target.table.id, targetColumn)
+        }
+        val columns = (target.dependsOnColumns + (if (!alreadyInJoin) table.columns else emptyList()) - sourceColumn)
+            .distinct() + sourceColumn
+        columns to entityTables
+    }
+
+    internal fun orderByExpressionsArray(): Array<Pair<Expression<*>, SortOrder>> = orderByExpressions.toTypedArray()
+
+    operator fun provideDelegate(
+        thisRef: Source,
+        property: KProperty<*>
+    ): R2dbcInnerTableLinkAccessor<SID, Source, ID, Target> = R2dbcInnerTableLinkAccessor(this, thisRef)
+
+    infix fun orderBy(order: List<Pair<Expression<*>, SortOrder>>) = this.also {
+        orderByExpressions.addAll(order)
+    }
+
+    infix fun orderBy(order: Pair<Expression<*>, SortOrder>) = orderBy(listOf(order))
+
+    infix fun orderBy(expression: Expression<*>) = orderBy(listOf(expression to SortOrder.ASC))
+}
+
+@Suppress("UNCHECKED_CAST")
+class R2dbcInnerTableLinkAccessor<SID : Any, Source : R2dbcEntity<SID>, ID : Any, Target : R2dbcEntity<ID>>(
+    private val link: R2dbcInnerTableLink<SID, Source, ID, Target>,
+    private val entity: Source
+) {
+    operator fun getValue(thisRef: Source, property: KProperty<*>): R2dbcInnerTableLinkAccessor<SID, Source, ID, Target> = this
+
+    suspend operator fun invoke(): SizedIterable<Target> {
+        if (entity.id._value == null && !entity.isNewEntity()) return emptySized()
+        val transaction = TransactionManager.currentOrNull()
+            ?: return entity.getReferenceFromCache(link.sourceColumn)
+
+        val (columns, entityTables) = link.columnsAndTables
+
+        val query: suspend () -> SizedIterable<Target> = {
+            @Suppress("SpreadOperator")
+            link.target.wrapRows(
+                entityTables.select(columns)
+                    .where { link.sourceColumn eq entity.id }
+                    .orderBy(*link.orderByExpressionsArray())
+            )
+        }
+        return transaction.entityCache.getOrPutReferrers<ID, Target>(link.sourceColumn, entity.id, query).also {
+            entity.storeReferenceInCache(link.sourceColumn, it)
+        }
+    }
+
+    suspend infix fun set(value: List<Target>) {
+        val tx = TransactionManager.current()
+        val entityCache = tx.entityCache
+        entityCache.flush()
+        val oldValue = invoke().toList()
+        val existingIds = oldValue.map { it.id }.toSet()
+        entityCache.removeReferrer(link.sourceColumn, entity.id)
+
+        val targetIds = value.map { it.id }
+        executeAsPartOfEntityLifecycle {
+            link.table.deleteWhere { (link.sourceColumn eq entity.id) and (link.targetColumn notInList targetIds) }
+            link.table.batchInsert(
+                targetIds.filter { it !in existingIds },
+                shouldReturnGeneratedValues = false
+            ) { targetId ->
+                this[link.sourceColumn] = entity.id
+                this[link.targetColumn] = targetId
+            }
+        }
+    }
+}

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcInnerTableLink.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcInnerTableLink.kt
@@ -82,8 +82,8 @@ class R2dbcInnerTableLink<SID : Any, Source : R2dbcEntity<SID>, ID : Any, Target
 
 @Suppress("UNCHECKED_CAST")
 class R2dbcInnerTableLinkAccessor<SID : Any, Source : R2dbcEntity<SID>, ID : Any, Target : R2dbcEntity<ID>>(
-    private val link: R2dbcInnerTableLink<SID, Source, ID, Target>,
-    private val entity: Source
+    val link: R2dbcInnerTableLink<SID, Source, ID, Target>,
+    val entity: Source
 ) {
     operator fun getValue(thisRef: Source, property: KProperty<*>): R2dbcInnerTableLinkAccessor<SID, Source, ID, Target> = this
 

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcReferrers.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcReferrers.kt
@@ -1,11 +1,12 @@
 package org.jetbrains.exposed.r2dbc.dao.relationships
 
-import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.r2dbc.SizedIterable
+import org.jetbrains.exposed.v1.r2dbc.emptySized
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import kotlin.reflect.KProperty
 
@@ -25,13 +26,13 @@ class R2dbcReferrers<ParentID : Any, in Parent : R2dbcEntity<ParentID>, ChildID 
     }
 
     @Suppress("NestedBlockDepth", "ForbiddenComment")
-    operator fun getValue(thisRef: Parent, property: KProperty<*>): suspend () -> List<Child> {
+    operator fun getValue(thisRef: Parent, property: KProperty<*>): suspend () -> SizedIterable<Child> {
         // Return a suspend lambda that will load the referrers when invoked
         return {
             // Check if entity ID is available
             if (thisRef.id._value == null) {
                 // TODO should it be error?
-                emptyList()
+                emptySized()
             } else {
                 val transaction = TransactionManager.currentOrNull()
 
@@ -39,9 +40,10 @@ class R2dbcReferrers<ParentID : Any, in Parent : R2dbcEntity<ParentID>, ChildID 
                 if (transaction == null) {
                     if (thisRef.hasInReferenceCache(reference)) {
                         val cached = thisRef.getReferenceFromCache<Any?>(reference)
+                        @Suppress("UNCHECKED_CAST")
                         when (cached) {
-                            is List<*> -> cached as List<Child>
-                            null -> emptyList()
+                            is SizedIterable<*> -> cached as SizedIterable<Child>
+                            null -> emptySized()
                             else -> error("Cached referrer has unexpected type: ${cached::class}")
                         }
                     } else {
@@ -57,15 +59,14 @@ class R2dbcReferrers<ParentID : Any, in Parent : R2dbcEntity<ParentID>, ChildID 
                     } as REF
 
                     // Build the query for child entities
-                    val query: suspend () -> List<Child> = {
-                        val resultRows = factory.find { reference eq refValue }.toList()
-                        resultRows.map { factory.wrapRow(it) }
+                    val query: suspend () -> SizedIterable<Child> = {
+                        factory.find { reference eq refValue }
                     }
 
                     // Execute query with caching if enabled
                     val result = if (cache) {
                         @Suppress("UNCHECKED_CAST")
-                        transaction.entityCache.getOrPutReferrers<ParentID>(reference, thisRef.id, query) as List<Child>
+                        (transaction.entityCache.getOrPutReferrers(reference, thisRef.id, query))
                     } else {
                         query()
                     }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcRelationshipExtensions.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcRelationshipExtensions.kt
@@ -76,3 +76,17 @@ infix fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child 
     R2dbcEntityClass<ParentID, Parent>.optionalBackReferencedOnSuspend(reference: Column<REF?>): R2dbcOptionalBackReference<ParentID, Parent, ChildID, Child, REF> {
     return R2dbcOptionalBackReference(reference, this)
 }
+
+/**
+ * Overload for referencing a non-nullable column as an optional back reference.
+ *
+ * The child entity's referencing column is required (non-nullable) but, from the parent
+ * side, the relationship is still optional: a child row may or may not exist. This mirrors
+ * JDBC's `optionalBackReferencedOn(Column<REF>)` overload.
+ */
+@Suppress("UNCHECKED_CAST")
+@JvmName("optionalBackReferencedOnSuspendNonNullable")
+infix fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF : Any>
+    R2dbcEntityClass<ParentID, Parent>.optionalBackReferencedOnSuspend(reference: Column<REF>): R2dbcOptionalBackReference<ParentID, Parent, ChildID, Child, REF> {
+    return R2dbcOptionalBackReference(reference as Column<REF?>, this)
+}

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/SuspendAccessor.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/SuspendAccessor.kt
@@ -1,19 +1,21 @@
 package org.jetbrains.exposed.r2dbc.dao.relationships
 
+import kotlinx.coroutines.flow.singleOrNull
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import kotlin.collections.get
 import kotlin.reflect.KProperty
 
 class SuspendAccessor<ID : Any, Parent : R2dbcEntity<ID>, REF : Any>(
-    private val reference: Column<REF>,
-    private val factory: R2dbcEntityClass<ID, @UnsafeVariance Parent>,
-    private val entity: R2dbcEntity<*>
+    internal val reference: Column<REF>,
+    internal val factory: R2dbcEntityClass<ID, @UnsafeVariance Parent>,
+    internal val entity: R2dbcEntity<*>
 ) {
     /**
      * getValue operator - returns this accessor which has invoke() and set operations.
@@ -73,16 +75,39 @@ class SuspendAccessor<ID : Any, Parent : R2dbcEntity<ID>, REF : Any>(
     }
 
     suspend operator fun invoke(): Parent {
-        @Suppress("ForbiddenComment")
-        // TODO: Implement reference loading similar to OptionalSuspendAccessor
-        TODO("Not yet implemented")
+        if (entity.hasInReferenceCache(reference)) {
+            return entity.getReferenceFromCache(reference)
+        }
+
+        // TODO incapsulate this logic inside entity to avoid checking for different fields outside.
+        @Suppress("UNCHECKED_CAST")
+        val refValue: REF = (entity.writeValues[reference as Column<Any?>] as? REF)
+            ?: (entity._readValues?.let { row -> row[reference] } as? REF)
+            ?: error("Reference column ${reference.name} has no value for entity ${entity.id}")
+
+        val parentEntity = when {
+            reference.referee == factory.table.id -> {
+                @Suppress("UNCHECKED_CAST")
+                factory.findById(refValue as EntityID<ID>)
+            }
+            reference.referee?.table == factory.table -> {
+                @Suppress("UNCHECKED_CAST")
+                val refereeColumn = reference.referee!! as Column<Any?>
+                factory.find { refereeColumn eq refValue }.singleOrNull()
+            }
+            else -> error("Reference column ${reference.name} does not point to any column in ${factory.table.tableName}")
+        } ?: error("Referenced entity not found for column ${reference.name} with value $refValue")
+
+        entity.storeReferenceInCache(reference, parentEntity)
+
+        return parentEntity
     }
 }
 
 class OptionalSuspendAccessor<ID : Any, Parent : R2dbcEntity<ID>, REF : Any>(
-    private val reference: Column<REF?>,
-    private val factory: R2dbcEntityClass<ID, @UnsafeVariance Parent>,
-    private val entity: R2dbcEntity<*>
+    internal val reference: Column<REF?>,
+    internal val factory: R2dbcEntityClass<ID, @UnsafeVariance Parent>,
+    internal val entity: R2dbcEntity<*>
 ) {
     operator fun getValue(thisRef: Any?, property: KProperty<*>): OptionalSuspendAccessor<ID, Parent, REF> {
         return this
@@ -147,13 +172,19 @@ class OptionalSuspendAccessor<ID : Any, Parent : R2dbcEntity<ID>, REF : Any>(
             return null
         }
 
-        @Suppress("UNCHECKED_CAST")
-        val parentId = when {
-            refValue is EntityID<*> && reference.referee == factory.table.id -> refValue as EntityID<ID>
-            else -> error("Reference column ${reference.name} does not point to ${factory.table.id}")
+        val parentEntity = when {
+            reference.referee == factory.table.id -> {
+                @Suppress("UNCHECKED_CAST")
+                factory.findById(refValue as EntityID<ID>)
+            }
+            reference.referee?.table == factory.table -> {
+                @Suppress("UNCHECKED_CAST")
+                val refereeColumn = reference.referee!! as Column<Any?>
+                factory.find { refereeColumn eq refValue }.singleOrNull()
+            }
+            else -> error("Reference column ${reference.name} does not point to any column in ${factory.table.tableName}")
         }
 
-        val parentEntity = factory.findById(parentId)
         entity.storeReferenceInCache(reference, parentEntity)
 
         return parentEntity

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/EntityCache.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/EntityCache.kt
@@ -49,16 +49,7 @@ class EntityCache(private val transaction: Transaction) {
             val diff = value - field
             field = value
             if (diff < 0) {
-                data.values.forEach { map ->
-                    val sizeExceed = map.size - value
-                    if (sizeExceed > 0) {
-                        val iterator = map.iterator()
-                        repeat(sizeExceed) {
-                            iterator.next()
-                            iterator.remove()
-                        }
-                    }
-                }
+                data.values.forEach { it.trimToFirst(value) }
             }
         }
 
@@ -351,5 +342,23 @@ fun Transaction.flushCache(): List<Entity<*>> {
         val newEntities = inserts.flatMap { it.value }
         flush()
         return newEntities
+    }
+}
+
+/**
+ * Drops entries from the front of this map until its [size] is at most [maxSize].
+ *
+ * Extracted from `EntityCache.maxEntitiesToStore`'s setter so the setter reads as intent
+ * ("trim each per-table map to the new max") rather than carrying the iterator mechanics inline.
+ * Relies on insertion-order iteration of the per-table cache (see `EntityCache.LimitedHashMap`)
+ * to evict the oldest entries first.
+ */
+private fun <K, V> MutableMap<K, V>.trimToFirst(maxSize: Int) {
+    val sizeExceed = size - maxSize
+    if (sizeExceed <= 0) return
+    val iterator = iterator()
+    repeat(sizeExceed) {
+        iterator.next()
+        iterator.remove()
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityTests.kt
@@ -258,7 +258,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testInsertNonChildWithoutFlush() {
         withTables(Boards, Posts, Categories) {
             val board = Board.new { name = "irrelevant" }
@@ -268,7 +267,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testThatQueriesWithinOtherQueryIteratorWorksFine() {
         withTables(Boards, Posts, Categories) {
             val board1 = Board.new { name = "irrelevant" }
@@ -283,7 +281,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testInsertChildWithFlush() {
         withTables(Boards, Posts, Categories) {
             val parent = Post.new { this.category = Category.new { title = "title" } }
@@ -295,7 +292,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testInsertChildWithChild() {
         withTables(Boards, Posts, Categories) {
             val parent = Post.new { this.category = Category.new { title = "title1" } }
@@ -309,7 +305,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testOptionalReferrersWithDifferentKeys() {
         withTables(Boards, Posts, Categories) {
             val board = Board.new { name = "irrelevant" }
@@ -326,7 +321,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testErrorOnSetToDeletedEntity() {
         withTables(Boards) {
             expectException<EntityNotFoundException> {
@@ -338,7 +332,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testCacheInvalidatedOnDSLDelete() {
         withTables(Boards) {
             val board1 = Board.new { name = "irrelevant" }
@@ -354,7 +347,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testCacheInvalidatedOnDSLUpdate() {
         withTables(Boards) {
             val board1 = Board.new { name = "irrelevant" }
@@ -387,7 +379,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testCacheInvalidatedOnDSLUpsert() {
         withTables(Items) { testDb ->
             val oldPrice = 20.0
@@ -427,7 +418,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testDaoFindByIdAndUpdate() {
         withTables(Items) {
             val oldPrice = 20.0
@@ -457,7 +447,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testDaoFindSingleByAndUpdate() {
         withTables(Items) {
             val oldPrice = 20.0
@@ -516,7 +505,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testOneToOneReference() {
         withTables(Humans, Users) {
             val user = User.create("testUser")
@@ -537,7 +525,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
     fun testSelfReferences() {
         withTables(SelfReferenceTable) {
@@ -549,7 +536,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testNonEntityIdReference() {
         withTables(Posts, Boards, Categories) {
             val category1 = Category.new {
@@ -574,7 +560,6 @@ class EntityTests : DatabaseTestsBase() {
 
     // https://github.com/JetBrains/Exposed/issues/439
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun callLimitOnRelationDoesntMutateTheCachedValue() {
         withTables(Posts, Boards, Categories) {
             addLogger(StdOutSqlLogger) // this is left in on purpose for flaky tests
@@ -602,7 +587,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testOrderByOnEntities() {
         withTables(Categories) {
             Categories.deleteAll()
@@ -617,7 +601,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testThatUpdateOfInsertedEntitiesGoesBeforeAnInsert() {
         withTables(Categories, Posts, Boards) {
             val category1 = Category.new {
@@ -673,7 +656,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testNewIdWithGet() {
         // SQL Server doesn't support an explicit id for auto-increment table
         withTables(listOf(TestDB.SQLSERVER), Parents, Children) {
@@ -694,7 +676,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun `newly created entity flushed successfully`() {
         withTables(Boards) {
             val board = Board.new { name = "Board1" }.apply {
@@ -709,7 +690,6 @@ class EntityTests : DatabaseTestsBase() {
         inTopLevelTransaction(null, statement = statement)
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun sharingEntityBetweenTransactions() {
         withTables(Humans) {
             val human1 = newTransaction {
@@ -845,7 +825,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadReferencesOnASizedIterable() {
         withTables(Regions, Schools) {
             val region1 = Region.new {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityTests.kt
@@ -12,11 +12,13 @@ import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.currentDialectTest
-import org.jetbrains.exposed.v1.tests.shared.*
-import org.junit.jupiter.api.Tag
+import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
+import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
+import org.jetbrains.exposed.v1.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.tests.shared.assertFalse
+import org.jetbrains.exposed.v1.tests.shared.expectException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.sql.Connection
@@ -866,7 +868,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testIterationOverSizedIterableWithPreload() {
         fun HashMap<String, Pair<Int, Long>>.assertEachQueryExecutedOnlyOnce() {
             forEach { (statement, stats) ->
@@ -934,7 +935,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadReferencesOnAnEntity() {
         withTables(Regions, Schools) {
             val region1 = Region.new {
@@ -967,7 +967,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadOptionalReferencesOnASizedIterable() {
         withTables(Regions, Schools) {
             val region1 = Region.new {
@@ -1008,7 +1007,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadOptionalReferencesOnAnEntity() {
         withTables(Regions, Schools) {
             val region1 = Region.new {
@@ -1039,7 +1037,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadReferrersOnASizedIterable() {
         withTables(Regions, Schools, Students) {
             val region1 = Region.new {
@@ -1101,7 +1098,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadReferrersOnAnEntity() {
         withTables(Regions, Schools, Students) {
             val region1 = Region.new {
@@ -1142,7 +1138,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadOptionalReferrersOnASizedIterable() {
         withTables(Regions, Schools, Students, Detentions) {
             val region1 = Region.new {
@@ -1191,7 +1186,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadInnerTableLinkOnASizedIterable() {
         withTables(Regions, Schools, Holidays, SchoolHolidays) {
             val now = System.currentTimeMillis()
@@ -1253,7 +1247,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadInnerTableLinkOnAnEntity() {
         withTables(Regions, Schools, Holidays, SchoolHolidays) {
             val now = System.currentTimeMillis()
@@ -1313,7 +1306,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadRelationAtDepth() {
         withTables(Regions, Schools, Holidays, SchoolHolidays, Students, Notes) {
             val region1 = Region.new {
@@ -1357,7 +1349,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadBackReferrenceOnASizedIterable() {
         withTables(Regions, Schools, Students, StudentBios) {
             val region1 = Region.new {
@@ -1403,7 +1394,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun preloadBackReferrenceOnAnEntity() {
         withTables(Regions, Schools, Students, StudentBios) {
             val region1 = Region.new {
@@ -1448,7 +1438,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun `test reference cache doesn't fully invalidated on set entity reference`() {
         withTables(Regions, Schools, Students, StudentBios) {
             val region1 = Region.new {
@@ -1481,7 +1470,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun `test nested entity initialization`() {
         withTables(Posts, Categories, Boards) {
             val post = Post.new {
@@ -1508,7 +1496,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testExplicitEntityConstructor() {
         var createBoardCalled = false
         fun createBoard(id: EntityID<Int>): Board {
@@ -1543,7 +1530,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testSelectFromStringIdTableWithPrimaryKeyByColumn() {
         withTables(RequestsTable) {
             Request.new {
@@ -1568,7 +1554,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testDatabaseGeneratedValues() {
         withTables(excludeSettings = listOf(TestDB.SQLITE), CreditCards) { testDb ->
             when (testDb) {
@@ -1627,7 +1612,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testEntityIdParam() {
         withTables(CreditCards) {
             val newCard = CreditCard.new {
@@ -1672,7 +1656,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testEagerLoadingWithStringParentId() {
         withTables(Countries, Dishes, configure = { keepLoadedReferencesOutOfTransaction = true }) {
             val lebanonId = Countries.insertAndGetId {
@@ -1742,7 +1725,6 @@ class EntityTests : DatabaseTestsBase() {
      * another column that is a unique index.
      */
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testEagerLoadingWithReferenceDifferentFromParentId() {
         withTables(Customers, Orders, configure = { keepLoadedReferencesOutOfTransaction = true }) {
             val customer1 = Customer.new {
@@ -1786,7 +1768,6 @@ class EntityTests : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testDifferentEntitiesMappedToTheSameTable() {
         withTables(TestTable) {
             val entityA = TestEntityA.new {


### PR DESCRIPTION
#### Description

New functionality                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                         
  - Eager loading (R2dbcEagerLoading.kt) — SizedIterable<T>.with(vararg KProperty1) and R2dbcEntity.load(...). Mirrors JDBC's with/load. 
  - Many-to-many (R2dbcInnerTableLink.kt + viaSuspend member extensions on R2dbcEntity) — counterpart of JDBC's InnerTableLink and via. Returns an accessor with suspend invoke() (read) and suspend infix set(List<T>) (replace) because Kotlin delegate operators can't be suspend.                                      
  - R2dbcEntityClass.attach(entity) — explicit verify-and-adopt step for reusing an entity across transactions (JDBC does this implicitly inside setValue via a sync DB probe, which R2DBC can't).                                                                                                                         
  - R2dbcEntityClass.reload(entity, flush) — same contract as JDBC's reload.                                                                                                                                                                                                                                               
  - R2dbcEntityClass.findByIdAndUpdate / findSingleByAndUpdate — same as JDBC.                                                                                                                                                                                                                                             
  - R2dbcEntity.delete() — previously missing; flushes pending changes, runs the DELETE, removes from cache. Skips insert-then-delete for never-flushed new entities.                                                                                                                                                      
  - R2dbcEntityCache.isScheduledForInsert / isStoredInData — parallel helpers to the existing isEntityInInitializationState.                                                                                                                                                                                               
  - optionalBackReferencedOnSuspend(Column<REF>) non-nullable overload — matches JDBC's overload set.


---

Comparing to JDBC it's not possible to make suspend operations during setting values to the entity fields. Because of that appeared extra method `attach()` to add entity from outer transaction to the current entity cache. Also managing of entities with self references is getting a bit more complicated, because in jdbc the entity will flushed right before setting self reference. Also it's not possible to check if the entity is already deleted in the moment of setting value to the field, so r2dbc dao just complains if the entity not in cache in this moment, rather than more detailed deletion status.
