### PR TITLE
fix: EXPOSED-1030 Nullable Strings are not handled by the PrimitiveTypeMapper

### DIFF
--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper.kt
@@ -62,6 +62,7 @@ class PrimitiveTypeMapper : TypeMapper {
             is UUIDColumnType -> java.util.UUID::class.java
             is CharacterColumnType -> java.lang.String::class.java
             is BooleanColumnType -> java.lang.Boolean::class.java
+            is StringColumnType -> java.lang.String::class.java
             else -> return false
         }
         statement.bindNull(index - 1, columnValueType)


### PR DESCRIPTION
#### Description

**Summary of the change**: Adds the handling of the `StringColumnType` to point to `java.lang.String`, instead of defaulting to an Object

**Detailed description**:
- **Why**: As described in the [EXPOSED-1030](https://youtrack.jetbrains.com/issue/EXPOSED-1030/Nullable-Strings-are-not-handled-by-the-PrimitiveTypeMapper) issue, this causes an unhandled exception on version 1.0.5-RELEASE of r2dbc-postgres driver. Although this issue does not happen in the latest 1.1.1.RELEASE of r2dbc-postgres driver, it potentially can be unhandled by other drivers as well. More to the point, I think this is due to the String types being treated as Object, when no mapping is found here to indicate they are of string type
- **What**: Handle the defined StringColumnType as a String type (adding to the `when` block).
- **How**: Just a simple addition to the `when` block. I've tested the functionality via a [demo repository](https://github.com/renatomrcosta/exposed-r2dbc-string-issue-demo) via a locally published version

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [x] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
https://youtrack.jetbrains.com/issue/EXPOSED-1030/Nullable-Strings-are-not-handled-by-the-PrimitiveTypeMapper