### PR TITLE
build: Declare plugin compatibility with Gradle features

### DIFF
--- a/exposed-gradle-plugin/build.gradle.kts
+++ b/exposed-gradle-plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.plugin.compatibility.compatibility
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -69,6 +70,11 @@ gradlePlugin {
             implementationClass = "org.jetbrains.exposed.v1.gradle.plugin.ExposedGradlePlugin"
             description = "Exposed Gradle Plugin configures the generation of migration scripts for applications that use Exposed"
             tags = setOf("exposed", "kotlin", "sql", "database", "orm")
+            compatibility {
+                features {
+                    configurationCache = true
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Add a `compatibility` block to the new plugins metadata block.

**Detailed description**:
- **Why**: According to the [plugin publish guide](https://plugins.gradle.org/docs/publish-plugin), this will eventually become a mandatory step.


Confirmed locally that the plugin is compatible with the configuration cache using the following steps:

1. Run task in a sample project with caching arg:

```bash
./gradlew generateMigrations --configuration-cache
```

---> Task passes successfully (script generated) with the following message:
```
Calculating task graph as no cached configuration is available for tasks: generateMigrations
````

2. Make more table changes and run same task a second time with caching arg

---> Task passes successfully (script generated) with the following message:
```
Reusing configuration cache
```

Compatibility ✅ 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - **build**
