### PR TITLE
fix: Avoid redundant PostgreSQL UUID type migration when only column default changes

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
@@ -391,48 +391,44 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
 
     override fun modifyColumn(column: Column<*>, columnDiff: ColumnDiff): List<String> {
         @OptIn(InternalApi::class)
-        val list = mutableListOf(
-            buildString {
-                val tr = currentTransaction()
-                append("ALTER TABLE ${tr.identity(column.table)} ")
-                val colName = tr.identity(column)
-
-                if (columnDiff.autoInc && column.autoIncColumnType != null) {
-                    val sequence = column.autoIncColumnType?.sequence
-                    if (sequence != null) {
-                        append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
-                        append(", ALTER COLUMN $colName DROP DEFAULT")
-                    } else {
-                        val fallbackSequenceName = fallbackSequenceName(tableName = column.table.tableName, columnName = column.name)
-                        append("ALTER COLUMN $colName SET DEFAULT nextval('$fallbackSequenceName')")
-                    }
-                } else if (columnDiff.autoInc && column.autoIncColumnType == null) {
-                    // based on logic in SchemaUtils.isIncorrectAutoInc this should only be possible if the existing
-                    // column in database is auto-incrementing while defined table is not
-                    append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
-                    append(", ALTER COLUMN $colName DROP DEFAULT")
+        val transaction = currentTransaction()
+        val colName = transaction.identity(column)
+        val alterColumnParts = buildList {
+            if (columnDiff.autoInc && column.autoIncColumnType != null) {
+                val sequence = column.autoIncColumnType?.sequence
+                if (sequence != null) {
+                    add("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
+                    add("ALTER COLUMN $colName DROP DEFAULT")
                 } else {
-                    append("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
+                    val fallbackSequenceName = fallbackSequenceName(tableName = column.table.tableName, columnName = column.name)
+                    add("ALTER COLUMN $colName SET DEFAULT nextval('$fallbackSequenceName')")
                 }
+            } else if (columnDiff.autoInc && column.autoIncColumnType == null) {
+                // based on logic in SchemaUtils.isIncorrectAutoInc this should only be possible if the existing
+                // column in database is auto-incrementing while defined table is not
+                add("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
+                add("ALTER COLUMN $colName DROP DEFAULT")
+            } else if (columnDiff.type) {
+                add("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
+            }
 
-                if (columnDiff.nullability) {
-                    append(", ALTER COLUMN $colName ")
-                    if (column.columnType.nullable) {
-                        append("DROP ")
-                    } else {
-                        append("SET ")
-                    }
-                    append("NOT NULL")
-                }
-                if (columnDiff.defaults) {
-                    column.dbDefaultValue?.let {
-                        append(", ALTER COLUMN $colName SET DEFAULT ${PostgreSQLDataTypeProvider.processForDefaultValue(it)}")
-                    } ?: run {
-                        append(", ALTER COLUMN $colName DROP DEFAULT")
-                    }
+            if (columnDiff.nullability) {
+                val nullability = if (column.columnType.nullable) "DROP" else "SET"
+                add("ALTER COLUMN $colName $nullability NOT NULL")
+            }
+            if (columnDiff.defaults) {
+                column.dbDefaultValue?.let {
+                    add("ALTER COLUMN $colName SET DEFAULT ${PostgreSQLDataTypeProvider.processForDefaultValue(it)}")
+                } ?: run {
+                    add("ALTER COLUMN $colName DROP DEFAULT")
                 }
             }
-        )
+        }
+
+        val list = mutableListOf<String>()
+        if (alterColumnParts.isNotEmpty()) {
+            list += "ALTER TABLE ${transaction.identity(column.table)} ${alterColumnParts.joinToString()}"
+        }
         if (columnDiff.autoInc && column.autoIncColumnType != null && column.autoIncColumnType?.sequence == null) {
             list.add(
                 buildString {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
@@ -408,7 +408,7 @@ open class PostgreSQLDialect(override val name: String = dialectName) : VendorDi
                 // column in database is auto-incrementing while defined table is not
                 add("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
                 add("ALTER COLUMN $colName DROP DEFAULT")
-            } else if (columnDiff.type) {
+            } else if (columnDiff.type || columnDiff.sizeAndScale) {
                 add("ALTER COLUMN $colName TYPE ${column.columnType.sqlType()}")
             }
 

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.v1.core.dao.id.UIntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.ULongIdTable
 import org.jetbrains.exposed.v1.core.dao.id.UuidTable
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.vendors.PrimaryKeyMetadata
@@ -408,6 +409,28 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
             }
 
             assertEqualLists(MigrationUtils.statementsRequiredForDatabaseMigration(testerWithAnotherDefinition), emptyList())
+        }
+    }
+
+    @Test
+    fun testUuidDefaultExpressionMigrationDoesNotAlterType() {
+        val initialTable = object : IdTable<JavaUUID>("locations") {
+            override val id = javaUUID("id").entityId()
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, initialTable) {
+            val tableWithDefault = object : IdTable<JavaUUID>("locations") {
+                private val randomUuid = CustomFunction<JavaUUID>("gen_random_uuid", UUIDColumnType())
+
+                override val id = javaUUID("id").defaultExpression(randomUuid).entityId()
+                override val primaryKey = PrimaryKey(id)
+            }
+
+            assertEqualLists(
+                listOf("ALTER TABLE locations ALTER COLUMN id SET DEFAULT gen_random_uuid()"),
+                MigrationUtils.statementsRequiredForDatabaseMigration(tableWithDefault, withLogs = false)
+            )
         }
     }
 

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.v1.core.dao.id.UIntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.ULongIdTable
 import org.jetbrains.exposed.v1.core.dao.id.UuidTable
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.vendors.PrimaryKeyMetadata
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
@@ -399,6 +400,28 @@ class DatabaseMigrationTests : R2dbcDatabaseTestsBase() {
             }
 
             assertEqualLists(MigrationUtils.statementsRequiredForDatabaseMigration(testerWithAnotherDefinition), emptyList())
+        }
+    }
+
+    @Test
+    fun testUuidDefaultExpressionMigrationDoesNotAlterType() {
+        val initialTable = object : IdTable<JavaUUID>("locations") {
+            override val id = javaUUID("id").entityId()
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, initialTable) {
+            val tableWithDefault = object : IdTable<JavaUUID>("locations") {
+                private val randomUuid = CustomFunction<JavaUUID>("gen_random_uuid", UUIDColumnType())
+
+                override val id = javaUUID("id").defaultExpression(randomUuid).entityId()
+                override val primaryKey = PrimaryKey(id)
+            }
+
+            assertEqualLists(
+                listOf("ALTER TABLE locations ALTER COLUMN id SET DEFAULT gen_random_uuid()"),
+                MigrationUtils.statementsRequiredForDatabaseMigration(tableWithDefault, withLogs = false)
+            )
         }
     }
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Avoid emitting a redundant PostgreSQL `ALTER COLUMN ... TYPE uuid` migration when only a UUID column default expression changed.

**Detailed description**:
- **Why**: PostgreSQL migration generation could report a type change for UUID columns even when the database column and Exposed table definition were both `uuid`, producing unnecessary SQL alongside the actual default change.
- **What**: PostgreSQL column migration generation now adds `ALTER COLUMN ... TYPE ...` only when `ColumnDiff.type` is set, while keeping the existing auto-increment handling intact.
- **How**: `PostgreSQLDialect.modifyColumn()` now builds the column alteration clauses from the individual diff flags before emitting the `ALTER TABLE` statement. A PostgreSQL regression test covers adding a `gen_random_uuid()` default expression to an existing UUID id column.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [X] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [X] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

Validation performed locally:
- `./gradlew :exposed-migration-jdbc:compileTestKotlin`
- `./gradlew :exposed-migration-jdbc:test_postgres --tests "org.jetbrains.exposed.v1.migration.jdbc.DatabaseMigrationTests.testUuidDefaultExpressionMigrationDoesNotAlterType"`
- `./gradlew :exposed-migration-jdbc:test_h2_v2 --tests "org.jetbrains.exposed.v1.migration.jdbc.DatabaseMigrationTests"`
- `./gradlew :exposed-core:apiCheck`
- `git diff --check`

---

#### Related Issues

Fixes #2442