### PR TITLE
fix: EXPOSED-1028 Return defensive copy from ExposedSpringTransactionAttributeSource

### DIFF
--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring/transaction/ExposedSpringTransactionAttributeSource.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring/transaction/ExposedSpringTransactionAttributeSource.kt
@@ -11,6 +11,9 @@ import java.sql.SQLException
 /**
  * A [TransactionAttributeSource] that adds [ExposedSQLException] to the rollback rules of the delegate.
  *
+ * The returned [TransactionAttribute] is a defensive copy, so the delegate's cached instance is never
+ * mutated. This makes [getTransactionAttribute] safe to invoke concurrently.
+ *
  * @property delegate The delegate [TransactionAttributeSource] to use. Defaults to [AnnotationTransactionAttributeSource].
  * If you use a custom [TransactionAttributeSource], you can pass it here.
  */
@@ -20,19 +23,23 @@ class ExposedSpringTransactionAttributeSource(
 ) : TransactionAttributeSource {
 
     override fun getTransactionAttribute(method: Method, targetClass: Class<*>?): TransactionAttribute? {
-        val attr = delegate.getTransactionAttribute(method, targetClass)
-        if (attr is RuleBasedTransactionAttribute) {
-            val rules = attr.rollbackRules.toMutableList()
-            rollbackExceptions.forEach { exception ->
-                val containsException = rules.any {
-                    it is RollbackRuleAttribute && it.exceptionName == exception.name
-                }
-                if (!containsException) {
-                    rules.add(RollbackRuleAttribute(exception))
-                }
+        val original = delegate.getTransactionAttribute(method, targetClass) ?: return null
+        if (original !is RuleBasedTransactionAttribute) return original
+
+        // The delegate (e.g. AnnotationTransactionAttributeSource) caches the returned attribute,
+        // so mutating it here would be a data race across concurrent callers. Make a defensive
+        // copy and only modify the copy.
+        val copy = RuleBasedTransactionAttribute(original)
+        val rules = copy.rollbackRules.toMutableList()
+        rollbackExceptions.forEach { exception ->
+            val containsException = rules.any {
+                it is RollbackRuleAttribute && it.exceptionName == exception.name
             }
-            attr.rollbackRules = rules
+            if (!containsException) {
+                rules.add(RollbackRuleAttribute(exception))
+            }
         }
-        return attr
+        copy.rollbackRules = rules
+        return copy
     }
 }

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring/transaction/SpringTransactionAttributeSourceConcurrencyTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring/transaction/SpringTransactionAttributeSourceConcurrencyTest.kt
@@ -1,0 +1,94 @@
+package org.jetbrains.exposed.v1.spring.transaction
+
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.interceptor.RollbackRuleAttribute
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute
+import java.sql.SQLException
+import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for thread-safety of [ExposedSpringTransactionAttributeSource].
+ *
+ * The class previously mutated the [RuleBasedTransactionAttribute] returned by its delegate.
+ * The default delegate, `AnnotationTransactionAttributeSource`, caches that instance per
+ * `(method, targetClass)`, so concurrent callers raced on a shared `rollbackRules` list.
+ * That race manifested in production as a `NullPointerException` thrown from
+ * `ArrayList.toArray` (unsafe publication of the new list through the non-volatile
+ * `rollbackRules` field). See YouTrack EXPOSED-1028.
+ */
+class SpringTransactionAttributeSourceConcurrencyTest {
+
+    @Test
+    fun `delegate's cached attribute is not mutated by source`() {
+        val delegate = AnnotationTransactionAttributeSource()
+        val source = ExposedSpringTransactionAttributeSource(delegate)
+        val method = Sample::class.java.getMethod("tx")
+        val targetClass = Sample::class.java
+
+        val before = (delegate.getTransactionAttribute(method, targetClass) as RuleBasedTransactionAttribute)
+            .rollbackRules.toList()
+
+        repeat(50) { source.getTransactionAttribute(method, targetClass) }
+
+        val after = (delegate.getTransactionAttribute(method, targetClass) as RuleBasedTransactionAttribute)
+            .rollbackRules.toList()
+
+        assertEquals(
+            before,
+            after,
+            "Delegate's cached rollbackRules must not be mutated by ExposedSpringTransactionAttributeSource"
+        )
+    }
+
+    @Test
+    fun `concurrent getTransactionAttribute calls are thread-safe`() {
+        val source = ExposedSpringTransactionAttributeSource()
+        val method = Sample::class.java.getMethod("tx")
+        val targetClass = Sample::class.java
+        val sqlExceptionName = SQLException::class.java.name
+
+        val threads = 16
+        val iterations = 1_000
+        val pool = Executors.newFixedThreadPool(threads)
+        val errors = CopyOnWriteArrayList<Throwable>()
+
+        try {
+            val tasks = (1..threads).map {
+                Callable {
+                    repeat(iterations) {
+                        runCatching {
+                            val attr = source.getTransactionAttribute(method, targetClass)
+                                as RuleBasedTransactionAttribute
+                            check(
+                                attr.rollbackRules.any {
+                                    it is RollbackRuleAttribute && it.exceptionName == sqlExceptionName
+                                }
+                            ) { "SQLException rollback rule is missing from the returned attribute" }
+                        }.onFailure { errors.add(it) }
+                    }
+                }
+            }
+            pool.invokeAll(tasks)
+        } finally {
+            pool.shutdown()
+            pool.awaitTermination(60, TimeUnit.SECONDS)
+        }
+
+        assertTrue(
+            errors.isEmpty(),
+            "Expected no errors under concurrent invocation, got ${errors.size}: ${errors.firstOrNull()}"
+        )
+    }
+
+    internal class Sample {
+        @Transactional
+        open fun tx() = Unit
+    }
+}

--- a/spring7-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring7/transaction/ExposedSpringTransactionAttributeSource.kt
+++ b/spring7-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring7/transaction/ExposedSpringTransactionAttributeSource.kt
@@ -11,6 +11,9 @@ import java.sql.SQLException
 /**
  * A [TransactionAttributeSource] that adds `ExposedSQLException` to the rollback rules of the delegate.
  *
+ * The returned [TransactionAttribute] is a defensive copy, so the delegate's cached instance is never
+ * mutated. This makes [getTransactionAttribute] safe to invoke concurrently.
+ *
  * @property delegate The delegate [TransactionAttributeSource] to use. Defaults to [AnnotationTransactionAttributeSource].
  * If you use a custom [TransactionAttributeSource], you can pass it here.
  */
@@ -20,19 +23,23 @@ class ExposedSpringTransactionAttributeSource(
 ) : TransactionAttributeSource {
 
     override fun getTransactionAttribute(method: Method, targetClass: Class<*>?): TransactionAttribute? {
-        val attr = delegate.getTransactionAttribute(method, targetClass)
-        if (attr is RuleBasedTransactionAttribute) {
-            val rules = attr.rollbackRules.toMutableList()
-            rollbackExceptions.forEach { exception ->
-                val containsException = rules.any {
-                    it is RollbackRuleAttribute && it.exceptionName == exception.name
-                }
-                if (!containsException) {
-                    rules.add(RollbackRuleAttribute(exception))
-                }
+        val original = delegate.getTransactionAttribute(method, targetClass) ?: return null
+        if (original !is RuleBasedTransactionAttribute) return original
+
+        // The delegate (e.g. AnnotationTransactionAttributeSource) caches the returned attribute,
+        // so mutating it here would be a data race across concurrent callers. Make a defensive
+        // copy and only modify the copy.
+        val copy = RuleBasedTransactionAttribute(original)
+        val rules = copy.rollbackRules.toMutableList()
+        rollbackExceptions.forEach { exception ->
+            val containsException = rules.any {
+                it is RollbackRuleAttribute && it.exceptionName == exception.name
             }
-            attr.rollbackRules = rules
+            if (!containsException) {
+                rules.add(RollbackRuleAttribute(exception))
+            }
         }
-        return attr
+        copy.rollbackRules = rules
+        return copy
     }
 }

--- a/spring7-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring7/transaction/SpringTransactionAttributeSourceConcurrencyTest.kt
+++ b/spring7-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring7/transaction/SpringTransactionAttributeSourceConcurrencyTest.kt
@@ -1,0 +1,94 @@
+package org.jetbrains.exposed.v1.spring7.transaction
+
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.annotation.AnnotationTransactionAttributeSource
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.interceptor.RollbackRuleAttribute
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute
+import java.sql.SQLException
+import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for thread-safety of [ExposedSpringTransactionAttributeSource].
+ *
+ * The class previously mutated the [RuleBasedTransactionAttribute] returned by its delegate.
+ * The default delegate, `AnnotationTransactionAttributeSource`, caches that instance per
+ * `(method, targetClass)`, so concurrent callers raced on a shared `rollbackRules` list.
+ * That race manifested in production as a `NullPointerException` thrown from
+ * `ArrayList.toArray` (unsafe publication of the new list through the non-volatile
+ * `rollbackRules` field). See YouTrack EXPOSED-1028.
+ */
+class SpringTransactionAttributeSourceConcurrencyTest {
+
+    @Test
+    fun `delegate's cached attribute is not mutated by source`() {
+        val delegate = AnnotationTransactionAttributeSource()
+        val source = ExposedSpringTransactionAttributeSource(delegate)
+        val method = Sample::class.java.getMethod("tx")
+        val targetClass = Sample::class.java
+
+        val before = (delegate.getTransactionAttribute(method, targetClass) as RuleBasedTransactionAttribute)
+            .rollbackRules.toList()
+
+        repeat(50) { source.getTransactionAttribute(method, targetClass) }
+
+        val after = (delegate.getTransactionAttribute(method, targetClass) as RuleBasedTransactionAttribute)
+            .rollbackRules.toList()
+
+        assertEquals(
+            before,
+            after,
+            "Delegate's cached rollbackRules must not be mutated by ExposedSpringTransactionAttributeSource"
+        )
+    }
+
+    @Test
+    fun `concurrent getTransactionAttribute calls are thread-safe`() {
+        val source = ExposedSpringTransactionAttributeSource()
+        val method = Sample::class.java.getMethod("tx")
+        val targetClass = Sample::class.java
+        val sqlExceptionName = SQLException::class.java.name
+
+        val threads = 16
+        val iterations = 1_000
+        val pool = Executors.newFixedThreadPool(threads)
+        val errors = CopyOnWriteArrayList<Throwable>()
+
+        try {
+            val tasks = (1..threads).map {
+                Callable {
+                    repeat(iterations) {
+                        runCatching {
+                            val attr = source.getTransactionAttribute(method, targetClass)
+                                as RuleBasedTransactionAttribute
+                            check(
+                                attr.rollbackRules.any {
+                                    it is RollbackRuleAttribute && it.exceptionName == sqlExceptionName
+                                }
+                            ) { "SQLException rollback rule is missing from the returned attribute" }
+                        }.onFailure { errors.add(it) }
+                    }
+                }
+            }
+            pool.invokeAll(tasks)
+        } finally {
+            pool.shutdown()
+            pool.awaitTermination(60, TimeUnit.SECONDS)
+        }
+
+        assertTrue(
+            errors.isEmpty(),
+            "Expected no errors under concurrent invocation, got ${errors.size}: ${errors.firstOrNull()}"
+        )
+    }
+
+    internal class Sample {
+        @Transactional
+        open fun tx() = Unit
+    }
+}


### PR DESCRIPTION

#### Description

**Summary of the change**: `ExposedSpringTransactionAttributeSource` now returns a defensive copy of the delegate's `RuleBasedTransactionAttribute` instead of mutating the shared, cached instance, fixing a thread-safety bug that caused `NullPointerException` under concurrent load.

**Detailed description**:
- **Why**: The default delegate, `AnnotationTransactionAttributeSource`, caches the `RuleBasedTransactionAttribute` it returns per `(method, targetClass)`. The previous implementation read `attr.rollbackRules.toMutableList()`, mutated the list, and assigned it back to `attr.rollbackRules` — a read-modify-write on shared state across concurrent callers. In production we observed `NullPointerException` thrown from `ArrayList.toArray` inside `kotlin.collections.toMutableList`: a reader thread observed the reference to the freshly-published `ArrayList` while its `elementData` field was still unset (classic unsafe publication through the non-volatile `rollbackRules` field). The stack trace and full analysis are in YouTrack [EXPOSED-1028](https://youtrack.jetbrains.com/issue/EXPOSED-1028).
- **What**: `getTransactionAttribute` now copies the delegate's attribute via the `RuleBasedTransactionAttribute(other)` copy constructor and only mutates the copy. The delegate's cached instance is no longer touched. The change is applied identically to `spring-transaction` (Spring 6) and `spring7-transaction` (Spring 7).
- **How**: A copy via `RuleBasedTransactionAttribute(other)` produces an independent attribute with its own `rollbackRules` list. The configurable `rollbackExceptions` constructor parameter is preserved, and the returned attribute remains semantically equivalent to the previous implementation (same propagation, isolation, timeout, read-only flag, and full set of rollback rules including the configured exceptions). Spring's `TransactionAttributeSource` contract does not promise instance identity, and `AbstractFallbackTransactionAttributeSource` itself returns copies in similar scenarios, so this is a non-breaking change.

Commits are split for clarity: the first adds failing regression tests (deterministic invariant + stress), the second applies the fix and turns them green.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
- YouTrack: https://youtrack.jetbrains.com/issue/EXPOSED-1028
- Original feature PR: #2398 (EXPOSED-593)
