### PR TITLE
fix: EXPOSED-1019 InstantColumnType misreads timestamps before Unix epoch

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/datetime/InstantColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/datetime/InstantColumnType.kt
@@ -67,7 +67,12 @@ abstract class InstantColumnType<T> : ColumnType<T>(), IDateColumnType {
 
     @Suppress("MagicNumber")
     private fun instantValueFromDB(value: Any): Instant = when (value) {
-        is Timestamp -> Instant.fromEpochSeconds(value.time / 1000, value.nanos)
+        // Math.floorDiv (not `/`) is required so pre-epoch Timestamps round-trip correctly.
+        // Timestamp.getTime() is in milliseconds and is negative for pre-epoch values, while
+        // getNanos() is always non-negative (0..999_999_999). Kotlin/JVM `/` truncates toward
+        // zero, so for example -10L / 1000L == 0 — but the correct floor for combining with
+        // a non-negative nanos remainder is -1. See EXPOSED-1019.
+        is Timestamp -> Instant.fromEpochSeconds(Math.floorDiv(value.time, 1000L), value.nanos)
         is String -> parseInstantFromString(value)
         is java.time.LocalDateTime -> {
             value.atZone(ZoneId.systemDefault())

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/KotlinTimeTests.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/KotlinTimeTests.kt
@@ -741,6 +741,38 @@ class KotlinTimeTests : DatabaseTestsBase() {
             assertEquals(now, valueFromDb)
         }
     }
+
+    /**
+     * Regression test for EXPOSED-1019.
+     *
+     * `InstantColumnType.instantValueFromDB` converts a `java.sql.Timestamp` into a
+     * `kotlin.time.Instant` with `Instant.fromEpochSeconds(value.time / 1000, value.nanos)`.
+     * `Timestamp.getTime()` is in milliseconds and can be negative for pre-epoch values, but
+     * Kotlin/JVM integer division truncates toward zero rather than flooring, so for example
+     * `-10L / 1000L == 0` (correct value would be `-1`).
+     *
+     * MariaDB is excluded: with its default strict `sql_mode` MariaDB rejects pre-epoch
+     * datetime literals at INSERT with `Incorrect datetime value` (SQL state 22007).
+     */
+    @Test
+    fun testInstantBeforeEpochRoundTrip() {
+        val tester = object : Table("ts_pre_epoch") {
+            val ts = timestamp("ts")
+        }
+
+        withTables(excludeSettings = listOf(TestDB.MARIADB), tester) {
+            val preEpoch = Instant.fromEpochMilliseconds(-10)
+            tester.insert {
+                it[ts] = preEpoch
+            }
+
+            val readBack = tester.selectAll().single()[tester.ts]
+
+            // Expected: 1969-12-31T23:59:59.990Z (-10 ms)
+            // Actual on the bug: 1970-01-01T00:00:00.990Z (+990 ms)
+            assertEquals(preEpoch, readBack)
+        }
+    }
 }
 
 fun <T> assertEqualDateTime(d1: T?, d2: T?) {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/KotlinTimeTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/KotlinTimeTests.kt
@@ -581,6 +581,38 @@ class KotlinTimeTests : R2dbcDatabaseTestsBase() {
             assertEquals(now, valueFromDb)
         }
     }
+
+    /**
+     * Regression test for EXPOSED-1019.
+     *
+     * `InstantColumnType.instantValueFromDB` converts a `java.sql.Timestamp` into a
+     * `kotlin.time.Instant` with `Instant.fromEpochSeconds(value.time / 1000, value.nanos)`.
+     * `Timestamp.getTime()` is in milliseconds and can be negative for pre-epoch values, but
+     * Kotlin/JVM integer division truncates toward zero rather than flooring, so for example
+     * `-10L / 1000L == 0` (correct value would be `-1`).
+     *
+     * MariaDB is excluded: with its default strict `sql_mode` MariaDB rejects pre-epoch
+     * datetime literals at INSERT with `Incorrect datetime value` (SQL state 22007).
+     */
+    @Test
+    fun testInstantBeforeEpochRoundTrip() {
+        val tester = object : Table("ts_pre_epoch") {
+            val ts = timestamp("ts")
+        }
+
+        withTables(excludeSettings = listOf(TestDB.MARIADB), tester) {
+            val preEpoch = Instant.fromEpochMilliseconds(-10)
+            tester.insert {
+                it[ts] = preEpoch
+            }
+
+            val readBack = tester.selectAll().single()[tester.ts]
+
+            // Expected: 1969-12-31T23:59:59.990Z (-10 ms)
+            // Actual on the bug: 1970-01-01T00:00:00.990Z (+990 ms)
+            assertEquals(preEpoch, readBack)
+        }
+    }
 }
 
 fun <T> assertEqualDateTime(d1: T?, d2: T?) {


### PR DESCRIPTION
#### Description
                                                      
  **Summary of the change**: Fix `InstantColumnType` mis-reading pre-epoch timestamps by replacing the                
  truncating-toward-zero integer division with `Math.floorDiv` when converting `java.sql.Timestamp.getTime()`         
  (milliseconds) to seconds for `Instant.fromEpochSeconds`.                                                           
                                                                                                                      
  **Detailed description**:                                                                                           
   
  - **Why**: `Timestamp.getTime()` returns milliseconds since epoch and is negative for pre-epoch values, but         
  `Timestamp.getNanos()` is always non-negative because the `Timestamp` constructor borrows from the seconds field to
  keep the nanos field in `[0, 1_000_000_000)`. The current code combines a truncated `value.time / 1000` with the    
  non-negative `value.nanos`, which gives the wrong instant for any negative millisecond value. Concrete example from
  the issue: `Instant.fromEpochMilliseconds(-10)` (i.e. `Timestamp(getTime = -10, getNanos = 990_000_000)`)
  round-trips as `+990 ms` instead of `−10 ms`.

  ---

  #### Type of Change                                                                                                 
   
  - [X] Bug fix                                                                                                       
                                                                                                                      
  Affected databases:
  - [X] All                                                                                                       
                                                                                                                      
                                                                                                               
  ---                                                                                                               

  #### Related Issues

  - [EXPOSED-1019](https://youtrack.jetbrains.com/issue/EXPOSED-1019) — InstantColumnType misreads timestamps before  
  Unix epoch