### PR TITLE
chore: EXPOSED-759 Configure Exposed Gradle plugin module for publishing

### DIFF
--- a/exposed-gradle-plugin/build.gradle.kts
+++ b/exposed-gradle-plugin/build.gradle.kts
@@ -73,6 +73,10 @@ gradlePlugin {
     }
 }
 
+signing {
+    isRequired = gradle.taskGraph.hasTask("publish")
+}
+
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_11)

--- a/exposed-gradle-plugin/build.gradle.kts
+++ b/exposed-gradle-plugin/build.gradle.kts
@@ -4,11 +4,15 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    `java-gradle-plugin`
     kotlin("jvm")
 
     alias(libs.plugins.dokka)
+    alias(libs.plugins.gradle.plugin.publish)
 }
+
+group = "org.jetbrains.exposed.plugin"
+version = "1.2.0"
+description = "Exposed Gradle plugin"
 
 repositories {
     mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ moneta = "1.4.5"
 hikariCP = "7.0.2"
 logcaptor = "2.12.6"
 maven-publish = "0.35.0"
+gradle-plugin-publish = "2.1.1"
 
 testcontainers = "2.0.5"
 
@@ -140,3 +141,4 @@ binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibil
 docker-compose = { id = "com.avast.gradle.docker-compose", version.ref = "docker-compose" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 maven-publish = { id = "com.vanniktech.maven.publish" }
+gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }


### PR DESCRIPTION
#### Description

**Summary of the change**: Setup new `exposed-gradle-plugin` module for publishing to both Gradle Plugin Portal and Maven Central.

```kotlin
plugins {
    kotlin("jvm") version "2.3.20"
    id("org.jetbrains.exposed.plugin") version "1.2.0"
}

exposed {
    migrations {
        // plugin configuration
    }
}

dependencies {
    implementation("org.jetbrains.exposed:exposed-core:1.2.0")
    implementation("org.jetbrains.exposed:exposed-jdbc:1.2.0")
}
```

**Detailed description**:
- **How**:

- [X] Include `exposed-gradle-plugin` in existing Maven Central publishing setup
- [X] Make sure Dokka and Kover include the new module too
- [X] Decide on versioning --> Should match current/latest Exposed version
- [X] Define metadata in `gradlePlugin` block
- [ ] Create a Gradle Plugin Portal team account
- [ ] Generate API keys & setup TC
- [ ] Configure signing

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - _Publishing chore_

---

#### Related Issues
[EXPOSED-759](https://youtrack.jetbrains.com/issue/EXPOSED-759/Configure-plugin-module-for-publishing)