### PR TITLE
chore: Migration from 0.61.0 to 1.0.0 version Claude skill

### DIFF
--- a/.claude/skills/migrate-to-1.0/SKILL.md
+++ b/.claude/skills/migrate-to-1.0/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: migrate-to-1.0
+description: "Migrates a Kotlin project from Exposed 0.x to Exposed 1.0. Scans Kotlin sources and build files, applies the mechanical changes documented in the official 1.0 migration guide (package renames, JDBC module moves, SqlExpressionBuilder lambda → top-level imports, build dependency bumps), and produces a report of items that need manual review. Use when the user wants to upgrade an existing Exposed project to 1.0 or mentions migrating from 0.x."
+user_invocable: true
+---
+
+# Migrate to Exposed 1.0
+
+Automates the **mechanical** parts of migrating a Kotlin project from Exposed 0.x to
+Exposed 1.0. Anything that requires human judgment is detected and reported in a summary
+at the end so the user can address it manually using the migration guide.
+
+The canonical source for what to migrate is the official guide:
+<https://github.com/JetBrains/Exposed/blob/main/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md>
+(or the local `Migration-Guide-1-0-0.md` if available).
+
+The reference files in `./references/` encode that guide as machine-applicable rules:
+
+- `package-renames.md` — every import-level rename, organised by category (always-apply,
+  JDBC-conditional, SqlExpressionBuilder, UUID, datetime, addLogger).
+- `module-detection.md` — heuristics for the project fact table
+  (`usesJdbc`, `usesR2dbc`, `usesDao`, …).
+- `build-files.md` — Gradle KTS / Groovy / version-catalog / Maven edit patterns.
+- `manual-review.md` — cases the skill must NOT auto-apply, with detection patterns.
+
+Load each reference file only when the corresponding phase below needs it.
+
+## Operating principles
+
+- Operate on the user's current working tree. Do **not** create branches or commits.
+- Never write outside the user's project root.
+- Never run `./gradlew` or any other build command on the user's project.
+- Idempotent at line level: every edit is a precise `Edit` (`old_string`/`new_string`),
+  so re-running the skill after partial completion is safe.
+- Cross-check: if a file was changed externally between Phase 1 and Phase 3 (an `Edit`
+  fails because `old_string` doesn't match), skip the file with a "skipped — file changed"
+  reason and continue.
+
+## Phase 1 — Discover (read-only)
+
+1. Detect Exposed version. Search these files for `org.jetbrains.exposed:` coordinates:
+    - `gradle/libs.versions.toml`
+    - all `build.gradle.kts` and `build.gradle` in the project (root + submodules)
+    - `pom.xml`
+      If no `0.x` Exposed coordinate is found, **stop here** and report
+      "no migration needed (no Exposed 0.x usage detected)."
+
+2. Build the project fact table per `references/module-detection.md`.
+
+3. Enumerate every Kotlin file under `src/` (recursively). For each file, run two scans:
+    - **Rename scan** — grep for any pattern in `references/package-renames.md` (sections
+      1–6). Record file:line + which pattern hit.
+    - **Manual-review scan** — grep for any pattern in `references/manual-review.md`.
+      Record file:line + which case.
+
+4. Print a Phase 1 summary to the user:
+   ```
+   Discovered:
+     • Exposed version <X.Y.Z> in <build files>
+     • Project flavor: usesJdbc=<bool>, usesR2dbc=<bool>, usesDao=<bool>, ...
+     • <N> Kotlin files contain 0.x imports (<M> imports total)
+     • <K> manual-review cases across <L> files
+     • Build files to update: <list>
+   ```
+
+## Phase 2 — Plan (interactive checkpoint)
+
+1. Print a one-paragraph plan to the user:
+   ```
+   Planned changes:
+     1. Apply <category-1> rewrites to <N1> files.
+     2. Apply <category-2> rewrites to <N2> files.
+     3. Update <build-file> dependencies.
+     4. Report <K> manual-review items at the end (no source edits).
+   ```
+
+2. **Stop and ask the user to confirm before any edits.** Wait for their response.
+
+3. If the user says "skip <category>", remove that category from the plan and proceed.
+   If the user declines, exit cleanly with no changes.
+
+## Phase 3 — Apply (write phase)
+
+For each Kotlin source file with rename hits, apply edits in this order:
+
+a. **Section 1 (always-apply renames)** from `references/package-renames.md`. Each row
+becomes one or more `Edit` calls (`old_string` = the 0.61.0 FQN; `new_string` = the
+1.0.0 FQN).
+
+b. **Section 2 (JDBC-conditional moves)** — only if the project's `usesJdbc` is true AND
+the file does not contain any R2DBC import. Apply each row as in (a).
+
+c. **Section 3 (`SqlExpressionBuilder` lambda imports)** — for every line of the form
+`import org.jetbrains.exposed.sql.SqlExpressionBuilder.<NAME>`, rewrite to
+`import org.jetbrains.exposed.v1.core.<NAME>`. The list of `<NAME>` values is in
+`package-renames.md` Section 3, but the rule is independent of which method —
+if the prefix matches, rewrite.
+
+d. **Section 4 (UUID)**, **Section 5 (Datetime)**, **Section 6 (StdOutSqlLogger / addLogger)**
+from `package-renames.md` — apply each row as in (a). For
+`import org.jetbrains.exposed.sql.addLogger`, **delete the import line** entirely
+instead of rewriting it (the function became a method).
+
+If any `Edit` fails (`old_string` not unique or not present), skip just that edit, record
+the reason, and continue with the rest of the file.
+
+For build files (`build.gradle.kts`, `build.gradle`, `gradle/libs.versions.toml`,
+`pom.xml`):
+
+e. Apply the patterns in `references/build-files.md` for the matching flavor. For
+ambiguous lines (a custom version variable that does not match the
+`exposed`-name rule), append `// TODO: review for Exposed 1.0` (or `# TODO: …`
+for `.toml`, or `<!-- TODO: ... -->` for XML) and add the line to the manual-review
+summary.
+
+The skill **never modifies** files matched by `manual-review.md` patterns beyond the
+mechanical rename edits in (a)–(d). The matches themselves get reported in Phase 4.
+
+## Phase 4 — Summarise
+
+Print a markdown report to stdout:
+
+````markdown
+# Migration summary
+
+## ✅ Files modified (<N> total)
+
+### Package renames (Section 1)
+
+- src/main/kotlin/com/example/Foo.kt — 4 imports
+- src/main/kotlin/com/example/Bar.kt — 2 imports
+  ...
+
+### JDBC moves (Section 2)
+
+- src/main/kotlin/com/example/Foo.kt — 3 imports
+  ...
+
+### SqlExpressionBuilder rewrites (Section 3)
+
+- src/main/kotlin/com/example/Foo.kt — 1 import
+  ...
+
+### UUID / Datetime / Logger
+
+- src/main/kotlin/com/example/Models.kt — 1 import
+
+## ✅ Build files modified
+
+```diff
+--- build.gradle.kts
++++ build.gradle.kts
+@@
+-implementation("org.jetbrains.exposed:exposed-core:0.61.0")
++implementation("org.jetbrains.exposed:exposed-core:1.0.0")
++implementation("org.jetbrains.exposed:exposed-jdbc:1.0.0")
+```
+
+## ⚠️ Manual review needed (<K> items)
+
+⚠️ src/main/kotlin/com/example/Tx.kt:42 custom-transaction-extension
+detected: fun Transaction.getVersion()
+guide:    "Transactions — Custom functions"
+action:   change the receiver to `JdbcTransaction`.
+
+⚠️ src/main/kotlin/com/example/Tx.kt:88 transaction-signature
+detected: transaction(db.transactionManager.defaultIsolationLevel, db = db) { ... }
+guide:    "transaction() signature changed"
+action:   db is now the first positional parameter; use named args for the rest.
+
+...
+
+## ⏭️ Skipped files (<S> total)
+
+- src/main/kotlin/com/example/Old.kt — old_string did not match (file may have been edited)
+
+## 📋 Suggested next steps
+
+1. Review the diff: `git diff`
+2. Compile: `./gradlew compileKotlin` (or your project's build command)
+3. Run tests: `./gradlew test`
+4. Address each ⚠️ item using the official migration guide:
+   https://github.com/JetBrains/Exposed/blob/main/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md
+5. When everything compiles and tests pass, commit:
+   `git commit -am "Migrate to Exposed 1.0"`
+````
+
+The skill stops here. No further actions, no commits.
+
+## Edge cases
+
+- **Project uses both JDBC and R2DBC.** The per-file decision in Phase 3 (b) handles this:
+  files importing R2DBC are not given JDBC-conditional moves.
+- **`exposed-spring-boot-starter`.** The skill does NOT replace it with
+  `exposed-spring-boot4-starter`. That's a Spring upgrade the user opts into. A note is
+  added to the manual-review summary instead.
+- **Custom Exposed-version variable.** If named to contain `exposed` (case-insensitive),
+  bumped automatically. Otherwise reported for manual review.
+- **No 0.x usage.** Exit cleanly in Phase 1 with "no migration needed."
+- **Nothing left to do after rerun.** All `Edit` calls fail because `old_string` is
+  already the new value. The summary reports zero modifications and zero skips.

--- a/.claude/skills/migrate-to-1.0/SKILL.md
+++ b/.claude/skills/migrate-to-1.0/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: migrate-to-1.0
-description: "Migrates a Kotlin project from Exposed 0.x to Exposed 1.0. Scans Kotlin sources and build files, applies the mechanical changes documented in the official 1.0 migration guide (package renames, JDBC module moves, SqlExpressionBuilder lambda → top-level imports, build dependency bumps), and produces a report of items that need manual review. Use when the user wants to upgrade an existing Exposed project to 1.0 or mentions migrating from 0.x."
+description: "Migrates a Kotlin project from Exposed 0.61.0 to Exposed 1.0. Scans Kotlin sources and build files, applies the mechanical changes documented in the official 1.0 migration guide (package renames, JDBC module moves, SqlExpressionBuilder lambda → top-level imports, build dependency bumps), and produces a report of items that need manual review. Use when the user wants to upgrade an existing Exposed 0.61.0 project to 1.0; for older 0.x versions the skill emits a compatibility warning and proceeds only with user confirmation."
 user_invocable: true
 ---
 
 # Migrate to Exposed 1.0
 
-Automates the **mechanical** parts of migrating a Kotlin project from Exposed 0.x to
-Exposed 1.0. Anything that requires human judgment is detected and reported in a summary
-at the end so the user can address it manually using the migration guide.
+Automates the **mechanical** parts of migrating a Kotlin project from Exposed **0.61.0**
+to Exposed 1.0. Anything that requires human judgment is detected and reported in a
+summary at the end so the user can address it manually using the migration guide.
+
+**Supported starting version: 0.61.0** (the last pre-1.0 release). The official
+Migration-Guide-1-0-0.md was written specifically for the 0.61.0 → 1.0.0 jump. If the
+detected version is older (e.g. 0.41.x, 0.55.x), the skill warns and asks for explicit
+confirmation before proceeding: the rules will still rewrite the package paths it
+recognises, but APIs introduced between the detected version and 0.61.0 are out of
+scope, and the user should upgrade to 0.61.0 first or expect a noisier manual-review
+list.
 
 The canonical source for what to migrate is the official guide:
-<https://github.com/JetBrains/Exposed/blob/main/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md>
+<https://www.jetbrains.com/help/exposed/migration-guide-1-0-0.html>
 (or the local `Migration-Guide-1-0-0.md` if available).
 
 The reference files in `./references/` encode that guide as machine-applicable rules:
@@ -38,12 +46,54 @@ Load each reference file only when the corresponding phase below needs it.
 
 ## Phase 1 — Discover (read-only)
 
-1. Detect Exposed version. Search these files for `org.jetbrains.exposed:` coordinates:
-    - `gradle/libs.versions.toml`
-    - all `build.gradle.kts` and `build.gradle` in the project (root + submodules)
-    - `pom.xml`
-      If no `0.x` Exposed coordinate is found, **stop here** and report
-      "no migration needed (no Exposed 0.x usage detected)."
+1. Determine whether migration is needed.
+
+   The real signal is whether any source file uses the old `0.x` package paths
+   (`org.jetbrains.exposed.sql.*`, `org.jetbrains.exposed.dao.*`,
+   `org.jetbrains.exposed.r2dbc.sql.*`, …). Version coordinates in build files are a
+   useful hint but don't always reflect reality — projects on a `1.0.0-beta-N` /
+   `1.0.0-rc-N` release already use the `v1.*` namespace and don't need this skill,
+   even though their coordinate isn't strictly `0.x`.
+
+   a. **Source scan:** look for any `import org.jetbrains.exposed.sql.` or
+      `import org.jetbrains.exposed.dao.` (and the R2DBC equivalents) in any `.kt`
+      file under `src/`. Record file:line for use in the rename-scan step below.
+
+   b. **Build-file scan:** look for `org.jetbrains.exposed:` coordinates in
+      `gradle/libs.versions.toml`, every `build.gradle.kts` / `build.gradle`, and
+      `pom.xml`. Record every coordinate version found.
+
+   c. If (a) finds zero old-namespace imports AND (b) finds no pre-1.0 coordinate
+      (everything is either `1.0.0` proper or higher, or no Exposed coordinate at all),
+      **stop here** and report:
+      ```
+      No migration needed. Your project does not use the old `org.jetbrains.exposed.sql.*` /
+      `.dao.*` namespace and the build files do not pin a pre-1.0 release. Projects on
+      `1.0.0-beta-N` / `1.0.0-rc-N` already use the new `v1.*` namespace and don't need
+      this skill.
+      ```
+
+   d. Otherwise, migration applies. Proceed with the version check below.
+
+   **Version check.** The supported starting version is `0.61.0`. If the detected
+   coordinate is something else under `0.x` (e.g. `0.41.x`, `0.55.x`), print the
+   warning below and let the user decide whether to continue:
+   ```
+   ⚠️  Detected Exposed <X.Y.Z>, but this skill targets the 0.61.0 → 1.0.0 migration.
+       Older 0.x versions may use APIs that were renamed or removed before 0.61.0;
+       those changes are NOT covered by this skill. Recommended path:
+         1. Upgrade your project to Exposed 0.61.0 first.
+         2. Re-run this skill.
+       Proceed anyway? The skill will rewrite recognised package paths, but expect a
+       noisier "manual review" list and possibly missed changes.
+   ```
+   If the user declines, exit cleanly. If they confirm, continue but include the
+   version-mismatch warning in the Phase 4 summary.
+
+   Beta/RC of 1.0 with `sql.*` imports somehow still present (e.g. a half-finished
+   manual migration) is also valid input: the source scan in (a) catches it and the
+   skill proceeds without emitting the `0.61.0` warning, since the user is already
+   targeting 1.0.0.
 
 2. Build the project fact table per `references/module-detection.md`.
 
@@ -180,7 +230,7 @@ action:   db is now the first positional parameter; use named args for the rest.
 2. Compile: `./gradlew compileKotlin` (or your project's build command)
 3. Run tests: `./gradlew test`
 4. Address each ⚠️ item using the official migration guide:
-   https://github.com/JetBrains/Exposed/blob/main/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md
+   https://www.jetbrains.com/help/exposed/migration-guide-1-0-0.html
 5. When everything compiles and tests pass, commit:
    `git commit -am "Migrate to Exposed 1.0"`
 ````

--- a/.claude/skills/migrate-to-1.0/references/build-files.md
+++ b/.claude/skills/migrate-to-1.0/references/build-files.md
@@ -1,0 +1,141 @@
+# Build-file edit patterns
+
+This file describes the mechanical edits the skill applies to a project's build
+configuration. The skill loads this file during Phase 3 (Apply) after detecting which
+build flavor the project uses.
+
+## Goals of the build-file edit phase
+
+For every recognized build-file flavor, the skill must:
+
+1. Bump every Exposed coordinate from `0.x.y` to `1.0.0`.
+2. Add `org.jetbrains.exposed:exposed-jdbc:1.0.0` if the project depends on `exposed-core`
+   but neither `exposed-jdbc` nor `exposed-r2dbc` (as `module-detection.md` flagged).
+3. Replace `exposed-migration` with `exposed-migration-core` AND `exposed-migration-jdbc`
+   (or `-r2dbc`, depending on `usesJdbc`/`usesR2dbc`) — see migration guide section
+   "Migration dependencies".
+4. Leave `exposed-spring-boot-starter` alone (still valid for Spring 6 / Spring Boot 3).
+   Do NOT auto-replace it with `exposed-spring-boot4-starter` — that's a Spring upgrade
+   the user must opt in to. Add a note to the manual-review summary instead.
+
+Anything ambiguous (custom version variables holding the version of >1 unrelated
+artifact, externally generated build scripts, etc.) is left alone with a comment
+`// TODO: review for Exposed 1.0` appended on the relevant line.
+
+## Pattern A — Gradle Kotlin DSL (`build.gradle.kts`)
+
+### A1. Direct version bump
+
+Match (regex over a single line):
+```
+implementation\("org\.jetbrains\.exposed:(exposed-[a-z0-9-]+):0\.[^"]+"\)
+```
+Replace with:
+```
+implementation("org.jetbrains.exposed:$1:1.0.0")
+```
+Same for `api`, `compileOnly`, `runtimeOnly`, `testImplementation`, etc. — the rule is on
+the artifact coordinate, not the configuration name.
+
+### A2. Variable-bound version
+
+Match a top-level `val` whose name contains `exposed` (case-insensitive) and whose value
+is a `0.x.y` string:
+```
+val exposedVersion = "0.61.0"
+```
+Replace with:
+```
+val exposedVersion = "1.0.0"
+```
+If the variable name does not contain `exposed`, leave it alone and add the line to the
+manual-review summary.
+
+### A3. `exposed-migration` split
+
+If a line matches:
+```
+implementation("org.jetbrains.exposed:exposed-migration:0.61.0")
+```
+Replace with two lines:
+```
+implementation("org.jetbrains.exposed:exposed-migration-core:1.0.0")
+implementation("org.jetbrains.exposed:exposed-migration-jdbc:1.0.0")
+```
+(use `-r2dbc` instead of `-jdbc` if `usesJdbc == false && usesR2dbc == true`).
+
+### A4. Add `exposed-jdbc` if missing
+
+If `exposed-core` is present and neither `exposed-jdbc` nor `exposed-r2dbc` is, append
+to the same `dependencies { ... }` block:
+```
+implementation("org.jetbrains.exposed:exposed-jdbc:1.0.0")
+```
+
+## Pattern B — Gradle Groovy DSL (`build.gradle`)
+
+Same rules as A, but with single quotes and Groovy `implementation 'group:name:version'`
+syntax. Replace double-quote forms `"..."` with the matching `'...'` form.
+
+## Pattern C — Version catalog (`gradle/libs.versions.toml`)
+
+### C1. Version bump in `[versions]`
+
+Match:
+```
+exposed = "0.61.0"
+```
+Replace with:
+```
+exposed = "1.0.0"
+```
+Variable name may also be `exposed-version` or similar — use a case-insensitive
+contains-`exposed` rule.
+
+### C2. Add `exposed-jdbc` library entry if missing
+
+If `exposed-core` exists in `[libraries]` and `exposed-jdbc` does not, append to
+`[libraries]`:
+```
+exposed-jdbc = { group = "org.jetbrains.exposed", name = "exposed-jdbc", version.ref = "exposed" }
+```
+The user must add `implementation(libs.exposed.jdbc)` to their `build.gradle.kts` —
+flag this in the manual-review summary because the catalog change alone doesn't add the
+dependency to any module.
+
+### C3. `exposed-migration` split
+
+If a `exposed-migration = ...` line exists, replace with:
+```
+exposed-migration-core = { group = "org.jetbrains.exposed", name = "exposed-migration-core", version.ref = "exposed" }
+exposed-migration-jdbc = { group = "org.jetbrains.exposed", name = "exposed-migration-jdbc", version.ref = "exposed" }
+```
+Flag the `libs.exposed.migration` consumer sites for manual update.
+
+## Pattern D — Maven (`pom.xml`)
+
+### D1. Version bump
+
+Match every `<dependency>` block whose `<groupId>org.jetbrains.exposed</groupId>` and
+`<version>0.x.y</version>`. Replace `<version>0.x.y</version>` with `<version>1.0.0</version>`.
+
+### D2. Add `exposed-jdbc`
+
+If `exposed-core` is present without `exposed-jdbc` or `exposed-r2dbc`, append a new
+`<dependency>` block for `exposed-jdbc:1.0.0` inside `<dependencies>`.
+
+### D3. `exposed-migration` split
+
+If `exposed-migration` is present, replace its `<dependency>` block with two:
+`exposed-migration-core` and `exposed-migration-jdbc`.
+
+## What to flag for manual review
+
+After the mechanical edits, add these to the manual-review summary if they apply:
+
+- Any `exposed-spring-boot-starter` usage with a note: "If you also want to migrate to
+  Spring Boot 4, replace this artifact with `exposed-spring-boot4-starter`. Otherwise
+  leave as-is."
+- Any version variable that did not match the `exposed`-named-variable rule.
+- Any custom convention plugin / `buildSrc` indirection touched during detection but not
+  edited.

--- a/.claude/skills/migrate-to-1.0/references/build-files.md
+++ b/.claude/skills/migrate-to-1.0/references/build-files.md
@@ -4,6 +4,13 @@ This file describes the mechanical edits the skill applies to a project's build
 configuration. The skill loads this file during Phase 3 (Apply) after detecting which
 build flavor the project uses.
 
+> **Scope note.** The version-bump regex below matches any pre-1.0 Exposed coordinate
+> (`0.x.y`) so the bump itself is purely mechanical. **The accompanying rename rules**
+> in `package-renames.md`, however, are derived specifically from the 0.61.0 → 1.0.0
+> migration guide. On a project pinned to an older 0.x version (say 0.41.x), the bump
+> still works but the rename coverage may be incomplete and the manual-review list will
+> be noisier. The skill warns the user about a version mismatch in Phase 1.
+
 ## Goals of the build-file edit phase
 
 For every recognized build-file flavor, the skill must:
@@ -133,9 +140,16 @@ If `exposed-migration` is present, replace its `<dependency>` block with two:
 
 After the mechanical edits, add these to the manual-review summary if they apply:
 
-- Any `exposed-spring-boot-starter` usage with a note: "If you also want to migrate to
-  Spring Boot 4, replace this artifact with `exposed-spring-boot4-starter`. Otherwise
-  leave as-is."
+- Any `exposed-spring-boot-starter` usage with a note: "Staying on Spring Boot 3 / Spring
+  Framework 6? Leave this artifact as-is. If you ALSO want to migrate to Spring Boot 4 /
+  Spring Framework 7, this artifact alone is not enough — you'll need to swap it for
+  `exposed-spring-boot4-starter` AND update import paths (e.g.
+  `org.jetbrains.exposed.v1.spring.boot.autoconfigure.ExposedAutoConfiguration` →
+  `org.jetbrains.exposed.v1.spring.boot4.autoconfigure.ExposedAutoConfiguration`).
+  Users of `SpringTransactionManager` directly should also swap the `spring-transaction`
+  dependency for `spring7-transaction`. See the full guidance in the migration guide
+  section **Spring dependencies**:
+  <https://www.jetbrains.com/help/exposed/migration-guide-1-0-0.html#spring-dependencies>."
 - Any version variable that did not match the `exposed`-named-variable rule.
 - Any custom convention plugin / `buildSrc` indirection touched during detection but not
   edited.

--- a/.claude/skills/migrate-to-1.0/references/manual-review.md
+++ b/.claude/skills/migrate-to-1.0/references/manual-review.md
@@ -1,0 +1,62 @@
+# Manual review
+
+This file lists migration cases the skill detects but does NOT auto-apply. For each case,
+the skill prints the file:line, what was detected, the migration-guide section, and a
+short instruction.
+
+## Detection patterns
+
+The skill greps every Kotlin file under `src/` for these patterns. Any match becomes one
+line in the manual-review summary. The skill does not edit these files except to apply
+unrelated import renames.
+
+| # | What to detect (substring or pattern)             | Migration-guide section                           | What the user must do                                                                                                  |
+|---|---------------------------------------------------|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| 1 | `fun Transaction.` (extension on the `Transaction` receiver) | "Transactions — Custom functions"      | Change the receiver to `JdbcTransaction` (or `R2dbcTransaction` for R2DBC code).                                       |
+| 2 | `inTopLevelTransaction(` with a positional first arg that is `Connection.TRANSACTION_*` | "transaction() signature changed" | Convert the call to use the named arg `transactionIsolation = …`. The first positional arg slot is now `db: Database`. |
+| 3 | `transaction(` with two-or-more positional args (any of which is a `transactionIsolation` value) | same as above                         | Same — use named args; `db` is now first.                                                                              |
+| 4 | `: Statement<` or `class … : Statement(` (custom `Statement` subclass) | "Statement builders and executables — Custom statements" | The `StatementType` parameter type changed from `String` to a sealed class. Update accordingly.                        |
+| 5 | `.exec(` followed by a positional `StatementType.X` arg | "exec() parameter type changed"                   | Pass the new sealed-class form.                                                                                        |
+| 6 | `class … : VendorDialect(`, `class … : DatabaseDialect(` | "DatabaseDialect and VendorDialect — Custom dialects"   | Multiple property-type signatures changed. Read the section.                                                            |
+| 7 | `.set(` or `.setArray(` on a `PreparedStatementApi` receiver | "PreparedStatementApi — set() removed", "setArray() removed" | These methods were removed. Use the new typed setters listed in the guide.                                              |
+| 8 | `: BaseBatchInsertStatement` (custom subclass)    | "BaseBatchInsertStatement removed"                | The class was removed. Switch to `BatchInsertStatement` or another supported type.                                      |
+| 9 | `CommentPosition.` reference                      | "CommentPosition ownership changed"               | The enum moved. Update the import; the qualifier-using-class changed.                                                  |
+| 10 | `.value` access on a `Case` object                | "Case property value removed"                     | The property was removed; use the alternative documented in the section.                                                |
+| 11 | `readObject(` override with a `String` parameter (custom `ColumnType`) | "readObject() parameter type changed"      | The parameter is now `Int` (column index). Update the override signature.                                              |
+| 12 | `ResultRow.create(` call                          | "ResultRow.create() parameter type changed"       | The factory's parameter type changed. Inspect call site.                                                               |
+| 13 | `StatementResult.Object.` reference               | "StatementResult.Object property type changed"    | Property type changed. Inspect the consumer.                                                                            |
+| 14 | `.execute(` whose return value is bound to a previously-typed variable | "execute() return type changed" | Return type is now driver-specific. Adjust the variable type or call.                                                  |
+| 15 | `areEquivalentColumnTypes(` reference             | "areEquivalentColumnTypes() deprecated"           | The function is deprecated; use the documented replacement.                                                            |
+| 16 | `resolveRefOptionFromJdbc(` reference             | "resolveRefOptionFromJdbc() removed"              | Removed. See the section for the alternative.                                                                          |
+| 17 | `supportsSelectForUpdate` property reference      | "supportsSelectForUpdate deprecated"              | Property is deprecated; use replacement.                                                                                |
+| 18 | `ENABLE_UPDATE_DELETE_LIMIT` reference            | "ENABLE_UPDATE_DELETE_LIMIT removed"              | Removed entirely.                                                                                                       |
+
+## Output format in the summary
+
+For each match, the summary line uses:
+
+```
+⚠️  <file>:<line>  <category>
+    detected: <short description>
+    guide:    <migration-guide section>
+    action:   <what to do>
+```
+
+Example:
+
+```
+⚠️  src/main/kotlin/com/example/Tx.kt:42  custom-transaction-extension
+    detected: fun Transaction.getVersion()
+    guide:    "Transactions — Custom functions"
+    action:   change the receiver to `JdbcTransaction` (or `R2dbcTransaction` for R2DBC).
+```
+
+## What the skill must NOT do for these cases
+
+- Do NOT rewrite the matched line, even partially. The risk of producing a half-broken edit
+  is higher than the value of the partial fix.
+- Do NOT add `// TODO` comments next to source lines (only to build-file lines per
+  `build-files.md`). Source files get reported via the summary; the user reviews on a
+  separate pass.
+- Do NOT skip subsequent steps just because a manual-review match was found. The skill
+  proceeds with mechanical changes in the same file.

--- a/.claude/skills/migrate-to-1.0/references/module-detection.md
+++ b/.claude/skills/migrate-to-1.0/references/module-detection.md
@@ -1,0 +1,81 @@
+# Module detection
+
+This file describes how the skill determines which Exposed modules a user's project depends
+on. The result is a small fact table the skill keeps in mind for the duration of one
+invocation:
+
+```
+{
+  "usesJdbc":            true | false,
+  "usesR2dbc":           true | false,
+  "usesDao":             true | false,
+  "usesSpring":          true | false,    // either spring-boot-starter or spring-boot4-starter
+  "usesSpring4":         true | false,    // boot4-starter specifically
+  "usesJson":            true | false,
+  "usesKotlinDatetime":  true | false,
+  "usesJodatime":        true | false,
+  "usesJavatime":        true | false,
+  "usesMigration":       true | false,
+  "usesCrypt":           true | false,
+  "usesMoney":           true | false
+}
+```
+
+## Detection — primary: build-file scan
+
+Look in the user's build files for these artifact IDs. Files to scan, in order:
+
+1. `gradle/libs.versions.toml`
+2. `build.gradle.kts` (project root + any submodule)
+3. `build.gradle` (Groovy variant)
+4. `pom.xml`
+
+For each file, search for the substrings below. Any match anywhere in the file flips
+the corresponding flag to `true`.
+
+| Artifact ID                     | Sets flag         |
+|---------------------------------|-------------------|
+| `exposed-jdbc`                  | usesJdbc          |
+| `exposed-r2dbc`                 | usesR2dbc         |
+| `exposed-dao`                   | usesDao           |
+| `exposed-spring-boot-starter`   | usesSpring        |
+| `exposed-spring-boot4-starter`  | usesSpring, usesSpring4 |
+| `exposed-json`                  | usesJson          |
+| `exposed-kotlin-datetime`       | usesKotlinDatetime |
+| `exposed-jodatime`              | usesJodatime      |
+| `exposed-java-time`             | usesJavatime      |
+| `exposed-migration` (or any `exposed-migration-*`) | usesMigration |
+| `exposed-crypt`                 | usesCrypt         |
+| `exposed-money`                 | usesMoney         |
+
+Special rule: a project that depends on `exposed-core` but on neither `exposed-jdbc` nor
+`exposed-r2dbc` is treated as `usesJdbc = true` (the 0.x default before the JDBC/R2DBC
+split). The skill records this as a "build-file change required" finding so the user adds
+the explicit `exposed-jdbc` dependency.
+
+## Detection — fallback: source-code scan
+
+If the build-file scan finds zero `exposed-*` artifacts (which can happen when the user
+uses a custom convention plugin or `buildSrc` indirection), fall back to grepping all
+Kotlin files under `src/` for these markers:
+
+| Pattern                                        | Sets flag     |
+|------------------------------------------------|---------------|
+| `org.jetbrains.exposed.sql.transactions.transaction` | usesJdbc      |
+| `R2dbcDatabase.connect`                              | usesR2dbc     |
+| `: IntEntity\(`, `: LongEntity\(`, `: UUIDEntity\(` (regex) | usesDao    |
+| `org.jetbrains.exposed.spring`                       | usesSpring    |
+
+The fallback is best-effort — if it returns no flags, the skill exits Phase 1 with
+"could not determine project flavor" and asks the user to confirm `usesJdbc` / `usesR2dbc`.
+
+## Per-file rule
+
+In addition to the project-level fact table, the skill makes a per-file decision when
+applying JDBC-conditional moves (Section 2 of `package-renames.md`). For a given Kotlin
+file:
+
+- If the file already imports `org.jetbrains.exposed.v1.r2dbc.*` or any pre-1.0 R2DBC
+  equivalent (`R2dbcDatabase`, etc.), skip JDBC-conditional moves *for that file* even
+  if the project as a whole has `usesJdbc = true`.
+- Otherwise apply JDBC-conditional moves to that file (if `usesJdbc` is true).

--- a/.claude/skills/migrate-to-1.0/references/module-detection.md
+++ b/.claude/skills/migrate-to-1.0/references/module-detection.md
@@ -9,8 +9,7 @@ invocation:
   "usesJdbc":            true | false,
   "usesR2dbc":           true | false,
   "usesDao":             true | false,
-  "usesSpring":          true | false,    // either spring-boot-starter or spring-boot4-starter
-  "usesSpring4":         true | false,    // boot4-starter specifically
+  "usesSpring":          true | false,    // spring-boot-starter
   "usesJson":            true | false,
   "usesKotlinDatetime":  true | false,
   "usesJodatime":        true | false,
@@ -20,6 +19,11 @@ invocation:
   "usesMoney":           true | false
 }
 ```
+
+> `exposed-spring-boot4-starter` is deliberately **not** in the detection table. It only
+> exists in Exposed 1.0+, so a project being migrated from 0.x cannot have it yet. The
+> manual-review note in `build-files.md` advises the user about it as part of the
+> migration target, not as something to detect in the source project.
 
 ## Detection — primary: build-file scan
 
@@ -39,7 +43,6 @@ the corresponding flag to `true`.
 | `exposed-r2dbc`                 | usesR2dbc         |
 | `exposed-dao`                   | usesDao           |
 | `exposed-spring-boot-starter`   | usesSpring        |
-| `exposed-spring-boot4-starter`  | usesSpring, usesSpring4 |
 | `exposed-json`                  | usesJson          |
 | `exposed-kotlin-datetime`       | usesKotlinDatetime |
 | `exposed-jodatime`              | usesJodatime      |

--- a/.claude/skills/migrate-to-1.0/references/package-renames.md
+++ b/.claude/skills/migrate-to-1.0/references/package-renames.md
@@ -1,0 +1,161 @@
+# Package renames
+
+This file lists every package-level rename that the skill applies to Kotlin source files,
+extracted from `Migration-Guide-1-0-0.md`. The skill loads this file during Phase 3 (Apply).
+
+The skill replaces full FQNs in `import` statements via `Edit`. It does not parse Kotlin AST;
+matching is purely textual on lines that start with `import org.jetbrains.exposed.`.
+
+## Section 1 — Pure renames (always apply)
+
+These renames apply unconditionally to any project. Source: migration guide section
+"Updated imports".
+
+| Old (0.61.0)                                  | New (1.0.0)                                     |
+|-----------------------------------------------|-------------------------------------------------|
+| `org.jetbrains.exposed.sql.Table`             | `org.jetbrains.exposed.v1.core.Table`           |
+| `org.jetbrains.exposed.sql.AbstractQuery`     | `org.jetbrains.exposed.v1.core.AbstractQuery`   |
+| `org.jetbrains.exposed.sql.Expression`        | `org.jetbrains.exposed.v1.core.Expression`      |
+| `org.jetbrains.exposed.dao.id.EntityID`       | `org.jetbrains.exposed.v1.core.dao.id.EntityID` |
+| `org.jetbrains.exposed.dao.IntEntity`         | `org.jetbrains.exposed.v1.dao.IntEntity`        |
+| `org.jetbrains.exposed.sql.javatime.datetime` | `org.jetbrains.exposed.v1.javatime.datetime`    |
+| `org.jetbrains.exposed.sql.json.json`         | `org.jetbrains.exposed.v1.json.json`            |
+| `org.jetbrains.exposed.sql.Transaction`       | `org.jetbrains.exposed.v1.core.Transaction`     |
+| `org.jetbrains.exposed.sql.TextColumnType`    | `org.jetbrains.exposed.v1.core.TextColumnType`  |
+| `org.jetbrains.exposed.sql.and`               | `org.jetbrains.exposed.v1.core.and`             |
+| `org.jetbrains.exposed.sql.count`             | `org.jetbrains.exposed.v1.core.count`           |
+| `org.jetbrains.exposed.sql.eq`                | `org.jetbrains.exposed.v1.core.eq`              |
+| `org.jetbrains.exposed.sql.greaterEq`         | `org.jetbrains.exposed.v1.core.greaterEq`       |
+| `org.jetbrains.exposed.sql.isNull`            | `org.jetbrains.exposed.v1.core.isNull`          |
+| `org.jetbrains.exposed.sql.isNotNull`         | `org.jetbrains.exposed.v1.core.isNotNull`       |
+| `org.jetbrains.exposed.sql.less`              | `org.jetbrains.exposed.v1.core.less`            |
+| `org.jetbrains.exposed.sql.like`              | `org.jetbrains.exposed.v1.core.like`            |
+| `org.jetbrains.exposed.sql.longLiteral`       | `org.jetbrains.exposed.v1.core.longLiteral`     |
+| `org.jetbrains.exposed.sql.plus`              | `org.jetbrains.exposed.v1.core.plus`            |
+| `org.jetbrains.exposed.sql.statements.BatchInsertStatement` | `org.jetbrains.exposed.v1.core.statements.BatchInsertStatement` |
+| `org.jetbrains.exposed.sql.statements.DeleteStatement`      | `org.jetbrains.exposed.v1.core.statements.DeleteStatement`      |
+| `org.jetbrains.exposed.sql.statements.api.RowApi`           | `org.jetbrains.exposed.v1.core.statements.api.RowApi`           |
+| `org.jetbrains.exposed.dao.id.IntIdTable`     | `org.jetbrains.exposed.v1.core.dao.id.IntIdTable` |
+| `org.jetbrains.exposed.dao.id.LongIdTable`    | `org.jetbrains.exposed.v1.core.dao.id.LongIdTable` |
+| `org.jetbrains.exposed.dao.id.CompositeIdTable` | `org.jetbrains.exposed.v1.core.dao.id.CompositeIdTable` |
+| `org.jetbrains.exposed.dao.IntEntityClass`    | `org.jetbrains.exposed.v1.dao.IntEntityClass`   |
+| `org.jetbrains.exposed.dao.LongEntity`        | `org.jetbrains.exposed.v1.dao.LongEntity`       |
+| `org.jetbrains.exposed.dao.LongEntityClass`   | `org.jetbrains.exposed.v1.dao.LongEntityClass`  |
+| `org.jetbrains.exposed.dao.CompositeEntity`   | `org.jetbrains.exposed.v1.dao.CompositeEntity`  |
+| `org.jetbrains.exposed.dao.CompositeEntityClass` | `org.jetbrains.exposed.v1.dao.CompositeEntityClass` |
+| `org.jetbrains.exposed.sql.kotlin.datetime.CurrentDate` | `org.jetbrains.exposed.v1.datetime.CurrentDate` |
+| `org.jetbrains.exposed.sql.transactions.TransactionManagerApi` | `org.jetbrains.exposed.v1.core.transactions.TransactionManagerApi` |
+
+**Wildcard imports also apply.** Treat each row as a prefix rule when the user has
+`import org.jetbrains.exposed.sql.*` etc.: rewrite it to the corresponding `v1.core.*`
+or `v1.dao.*` wildcard.
+
+## Section 2 — JDBC-conditional moves (apply only if `usesJdbc == true`)
+
+These imports moved from `exposed-core` to `exposed-jdbc`. They must NOT be rewritten in
+files that are R2DBC-only. Source: migration guide section "Moved imports".
+
+When a file matches both a wildcard rule and a specific rule for the same import, apply the more specific rule first — the wildcard exists only as a fallback.
+
+| Old (0.61.0)                                                | New (1.0.0)                                                     |
+|-------------------------------------------------------------|-----------------------------------------------------------------|
+| `org.jetbrains.exposed.sql.Database`                        | `org.jetbrains.exposed.v1.jdbc.Database`                        |
+| `org.jetbrains.exposed.sql.SchemaUtils`                     | `org.jetbrains.exposed.v1.jdbc.SchemaUtils`                     |
+| `org.jetbrains.exposed.sql.Query`                           | `org.jetbrains.exposed.v1.jdbc.Query`                           |
+| `org.jetbrains.exposed.sql.transactions.TransactionManager` | `org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager` |
+| `org.jetbrains.exposed.sql.transactions.transaction`        | `org.jetbrains.exposed.v1.jdbc.transactions.transaction`        |
+| `org.jetbrains.exposed.sql.select`                          | `org.jetbrains.exposed.v1.jdbc.select`                          |
+| `org.jetbrains.exposed.sql.selectAll`                       | `org.jetbrains.exposed.v1.jdbc.selectAll`                       |
+| `org.jetbrains.exposed.sql.andWhere`                        | `org.jetbrains.exposed.v1.jdbc.andWhere`                        |
+| `org.jetbrains.exposed.sql.exists`                          | `org.jetbrains.exposed.v1.jdbc.exists`                          |
+| `org.jetbrains.exposed.sql.insert`                          | `org.jetbrains.exposed.v1.jdbc.insert`                          |
+| `org.jetbrains.exposed.sql.update`                          | `org.jetbrains.exposed.v1.jdbc.update`                          |
+| `org.jetbrains.exposed.sql.transactions.*`                  | `org.jetbrains.exposed.v1.jdbc.transactions.*`                  |
+| `org.jetbrains.exposed.sql.transactions.inTopLevelTransaction` | `org.jetbrains.exposed.v1.jdbc.transactions.inTopLevelTransaction` |
+| `org.jetbrains.exposed.sql.vendors.currentDialect`          | `org.jetbrains.exposed.v1.jdbc.vendors.currentDialectMetadata`  |
+| `org.jetbrains.exposed.sql.statements.toExecutable`         | `org.jetbrains.exposed.v1.jdbc.statements.toExecutable`         |
+| `org.jetbrains.exposed.sql.statements.jdbc.JdbcResult`      | `org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult`      |
+| `org.jetbrains.exposed.sql.migration.MigrationUtils`        | `org.jetbrains.exposed.v1.migration.jdbc.MigrationUtils`        |
+
+**Per-file decision rule:** if a file imports `R2dbcDatabase` or
+`org.jetbrains.exposed.v1.r2dbc.*` (or pre-1.0 R2DBC equivalent), skip JDBC-conditional
+moves for that file even when `usesJdbc == true` at the project level.
+
+## Section 3 — `SqlExpressionBuilder` lambda imports (mechanical rewrite)
+
+The `SqlExpressionBuilder` qualifier is removed; methods are imported as top-level functions
+from `org.jetbrains.exposed.v1.core`. Source: migration guide section
+"`SqlExpressionBuilder` method imports".
+
+For every line of the form
+`import org.jetbrains.exposed.sql.SqlExpressionBuilder.<NAME>`,
+rewrite to
+`import org.jetbrains.exposed.v1.core.<NAME>`.
+
+Known method names (extracted from the migration guide examples):
+
+- `less`, `lessEq`, `greater`, `greaterEq`
+- `eq`, `neq`
+- `isNull`, `isNotNull`
+- `like`, `notLike`
+- `concat`, `plus`, `minus`, `times`, `div`, `rem`
+- `and`, `or`, `not`
+- `between`, `inList`, `notInList`
+
+If a name is not in this list but appears as
+`org.jetbrains.exposed.sql.SqlExpressionBuilder.<NAME>`, apply the same rewrite — the rule
+is independent of which method it is.
+
+## Section 4 — UUID column type rename
+
+Source: migration guide section "Updated UUID type classes".
+
+The original classes for storing `java.util.UUID` values have been moved to new `.java.*`
+packages to avoid name shadowing with the new `kotlin.uuid.Uuid` variants. The new
+`UuidColumnType`, `UuidTable`, `UuidEntity`, and `UuidEntityClass` classes accept
+`kotlin.uuid.Uuid` instead.
+
+| Old (0.61.0)                                      | New (1.0.0)                                                   |
+|---------------------------------------------------|---------------------------------------------------------------|
+| `org.jetbrains.exposed.sql.UUIDColumnType`        | `org.jetbrains.exposed.v1.core.java.UUIDColumnType`           |
+| `org.jetbrains.exposed.dao.id.UUIDTable`          | `org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable`         |
+| `org.jetbrains.exposed.dao.UUIDEntity`            | `org.jetbrains.exposed.v1.dao.java.UUIDEntity`                |
+| `org.jetbrains.exposed.dao.UUIDEntityClass`       | `org.jetbrains.exposed.v1.dao.java.UUIDEntityClass`           |
+
+Additionally, `Table.uuid()` now accepts `kotlin.uuid.Uuid`; to continue using
+`java.util.UUID` values, replace calls to `uuid()` with `javaUUID()` and add:
+`import org.jetbrains.exposed.v1.core.java.javaUUID`.
+
+## Section 5 — Datetime column type rename
+
+Source: migration guide section "Datetime column type classes refactored". Some
+class names changed when the column-type hierarchy was unified.
+
+The `exposed-java-time` and `exposed-kotlin-datetime` artifacts retain their original class
+names (only the package prefix changes from `org.jetbrains.exposed.sql.*` to
+`org.jetbrains.exposed.v1.*`). The `exposed-jodatime` artifact had more significant
+class-level renames:
+
+| Old (0.61.0)                                                          | New (1.0.0)                                                         |
+|-----------------------------------------------------------------------|---------------------------------------------------------------------|
+| `org.jetbrains.exposed.sql.jodatime.DateColumnType` (time=false)      | `org.jetbrains.exposed.v1.jodatime.JodaLocalDateColumnType`         |
+| `org.jetbrains.exposed.sql.jodatime.DateColumnType` (time=true)       | `org.jetbrains.exposed.v1.jodatime.JodaLocalDateTimeColumnType`     |
+| `org.jetbrains.exposed.sql.jodatime.LocalTimeColumnType`              | `org.jetbrains.exposed.v1.jodatime.JodaLocalTimeColumnType`         |
+| `org.jetbrains.exposed.sql.jodatime.DateTimeWithTimeZoneColumnType`   | `org.jetbrains.exposed.v1.jodatime.DateTimeWithTimeZoneColumnType`  |
+
+Note: `DateColumnType` in `exposed-jodatime` had a `time` boolean constructor parameter
+that determined which class it maps to in 1.0.0. If the call site uses `DateColumnType(time=false)`
+it becomes `JodaLocalDateColumnType`; `DateColumnType(time=true)` becomes
+`JodaLocalDateTimeColumnType`. This split cannot be resolved purely from import lines — flag
+it in the manual-review checklist when `org.jetbrains.exposed.sql.jodatime.DateColumnType`
+is found.
+
+## Section 6 — `addLogger` and `StdOutSqlLogger`
+
+| Old (0.61.0)                                | New (1.0.0)                                      |
+|---------------------------------------------|--------------------------------------------------|
+| `org.jetbrains.exposed.sql.StdOutSqlLogger` | `org.jetbrains.exposed.v1.core.StdOutSqlLogger`  |
+
+The free-function `import org.jetbrains.exposed.sql.addLogger` is removed entirely
+(in 1.0.0 `addLogger` is a method on the new `Transaction` class). The skill should
+delete the line, not rewrite it.

--- a/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md
+++ b/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md
@@ -11,6 +11,11 @@ to accommodate reactive database access while preserving existing functionality.
 If your project uses [Claude Code](https://claude.com/claude-code), you can apply the
 mechanical parts of this migration automatically.
 
+The skill targets the **0.61.0 → 1.0.0** migration specifically — the same scope as this
+guide. If your project is on an older 0.x release (for example 0.55.x or 0.41.x), the
+skill will warn and ask for confirmation before proceeding. The recommended path is to
+upgrade to 0.61.0 first and then re-run the skill.
+
 ### Install
 
 1. Download the skill folder from the Exposed repository:

--- a/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md
+++ b/documentation-website/Writerside/topics/Migration-Guide-1-0-0.md
@@ -6,6 +6,36 @@ This guide provides instructions on how to migrate from Exposed version 0.61.0 t
 Version 1.0.0 introduces R2DBC support on top of the existing JDBC support. Most of the changes in this release were made
 to accommodate reactive database access while preserving existing functionality.
 
+## Migrating with Claude Code
+
+If your project uses [Claude Code](https://claude.com/claude-code), you can apply the
+mechanical parts of this migration automatically.
+
+### Install
+
+1. Download the skill folder from the Exposed repository:
+   [`.claude/skills/migrate-to-1.0/`](https://github.com/JetBrains/Exposed/tree/main/.claude/skills/migrate-to-1.0).
+2. Copy the entire `migrate-to-1.0/` directory into your project at
+   `<your-project>/.claude/skills/migrate-to-1.0/`.
+
+### Run
+
+In Claude Code, from your project root, invoke:
+
+```
+/migrate-to-1.0
+```
+
+The skill scans your code, proposes a plan, asks you to confirm, and then applies the
+mechanical changes (imports, package renames, `SqlExpressionBuilder` lambda imports,
+build dependency bumps). Anything requiring human judgment — custom `Transaction`
+extensions, custom statements or dialects, the `transaction()` signature change, etc. —
+is reported in a summary at the end so you can address it manually using the rest of
+this guide.
+
+The skill operates only on your working tree; it does not create branches or commits.
+Review the changes with `git diff` and commit when you are satisfied.
+
 ## Import versioning and package renaming
 
 ### Updated imports


### PR DESCRIPTION
#### Description                                                                                                                                                               
                                                                                                                                                                               
  **Summary of the change**: Add a Claude Code skill, `migrate-to-1.0`, that automates the mechanical parts of upgrading a Kotlin project from Exposed 0.x to Exposed 1.0        
  (package renames, JDBC module moves, `SqlExpressionBuilder` lambda imports, build dependency bumps). The skill is documented in a new "Migrating with Claude Code" section in
  `Migration-Guide-1-0-0.md`.                                                                                                                                                    
                                                                                                                                                                              
                                                                                                                                                                                 
  #### How users use it                                                                                                                                                          
                                                                                                                                                                               
  ```
  # In the user's project root
  mkdir -p .claude/skills                                                                                                                                                        
  cp -r <exposed-checkout>/.claude/skills/migrate-to-1.0 .claude/skills/
                                                                                                                                                                                 
  # In Claude Code                                                                                                                                                             
  /migrate-to-1.0                                                                                                                                                                
  ```                                                                                                                                                                            
   
  The skill prints a discovery summary, asks for confirmation, then applies the mechanical edits and prints a review report. 