### PR TITLE
feat: port JDBC DAO entity tests to R2DBC

### DIFF
--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/demo/dao/SamplesDao.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/demo/dao/SamplesDao.kt
@@ -1,0 +1,90 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.demo.dao
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.v1.core.StdOutSqlLogger
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.jupiter.api.Assumptions
+import kotlin.test.Test
+
+object Users : IntIdTable() {
+    val name = varchar("name", 50).index()
+    val city = reference("city", Cities)
+    val age = integer("age")
+}
+
+object Cities : IntIdTable() {
+    val name = varchar("name", 50)
+}
+
+class User(id: EntityID<Int>) : IntR2dbcEntity(id) {
+    companion object : IntR2dbcEntityClass<User>(Users)
+
+    var name by Users.name
+    val city by City referencedOnSuspend Users.city
+    var age by Users.age
+}
+
+class City(id: EntityID<Int>) : IntR2dbcEntity(id) {
+    companion object : IntR2dbcEntityClass<City>(Cities)
+
+    var name by Cities.name
+    val users by User referrersOnSuspend Users.city
+}
+
+fun main() = runBlocking {
+    Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+    R2dbcDatabase.connect("r2dbc:h2:mem:///test", user = "root", password = "")
+
+    suspendTransaction {
+        addLogger(StdOutSqlLogger)
+
+        SchemaUtils.create(Cities, Users)
+
+        val stPete = City.new {
+            name = "St. Petersburg"
+        }
+
+        val munich = City.new {
+            name = "Munich"
+        }
+
+        User.new {
+            name = "a"
+            city set stPete
+            age = 5
+        }
+
+        User.new {
+            name = "b"
+            city set stPete
+            age = 27
+        }
+
+        User.new {
+            name = "c"
+            city set munich
+            age = 42
+        }
+
+        println("Cities: ${City.all().toList().joinToString { it.name }}")
+        println("Users in ${stPete.name}: ${stPete.users().toList().joinToString { it.name }}")
+        println("Adults: ${User.find { Users.age greaterEq 18 }.toList().joinToString { it.name }}")
+    }
+}
+
+class SamplesDao {
+    @Test
+    fun ensureSamplesDoesntCrash() {
+        main()
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/h2/R2dbcEntityReferenceCacheTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/h2/R2dbcEntityReferenceCacheTest.kt
@@ -1,0 +1,549 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.h2
+
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.dao.r2dbc.tests.demo.dao.Cities
+import org.jetbrains.exposed.dao.r2dbc.tests.demo.dao.City
+import org.jetbrains.exposed.dao.r2dbc.tests.demo.dao.User
+import org.jetbrains.exposed.dao.r2dbc.tests.demo.dao.Users
+import org.jetbrains.exposed.dao.r2dbc.tests.shared.EntityTestsData
+import org.jetbrains.exposed.dao.r2dbc.tests.shared.R2dbcEntityTests
+import org.jetbrains.exposed.dao.r2dbc.tests.shared.VNumber
+import org.jetbrains.exposed.dao.r2dbc.tests.shared.VString
+import org.jetbrains.exposed.dao.r2dbc.tests.shared.ViaTestData
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
+import org.jetbrains.exposed.r2dbc.dao.flushCache
+import org.jetbrains.exposed.r2dbc.dao.relationships.load
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualCollections
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+import kotlin.properties.Delegates
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
+
+class R2dbcEntityReferenceCacheTest : R2dbcDatabaseTestsBase() {
+    private val db by lazy {
+        TestDB.H2_V2.connect()
+    }
+
+    private val dbWithCache by lazy {
+        TestDB.H2_V2.connect {
+            keepLoadedReferencesOutOfTransaction = true
+        }
+    }
+
+    private suspend fun executeOnH2(vararg tables: Table, body: suspend () -> Unit) {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+        var testWasStarted = false
+        suspendTransaction(db) {
+            SchemaUtils.create(*tables)
+            testWasStarted = true
+        }
+        Assumptions.assumeTrue(testWasStarted)
+        if (testWasStarted) {
+            try {
+                body()
+            } finally {
+                suspendTransaction(db) {
+                    SchemaUtils.drop(*tables)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test referenceOn works out of transaction`() = runTest {
+        var y1: EntityTestsData.YEntity by Delegates.notNull()
+        var b1: EntityTestsData.BEntity by Delegates.notNull()
+        executeOnH2(EntityTestsData.XTable, EntityTestsData.YTable) {
+            suspendTransaction(db) {
+                y1 = EntityTestsData.YEntity.new {
+                    this.x = true
+                }
+                b1 = EntityTestsData.BEntity.new {
+                    this.b1 = true
+                    this.y set y1
+                }
+            }
+            assertFails { y1.b() }
+            assertFails { b1.y() }
+
+            suspendTransaction(dbWithCache) {
+                y1.refresh()
+                b1.refresh()
+                assertEquals(b1.id, y1.b()?.id)
+                assertEquals(y1.id, b1.y()?.id)
+            }
+
+            assertEquals(b1.id, y1.b()?.id)
+            assertEquals(y1.id, b1.y()?.id)
+        }
+    }
+
+    @Test
+    fun `test backReferencedOn & optionalBackReferencedOn work out of transaction via load`() = runTest {
+        var y1: EntityTestsData.YEntity by Delegates.notNull()
+        var b1: EntityTestsData.BEntity by Delegates.notNull()
+        executeOnH2(EntityTestsData.XTable, EntityTestsData.YTable) {
+            suspendTransaction(db) {
+                y1 = EntityTestsData.YEntity.new {}
+                b1 = EntityTestsData.BEntity.new {
+                    this.y set y1
+                }
+            }
+            // R2DBC: property access returns a `suspend () -> ...` accessor — only invocation
+            // performs the DB lookup that must fail when there's no transaction.
+            assertFails { y1.b() }
+            assertFails { y1.bOpt() }
+
+            suspendTransaction(dbWithCache) {
+                y1.refresh()
+                b1.refresh()
+                y1.load(EntityTestsData.YEntity::b, EntityTestsData.YEntity::bOpt)
+            }
+
+            assertEquals(b1.id, y1.b()?.id)
+            assertEquals(b1.id, y1.bOpt()?.id)
+        }
+    }
+
+    @Test
+    fun `test optionalBackReferencedOn and optionalReferencedOn work when value is missing`() = runTest {
+        var y1: EntityTestsData.YEntity by Delegates.notNull()
+        var b1: EntityTestsData.BEntity by Delegates.notNull()
+        executeOnH2(EntityTestsData.XTable, EntityTestsData.YTable) {
+            suspendTransaction(db) {
+                y1 = EntityTestsData.YEntity.new {}
+                b1 = EntityTestsData.BEntity.new {}
+            }
+
+            suspendTransaction(dbWithCache) {
+                y1.refresh()
+                b1.refresh()
+                y1.load(EntityTestsData.YEntity::bOpt)
+                b1.load(EntityTestsData.BEntity::y)
+            }
+
+            // R2DBC: property access returns the accessor lambda — invoke it to get the actual
+            // (null) value pinned in the per-entity reference cache by `load(...)`.
+            assertNull(y1.bOpt())
+            assertNull(b1.y())
+        }
+    }
+
+    @Test
+    fun `test referenceOn works out of transaction via with`() = runTest {
+        var b1: R2dbcEntityTests.Board by Delegates.notNull()
+        var p1: R2dbcEntityTests.Post by Delegates.notNull()
+        var p2: R2dbcEntityTests.Post by Delegates.notNull()
+        executeOnH2(R2dbcEntityTests.Boards, R2dbcEntityTests.Posts, R2dbcEntityTests.Categories) {
+            suspendTransaction(db) {
+                b1 = R2dbcEntityTests.Board.new {
+                    name = "test-board"
+                }
+                p1 = R2dbcEntityTests.Post.new {
+                    board set b1
+                }
+                p2 = R2dbcEntityTests.Post.new {
+                    board set b1
+                }
+            }
+            assertFails { b1.posts().toList() }
+            assertFails { p1.board()?.id }
+            assertFails { p2.board()?.id }
+
+            suspendTransaction(dbWithCache) {
+                b1.refresh()
+                p1.refresh()
+                p2.refresh()
+                listOf(p1, p2).with(R2dbcEntityTests.Post::board)
+            }
+
+            assertEquals(b1.id, p1.board()?.id)
+            assertEquals(b1.id, p2.board()?.id)
+        }
+    }
+
+    @Test
+    fun `test referrersOn works out of transaction`() = runTest {
+        var b1: R2dbcEntityTests.Board by Delegates.notNull()
+        var p1: R2dbcEntityTests.Post by Delegates.notNull()
+        var p2: R2dbcEntityTests.Post by Delegates.notNull()
+        executeOnH2(R2dbcEntityTests.Boards, R2dbcEntityTests.Posts, R2dbcEntityTests.Categories) {
+            suspendTransaction(db) {
+                b1 = R2dbcEntityTests.Board.new {
+                    name = "test-board"
+                }
+                p1 = R2dbcEntityTests.Post.new {
+                    board set b1
+                }
+                p2 = R2dbcEntityTests.Post.new {
+                    board set b1
+                }
+            }
+
+            assertFails { b1.posts().toList() }
+            assertFails { p1.board()?.id }
+            assertFails { p2.board()?.id }
+
+            suspendTransaction(dbWithCache) {
+                b1.refresh()
+                p1.refresh()
+                p2.refresh()
+                assertEquals(b1.id, p1.board()?.id)
+                assertEquals(b1.id, p2.board()?.id)
+                assertEqualCollections(b1.posts().map { it.id }.toList(), p1.id, p2.id)
+            }
+
+            assertEquals(b1.id, p1.board()?.id)
+            assertEquals(b1.id, p2.board()?.id)
+            assertEqualCollections(b1.posts().map { it.id }.toList(), p1.id, p2.id)
+        }
+    }
+
+    @Test
+    fun `test optionalReferrersOn works out of transaction via warmup`() = runTest {
+        var b1: R2dbcEntityTests.Board by Delegates.notNull()
+        var p1: R2dbcEntityTests.Post by Delegates.notNull()
+        var p2: R2dbcEntityTests.Post by Delegates.notNull()
+        executeOnH2(R2dbcEntityTests.Boards, R2dbcEntityTests.Posts, R2dbcEntityTests.Categories) {
+            suspendTransaction(db) {
+                b1 = R2dbcEntityTests.Board.new {
+                    name = "test-board"
+                }
+                p1 = R2dbcEntityTests.Post.new {
+                    board set b1
+                }
+                p2 = R2dbcEntityTests.Post.new {
+                    board set b1
+                }
+            }
+            assertFails { b1.posts().toList() }
+            assertFails { p1.board()?.id }
+            assertFails { p2.board()?.id }
+
+            suspendTransaction(dbWithCache) {
+                b1.refresh()
+                p1.refresh()
+                p2.refresh()
+                b1.load(R2dbcEntityTests.Board::posts)
+                assertEqualCollections(b1.posts().map { it.id }, p1.id, p2.id)
+            }
+
+            assertEqualCollections(b1.posts().map { it.id }, p1.id, p2.id)
+        }
+    }
+
+    @Test
+    fun `test referrersOn works out of transaction via warmup`() = runTest {
+        var c1: City by Delegates.notNull()
+        var u1: User by Delegates.notNull()
+        var u2: User by Delegates.notNull()
+        executeOnH2(Cities, Users) {
+            suspendTransaction(dbWithCache) {
+                c1 = City.new {
+                    name = "Seoul"
+                }
+                u1 = User.new {
+                    name = "a"
+                    city set c1
+                    age = 5
+                }
+                u2 = User.new {
+                    name = "b"
+                    city set c1
+                    age = 27
+                }
+                City.all().with(City::users).toList()
+            }
+            assertEqualCollections(c1.users().map { it.id }.toList(), u1.id, u2.id)
+        }
+    }
+
+    @Test
+    fun `test via reference out of transaction`() = runTest {
+        var n: VNumber by Delegates.notNull()
+        var s1: VString by Delegates.notNull()
+        var s2: VString by Delegates.notNull()
+        executeOnH2(*ViaTestData.allTables) {
+            suspendTransaction(db) {
+                n = VNumber.new { number = 10 }
+                s1 = VString.new { text = "aaa" }
+                s2 = VString.new { text = "bbb" }
+                n.connectedStrings set listOf(s1, s2)
+            }
+
+            assertFails { n.connectedStrings().toList() }
+            suspendTransaction(dbWithCache) {
+                n.refresh()
+                s1.refresh()
+                s2.refresh()
+                assertEqualCollections(n.connectedStrings().map { it.id }.toList(), s1.id, s2.id)
+            }
+            assertEqualCollections(n.connectedStrings().map { it.id }, s1.id, s2.id)
+        }
+    }
+
+    @Test
+    fun `test via reference load out of transaction`() = runTest {
+        var n: VNumber by Delegates.notNull()
+        var s1: VString by Delegates.notNull()
+        var s2: VString by Delegates.notNull()
+        executeOnH2(*ViaTestData.allTables) {
+            suspendTransaction(db) {
+                n = VNumber.new { number = 10 }
+                s1 = VString.new { text = "aaa" }
+                s2 = VString.new { text = "bbb" }
+                n.connectedStrings set listOf(s1, s2)
+            }
+
+            assertFails { n.connectedStrings().toList() }
+            suspendTransaction(dbWithCache) {
+                n.refresh()
+                s1.refresh()
+                s2.refresh()
+                n.load(VNumber::connectedStrings)
+                assertEqualCollections(n.connectedStrings().map { it.id }.toList(), s1.id, s2.id)
+            }
+            assertEqualCollections(n.connectedStrings().map { it.id }.toList(), s1.id, s2.id)
+
+            suspendTransaction(dbWithCache) {
+                n.connectedStrings set listOf(s1)
+                assertEqualCollections(n.connectedStrings().map { it.id }.toList(), s1.id)
+                n.load(VNumber::connectedStrings)
+                assertEqualCollections(n.connectedStrings().map { it.id }.toList(), s1.id)
+            }
+        }
+    }
+
+    object Customers : IntIdTable() {
+        val name = varchar("name", 10)
+    }
+
+    object Orders : IntIdTable() {
+        val customer = reference("customer", Customers)
+        val ref = varchar("name", 10)
+    }
+
+    object OrderItems : IntIdTable() {
+        val order = reference("order", Orders)
+        val sku = varchar("sky", 10)
+    }
+
+    object Addresses : IntIdTable() {
+        val customer = reference("customer", Customers)
+        val street = varchar("street", 10)
+    }
+
+    object Roles : IntIdTable() {
+        val name = varchar("name", 10)
+    }
+
+    object CustomerRoles : IntIdTable() {
+        val customer = reference("customer", Customers, onDelete = ReferenceOption.CASCADE)
+        val role = reference("role", Roles, onDelete = ReferenceOption.CASCADE)
+    }
+
+    class Customer(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var name by Customers.name
+        val orders by Order.referrersOnSuspend(Orders.customer)
+        val addresses by Address.referrersOnSuspend(Addresses.customer)
+        val customerRoles by CustomerRole.referrersOnSuspend(CustomerRoles.customer)
+
+        companion object : IntR2dbcEntityClass<Customer>(Customers)
+    }
+
+    class Order(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var ref by Orders.ref
+        val customer by Customer.referencedOnSuspend(Orders.customer)
+        val items by OrderItem.referrersOnSuspend(OrderItems.order)
+
+        companion object : IntR2dbcEntityClass<Order>(Orders)
+    }
+
+    class OrderItem(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var sku by OrderItems.sku
+        val order by Order.referencedOnSuspend(OrderItems.order)
+
+        companion object : IntR2dbcEntityClass<OrderItem>(OrderItems)
+    }
+
+    class Address(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var street by Addresses.street
+        val customer by Customer.referencedOnSuspend(Addresses.customer)
+
+        companion object : IntR2dbcEntityClass<Address>(Addresses)
+    }
+
+    class Role(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var name by Roles.name
+
+        companion object : IntR2dbcEntityClass<Role>(Roles)
+    }
+
+    class CustomerRole(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        val customer by Customer.referencedOnSuspend(CustomerRoles.customer)
+        val role by Role.referencedOnSuspend(CustomerRoles.role)
+
+        companion object : IntR2dbcEntityClass<CustomerRole>(CustomerRoles)
+    }
+
+    @Test
+    fun `dont flush indirectly related entities on insert`() {
+        withTables(Customers, Orders, OrderItems, Addresses) {
+            val customer1 = Customer.new { name = "Test" }
+            val order1 = Order.new {
+                customer set customer1
+                ref = "Test"
+            }
+
+            val orderItem1 = OrderItem.new {
+                order set order1
+                sku = "Test"
+            }
+
+            assertEqualCollections(listOf(order1), customer1.orders().toList())
+            assertEqualCollections(emptyList(), customer1.addresses().toList())
+            assertNotNull(entityCache.getReferrers<Order>(customer1.id, Orders.customer))
+            assertNotNull(entityCache.getReferrers<Address>(customer1.id, Addresses.customer))
+
+            assertEquals(1, order1.items().toList().size)
+            assertEquals(orderItem1, order1.items().single())
+            assertNotNull(entityCache.getReferrers<OrderItem>(order1.id, OrderItems.order))
+
+            Address.new {
+                customer set customer1
+                street = "Test"
+            }
+
+            flushCache()
+
+            assertNull(entityCache.getReferrers<Address>(customer1.id, Addresses.customer))
+            assertNotNull(entityCache.getReferrers<Order>(customer1.id, Orders.customer))
+            assertNotNull(entityCache.getReferrers<OrderItem>(order1.id, OrderItems.order))
+
+            val customer2 = Customer.new { name = "Test2" }
+
+            flushCache()
+
+            assertNull(entityCache.getReferrers<Address>(customer1.id, Addresses.customer))
+            assertNotNull(entityCache.getReferrers<Order>(customer1.id, Orders.customer))
+            assertNull(entityCache.getReferrers<Address>(customer2.id, Addresses.customer))
+            assertNull(entityCache.getReferrers<Order>(customer2.id, Orders.customer))
+
+            assertNotNull(entityCache.getReferrers<OrderItem>(order1.id, OrderItems.order))
+        }
+    }
+
+    @Test
+    fun `dont flush indirectly related entities on delete`() {
+        withTables(Customers, Orders, OrderItems, Addresses) {
+            val customer1 = Customer.new { name = "Test" }
+            val order1 = Order.new {
+                customer set customer1
+                ref = "Test"
+            }
+
+            val order2 = Order.new {
+                customer set customer1
+                ref = "Test2"
+            }
+
+            OrderItem.new {
+                order set order1
+                sku = "Test"
+            }
+
+            val orderItem2 = OrderItem.new {
+                order set order2
+                sku = "Test2"
+            }
+
+            Address.new {
+                customer set customer1
+                street = "Test"
+            }
+
+            flushCache()
+
+            // Load caches
+            customer1.orders().toList()
+            customer1.addresses().toList()
+            order1.items().toList()
+            order2.items().toList()
+
+            assertNotNull(entityCache.getReferrers<Order>(customer1.id, Orders.customer))
+            assertNotNull(entityCache.getReferrers<Address>(customer1.id, Addresses.customer))
+            assertNotNull(entityCache.getReferrers<OrderItem>(order1.id, OrderItems.order))
+            assertNotNull(entityCache.getReferrers<OrderItem>(order2.id, OrderItems.order))
+
+            orderItem2.delete()
+
+            assertNotNull(entityCache.getReferrers<Order>(customer1.id, Orders.customer))
+            assertNotNull(entityCache.getReferrers<Address>(customer1.id, Addresses.customer))
+            assertNull(entityCache.getReferrers<OrderItem>(order1.id, OrderItems.order))
+            assertNull(entityCache.getReferrers<OrderItem>(order2.id, OrderItems.order))
+
+            // Load caches
+            customer1.orders().toList()
+            customer1.addresses().toList()
+            order1.items().toList()
+            order2.items().toList()
+
+            order2.delete()
+            assertNull(entityCache.getReferrers<Order>(customer1.id, Orders.customer))
+            assertNotNull(entityCache.getReferrers<Address>(customer1.id, Addresses.customer))
+            assertNull(entityCache.getReferrers<OrderItem>(order1.id, OrderItems.order))
+            assertNull(entityCache.getReferrers<OrderItem>(order2.id, OrderItems.order))
+        }
+    }
+
+    @Test
+    fun `dont flush indirectly related entities with inner table`() {
+        withTables(Customers, Roles, CustomerRoles) {
+            val customer1 = Customer.new { name = "Test" }
+            val role1 = Role.new { name = "Test" }
+            val customerRole1 = CustomerRole.new {
+                customer set customer1
+                role set role1
+            }
+
+            flushCache()
+            assertEqualCollections(listOf(customerRole1), customer1.customerRoles().toList())
+            val role2 = Role.new { name = "Test2" }
+
+            flushCache()
+            assertNotNull(entityCache.getReferrers<CustomerRole>(customer1.id, CustomerRoles.customer))
+
+            val customerRole2 = CustomerRole.new {
+                customer set customer1
+                role set role2
+            }
+            flushCache()
+
+            assertNull(entityCache.getReferrers<Address>(customer1.id, CustomerRoles.customer))
+
+            assertEqualCollections(listOf(customerRole1, customerRole2), customer1.customerRoles().toList())
+            assertNotNull(entityCache.getReferrers<Address>(customer1.id, CustomerRoles.customer))
+
+            role2.delete()
+            assertNull(entityCache.getReferrers<Address>(customer1.id, CustomerRoles.customer))
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/h2/R2dbcMultiDatabaseEntityTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/h2/R2dbcMultiDatabaseEntityTest.kt
@@ -1,0 +1,230 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.h2
+
+import io.r2dbc.spi.IsolationLevel
+import kotlinx.coroutines.flow.all
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.dao.r2dbc.tests.shared.EntityTestsData
+import org.jetbrains.exposed.v1.core.DatabaseConfig.Companion.invoke
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
+import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.r2dbc.transactions.inTopLevelSuspendTransaction
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+import kotlin.properties.Delegates
+import kotlin.test.Test
+
+class R2dbcMultiDatabaseEntityTest : R2dbcDatabaseTestsBase() {
+    private val db1 by lazy {
+        R2dbcDatabase.connect(
+            "r2dbc:h2:mem:///db1;DB_CLOSE_DELAY=-1;", user = "root", password = "",
+            databaseConfig = R2dbcDatabaseConfig {
+                defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
+            }
+        )
+    }
+    private val db2 by lazy {
+        R2dbcDatabase.connect(
+            "r2dbc:h2:mem:///db2;DB_CLOSE_DELAY=-1;", user = "root", password = "",
+            databaseConfig = R2dbcDatabaseConfig {
+                defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
+            }
+        )
+    }
+    private var currentDB: R2dbcDatabase? = null
+
+    @BeforeEach
+    fun before() = runBlocking {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+        TransactionManager.currentOrNull()?.let {
+            currentDB = it.db
+        }
+        suspendTransaction(db1) {
+            SchemaUtils.create(EntityTestsData.XTable, EntityTestsData.YTable)
+        }
+        suspendTransaction(db2) {
+            SchemaUtils.create(EntityTestsData.XTable, EntityTestsData.YTable)
+        }
+    }
+
+    @AfterEach
+    fun after() = runBlocking {
+        if (TestDB.H2_V2 in TestDB.enabledDialects()) {
+            suspendTransaction(db1) {
+                SchemaUtils.drop(EntityTestsData.XTable, EntityTestsData.YTable)
+            }
+            suspendTransaction(db2) {
+                SchemaUtils.drop(EntityTestsData.XTable, EntityTestsData.YTable)
+            }
+        }
+    }
+
+    @Test
+    fun testSimpleCreateEntitiesInDifferentDatabase() = runTest {
+        suspendTransaction(db1) {
+            EntityTestsData.XEntity.new {
+                this.b1 = true
+            }
+        }
+
+        suspendTransaction(db2) {
+            EntityTestsData.XEntity.new {
+                this.b1 = false
+            }
+
+            EntityTestsData.XEntity.new {
+                this.b1 = false
+            }
+        }
+
+        suspendTransaction(db1) {
+            assertEquals(1L, EntityTestsData.XEntity.all().count())
+            assertEquals(true, EntityTestsData.XEntity.all().single().b1)
+        }
+
+        suspendTransaction(db2) {
+            assertEquals(2L, EntityTestsData.XEntity.all().count())
+            assertEquals(true, EntityTestsData.XEntity.all().all { !it.b1 })
+        }
+    }
+
+    @Test
+    fun testEmbeddedInsertsInDifferentDatabase() = runTest {
+        suspendTransaction(db1) {
+            EntityTestsData.XEntity.new {
+                this.b1 = true
+            }
+
+            assertEquals(1L, EntityTestsData.XEntity.all().count())
+            assertEquals(true, EntityTestsData.XEntity.all().single().b1)
+
+            suspendTransaction(db2) {
+                assertEquals(0L, EntityTestsData.XEntity.all().count())
+                EntityTestsData.XEntity.new {
+                    this.b1 = false
+                }
+
+                EntityTestsData.XEntity.new {
+                    this.b1 = false
+                }
+                assertEquals(2L, EntityTestsData.XEntity.all().count())
+                assertEquals(true, EntityTestsData.XEntity.all().all { !it.b1 })
+            }
+
+            assertEquals(1L, EntityTestsData.XEntity.all().count())
+            assertEquals(true, EntityTestsData.XEntity.all().single().b1)
+        }
+    }
+
+    @Test
+    fun testEmbeddedInsertsInDifferentDatabaseDepth2() = runTest {
+        suspendTransaction(db1) {
+            EntityTestsData.XEntity.new {
+                this.b1 = true
+            }
+
+            assertEquals(1L, EntityTestsData.XEntity.all().count())
+            assertEquals(true, EntityTestsData.XEntity.all().single().b1)
+
+            suspendTransaction(db2) {
+                assertEquals(0L, EntityTestsData.XEntity.all().count())
+                EntityTestsData.XEntity.new {
+                    this.b1 = false
+                }
+
+                EntityTestsData.XEntity.new {
+                    this.b1 = false
+                }
+                assertEquals(2L, EntityTestsData.XEntity.all().count())
+                assertEquals(true, EntityTestsData.XEntity.all().all { !it.b1 })
+
+                suspendTransaction(db1) {
+                    EntityTestsData.XEntity.new {
+                        this.b1 = true
+                    }
+
+                    EntityTestsData.XEntity.new {
+                        this.b1 = false
+                    }
+                    assertEquals(3L, EntityTestsData.XEntity.all().count())
+                }
+                assertEquals(2L, EntityTestsData.XEntity.all().count())
+            }
+
+            assertEquals(3L, EntityTestsData.XEntity.all().count())
+            assertEqualLists(listOf(true, true, false), EntityTestsData.XEntity.all().map { it.b1 }.toList())
+        }
+    }
+
+    @Test
+    fun crossReferencesAllowedForEntitiesFromSameDatabase() = runTest {
+        var db1b1 by Delegates.notNull<EntityTestsData.BEntity>()
+        var db2b1 by Delegates.notNull<EntityTestsData.BEntity>()
+        var db1y1 by Delegates.notNull<EntityTestsData.YEntity>()
+        var db2y1 by Delegates.notNull<EntityTestsData.YEntity>()
+        suspendTransaction(db1) {
+            db1b1 = EntityTestsData.BEntity.new(1) { }
+
+            suspendTransaction(db2) {
+                assertEquals(0L, EntityTestsData.BEntity.count())
+                db2b1 = EntityTestsData.BEntity.new(2) { }
+                db2y1 = EntityTestsData.YEntity.new("2") { }
+                db2b1.y set db2y1
+            }
+            assertEquals(1L, EntityTestsData.BEntity.count())
+            assertNotNull(EntityTestsData.BEntity[1])
+
+            db1y1 = EntityTestsData.YEntity.new("1") { }
+            db1b1.y set db1y1
+
+            commit()
+
+            suspendTransaction(db2) {
+                assertNull(EntityTestsData.BEntity.testCache(EntityID(2, EntityTestsData.BEntity.table)))
+                val b2Reread = EntityTestsData.BEntity.all().single()
+                assertEquals(db2b1.id, b2Reread.id)
+                assertEquals(db2y1.id, b2Reread.y()?.id)
+                b2Reread.y set null
+            }
+        }
+        inTopLevelSuspendTransaction(db1, IsolationLevel.READ_COMMITTED) {
+            maxAttempts = 1
+            assertNull(EntityTestsData.BEntity.testCache(db1b1.id))
+            val b1Reread = EntityTestsData.BEntity[db1b1.id]
+            assertEquals(db1b1.id, b1Reread.id)
+            assertEquals(db1y1.id, EntityTestsData.YEntity[db1y1.id].id)
+            assertEquals(db1y1.id, b1Reread.y()?.id)
+        }
+    }
+
+    @Test
+    fun crossReferencesProhibitedForEntitiesFromDifferentDB() = runTest {
+        Assertions.assertThrows(IllegalStateException::class.java) {
+            runBlocking {
+                suspendTransaction(db1) {
+                    val db1b1 = EntityTestsData.BEntity.new(1) { }
+
+                    suspendTransaction(db2) {
+                        assertEquals(0L, EntityTestsData.BEntity.count())
+                        db1b1.y set EntityTestsData.YEntity.new("2") { }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityCacheRefreshTests.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityCacheRefreshTests.kt
@@ -1,0 +1,207 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import io.r2dbc.spi.IsolationLevel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.r2dbc.select
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.transactions.inTopLevelSuspendTransaction
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.jetbrains.exposed.v1.r2dbc.update
+import org.junit.jupiter.api.Assumptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class R2dbcEntityCacheRefreshTests : R2dbcDatabaseTestsBase() {
+    val excludedDbs = listOf(TestDB.SQLSERVER)
+
+    object TestTable : IntIdTable("entity_cache_refresh_test") {
+        val value = integer("value")
+    }
+
+    class TestEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by TestTable.value
+
+        companion object : IntR2dbcEntityClass<TestEntity>(TestTable)
+    }
+
+    // Extended table for testing partial SELECT with multiple columns
+    object ExtendedTestTable : IntIdTable("extended_test") {
+        val value = integer("value")
+        val name = varchar("name", 50)
+    }
+
+    class ExtendedTestEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by ExtendedTestTable.value
+        var name by ExtendedTestTable.name
+
+        companion object : IntR2dbcEntityClass<ExtendedTestEntity>(ExtendedTestTable)
+    }
+
+    @Test
+    fun testConcurrentIncrementsWithSelectForUpdate() {
+        if (dialect in excludedDbs) {
+            Assumptions.assumeFalse(true)
+        }
+
+        withTables(TestTable) {
+            val db = dialect.connect()
+
+            // Create a single entity with initial value 0
+            val entityIdValue = suspendTransaction(db = db) {
+                val entity = TestEntity.new { value = 0 }
+
+                entity.flush()
+
+                entity.id.value
+            }
+
+            val threadCount = 20
+
+            runBlocking(Dispatchers.IO) {
+                List(threadCount) {
+                    launch {
+                        suspendTransaction(db = db, transactionIsolation = IsolationLevel.READ_COMMITTED) {
+                            // This is important line, because it forces DAO to cache
+                            // the value from the beginning of transaction
+                            TestEntity.find { TestTable.id eq entityIdValue }.single()
+
+                            val entity = TestEntity.find { TestTable.id eq entityIdValue }
+                                .forUpdate()
+                                .single()
+
+                            val currentValue = entity.value
+
+                            entity.value = currentValue + 1
+                        }
+                    }
+                }.forEach { it.join() }
+            }
+
+            // Verify all increments were applied
+            suspendTransaction(db = db) {
+                val finalEntity = TestEntity[entityIdValue]
+                assertEquals(
+                    threadCount,
+                    finalEntity.value,
+                    "Expected value to be $threadCount after $threadCount concurrent increments, " +
+                        "but got ${finalEntity.value}. This indicates lost updates due to stale cache."
+                )
+            }
+        }
+    }
+
+    /**
+     * Scenario:
+     * 1. Transaction T1 reads entity with value A (entity gets cached)
+     * 2. Transaction T2 updates entity value to B and commits
+     * 3. Transaction T1 performs SELECT FOR UPDATE on the same entity
+     * 4. Transaction T1 should see value B, not cached value A
+     */
+    @Test
+    fun testSelectForUpdateReturnsCurrentData() {
+        // Skip databases that don't support SELECT FOR UPDATE
+        if (dialect in excludedDbs) {
+            Assumptions.assumeFalse(true)
+        }
+
+        withTables(TestTable) {
+            val db1 = dialect.connect()
+            val db2 = dialect.connect()
+
+            val entityId = suspendTransaction(db = db1) {
+                TestEntity.new { value = 100 }.id
+            }
+
+            suspendTransaction(db = db1, transactionIsolation = IsolationLevel.READ_COMMITTED) {
+                val entity = TestEntity[entityId]
+                assertEquals(100, entity.value, "Initial value should be 100")
+
+                // In a separate transaction, update the value
+                suspendTransaction(db = db2) {
+                    val entity2 = TestEntity[entityId]
+                    entity2.value = 200
+                }
+
+                val entityWithForUpdate = TestEntity.find { TestTable.id eq entityId.value }
+                    .forUpdate()
+                    .single()
+
+                assertEquals(
+                    200,
+                    entityWithForUpdate.value,
+                    "SELECT FOR UPDATE should return fresh data (200), not cached data (100)"
+                )
+
+                assertEquals(
+                    entity.id.value,
+                    entityWithForUpdate.id.value,
+                    "Should be the same entity instance"
+                )
+            }
+        }
+    }
+
+    /**
+     * This test verifies that when users manually create a partial SELECT
+     * (selecting only some columns) and call wrapRow(), the method performs a selective merge:
+     * - Columns in the partial SELECT are updated with fresh data
+     * - Columns not in the partial SELECT retain their previously cached values
+     *
+     * This ensures that manual DSL queries combined with wrapRow() work correctly.
+     */
+    @Test
+    fun testManualPartialSelectMergesWithCachedColumns() {
+        withTables(ExtendedTestTable) {
+            val entityId = ExtendedTestEntity.new {
+                value = 100
+                name = "Original"
+            }.id
+            commit()
+
+            // Load entity fully (all columns cached)
+            val fullEntity = ExtendedTestEntity[entityId]
+            assertEquals(100, fullEntity.value)
+            assertEquals("Original", fullEntity.name)
+
+            val db2 = db
+            inTopLevelSuspendTransaction(db = db2) {
+                ExtendedTestTable.update({ ExtendedTestTable.id eq entityId }) {
+                    it[value] = 200
+                    it[name] = "Updated"
+                }
+            }
+
+            val partialResults = ExtendedTestTable
+                .select(ExtendedTestTable.id, ExtendedTestTable.value)
+                .where { ExtendedTestTable.id eq entityId.value }
+                .map { row -> ExtendedTestEntity.wrapRow(row) }
+
+            val entityFromPartial = partialResults.single()
+
+            // Should see new value, because the new value was fetched from the query
+            assertEquals(
+                200,
+                entityFromPartial.value,
+                "Value should be updated from partial SELECT"
+            )
+
+            assertEquals(
+                "Original",
+                entityFromPartial.name,
+                "Name should still be accessible from cached data (not in partial SELECT)"
+            )
+
+            assertEquals(entityId.value, entityFromPartial.id.value)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityCacheTests.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityCacheTests.kt
@@ -1,0 +1,353 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import io.r2dbc.spi.IsolationLevel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.forEach
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
+import org.jetbrains.exposed.r2dbc.dao.flushCache
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Table.PrimaryKey
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.exposedLogger
+import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.deleteAll
+import org.jetbrains.exposed.v1.r2dbc.insert
+import org.jetbrains.exposed.v1.r2dbc.selectAll
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualCollections
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+import java.sql.SQLException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.toList
+import kotlin.random.Random
+
+class R2dbcEntityCacheTests : R2dbcDatabaseTestsBase() {
+    object TestTable : IntIdTable("TestCache") {
+        val value = integer("value")
+    }
+
+    class TestEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by TestTable.value
+
+        companion object : IntR2dbcEntityClass<TestEntity>(TestTable)
+    }
+
+    @Test
+    fun testGlobalEntityCacheLimit() = runTest {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+        val entitiesCount = 25
+        val cacheSize = 10
+        val db = TestDB.H2_V2.connect {
+            maxEntitiesToStoreInCachePerEntity = cacheSize
+        }
+
+        suspendTransaction(db) {
+            try {
+                SchemaUtils.create(TestTable)
+
+                repeat(entitiesCount) {
+                    TestEntity.new {
+                        value = Random.nextInt()
+                    }
+                }
+
+                val allEntities = TestEntity.all().toList()
+                assertEquals(entitiesCount, allEntities.size)
+                val allCachedEntities = entityCache.findAll(TestEntity)
+                assertEquals(cacheSize, allCachedEntities.size)
+                assertEqualCollections(allEntities.drop(entitiesCount - cacheSize), allCachedEntities)
+            } finally {
+                SchemaUtils.drop(TestTable)
+            }
+        }
+    }
+
+    @Test
+    fun testGlobalEntityCacheLimitZero() = runTest {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+        val entitiesCount = 25
+        val db = TestDB.H2_V2.connect()
+        val dbNoCache = TestDB.H2_V2.connect {
+            maxEntitiesToStoreInCachePerEntity = 10
+        }
+
+        val entityIds = suspendTransaction(db) {
+            SchemaUtils.create(TestTable)
+
+            repeat(entitiesCount) {
+                TestEntity.new {
+                    value = Random.nextInt()
+                }
+            }
+
+            val entityIds = TestTable.selectAll().map { it[TestTable.id] }.toList()
+            val initialStatementCount = statementCount
+            entityIds.forEach {
+                TestEntity[it]
+            }
+            // All read from cache
+            assertEquals(initialStatementCount, statementCount)
+
+            entityCache.clear()
+            // Load all into cache
+            TestEntity.all().toList()
+
+            entityIds.forEach {
+                TestEntity[it]
+            }
+            assertEquals(initialStatementCount + 1, statementCount)
+            entityIds
+        }
+
+        suspendTransaction(dbNoCache) {
+            debug = true
+            TestEntity.all().toList()
+            assertEquals(1, statementCount)
+            val initialStatementCount = statementCount
+            entityIds.forEach {
+                TestEntity[it]
+            }
+            assertEquals(initialStatementCount + entitiesCount, statementCount)
+            SchemaUtils.drop(TestTable)
+        }
+    }
+
+    @Test
+    fun testPerTransactionEntityCacheLimit() {
+        val entitiesCount = 25
+        val cacheSize = 10
+        withTables(TestTable) {
+            entityCache.maxEntitiesToStore = 10
+
+            repeat(entitiesCount) {
+                TestEntity.new {
+                    value = Random.nextInt()
+                }
+            }
+
+            val allEntities = TestEntity.all().toList()
+            assertEquals(entitiesCount, allEntities.size)
+            val allCachedEntities = entityCache.findAll(TestEntity)
+            assertEquals(cacheSize, allCachedEntities.size)
+            assertEqualCollections(allEntities.drop(entitiesCount - cacheSize), allCachedEntities)
+        }
+    }
+
+    @Test
+    fun changeEntityCacheMaxEntitiesToStoreInMiddleOfTransaction() {
+        withTables(TestTable) {
+            repeat(20) {
+                TestEntity.new {
+                    value = Random.nextInt()
+                }
+            }
+            entityCache.clear()
+
+            TestEntity.all().limit(15).toList()
+            assertEquals(15, entityCache.findAll(TestEntity).size)
+
+            entityCache.maxEntitiesToStore = 18
+            TestEntity.all().toList()
+            assertEquals(18, entityCache.findAll(TestEntity).size)
+
+            // Resize current cache
+            entityCache.maxEntitiesToStore = 10
+            assertEquals(10, entityCache.findAll(TestEntity).size)
+
+            entityCache.maxEntitiesToStore = 18
+            TestEntity.all().toList()
+            assertEquals(18, entityCache.findAll(TestEntity).size)
+
+            // Disable cache
+            entityCache.maxEntitiesToStore = 0
+            assertEquals(0, entityCache.findAll(TestEntity).size)
+        }
+    }
+
+    @Test
+    fun `EntityCache should not be cleaned on explicit commit`() {
+        withTables(TestTable) {
+            val entity = TestEntity.new {
+                value = Random.nextInt()
+            }
+            assertEquals(entity, TestEntity.testCache(entity.id))
+            commit()
+            assertEquals(entity, TestEntity.testCache(entity.id))
+        }
+    }
+
+    object TableWithDefaultValue : IdTable<Int>() {
+        val value = integer("value")
+        val valueWithDefault = integer("valueWithDefault")
+            .default(10)
+
+        override val id: Column<EntityID<Int>> = integer("id")
+            .clientDefault { Random.nextInt() }
+            .entityId()
+
+        override val primaryKey: PrimaryKey = PrimaryKey(id)
+    }
+
+    class TableWithDefaultValueEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by TableWithDefaultValue.value
+
+        var valueWithDefault by TableWithDefaultValue.valueWithDefault
+
+        companion object : IntR2dbcEntityClass<TableWithDefaultValueEntity>(TableWithDefaultValue)
+    }
+
+    @Test
+    fun entitiesWithDifferentAmountOfFieldsCouldBeCreated() {
+        withTables(TableWithDefaultValue) {
+            TableWithDefaultValueEntity.new {
+                value = 1
+            }
+            TableWithDefaultValueEntity.new {
+                value = 2
+                valueWithDefault = 1
+            }
+
+            // It's the key flush. It must not fail with inconsistent batch insert statement.
+            // The table also should have client side default value. Otherwise the `writeValues`
+            // would be extended with default values inside `EntityClass::new()` method.
+            flushCache()
+            entityCache.clear()
+
+            val entity = TableWithDefaultValueEntity.find { TableWithDefaultValue.value eq 1 }.first()
+            assertEquals(10, entity.valueWithDefault)
+        }
+    }
+
+    /**
+     * EXPOSED-886 Changes made to DAO (entity) can be lost on serializable transaction retry (Postgres)
+     */
+    @Test
+    fun testConcurrentSerializableAccessWithTransactionsRetry() = runBlocking(Dispatchers.IO) {
+        val testSize = 10
+
+        // There is no SQLITE R2DBC driver
+        // Only SQLite complains that the TestTable doesn't exists
+        // if (dialect in listOf(TestDB.SQLITE)) {
+        //     Assumptions.assumeFalse(true)
+        // }
+
+        val db1 = dialect.connect()
+        try {
+            suspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE, db = db1) {
+                SchemaUtils.create(TestTable)
+                TestTable.deleteAll()
+
+                repeat(testSize) {
+                    TestTable.insert {
+                        it[value] = 0
+                    }
+                }
+            }
+
+            val entities = suspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE, db = db1) {
+                TestEntity
+                    .find { TestTable.value eq 0 }
+                    .toList()
+            }
+            exposedLogger.info("total entities {}", entities.size)
+
+            List(entities.size) { index ->
+                async {
+                    val statementInvocationNumber = AtomicInteger(0)
+                    suspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE, db = db1) {
+                        maxAttempts = 50
+
+                        val entity = entities[index]
+                        // R2DBC: entity was loaded in a different transaction — re-attach to
+                        // the current transaction's cache before mutating (setValue is non-suspend).
+                        TestEntity.attach(entity)
+                        entity.value = 1
+
+                        exposedLogger.info(
+                            "Updating entity id={} invocation={}  writeValuesSize={}",
+                            entities[index].id,
+                            statementInvocationNumber.incrementAndGet(),
+                            entities[index].writeValues.size
+                        )
+                    }
+                }
+            }.awaitAll()
+
+            entities.forEach {
+                suspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE, db = db1) {
+                    exposedLogger.info("DAO state after update: {} value={} writeValuesSize={}", it.id, it.value, it.writeValues.size)
+                }
+            }
+
+            val db2 = dialect.connect()
+
+            val notUpdated = suspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE, db = db2) {
+                TestTable
+                    .selectAll()
+                    .where { TestTable.value eq 0 }
+                    .toList()
+            }
+
+            notUpdated.forEach {
+                exposedLogger.info("not updated: {} value={}", it[TestTable.id], it[TestTable.value])
+            }
+
+            if (notUpdated.isNotEmpty()) {
+                error("Not all entries updated, wrong value for ${notUpdated.size}")
+            }
+        } finally {
+            suspendTransaction(db1) {
+                SchemaUtils.drop(TestTable)
+            }
+        }
+    }
+
+    @Test
+    fun testEntityRestoresStateOnTransactionRestart() {
+        withConnection(dialect) { database, testDb ->
+            try {
+                val entity = suspendTransaction {
+                    SchemaUtils.create(TestTable)
+
+                    TestEntity.new { value = 1 }
+                }
+
+                suspendTransaction {
+                    maxAttempts = 5
+
+                    // R2DBC: an entity loaded in another transaction must be explicitly
+                    // re-attached to the current transaction's cache before it can be mutated
+                    // (setValue is non-suspend so it cannot auto-load like JDBC does).
+                    TestEntity.attach(entity)
+
+                    assertEquals(1, entity.value)
+                    entity.value += 1
+
+                    throw SQLException("force transaction rollback and restart")
+                }
+            } catch (_: SQLException) {
+                // do nothing
+            } finally {
+                suspendTransaction {
+                    SchemaUtils.drop(TestTable)
+                }
+            }
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityFieldWithTransformTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityFieldWithTransformTest.kt
@@ -1,0 +1,172 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.r2dbc.selectAll
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
+import java.math.BigDecimal
+import kotlin.random.Random
+import kotlin.test.Test
+
+class R2dbcEntityFieldWithTransformTest : R2dbcDatabaseTestsBase() {
+    object TransformationsTable : IntIdTable() {
+        val value = varchar("value", 50)
+    }
+
+    object NullableTransformationsTable : IntIdTable() {
+        val value = varchar("nullable", 50).nullable()
+    }
+
+    class TransformationEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<TransformationEntity>(TransformationsTable)
+
+        var value by TransformationsTable.value.transform(
+            unwrap = { "transformed-$it" },
+            wrap = { it.replace("transformed-", "") }
+        )
+    }
+
+    class NullableTransformationEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<NullableTransformationEntity>(NullableTransformationsTable)
+
+        var value by NullableTransformationsTable.value.transform(
+            unwrap = { "transformed-$it" },
+            wrap = { it?.replace("transformed-", "") }
+        )
+    }
+
+    @Test
+    fun testSetAndGetValue() {
+        withTables(TransformationsTable) {
+            val entity = TransformationEntity.new {
+                value = "stuff"
+            }
+
+            assertEquals("stuff", entity.value)
+
+            val row = TransformationsTable.selectAll()
+                .where(Op.TRUE)
+                .first()
+
+            assertEquals("transformed-stuff", row[TransformationsTable.value])
+        }
+    }
+
+    @Test
+    fun testSetAndGetNullableValueWhilePresent() {
+        withTables(NullableTransformationsTable) {
+            val entity = NullableTransformationEntity.new {
+                value = "stuff"
+            }
+
+            assertEquals("stuff", entity.value)
+
+            val row = NullableTransformationsTable.selectAll()
+                .where(Op.TRUE)
+                .first()
+
+            assertEquals("transformed-stuff", row[NullableTransformationsTable.value])
+        }
+    }
+
+    @Test
+    fun testSetAndGetNullableValueWhileAbsent() {
+        withTables(NullableTransformationsTable) {
+            val entity = NullableTransformationEntity.new {}
+
+            assertEquals(null, entity.value)
+
+            val row = NullableTransformationsTable.selectAll()
+                .where(Op.TRUE)
+                .first()
+
+            assertEquals(null, row[NullableTransformationsTable.value])
+        }
+    }
+
+    object TableWithTransforms : IntIdTable() {
+        val value = varchar("value", 50)
+            .transform(wrap = { it.toBigDecimal() }, unwrap = { it.toString() })
+    }
+
+    class TableWithTransform(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<TableWithTransform>(TableWithTransforms)
+
+        var value by TableWithTransforms.value.transform(wrap = { it.toInt() }, unwrap = { it.toBigDecimal() })
+    }
+
+    @Test
+    fun testDaoTransformWithDslTransform() {
+        withTables(TableWithTransforms) {
+            TableWithTransform.new {
+                value = 10
+            }
+
+            // Correct DAO value
+            assertEquals(10, TableWithTransform.all().first().value)
+
+            // Correct DSL value
+            assertEquals(BigDecimal(10), TableWithTransforms.selectAll().first()[TableWithTransforms.value])
+        }
+    }
+
+    class ChainedTransformationEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<ChainedTransformationEntity>(TransformationsTable)
+
+        var value by TransformationsTable.value
+            .transform(
+                unwrap = { "transformed-$it" },
+                wrap = { it.replace("transformed-", "") }
+            )
+            .transform(
+                unwrap = { if (it.length > 5) it.slice(0..4) else it },
+                wrap = { it }
+            )
+    }
+
+    @Test
+    fun testChainedTransformation() {
+        withTables(TransformationsTable) {
+            ChainedTransformationEntity.new {
+                value = "qwertyuiop"
+            }
+
+            assertEquals("qwert", ChainedTransformationEntity.all().first().value)
+        }
+    }
+
+    class MemoizedChainedTransformationEntity(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<MemoizedChainedTransformationEntity>(TransformationsTable)
+
+        var value by TransformationsTable.value
+            .transform(
+                unwrap = { "transformed-$it" },
+                wrap = { it.replace("transformed-", "") }
+            )
+            .memoizedTransform(
+                unwrap = { it + Random(10).nextInt(0, 100) },
+                wrap = { it }
+            )
+    }
+
+    @Test
+    fun testMemoizedChainedTransformation() {
+        withTables(TransformationsTable) {
+            MemoizedChainedTransformationEntity.new {
+                value = "value#"
+            }
+
+            val entity = MemoizedChainedTransformationEntity.all().first()
+
+            val firstRead = entity.value
+            assertTrue(firstRead.startsWith("value#"))
+            assertEquals(firstRead, entity.value)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityHookTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityHookTest.kt
@@ -1,0 +1,374 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.single
+import org.jetbrains.exposed.r2dbc.dao.EntityChange
+import org.jetbrains.exposed.r2dbc.dao.EntityChangeType
+import org.jetbrains.exposed.r2dbc.dao.EntityHook
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.flushCache
+import org.jetbrains.exposed.r2dbc.dao.registeredChanges
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.toEntity
+import org.jetbrains.exposed.r2dbc.dao.withHook
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualCollections
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import kotlin.test.Test
+
+object EntityHookTestData {
+    object Users : IntIdTable() {
+        val name = varchar("name", 50).index()
+        val age = integer("age")
+    }
+
+    object Cities : IntIdTable() {
+        val name = varchar("name", 50)
+        val country = reference("country", Countries)
+    }
+
+    object Countries : IntIdTable() {
+        val name = varchar("name", 50)
+    }
+
+    object UsersToCities : Table() {
+        val user = reference("user", Users, onDelete = ReferenceOption.CASCADE)
+        val city = reference("city", Cities, onDelete = ReferenceOption.CASCADE)
+    }
+
+    class User(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<User>(Users)
+
+        var name by Users.name
+        var age by Users.age
+        val cities by City viaSuspend UsersToCities
+    }
+
+    class City(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<City>(Cities)
+
+        var name by Cities.name
+        val users by User viaSuspend UsersToCities
+        val country by Country referencedOnSuspend Cities.country
+    }
+
+    class Country(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<Country>(Countries)
+
+        var name by Countries.name
+        val cities by City referrersOnSuspend Cities.country
+    }
+
+    val allTables = arrayOf(Users, Cities, UsersToCities, Countries)
+}
+
+class R2dbcEntityHookTest : R2dbcDatabaseTestsBase() {
+    private suspend fun <T> trackChanges(
+        statement: suspend R2dbcTransaction.() -> T
+    ): Triple<T, Collection<EntityChange>, String> {
+        val alreadyChanged = TransactionManager.current().registeredChanges().size
+        return suspendTransaction {
+            val result = statement()
+            flushCache()
+            Triple(result, registeredChanges().drop(alreadyChanged), transactionId)
+        }
+    }
+
+    @Test
+    fun testCreated01() {
+        withTables(*EntityHookTestData.allTables) {
+            val (_, events, txId) = trackChanges {
+                val ru = EntityHookTestData.Country.new {
+                    name = "RU"
+                }
+                val x = EntityHookTestData.City.new {
+                    name = "St. Petersburg"
+                    country set ru
+                }
+            }
+
+            assertEquals(2, events.count())
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.City)?.name }, "St. Petersburg")
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.Country)?.name }, "RU")
+            events.forEach {
+                assertEquals(txId, it.transactionId)
+            }
+        }
+    }
+
+    @Test
+    fun testDeleted01() {
+        withTables(*EntityHookTestData.allTables) {
+            val spbId = suspendTransaction {
+                val ru = EntityHookTestData.Country.new {
+                    name = "RU"
+                }
+                val x = EntityHookTestData.City.new {
+                    name = "St. Petersburg"
+                    country set ru
+                }
+
+                flushCache()
+                x.id
+            }
+
+            val (_, events, txId) = trackChanges {
+                val spb = EntityHookTestData.City.findById(spbId)!!
+                spb.delete()
+            }
+
+            assertEquals(1, events.count())
+            assertEquals(EntityChangeType.Removed, events.single().changeType)
+            assertEquals(spbId, events.single().entityId)
+            assertEquals(txId, events.single().transactionId)
+        }
+    }
+
+    @Test
+    fun testModifiedSimple01() {
+        withTables(*EntityHookTestData.allTables) {
+            val (_, events1, _) = trackChanges {
+                val ru = EntityHookTestData.Country.new {
+                    name = "RU"
+                }
+                EntityHookTestData.City.new {
+                    name = "St. Petersburg"
+                    country set ru
+                }
+            }
+
+            assertEquals(2, events1.count())
+
+            val (_, events2, txId) = trackChanges {
+                val de = EntityHookTestData.Country.new {
+                    name = "DE"
+                }
+                val x = EntityHookTestData.City.all().single()
+                x.name = "Munich"
+                x.country set de
+            }
+            // One may expect change for RU but we do not send it due to performance reasons
+            assertEquals(2, events2.count())
+            assertEqualCollections(events2.mapNotNull { it.toEntity(EntityHookTestData.City)?.name }, "Munich")
+            assertEqualCollections(events2.mapNotNull { it.toEntity(EntityHookTestData.Country)?.name }, "DE")
+            events2.forEach {
+                assertEquals(txId, it.transactionId)
+            }
+        }
+    }
+
+    @Test
+    fun testModifiedInnerTable01() {
+        withTables(*EntityHookTestData.allTables) {
+            suspendTransaction {
+                val ru = EntityHookTestData.Country.new {
+                    name = "RU"
+                }
+                val de = EntityHookTestData.Country.new {
+                    name = "DE"
+                }
+                EntityHookTestData.City.new {
+                    name = "St. Petersburg"
+                    country set ru
+                }
+                EntityHookTestData.City.new {
+                    name = "Munich"
+                    country set de
+                }
+                EntityHookTestData.User.new {
+                    name = "John"
+                    age = 30
+                }
+
+                flushCache()
+            }
+
+            val (_, events, txId) = trackChanges {
+                val spb = EntityHookTestData.City.find { EntityHookTestData.Cities.name eq "St. Petersburg" }.single()
+                val john = EntityHookTestData.User.all().single()
+                john.cities set listOf(spb)
+            }
+
+            assertEquals(2, events.count())
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.City)?.name }, "St. Petersburg")
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.User)?.name }, "John")
+            events.forEach {
+                assertEquals(txId, it.transactionId)
+            }
+        }
+    }
+
+    @Test
+    fun testModifiedInnerTable02() {
+        withTables(*EntityHookTestData.allTables) {
+            suspendTransaction {
+                val ru = EntityHookTestData.Country.new {
+                    name = "RU"
+                }
+                val de = EntityHookTestData.Country.new {
+                    name = "DE"
+                }
+                val spb = EntityHookTestData.City.new {
+                    name = "St. Petersburg"
+                    country set ru
+                }
+                val muc = EntityHookTestData.City.new {
+                    name = "Munich"
+                    country set de
+                }
+                val john = EntityHookTestData.User.new {
+                    name = "John"
+                    age = 30
+                }
+
+                john.cities set listOf(muc)
+                flushCache()
+            }
+
+            val (_, events, txId) = trackChanges {
+                val spb = EntityHookTestData.City.find { EntityHookTestData.Cities.name eq "St. Petersburg" }.single()
+                val john = EntityHookTestData.User.all().single()
+                john.cities set listOf(spb)
+            }
+
+            assertEquals(3, events.count())
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.City)?.name }, "St. Petersburg", "Munich")
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.User)?.name }, "John")
+            events.forEach {
+                assertEquals(txId, it.transactionId)
+            }
+        }
+    }
+
+    @Test
+    fun testModifiedInnerTable03() {
+        withTables(*EntityHookTestData.allTables) {
+            suspendTransaction {
+                val ru = EntityHookTestData.Country.new {
+                    name = "RU"
+                }
+                val de = EntityHookTestData.Country.new {
+                    name = "DE"
+                }
+                val spb = EntityHookTestData.City.new {
+                    name = "St. Petersburg"
+                    country set ru
+                }
+                val muc = EntityHookTestData.City.new {
+                    name = "Munich"
+                    country set de
+                }
+                val john = EntityHookTestData.User.new {
+                    name = "John"
+                    age = 30
+                }
+
+                john.cities set listOf(spb)
+                flushCache()
+            }
+
+            val (_, events, txId) = trackChanges {
+                val john = EntityHookTestData.User.all().single()
+                john.cities set emptyList()
+            }
+
+            assertEquals(2, events.count())
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.City)?.name }, "St. Petersburg")
+            assertEqualCollections(events.mapNotNull { it.toEntity(EntityHookTestData.User)?.name }, "John")
+            events.forEach {
+                assertEquals(txId, it.transactionId)
+            }
+        }
+    }
+
+    @Test
+    fun `single entity flush should trigger events`() {
+        withTables(EntityHookTestData.User.table) {
+            val (user, events, _) = trackChanges {
+                EntityHookTestData.User.new {
+                    name = "John"
+                    age = 30
+                }.apply { flush() }
+            }
+
+            assertEquals(1, events.size)
+            val createEvent = events.single()
+            assertEquals(user.id, createEvent.entityId)
+            assertEquals(EntityChangeType.Created, createEvent.changeType)
+
+            val (_, events2, _) = trackChanges {
+                user.name = "Carl"
+                user.flush()
+            }
+
+            assertEquals("Carl", user.name)
+            assertEquals(1, events2.size)
+            val updateEvent = events2.single()
+            assertEquals(user.id, updateEvent.entityId)
+            assertEquals(EntityChangeType.Updated, updateEvent.changeType)
+        }
+    }
+
+    @Test
+    fun testCallingFlushNotifiesEntityHookSubscribers() {
+        withTables(EntityHookTestData.User.table) {
+            var hookCalls = 0
+            val user = EntityHookTestData.User.new {
+                name = "1@test.local"
+                age = 30
+            }
+            user.flush()
+
+            EntityHook.subscribe {
+                hookCalls++
+            }
+
+            user.name = "2@test.local"
+            assertEquals(0, hookCalls)
+
+            user.flush()
+            assertEquals(1, hookCalls)
+
+            user.name = "3@test.local"
+            assertEquals(1, hookCalls)
+
+            commit()
+            assertEquals(2, hookCalls)
+        }
+    }
+
+    @Test
+    fun testWithHook() {
+        withTables(EntityHookTestData.User.table) {
+            var hookCalls = 0
+
+            withHook({ hookCalls++ }) {
+                val user = EntityHookTestData.User.new {
+                    name = "name 1"
+                    age = 25
+                }
+                user.flush()
+
+                user.name = "name 2"
+            }
+
+            assertEquals(2, hookCalls)
+
+            // Change value outside the 'withHook'
+            val user = EntityHookTestData.User.all().first()
+            user.name = "name 3"
+            user.flush()
+
+            assertEquals(2, hookCalls)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityTests.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityTests.kt
@@ -14,13 +14,9 @@ import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.r2dbc.dao.exceptions.R2dbcEntityNotFoundException
 import org.jetbrains.exposed.r2dbc.dao.flushCache
-import org.jetbrains.exposed.r2dbc.dao.relationships.backReferencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.load
-import org.jetbrains.exposed.r2dbc.dao.relationships.optionalBackReferencedOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.optionalReferencedOnSuspend
-import org.jetbrains.exposed.r2dbc.dao.relationships.optionalReferrersOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
-import org.jetbrains.exposed.r2dbc.dao.relationships.referrersOnSuspend
 import org.jetbrains.exposed.r2dbc.dao.relationships.with
 import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Column

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityWithBlobTests.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcEntityWithBlobTests.kt
@@ -1,0 +1,54 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.flushCache
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.statements.api.ExposedBlob
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.junit.jupiter.api.assertNull
+import java.util.UUID
+import kotlin.test.Test
+
+class R2dbcEntityWithBlobTests : R2dbcDatabaseTestsBase() {
+
+    object BlobTable : IdTable<String>("YTable") {
+        override val id: Column<EntityID<String>> = varchar("uuid", 36).entityId().clientDefault {
+            EntityID(UUID.randomUUID().toString(), EntityTestsData.YTable)
+        }
+
+        val blob = blob("content").nullable()
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    class BlobEntity(id: EntityID<String>) : R2dbcEntity<String>(id) {
+        var content by BlobTable.blob
+
+        companion object : R2dbcEntityClass<String, BlobEntity>(BlobTable)
+    }
+
+    @Test
+    fun testBlobField() {
+        withTables(BlobTable) {
+            val y1 = BlobEntity.new {
+                content = ExposedBlob("foo".toByteArray())
+            }
+
+            flushCache()
+            var y2 = BlobEntity.reload(y1)!!
+            assertEquals(String(y2.content!!.bytes), "foo")
+
+            y2.content = null
+            flushCache()
+            y2 = BlobEntity.reload(y1)!!
+            assertNull(y2.content)
+
+            y2.content = ExposedBlob("foo2".toByteArray())
+            flushCache()
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcForeignIdEntityTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcForeignIdEntityTest.kt
@@ -1,0 +1,99 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertFalse
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class R2dbcForeignIdEntityTest : R2dbcDatabaseTestsBase() {
+    object Schema {
+
+        object Projects : LongIdTable() {
+            val name = varchar("name", 50)
+        }
+
+        object ProjectConfigs : IdTable<Long>() {
+            override val id = reference("id", Projects)
+            val setting = bool("setting")
+        }
+
+        object Actors : IdTable<String>("actors") {
+            override val id = varchar("guild_id", 13).entityId()
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        object Roles : IntIdTable("roles") {
+            val actor = reference("guild_id", Actors)
+        }
+    }
+
+    class Project(id: EntityID<Long>) : LongR2dbcEntity(id) {
+        companion object : LongR2dbcEntityClass<Project>(Schema.Projects)
+
+        var name by Schema.Projects.name
+    }
+
+    class ProjectConfig(id: EntityID<Long>) : LongR2dbcEntity(id) {
+        companion object : LongR2dbcEntityClass<ProjectConfig>(Schema.ProjectConfigs)
+
+        var setting by Schema.ProjectConfigs.setting
+    }
+
+    class Actor(id: EntityID<String>) : R2dbcEntity<String>(id) {
+        companion object : R2dbcEntityClass<String, Actor>(Schema.Actors)
+
+        val roles by Role referrersOnSuspend Schema.Roles.actor
+    }
+
+    class Role(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<Role>(Schema.Roles)
+
+        val actor by Actor referencedOnSuspend Schema.Roles.actor
+    }
+
+    @Test
+    fun foreignIdEntityUpdate() {
+        // reproducer for https://github.com/JetBrains/Exposed/issues/880
+        withTables(Schema.Projects, Schema.ProjectConfigs, configure = { useNestedTransactions = true }) {
+            suspendTransaction {
+                // TODO we definitely need `newAndFlush()` alternative to the `new()` method
+                val projectId = Project.new { name = "Space" }.also { entityCache.flush() }.id.value
+                ProjectConfig.new(projectId) { setting = true }
+            }
+
+            suspendTransaction {
+                ProjectConfig.all().first().setting = false
+            }
+
+            suspendTransaction {
+                assertFalse(ProjectConfig.all().first().setting)
+            }
+        }
+    }
+
+    @Test
+    fun testReferencedEntitiesWithIdenticalColumnNames() {
+        withTables(Schema.Actors, Schema.Roles) {
+            val actorA = Actor.new("3746529") { }
+            val roleA = Role.new { actor set actorA }
+            val roleB = Role.new { actor set actorA }
+
+            assertContentEquals(listOf(roleA, roleB), actorA.roles().toList())
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcJavaUUIDTableEntityTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcJavaUUIDTableEntityTest.kt
@@ -1,0 +1,201 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.java.UUIDR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.java.UUIDR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.r2dbc.exists
+import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import kotlin.test.Test
+import java.util.UUID as JavaUUID
+
+class R2dbcJavaUUIDTableEntityTest : R2dbcDatabaseTestsBase() {
+
+    @Suppress("MemberNameEqualsClassName")
+    object JavaUUIDTables {
+        object Cities : UUIDTable() {
+            val name = varchar("name", 50)
+        }
+
+        class City(id: EntityID<JavaUUID>) : UUIDR2dbcEntity(id) {
+            companion object : UUIDR2dbcEntityClass<City>(Cities, null, null)
+
+            var name by Cities.name
+            val towns by Town referrersOnSuspend Towns.cityId
+        }
+
+        object People : UUIDTable() {
+            val name = varchar("name", 80)
+            val cityId = reference("city_id", Cities)
+        }
+
+        class Person(id: EntityID<JavaUUID>) : UUIDR2dbcEntity(id) {
+            companion object : UUIDR2dbcEntityClass<Person>(People)
+
+            var name by People.name
+            val city by City referencedOnSuspend People.cityId
+        }
+
+        object Addresses : UUIDTable() {
+            val person = reference("person_id", People)
+            val city = reference("city_id", Cities)
+            val address = varchar("address", 255)
+        }
+
+        class Address(id: EntityID<JavaUUID>) : UUIDR2dbcEntity(id) {
+            companion object : UUIDR2dbcEntityClass<Address>(Addresses)
+
+            val person by Person.referencedOnSuspend(Addresses.person)
+            val city by City.referencedOnSuspend(Addresses.city)
+            var address by Addresses.address
+        }
+
+        object Towns : UUIDTable("towns") {
+            val cityId: Column<JavaUUID> = javaUUID("city_id").references(Cities.id)
+        }
+
+        class Town(id: EntityID<JavaUUID>) : UUIDR2dbcEntity(id) {
+            companion object : UUIDR2dbcEntityClass<Town>(Towns)
+
+            val city by City referencedOnSuspend Towns.cityId
+        }
+    }
+
+    @Test
+    fun `create tables`() {
+        withTables(JavaUUIDTables.Cities, JavaUUIDTables.People) {
+            assertEquals(true, JavaUUIDTables.Cities.exists())
+            assertEquals(true, JavaUUIDTables.People.exists())
+        }
+    }
+
+    @Test
+    fun `create records`() {
+        withTables(JavaUUIDTables.Cities, JavaUUIDTables.People) {
+            val mumbai = JavaUUIDTables.City.new { name = "Mumbai" }
+            val pune = JavaUUIDTables.City.new { name = "Pune" }
+            JavaUUIDTables.Person.new(JavaUUID.randomUUID()) {
+                name = "David D'souza"
+                city set mumbai
+            }
+            JavaUUIDTables.Person.new(JavaUUID.randomUUID()) {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            JavaUUIDTables.Person.new(JavaUUID.randomUUID()) {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            val allCities = JavaUUIDTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(true, allCities.contains<String>("Pune"))
+            assertEquals(false, allCities.contains<String>("Chennai"))
+
+            val allPeople = JavaUUIDTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("David D'souza", "Pune")))
+        }
+    }
+
+    @Test
+    fun `update and delete records`() {
+        withTables(JavaUUIDTables.Cities, JavaUUIDTables.People) {
+            val mumbai = JavaUUIDTables.City.new(JavaUUID.randomUUID()) { name = "Mumbai" }
+            val pune = JavaUUIDTables.City.new(JavaUUID.randomUUID()) { name = "Pune" }
+            JavaUUIDTables.Person.new(JavaUUID.randomUUID()) {
+                name = "David D'souza"
+                city set mumbai
+            }
+            JavaUUIDTables.Person.new(JavaUUID.randomUUID()) {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            val tanu = JavaUUIDTables.Person.new(JavaUUID.randomUUID()) {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            tanu.delete()
+            pune.delete()
+
+            val allCities = JavaUUIDTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(false, allCities.contains<String>("Pune"))
+
+            val allPeople = JavaUUIDTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("Tanu Arora", "Pune")))
+        }
+    }
+
+    @Test
+    fun `insert with inner table`() {
+        withTables(JavaUUIDTables.Addresses, JavaUUIDTables.Cities, JavaUUIDTables.People) {
+            val city1 = JavaUUIDTables.City.new {
+                name = "city1"
+            }
+            val person1 = JavaUUIDTables.Person.new {
+                name = "person1"
+                city set city1
+            }
+
+            val address1 = JavaUUIDTables.Address.new {
+                person set person1
+                city set city1
+                address = "address1"
+            }
+
+            val address2 = JavaUUIDTables.Address.new {
+                person set person1
+                city set city1
+                address = "address2"
+            }
+
+            address1.refresh(flush = true)
+            assertEquals("address1", address1.address)
+
+            address2.refresh(flush = true)
+            assertEquals("address2", address2.address)
+        }
+    }
+
+    @Test
+    fun testForeignKeyBetweenUUIDAndEntityIDColumns() {
+        withTables(JavaUUIDTables.Cities, JavaUUIDTables.Towns) {
+            val cId = JavaUUIDTables.Cities.insertAndGetId {
+                it[name] = "City A"
+            }
+            val tId = JavaUUIDTables.Towns.insertAndGetId {
+                it[cityId] = cId.value
+            }
+
+            // lazy loaded referencedOn
+            val town1 = JavaUUIDTables.Town.all().single()
+            assertEquals(cId, town1.city().id)
+
+            // eager loaded referencedOn
+            val town1WithCity = JavaUUIDTables.Town.all().with(JavaUUIDTables.Town::city).single()
+            assertEquals(cId, town1WithCity.city().id)
+
+            // lazy loaded referrersOn
+            val city1 = JavaUUIDTables.City.all().single()
+            val towns = city1.towns()
+            assertEquals(cId, towns.first().city().id)
+
+            // eager loaded referrersOn
+            val city1WithTowns = JavaUUIDTables.City.all().with(JavaUUIDTables.City::towns).single()
+            assertEquals(tId, city1WithTowns.towns().first().id)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcLongIdTableEntityTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcLongIdTableEntityTest.kt
@@ -1,0 +1,152 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.LongR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.r2dbc.exists
+import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import kotlin.test.Test
+
+class R2dbcLongIdTableEntityTest : R2dbcDatabaseTestsBase() {
+    object LongIdTables {
+        object Cities : LongIdTable() {
+            val name = varchar("name", 50)
+        }
+
+        class City(id: EntityID<Long>) : LongR2dbcEntity(id) {
+            companion object : LongR2dbcEntityClass<City>(Cities)
+
+            var name by Cities.name
+            val towns by Town referrersOnSuspend Towns.cityId
+        }
+
+        object People : LongIdTable() {
+            val name = varchar("name", 80)
+            val cityId = reference("city_id", Cities)
+        }
+
+        class Person(id: EntityID<Long>) : LongR2dbcEntity(id) {
+            companion object : LongR2dbcEntityClass<Person>(People)
+
+            var name by People.name
+            val city by City referencedOnSuspend People.cityId
+        }
+
+        object Towns : LongIdTable("towns") {
+            val cityId: Column<Long> = long("city_id").references(Cities.id)
+        }
+
+        class Town(id: EntityID<Long>) : LongR2dbcEntity(id) {
+            companion object : LongR2dbcEntityClass<Town>(Towns)
+
+            val city by City referencedOnSuspend Towns.cityId
+        }
+    }
+
+    @Test
+    fun `create tables`() {
+        withTables(LongIdTables.Cities, LongIdTables.People) {
+            assertEquals(true, LongIdTables.Cities.exists())
+            assertEquals(true, LongIdTables.People.exists())
+        }
+    }
+
+    @Test
+    fun `create records`() {
+        withTables(LongIdTables.Cities, LongIdTables.People) {
+            val mumbai = LongIdTables.City.new { name = "Mumbai" }
+            val pune = LongIdTables.City.new { name = "Pune" }
+            LongIdTables.Person.new {
+                name = "David D'souza"
+                city set mumbai
+            }
+            LongIdTables.Person.new {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            LongIdTables.Person.new {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            val allCities = LongIdTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(true, allCities.contains<String>("Pune"))
+            assertEquals(false, allCities.contains<String>("Chennai"))
+
+            val allPeople = LongIdTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("David D'souza", "Pune")))
+        }
+    }
+
+    @Test
+    fun `update and delete records`() {
+        withTables(LongIdTables.Cities, LongIdTables.People) {
+            val mumbai = LongIdTables.City.new { name = "Mumbai" }
+            val pune = LongIdTables.City.new { name = "Pune" }
+            LongIdTables.Person.new {
+                name = "David D'souza"
+                city set mumbai
+            }
+            LongIdTables.Person.new {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            val tanu = LongIdTables.Person.new {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            tanu.delete()
+            pune.delete()
+
+            val allCities = LongIdTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(false, allCities.contains<String>("Pune"))
+
+            val allPeople = LongIdTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("Tanu Arora", "Pune")))
+        }
+    }
+
+    @Test
+    fun testForeignKeyBetweenLongAndEntityIDColumns() {
+        withTables(LongIdTables.Cities, LongIdTables.Towns) {
+            val cId = LongIdTables.Cities.insertAndGetId {
+                it[name] = "City A"
+            }
+            val tId = LongIdTables.Towns.insertAndGetId {
+                it[cityId] = cId.value
+            }
+
+            // lazy loaded referencedOn
+            val town1 = LongIdTables.Town.all().single()
+            assertEquals(cId, town1.city().id)
+
+            // eager loaded referencedOn
+            val town1WithCity = LongIdTables.Town.all().with(LongIdTables.Town::city).single()
+            assertEquals(cId, town1WithCity.city().id)
+
+            // lazy loaded referrersOn
+            val city1 = LongIdTables.City.all().single()
+            val towns = city1.towns()
+            assertEquals(cId, towns.first().city().id)
+
+            // eager loaded referrersOn
+            val city1WithTowns = LongIdTables.City.all().with(LongIdTables.City::towns).single()
+            assertEquals(tId, city1WithTowns.towns().first().id)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcNonAutoIncEntities.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcNonAutoIncEntities.kt
@@ -1,0 +1,134 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.any
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.flushCache
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.r2dbc.update
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+
+class R2dbcNonAutoIncEntities : R2dbcDatabaseTestsBase() {
+    abstract class BaseNonAutoIncTable(name: String) : IdTable<Int>(name) {
+        override val id = integer("id").entityId()
+        val b1 = bool("b1")
+    }
+
+    object NotAutoIntIdTable : BaseNonAutoIncTable("") {
+        val defaultedInt = integer("i1")
+    }
+
+    class NotAutoEntity(id: EntityID<Int>) : R2dbcEntity<Int>(id) {
+        var b1 by NotAutoIntIdTable.b1
+        var defaultedInNew by NotAutoIntIdTable.defaultedInt
+
+        companion object : R2dbcEntityClass<Int, NotAutoEntity>(NotAutoIntIdTable) {
+            val lastId = AtomicInteger(0)
+            internal const val defaultInt = 42
+            fun new(b: Boolean) = new(lastId.incrementAndGet()) { b1 = b }
+
+            override fun new(id: Int?, init: NotAutoEntity.() -> Unit): NotAutoEntity {
+                return super.new(id ?: lastId.incrementAndGet()) {
+                    defaultedInNew = defaultInt
+                    init()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testDefaultsWithOverrideNew() {
+        withTables(NotAutoIntIdTable) {
+            val entity1 = NotAutoEntity.new(true)
+            assertEquals(true, entity1.b1)
+            assertEquals(NotAutoEntity.defaultInt, entity1.defaultedInNew)
+
+            val entity2 = NotAutoEntity.new {
+                b1 = false
+                defaultedInNew = 1
+            }
+            assertEquals(false, entity2.b1)
+            assertEquals(1, entity2.defaultedInNew)
+        }
+    }
+
+    @Test
+    fun testNotAutoIncTable() {
+        withTables(NotAutoIntIdTable) {
+            val e1 = NotAutoEntity.new(true)
+            val e2 = NotAutoEntity.new(false)
+
+            TransactionManager.current().flushCache()
+
+            val all = NotAutoEntity.all()
+            assert(all.any { it.id == e1.id })
+            assert(all.any { it.id == e2.id })
+        }
+    }
+
+    object CustomPrimaryKeyColumnTable : IdTable<String>() {
+        val customId: Column<String> = varchar("customId", 256)
+        override val primaryKey = PrimaryKey(customId)
+        override val id: Column<EntityID<String>> = customId.entityId()
+    }
+
+    class CustomPrimaryKeyColumnEntity(id: EntityID<String>) : R2dbcEntity<String>(id) {
+        companion object : R2dbcEntityClass<String, CustomPrimaryKeyColumnEntity>(CustomPrimaryKeyColumnTable)
+
+        var customId by CustomPrimaryKeyColumnTable.customId
+    }
+
+    @Test
+    fun testIdValueIsTheSameAsCustomPrimaryKeyColumn() {
+        withTables(CustomPrimaryKeyColumnTable) {
+            val request = CustomPrimaryKeyColumnEntity.new {
+                customId = "customIdValue"
+            }
+            flushCache()
+
+            assertEquals("customIdValue", request.id.value)
+        }
+    }
+
+    object RequestsTable : IdTable<String>() {
+        val requestId = varchar("request_id", 256)
+        val deleted = bool("deleted")
+        override val primaryKey: PrimaryKey = PrimaryKey(requestId)
+        override val id: Column<EntityID<String>> = requestId.entityId()
+    }
+
+    class Request(id: EntityID<String>) : R2dbcEntity<String>(id) {
+        companion object : R2dbcEntityClass<String, Request>(RequestsTable)
+
+        var requestId by RequestsTable.requestId
+        var deleted by RequestsTable.deleted
+
+        override suspend fun delete() {
+            RequestsTable.update({ RequestsTable.id eq id }) {
+                it[deleted] = true
+            }
+        }
+    }
+
+    @Test
+    fun testAccessEntityIdFromOverrideEntityMethod() {
+        withTables(RequestsTable) {
+            val request = Request.new {
+                requestId = "test1"
+                deleted = false
+            }
+
+            request.delete()
+
+            val updated = Request["test1"]
+            assertEquals(true, updated.deleted)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcOrderedReferenceTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcOrderedReferenceTest.kt
@@ -1,0 +1,249 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
+import org.jetbrains.exposed.r2dbc.dao.relationships.load
+import org.jetbrains.exposed.r2dbc.dao.relationships.optionalReferencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.statements.StatementContext
+import org.jetbrains.exposed.v1.core.statements.StatementInterceptor
+import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.insert
+import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
+import kotlin.math.max
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class R2dbcOrderedReferenceTest : R2dbcDatabaseTestsBase() {
+    object Users : IntIdTable()
+
+    object UserRatings : IntIdTable() {
+        val value = integer("value")
+        val user = reference("user", Users)
+    }
+
+    object UserNullableRatings : IntIdTable() {
+        val value = integer("value")
+        val user = reference("user", Users).nullable()
+    }
+
+    class UserRatingDefaultOrder(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserRatingDefaultOrder>(UserRatings)
+
+        var value by UserRatings.value
+        val user by UserDefaultOrder referencedOnSuspend UserRatings.user
+    }
+
+    class UserNullableRatingDefaultOrder(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserNullableRatingDefaultOrder>(UserNullableRatings)
+
+        var value by UserNullableRatings.value
+        val user by UserDefaultOrder optionalReferencedOnSuspend UserNullableRatings.user
+    }
+
+    class UserDefaultOrder(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserDefaultOrder>(Users)
+
+        val ratings by UserRatingDefaultOrder referrersOnSuspend UserRatings.user orderBy UserRatings.value
+        val nullableRatings by UserNullableRatingDefaultOrder optionalReferrersOnSuspend UserNullableRatings.user orderBy UserNullableRatings.value
+    }
+
+    @Test
+    fun testDefaultOrder() {
+        withOrderedReferenceTestTables {
+            val user = UserDefaultOrder.all().first()
+
+            unsortedRatingValues.sorted().toList().zip(user.ratings().toList()).forEach { (value, rating) ->
+                assertEquals(value, rating.value)
+            }
+            unsortedRatingValues.sorted().zip(user.nullableRatings().toList()).forEach { (value, rating) ->
+                assertEquals(value, rating.value)
+            }
+        }
+    }
+
+    @Test
+    fun testNoDuplicatedOrderByPartsInQuery() {
+        // This interceptor counts duplicated ORDER BY parts in the sql sent to database.
+        // We want to be sure that DAO doesn't create duplicated parts.
+        val interceptor = object : StatementInterceptor {
+            var maxDuplicates = 0
+            override fun beforeExecution(transaction: Transaction, context: StatementContext) {
+                val duplicatedPartsAmount = context.statement.prepareSQL(transaction)
+                    // Get all the parts from order by section
+                    .lowercase()
+                    .substringAfter("order by")
+                    .split(",")
+                    .map { it.trim() }
+                    // Count the occurrences of each part and take maximum
+                    .groupBy { it }
+                    .mapValues { (_, list) -> list.size }
+                    .maxByOrNull { it.value }
+                    ?.value ?: 0
+
+                maxDuplicates = max(maxDuplicates, duplicatedPartsAmount)
+            }
+        }
+
+        withOrderedReferenceTestTables {
+            registerInterceptor(interceptor)
+            // `orderBy` on references in DAO Entity classes could collect duplicated parts.
+            // That method is executed on every access to the field, so every query has
+            // one more duplicated part
+            // It's mentioned in the original issue
+            // 'EXPOSED-950 Order by clause is repeated hundredfold'
+            repeat(5) {
+                val user = UserDefaultOrder.all().first()
+                entityCache.clear()
+
+                // This sections needs only to force DAO fetch the data to execute SQL queries
+                user.ratings().forEach { rating ->
+                    assertNotNull(rating.value)
+                }
+
+                assertEquals(1, interceptor.maxDuplicates)
+            }
+        }
+    }
+
+    class UserRatingMultiColumn(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserRatingMultiColumn>(UserRatings)
+
+        var value by UserRatings.value
+        val user by UserMultiColumn referencedOnSuspend UserRatings.user
+    }
+
+    class UserNullableRatingMultiColumn(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserNullableRatingMultiColumn>(UserNullableRatings)
+
+        var value by UserNullableRatings.value
+        val user by UserMultiColumn optionalReferencedOnSuspend UserNullableRatings.user
+    }
+
+    class UserMultiColumn(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserMultiColumn>(Users)
+
+        val ratings by UserRatingMultiColumn
+            .referrersOnSuspend(UserRatings.user)
+            .orderBy(UserRatings.value to SortOrder.DESC, UserRatings.id to SortOrder.DESC)
+        val nullableRatings by UserNullableRatingMultiColumn
+            .optionalReferrersOnSuspend(UserNullableRatings.user)
+            .orderBy(
+                UserNullableRatings.value to SortOrder.DESC,
+                UserNullableRatings.id to SortOrder.DESC
+            )
+    }
+
+    @Test
+    fun testMultiColumnOrder() {
+        withOrderedReferenceTestTables {
+            val ratings = UserMultiColumn.all().first().ratings().toList()
+            val nullableRatings = UserMultiColumn.all().first().nullableRatings().toList()
+
+            // Ensure each value is less than the one before it.
+            // IDs should be sorted within groups of identical values.
+            fun assertRatingsOrdered(current: UserRatingMultiColumn, prev: UserRatingMultiColumn) {
+                assertTrue(current.value <= prev.value)
+                if (current.value == prev.value) {
+                    assertTrue(current.id.value <= prev.id.value)
+                }
+            }
+
+            fun assertNullableRatingsOrdered(current: UserNullableRatingMultiColumn, prev: UserNullableRatingMultiColumn) {
+                assertTrue(current.value <= prev.value)
+                if (current.value == prev.value) {
+                    assertTrue(current.id.value <= prev.id.value)
+                }
+            }
+
+            for (i in 1..<ratings.size) {
+                assertRatingsOrdered(ratings[i], ratings[i - 1])
+                assertNullableRatingsOrdered(nullableRatings[i], nullableRatings[i - 1])
+            }
+        }
+    }
+
+    class UserRatingChainedColumn(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserRatingChainedColumn>(UserRatings)
+
+        var value by UserRatings.value
+        val user by UserChainedColumn referencedOnSuspend UserRatings.user
+    }
+
+    class UserChainedColumn(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<UserChainedColumn>(Users)
+
+        val ratings by UserRatingChainedColumn referrersOnSuspend UserRatings.user orderBy
+            (UserRatings.value to SortOrder.DESC) orderBy (UserRatings.id to SortOrder.DESC)
+    }
+
+    @Test
+    fun testChainedOrderBy() {
+        withOrderedReferenceTestTables {
+            val ratings = UserChainedColumn.all().first().ratings().toList()
+
+            fun assertRatingsOrdered(current: UserRatingChainedColumn, prev: UserRatingChainedColumn) {
+                assertTrue(current.value <= prev.value)
+                if (current.value == prev.value) {
+                    assertTrue(current.id.value <= prev.id.value)
+                }
+            }
+
+            for (i in 1..<ratings.size) {
+                assertRatingsOrdered(ratings[i], ratings[i - 1])
+            }
+        }
+    }
+
+    @Test
+    fun testOrderByWithEagerLoad() {
+        withOrderedReferenceTestTables {
+            // Clearing cache is not critical, just to be sure that there are no caches from
+            //  creating entities step
+            entityCache.clear()
+
+            val user = UserDefaultOrder.all().first().load(UserDefaultOrder::ratings)
+
+            val expected = user.ratings().map { it.value }.toList().sorted()
+            val actual = user.ratings().map { it.value }
+
+            assertEqualLists(expected, actual)
+        }
+    }
+
+    private val unsortedRatingValues = listOf(0, 3, 1, 2, 4, 4, 5, 4, 5, 6, 9, 8)
+
+    private fun withOrderedReferenceTestTables(statement: suspend R2dbcTransaction.(TestDB) -> Unit) {
+        withTables(Users, UserRatings, UserNullableRatings) { db ->
+            val userId = Users.insertAndGetId { }
+            unsortedRatingValues.forEach { value ->
+                UserRatings.insert {
+                    it[user] = userId
+                    it[UserRatings.value] = value
+                }
+                UserNullableRatings.insert {
+                    it[user] = userId
+                    it[UserRatings.value] = value
+                }
+                UserNullableRatings.insert {
+                    it[user] = null
+                    it[UserRatings.value] = value
+                }
+            }
+            statement(db)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcSelfReferenceTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcSelfReferenceTest.kt
@@ -1,0 +1,105 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.DMLTestsData
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class R2dbcSelfReferenceTest {
+
+    @Test
+    fun simpleTest() {
+        assertEqualLists(listOf(DMLTestsData.Cities), SchemaUtils.sortTablesByReferences(listOf(DMLTestsData.Cities)))
+        assertEqualLists(listOf(DMLTestsData.Cities, DMLTestsData.Users), SchemaUtils.sortTablesByReferences(listOf(DMLTestsData.Users)))
+
+        val rightOrder = listOf(DMLTestsData.Cities, DMLTestsData.Users, DMLTestsData.UserData)
+        val r1 = SchemaUtils.sortTablesByReferences(listOf(DMLTestsData.Cities, DMLTestsData.UserData, DMLTestsData.Users))
+        val r2 = SchemaUtils.sortTablesByReferences(listOf(DMLTestsData.UserData, DMLTestsData.Cities, DMLTestsData.Users))
+        val r3 = SchemaUtils.sortTablesByReferences(listOf(DMLTestsData.Users, DMLTestsData.Cities, DMLTestsData.UserData))
+        assertEqualLists(rightOrder, r1)
+        assertEqualLists(rightOrder, r2)
+        assertEqualLists(rightOrder, r3)
+    }
+
+    object TestTables {
+        object cities : Table() {
+            val id = integer("id").autoIncrement()
+            val name = varchar("name", 50)
+            val strange_id = varchar("strange_id", 10).references(strangeTable.id)
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        object users : Table() {
+            val id = varchar("id", 10)
+            val name = varchar("name", length = 50)
+            val cityId = (integer("city_id") references cities.id).nullable()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        object noRefereeTable : Table() {
+            val id = varchar("id", 10)
+            val col1 = varchar("col1", 10)
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        object refereeTable : Table() {
+            val id = varchar("id", 10)
+            val ref = reference("ref", noRefereeTable.id)
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        object referencedTable : IntIdTable() {
+            val col3 = varchar("col3", 10)
+        }
+
+        object strangeTable : Table() {
+            val id = varchar("id", 10)
+            val user_id = varchar("user_id", 10) references users.id
+            val comment = varchar("comment", 30)
+            val value = integer("value")
+
+            override val primaryKey = PrimaryKey(id)
+        }
+    }
+
+    @Test
+    fun cycleReferencesCheckTest() {
+        val original = listOf(
+            TestTables.cities,
+            TestTables.users,
+            TestTables.strangeTable,
+            TestTables.noRefereeTable,
+            TestTables.refereeTable,
+            TestTables.referencedTable
+        )
+        val sortedTables = SchemaUtils.sortTablesByReferences(original)
+        val expected = listOf(
+            TestTables.users,
+            TestTables.strangeTable,
+            TestTables.cities,
+            TestTables.noRefereeTable,
+            TestTables.refereeTable,
+            TestTables.referencedTable
+        )
+
+        assertEqualLists(expected, sortedTables)
+    }
+
+    @Test
+    fun testHasCycle() {
+        assertFalse(SchemaUtils.checkCycle(TestTables.referencedTable))
+        assertFalse(SchemaUtils.checkCycle(TestTables.refereeTable))
+        assertFalse(SchemaUtils.checkCycle(TestTables.noRefereeTable))
+        assertTrue(SchemaUtils.checkCycle(TestTables.users))
+        assertTrue(SchemaUtils.checkCycle(TestTables.cities))
+        assertTrue(SchemaUtils.checkCycle(TestTables.strangeTable))
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcUIntIdTableEntityTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcUIntIdTableEntityTest.kt
@@ -1,0 +1,153 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.UIntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.UIntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.UIntIdTable
+import org.jetbrains.exposed.v1.r2dbc.exists
+import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import kotlin.test.Test
+
+class R2dbcUIntIdTableEntityTest : R2dbcDatabaseTestsBase() {
+
+    @Test
+    fun `create tables`() {
+        withTables(UIntIdTables.Cities, UIntIdTables.People) {
+            assertEquals(true, UIntIdTables.Cities.exists())
+            assertEquals(true, UIntIdTables.People.exists())
+        }
+    }
+
+    @Test
+    fun `create records`() {
+        withTables(UIntIdTables.Cities, UIntIdTables.People) {
+            val mumbai = UIntIdTables.City.new { name = "Mumbai" }
+            val pune = UIntIdTables.City.new { name = "Pune" }
+            UIntIdTables.Person.new {
+                name = "David D'souza"
+                city set mumbai
+            }
+            UIntIdTables.Person.new {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            UIntIdTables.Person.new {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            val allCities = UIntIdTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(true, allCities.contains<String>("Pune"))
+            assertEquals(false, allCities.contains<String>("Chennai"))
+
+            val allPeople = UIntIdTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("David D'souza", "Pune")))
+        }
+    }
+
+    @Test
+    fun `update and delete records`() {
+        withTables(UIntIdTables.Cities, UIntIdTables.People) {
+            val mumbai = UIntIdTables.City.new { name = "Mumbai" }
+            val pune = UIntIdTables.City.new { name = "Pune" }
+            UIntIdTables.Person.new {
+                name = "David D'souza"
+                city set mumbai
+            }
+            UIntIdTables.Person.new {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            val tanu = UIntIdTables.Person.new {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            tanu.delete()
+            pune.delete()
+
+            val allCities = UIntIdTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(false, allCities.contains<String>("Pune"))
+
+            val allPeople = UIntIdTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("Tanu Arora", "Pune")))
+        }
+    }
+
+    @Test
+    fun testForeignKeyBetweenUIntAndEntityIDColumns() {
+        withTables(UIntIdTables.Cities, UIntIdTables.Towns) {
+            val cId = UIntIdTables.Cities.insertAndGetId {
+                it[name] = "City A"
+            }
+            val tId = UIntIdTables.Towns.insertAndGetId {
+                it[cityId] = cId.value
+            }
+
+            // lazy loaded referencedOn
+            val town1 = UIntIdTables.Town.all().single()
+            assertEquals(cId, town1.city().id)
+
+            // eager loaded referencedOn
+            val town1WithCity = UIntIdTables.Town.all().with(UIntIdTables.Town::city).single()
+            assertEquals(cId, town1WithCity.city().id)
+
+            // lazy loaded referrersOn
+            val city1 = UIntIdTables.City.all().single()
+            val towns = city1.towns()
+            assertEquals(cId, towns.first().city().id)
+
+            // eager loaded referrersOn
+            val city1WithTowns = UIntIdTables.City.all().with(UIntIdTables.City::towns).single()
+            assertEquals(tId, city1WithTowns.towns().first().id)
+        }
+    }
+}
+
+object UIntIdTables {
+    object Cities : UIntIdTable() {
+        val name = varchar("name", 50)
+    }
+
+    class City(id: EntityID<UInt>) : UIntR2dbcEntity(id) {
+        companion object : UIntR2dbcEntityClass<City>(Cities)
+
+        var name by Cities.name
+        val towns by Town referrersOnSuspend Towns.cityId
+    }
+
+    object People : UIntIdTable() {
+        val name = varchar("name", 80)
+        val cityId = reference("city_id", Cities)
+    }
+
+    class Person(id: EntityID<UInt>) : UIntR2dbcEntity(id) {
+        companion object : UIntR2dbcEntityClass<Person>(People)
+
+        var name by People.name
+        val city by City referencedOnSuspend People.cityId
+    }
+
+    object Towns : UIntIdTable("towns") {
+        val cityId: Column<UInt> = uinteger("city_id").references(Cities.id)
+    }
+
+    class Town(id: EntityID<UInt>) : UIntR2dbcEntity(id) {
+        companion object : UIntR2dbcEntityClass<Town>(Towns)
+
+        val city by City referencedOnSuspend Towns.cityId
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcULongIdTableEntityTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcULongIdTableEntityTest.kt
@@ -1,0 +1,157 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.ULongR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.ULongR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.ULongIdTable
+import org.jetbrains.exposed.v1.r2dbc.exists
+import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.junit.jupiter.api.Test
+
+class R2dbcULongIdTableEntityTest : R2dbcDatabaseTestsBase() {
+
+    @Test
+    fun `create tables`() {
+        withTables(ULongIdTables.People) {
+            assertEquals(true, ULongIdTables.Cities.exists())
+            assertEquals(true, ULongIdTables.People.exists())
+        }
+    }
+
+    @Test
+    fun `create records`() {
+        withTables(ULongIdTables.People) {
+            val mumbai = ULongIdTables.City.new { name = "Mumbai" }
+            val pune = ULongIdTables.City.new { name = "Pune" }
+            ULongIdTables.Person.new {
+                name = "David D'souza"
+                city set mumbai
+            }
+            ULongIdTables.Person.new {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            ULongIdTables.Person.new {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            val allCities = ULongIdTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(true, allCities.contains<String>("Pune"))
+            assertEquals(false, allCities.contains<String>("Chennai"))
+
+            val allPeople = ULongIdTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("David D'souza", "Pune")))
+        }
+    }
+
+    @Test
+    fun `update and delete records`() {
+        withTables(ULongIdTables.People) {
+            val mumbai = ULongIdTables.City.new { name = "Mumbai" }
+            val pune = ULongIdTables.City.new { name = "Pune" }
+            ULongIdTables.Person.new {
+                name = "David D'souza"
+                city set mumbai
+            }
+            ULongIdTables.Person.new {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            val tanu = ULongIdTables.Person.new {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            tanu.delete()
+            pune.delete()
+
+            val allCities = ULongIdTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(false, allCities.contains<String>("Pune"))
+
+            val allPeople = ULongIdTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("Tanu Arora", "Pune")))
+        }
+    }
+
+    @Test
+    fun testForeignKeyBetweenULongAndEntityIDColumns() {
+        withTables(ULongIdTables.Cities, ULongIdTables.Towns) {
+            val cId = ULongIdTables.Cities.insertAndGetId {
+                it[name] = "City A"
+            }
+            val tId = ULongIdTables.Towns.insertAndGetId {
+                it[cityId] = cId.value
+            }
+
+            // lazy loaded referencedOn
+            val town1 = ULongIdTables.Town.all().single()
+            assertEquals(cId, town1.city().id)
+
+            // eager loaded referencedOn
+            val town1WithCity =
+                ULongIdTables.Town.all().with(ULongIdTables.Town::city)
+                    .single()
+            assertEquals(cId, town1WithCity.city().id)
+
+            // lazy loaded referrersOn
+            val city1 = ULongIdTables.City.all().single()
+            val towns = city1.towns()
+            assertEquals(cId, towns.first().city().id)
+
+            // eager loaded referrersOn
+            val city1WithTowns =
+                ULongIdTables.City.all().with(ULongIdTables.City::towns)
+                    .single()
+            assertEquals(tId, city1WithTowns.towns().first().id)
+        }
+    }
+}
+
+object ULongIdTables {
+    object Cities : ULongIdTable() {
+        val name = varchar("name", 50)
+    }
+
+    class City(id: EntityID<ULong>) : ULongR2dbcEntity(id) {
+        companion object : ULongR2dbcEntityClass<City>(Cities)
+
+        var name by Cities.name
+        val towns by Town referrersOnSuspend Towns.cityId
+    }
+
+    object People : ULongIdTable() {
+        val name = varchar("name", 80)
+        val cityId = reference("city_id", Cities)
+    }
+
+    class Person(id: EntityID<ULong>) : ULongR2dbcEntity(id) {
+        companion object : ULongR2dbcEntityClass<Person>(People)
+
+        var name by People.name
+        val city by City referencedOnSuspend People.cityId
+    }
+
+    object Towns : ULongIdTable("towns") {
+        val cityId: Column<ULong> = ulong("city_id").references(Cities.id)
+    }
+
+    class Town(id: EntityID<ULong>) : ULongR2dbcEntity(id) {
+        companion object : ULongR2dbcEntityClass<Town>(Towns)
+
+        val city by City referencedOnSuspend Towns.cityId
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcUuidTableEntityTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcUuidTableEntityTest.kt
@@ -1,0 +1,248 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.UuidR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.UuidR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.UuidTable
+import org.jetbrains.exposed.v1.r2dbc.exists
+import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
+import org.jetbrains.exposed.v1.r2dbc.tests.versionNumber
+import kotlin.test.Test
+import kotlin.uuid.Uuid
+
+class R2dbcUuidTableEntityTest : R2dbcDatabaseTestsBase() {
+    @Suppress("MemberNameEqualsClassName")
+    object UuidTables {
+        object Cities : UuidTable() {
+            val name = varchar("name", 50)
+        }
+
+        class City(id: EntityID<Uuid>) : UuidR2dbcEntity(id) {
+            companion object : UuidR2dbcEntityClass<City>(Cities)
+
+            var name by Cities.name
+            val towns by Town referrersOnSuspend Towns.cityId
+        }
+
+        object People : UuidTable() {
+            val name = varchar("name", 80)
+            val cityId = reference("city_id", Cities)
+        }
+
+        class Person(id: EntityID<Uuid>) : UuidR2dbcEntity(id) {
+            companion object : UuidR2dbcEntityClass<Person>(People)
+
+            var name by People.name
+            val city by City referencedOnSuspend People.cityId
+        }
+
+        object Addresses : UuidTable() {
+            val person = reference("person_id", People)
+            val city = reference("city_id", Cities)
+            val address = varchar("address", 255)
+        }
+
+        class Address(id: EntityID<Uuid>) : UuidR2dbcEntity(id) {
+            companion object : UuidR2dbcEntityClass<Address>(Addresses)
+
+            val person by Person.referencedOnSuspend(Addresses.person)
+            val city by City.referencedOnSuspend(Addresses.city)
+            var address by Addresses.address
+        }
+
+        object Towns : UuidTable("towns") {
+            val cityId: Column<Uuid> = uuid("city_id").references(Cities.id)
+        }
+
+        class Town(id: EntityID<Uuid>) : UuidR2dbcEntity(id) {
+            companion object : UuidR2dbcEntityClass<Town>(Towns)
+
+            val city by City referencedOnSuspend Towns.cityId
+        }
+
+        object Books : UuidTable(uuidVersion = UuidVersion.V7) { // id should use V7
+            val title = varchar("title", 256)
+            val ssid = uuid("ssid").autoGenerate() // should use V4
+            val pubId = uuid("pub_id").autoGenerate(UuidVersion.V7) // should use V7
+            val pubCityId = reference("pub_city_id", Cities) // should use V4 as Cities uses V4
+        }
+
+        class Book(id: EntityID<Uuid>) : UuidR2dbcEntity(id) {
+            companion object : UuidR2dbcEntityClass<Book>(Books)
+
+            var title by Books.title
+            var ssid by Books.ssid
+            var pubId by Books.pubId
+            val pubCity by City referencedOnSuspend Books.pubCityId
+        }
+    }
+
+    @Test
+    fun `create tables`() {
+        withTables(UuidTables.Cities, UuidTables.People) {
+            assertEquals(true, UuidTables.Cities.exists())
+            assertEquals(true, UuidTables.People.exists())
+        }
+    }
+
+    @Test
+    fun `create records`() {
+        withTables(UuidTables.Cities, UuidTables.People) {
+            val mumbai = UuidTables.City.new { name = "Mumbai" }
+            val pune = UuidTables.City.new { name = "Pune" }
+            UuidTables.Person.new(Uuid.random()) {
+                name = "David D'souza"
+                city set mumbai
+            }
+            UuidTables.Person.new(Uuid.random()) {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            UuidTables.Person.new(Uuid.random()) {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            val allCities = UuidTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(true, allCities.contains<String>("Pune"))
+            assertEquals(false, allCities.contains<String>("Chennai"))
+
+            val allPeople = UuidTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("David D'souza", "Pune")))
+        }
+    }
+
+    @Test
+    fun `update and delete records`() {
+        withTables(UuidTables.Cities, UuidTables.People) {
+            val mumbai = UuidTables.City.new(Uuid.random()) { name = "Mumbai" }
+            val pune = UuidTables.City.new(Uuid.random()) { name = "Pune" }
+            UuidTables.Person.new(Uuid.random()) {
+                name = "David D'souza"
+                city set mumbai
+            }
+            UuidTables.Person.new(Uuid.random()) {
+                name = "Tushar Mumbaikar"
+                city set mumbai
+            }
+            val tanu = UuidTables.Person.new(Uuid.random()) {
+                name = "Tanu Arora"
+                city set pune
+            }
+
+            tanu.delete()
+            pune.delete()
+
+            val allCities = UuidTables.City.all().map { it.name }.toList()
+            assertEquals(true, allCities.contains<String>("Mumbai"))
+            assertEquals(false, allCities.contains<String>("Pune"))
+
+            val allPeople = UuidTables.Person.all().map { Pair(it.name, it.city().name) }.toList()
+            assertEquals(true, allPeople.contains(Pair("David D'souza", "Mumbai")))
+            assertEquals(false, allPeople.contains(Pair("Tanu Arora", "Pune")))
+        }
+    }
+
+    @Test
+    fun `insert with inner table`() {
+        withTables(UuidTables.Addresses, UuidTables.Cities, UuidTables.People) {
+            val city1 = UuidTables.City.new {
+                name = "city1"
+            }
+            val person1 = UuidTables.Person.new {
+                name = "person1"
+                city set city1
+            }
+
+            val address1 = UuidTables.Address.new {
+                person set person1
+                city set city1
+                address = "address1"
+            }
+
+            val address2 = UuidTables.Address.new {
+                person set person1
+                city set city1
+                address = "address2"
+            }
+
+            address1.refresh(flush = true)
+            assertEquals("address1", address1.address)
+
+            address2.refresh(flush = true)
+            assertEquals("address2", address2.address)
+        }
+    }
+
+    @Test
+    fun testForeignKeyBetweenUuidAndEntityIDColumns() {
+        withTables(UuidTables.Cities, UuidTables.Towns) {
+            val cId = UuidTables.Cities.insertAndGetId {
+                it[name] = "City A"
+            }
+            val tId = UuidTables.Towns.insertAndGetId {
+                it[cityId] = cId.value
+            }
+
+            // lazy loaded referencedOn
+            val town1 = UuidTables.Town.all().single()
+            assertEquals(cId, town1.city().id)
+
+            // eager loaded referencedOn
+            val town1WithCity = UuidTables.Town.all().with(UuidTables.Town::city).single()
+            assertEquals(cId, town1WithCity.city().id)
+
+            // lazy loaded referrersOn
+            val city1 = UuidTables.City.all().single()
+            val towns = city1.towns()
+            assertEquals(cId, towns.first().city().id)
+
+            // eager loaded referrersOn
+            val city1WithTowns = UuidTables.City.all().with(UuidTables.City::towns).single()
+            assertEquals(tId, city1WithTowns.towns().first().id)
+        }
+    }
+
+    @Test
+    fun testUuidVersionAutoGenerated() {
+        withTables(UuidTables.Cities, UuidTables.Books) {
+            // generateV4() used by default if UuidTable primary constructor used
+            val munich = UuidTables.City.new { name = "Munich" }
+            assertEquals(4, munich.id.value.versionNumber())
+
+            // UuidTable secondary constructor used with generateV7() enabled
+            val book1 = UuidTables.Book.new {
+                title = "Joy of Kotlin"
+                pubCity set munich
+            }
+            // so only the UuidTable.id should automatically use V7 now
+            assertEquals(7, book1.id.value.versionNumber())
+            // other Uuid columns detected in the table should use whatever version they are defined to use
+            assertEquals(4, book1.ssid.versionNumber())
+            assertEquals(7, book1.pubId.versionNumber())
+            assertEquals(4, book1.pubCity().id.value.versionNumber())
+
+            Thread.sleep(100)
+
+            val book2 = UuidTables.Book.new {
+                title = "Kotlin in Action"
+                pubCity set munich
+            }
+            assertEquals(7, book2.id.value.versionNumber())
+            // time-based Uuids are strictly ordered
+            assertTrue(book1.id.value < book2.id.value)
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcViaTest.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcViaTest.kt
@@ -1,0 +1,399 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import io.r2dbc.spi.IsolationLevel
+import kotlinx.coroutines.flow.singleOrNull
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.CompositeR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.CompositeR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.UuidR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.UuidR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.entityCache
+import org.jetbrains.exposed.r2dbc.dao.relationships.R2dbcInnerTableLinkAccessor
+import org.jetbrains.exposed.r2dbc.dao.relationships.with
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.dao.id.CompositeID
+import org.jetbrains.exposed.v1.core.dao.id.CompositeIdTable
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.core.dao.id.UuidTable
+import org.jetbrains.exposed.v1.r2dbc.selectAll
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualCollections
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.r2dbc.transactions.inTopLevelSuspendTransaction
+import java.util.Objects
+import kotlin.reflect.jvm.isAccessible
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+object ViaTestData {
+    object NumbersTable : UuidTable() {
+        val number = integer("number")
+    }
+
+    object StringsTable : IdTable<Long>("") {
+        override val id: Column<EntityID<Long>> = long("id").autoIncrement().entityId()
+        val text = varchar("text", 10)
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    interface IConnectionTable {
+        val numId: Column<EntityID<Uuid>>
+        val stringId: Column<EntityID<Long>>
+    }
+
+    object ConnectionTable : Table(), IConnectionTable {
+        override val numId = reference("numId", NumbersTable, ReferenceOption.CASCADE)
+        override val stringId = reference("stringId", StringsTable, ReferenceOption.CASCADE)
+
+        init {
+            index(true, numId, stringId)
+        }
+    }
+
+    object ConnectionAutoIncTable : IntIdTable(), IConnectionTable {
+        override val numId = reference("numId", NumbersTable, ReferenceOption.CASCADE)
+        override val stringId = reference("stringId", StringsTable, ReferenceOption.CASCADE)
+
+        init {
+            index(true, numId, stringId)
+        }
+    }
+
+    val allTables: Array<Table> = arrayOf(NumbersTable, StringsTable, ConnectionTable, ConnectionAutoIncTable)
+}
+
+class VNumber(id: EntityID<Uuid>) : UuidR2dbcEntity(id) {
+    var number by ViaTestData.NumbersTable.number
+    val connectedStrings by VString viaSuspend ViaTestData.ConnectionTable
+    val connectedAutoStrings by VString viaSuspend ViaTestData.ConnectionAutoIncTable
+
+    companion object : UuidR2dbcEntityClass<VNumber>(ViaTestData.NumbersTable)
+}
+
+class VString(id: EntityID<Long>) : R2dbcEntity<Long>(id) {
+    var text by ViaTestData.StringsTable.text
+
+    companion object : R2dbcEntityClass<Long, VString>(ViaTestData.StringsTable)
+}
+
+class R2dbcViaTest : R2dbcDatabaseTestsBase() {
+    private suspend fun VNumber.testWithBothTables(valuesToSet: List<VString>, body: suspend (ViaTestData.IConnectionTable, List<ResultRow>) -> Unit) {
+        listOf(ViaTestData.ConnectionTable, ViaTestData.ConnectionAutoIncTable).forEach { t ->
+            if (t == ViaTestData.ConnectionTable) {
+                connectedStrings set valuesToSet
+            } else {
+                connectedAutoStrings set valuesToSet
+            }
+
+            val result = t.selectAll().toList()
+            body(t, result)
+        }
+    }
+
+    @Test
+    fun testConnection01() {
+        withTables(*ViaTestData.allTables) {
+            val n = VNumber.new { number = 10 }
+            val s = VString.new { text = "aaa" }
+            n.testWithBothTables(listOf(s)) { table, result ->
+                val row = result.single()
+                assertEquals(n.id, row[table.numId])
+                assertEquals(s.id, row[table.stringId])
+            }
+        }
+    }
+
+    @Test
+    fun testConnection02() {
+        withTables(*ViaTestData.allTables) {
+            val n1 = VNumber.new { number = 1 }
+            val n2 = VNumber.new { number = 2 }
+            val s1 = VString.new { text = "aaa" }
+            val s2 = VString.new { text = "bbb" }
+
+            n1.testWithBothTables(listOf(s1, s2)) { table, row ->
+                assertEquals(2, row.count())
+                assertEquals(n1.id, row[0][table.numId])
+                assertEquals(n1.id, row[1][table.numId])
+                assertEqualCollections(listOf(s1.id, s2.id), row.map { it[table.stringId] })
+            }
+        }
+    }
+
+    @Test
+    fun testConnection03() {
+        withTables(*ViaTestData.allTables) {
+            val n1 = VNumber.new { number = 1 }
+            val n2 = VNumber.new { number = 2 }
+            val s1 = VString.new { text = "aaa" }
+            val s2 = VString.new { text = "bbb" }
+
+            n1.testWithBothTables(listOf(s1, s2)) { _, _ -> }
+            n2.testWithBothTables(listOf(s1, s2)) { _, row ->
+                assertEquals(4, row.count())
+                assertEqualCollections(n1.connectedStrings(), listOf(s1, s2))
+                assertEqualCollections(n2.connectedStrings(), listOf(s1, s2))
+            }
+
+            n1.testWithBothTables(emptyList()) { table, row ->
+                assertEquals(2, row.count())
+                assertEquals(n2.id, row[0][table.numId])
+                assertEquals(n2.id, row[1][table.numId])
+                assertEqualCollections(n1.connectedStrings(), emptyList())
+                assertEqualCollections(n2.connectedStrings(), listOf(s1, s2))
+            }
+        }
+    }
+
+    @Test
+    fun testConnection04() {
+        withTables(*ViaTestData.allTables) {
+            val n1 = VNumber.new { number = 1 }
+            val n2 = VNumber.new { number = 2 }
+            val s1 = VString.new { text = "aaa" }
+            val s2 = VString.new { text = "bbb" }
+
+            n1.testWithBothTables(listOf(s1, s2)) { _, _ -> }
+            n2.testWithBothTables(listOf(s1, s2)) { _, row ->
+                assertEquals(4, row.count())
+                assertEqualCollections(n1.connectedStrings(), listOf(s1, s2))
+                assertEqualCollections(n2.connectedStrings(), listOf(s1, s2))
+            }
+
+            n1.testWithBothTables(listOf(s1)) { _, row ->
+                assertEquals(3, row.count())
+                assertEqualCollections(n1.connectedStrings(), listOf(s1))
+                assertEqualCollections(n2.connectedStrings(), listOf(s1, s2))
+            }
+        }
+    }
+
+    object NodesTable : IntIdTable() {
+        val name = varchar("name", 50)
+    }
+
+    object NodeToNodes : Table() {
+        val parent = reference("parent_node_id", NodesTable)
+        val child = reference("child_user_id", NodesTable)
+    }
+
+    class Node(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<Node>(NodesTable)
+
+        var name by NodesTable.name
+        val parents by Node.viaSuspend(NodeToNodes.child, NodeToNodes.parent)
+        val children by Node.viaSuspend(NodeToNodes.parent, NodeToNodes.child)
+
+        override fun equals(other: Any?): Boolean = (other as? Node)?.id == id
+
+        override fun hashCode(): Int = Objects.hash(id)
+    }
+
+    @Test
+    fun testHierarchicalReferences() {
+        withTables(NodesTable, NodeToNodes) {
+            val root = Node.new { name = "root" }
+            val child1 = Node.new {
+                name = "child1"
+            }
+            // TODO at the current moment it's not possible to set this value inside `new()`, becuase `new(){}` block is non suspend
+            child1.parents set listOf(root)
+
+            assertEquals(0L, root.parents().count())
+            assertEquals(1L, root.children().count())
+
+            val child2 = Node.new { name = "child2" }
+            root.children set listOf(child1, child2)
+
+            assertEquals(root, child1.parents().singleOrNull())
+            assertEquals(root, child2.parents().singleOrNull())
+        }
+    }
+
+    @Test
+    fun testRefresh() {
+        withTables(*ViaTestData.allTables) {
+            val s = VString.new { text = "ccc" }.apply {
+                refresh(true)
+            }
+            assertEquals("ccc", s.text)
+        }
+    }
+
+    @Test
+    fun testWarmUpOnHierarchicalEntities() {
+        withTables(NodesTable, NodeToNodes) {
+            val child1 = Node.new { name = "child1" }
+            val child2 = Node.new { name = "child1" }
+            val root1 = Node.new {
+                name = "root1"
+            }
+            // TODO same problem with `new(){}` block
+            root1.children set listOf(child1)
+
+            val root2 = Node.new {
+                name = "root2"
+            }
+            // TODO same problem with `new(){}` block
+            root2.children set listOf(child1, child2)
+
+            entityCache.clear(flush = true)
+
+            suspend fun checkChildrenReferences(node: Node, values: List<Node>) {
+                val sourceColumn = (Node::children.apply { isAccessible = true }.getDelegate(node) as R2dbcInnerTableLinkAccessor<*, *, *, *>).link.sourceColumn
+                val children = entityCache.getReferrers<Node>(node.id, sourceColumn)
+                assertEqualLists(children?.toList().orEmpty(), values)
+            }
+
+            Node.all().with(Node::children).toList()
+            checkChildrenReferences(child1, emptyList())
+            checkChildrenReferences(child2, emptyList())
+            checkChildrenReferences(root1, listOf(child1))
+            checkChildrenReferences(root2, listOf(child1, child2))
+
+            suspend fun checkParentsReferences(node: Node, values: List<Node>) {
+                val sourceColumn = (Node::parents.apply { isAccessible = true }.getDelegate(node) as R2dbcInnerTableLinkAccessor<*, *, *, *>).link.sourceColumn
+                val children = entityCache.getReferrers<Node>(node.id, sourceColumn)
+                assertEqualLists(children?.toList().orEmpty(), values)
+            }
+
+            Node.all().with(Node::parents).toList()
+            checkParentsReferences(child1, listOf(root1, root2))
+            checkParentsReferences(child2, listOf(root2))
+            checkParentsReferences(root1, emptyList())
+            checkParentsReferences(root2, emptyList())
+        }
+    }
+
+    class NodeOrdered(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<NodeOrdered>(NodesTable)
+
+        var name by NodesTable.name
+        val parents by NodeOrdered.viaSuspend(NodeToNodes.child, NodeToNodes.parent)
+        val children by NodeOrdered.viaSuspend(NodeToNodes.parent, NodeToNodes.child) orderBy (NodesTable.name to SortOrder.ASC)
+
+        override fun equals(other: Any?): Boolean = (other as? NodeOrdered)?.id == id
+
+        override fun hashCode(): Int = Objects.hash(id)
+    }
+
+    @Test
+    fun testOrderBy() {
+        withTables(NodesTable, NodeToNodes) {
+            val root = NodeOrdered.new { name = "root" }
+            listOf("#3", "#0", "#2", "#4", "#1").forEach {
+                val n = NodeOrdered.new {
+                    name = it
+                }
+                // TODO same problem with `new(){}` block
+                n.parents set listOf(root)
+            }
+
+            root.children().toList().forEachIndexed { index, node ->
+                assertEquals("#$index", node.name)
+            }
+        }
+    }
+
+    object Projects : IntIdTable("projects") {
+        val name = varchar("name", 50)
+    }
+
+    class Project(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<Project>(Projects)
+
+        var name by Projects.name
+        val tasks by Task viaSuspend ProjectTasks
+    }
+
+    object ProjectTasks : CompositeIdTable("project_tasks") {
+        val project = reference("project", Projects, onDelete = ReferenceOption.CASCADE)
+        val task = reference("task", Tasks, onDelete = ReferenceOption.CASCADE)
+        val approved = bool("approved")
+
+        override val primaryKey = PrimaryKey(project, task)
+
+        init {
+            addIdColumn(project)
+            addIdColumn(task)
+        }
+    }
+
+    class ProjectTask(id: EntityID<CompositeID>) : CompositeR2dbcEntity(id) {
+        companion object : CompositeR2dbcEntityClass<ProjectTask>(ProjectTasks)
+
+        var approved by ProjectTasks.approved
+    }
+
+    object Tasks : IntIdTable("tasks") {
+        val title = varchar("title", 64)
+    }
+
+    class Task(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        companion object : IntR2dbcEntityClass<Task>(Tasks)
+
+        var title by Tasks.title
+        val approved by ProjectTasks.approved
+    }
+
+    @Test
+    fun testAdditionalLinkDataUsingCompositeIdInnerTable() {
+        withTables(Projects, Tasks, ProjectTasks) {
+            val p1 = Project.new { name = "Project 1" }
+            val p2 = Project.new { name = "Project 2" }
+            val t1 = Task.new { title = "Task 1" }
+            val t2 = Task.new { title = "Task 2" }
+            val t3 = Task.new { title = "Task 3" }
+
+            ProjectTask.new(
+                CompositeID {
+                    it[ProjectTasks.task] = t1.id
+                    it[ProjectTasks.project] = p1.id
+                }
+            ) { approved = true }
+            ProjectTask.new(
+                CompositeID {
+                    it[ProjectTasks.task] = t2.id
+                    it[ProjectTasks.project] = p2.id
+                }
+            ) { approved = false }
+            ProjectTask.new(
+                CompositeID {
+                    it[ProjectTasks.task] = t3.id
+                    it[ProjectTasks.project] = p2.id
+                }
+            ) { approved = false }
+
+            commit()
+
+            inTopLevelSuspendTransaction(transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                maxAttempts = 1
+                Project.all().with(Project::tasks)
+                val cache = TransactionManager.current().entityCache
+
+                val p1Tasks = cache.getReferrers<Task>(p1.id, ProjectTasks.project)?.toList().orEmpty()
+                assertEqualLists(p1Tasks.map { it.id }, listOf(t1.id))
+                assertTrue { p1Tasks.all { task -> task.approved } }
+
+                val p2Tasks = cache.getReferrers<Task>(p2.id, ProjectTasks.project)?.toList().orEmpty()
+                assertEqualLists(p2Tasks.map { it.id }, listOf(t2.id, t3.id))
+                assertFalse { p1Tasks.all { task -> !task.approved } }
+            }
+        }
+    }
+}

--- a/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcWarmUpLinkedReferencesTests.kt
+++ b/exposed-dao-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/dao/r2dbc/tests/shared/R2dbcWarmUpLinkedReferencesTests.kt
@@ -1,0 +1,69 @@
+package org.jetbrains.exposed.dao.r2dbc.tests.shared
+
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.IntR2dbcEntityClass
+import org.jetbrains.exposed.r2dbc.dao.flushCache
+import org.jetbrains.exposed.r2dbc.dao.relationships.referencedOnSuspend
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import kotlin.test.Test
+
+class R2dbcWarmUpLinkedReferencesTests : R2dbcDatabaseTestsBase() {
+
+    object Box : IntIdTable() {
+        val value = integer("value")
+    }
+
+    class EBox(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by Box.value
+
+        companion object : IntR2dbcEntityClass<EBox>(Box)
+    }
+
+    object BoxItem : IntIdTable() {
+        val box = reference("box", Box)
+
+        val value = integer("value")
+    }
+
+    class EBoxItem(id: EntityID<Int>) : IntR2dbcEntity(id) {
+        var value by BoxItem.value
+        val box by EBox referencedOnSuspend BoxItem.box
+
+        companion object : IntR2dbcEntityClass<EBoxItem>(BoxItem)
+    }
+
+    @Test
+    fun warmUpLinkedReferencesShouldNotReturnAllTheValueFromCache() {
+        withTables(Box, BoxItem) {
+            val boxEntities = (0..4).map {
+                EBox.new {
+                    value = it
+                }
+            }
+
+            // TODO R2DBC: flush before reading `it.id.value` — `R2dbcDaoEntityID` cannot trigger a
+            //  suspending `flushInserts` from a non-suspend property accessor, so we flush
+            //  explicitly to populate the auto-increment ids before referencing them below.
+            flushCache()
+
+            boxEntities.forEach {
+                val e = EBoxItem.new {
+                    value = it.id.value
+                }
+                // TODO again setting out of `new()`
+                e.box set it
+            }
+
+            val ids = boxEntities.map { it.id }
+
+            // Warm up all the entities to fill the cache
+            EBox.warmUpLinkedReferences(ids, BoxItem)
+
+            val warmedUp = EBox.warmUpLinkedReferences(ids.slice(0..2), BoxItem)
+            assertEquals(3, warmedUp.size)
+        }
+    }
+}

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/CompositeEntity.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/CompositeEntity.kt
@@ -1,0 +1,13 @@
+package org.jetbrains.exposed.r2dbc.dao
+
+import org.jetbrains.exposed.v1.core.dao.id.CompositeID
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+
+abstract class CompositeR2dbcEntity(id: EntityID<CompositeID>) : R2dbcEntity<CompositeID>(id)
+
+abstract class CompositeR2dbcEntityClass<out E : CompositeR2dbcEntity>(
+    table: IdTable<CompositeID>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<CompositeID>) -> E)? = null
+) : R2dbcEntityClass<CompositeID, E>(table, entityType, entityCtor)

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/EntityFieldWithTransform.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/EntityFieldWithTransform.kt
@@ -1,0 +1,40 @@
+package org.jetbrains.exposed.r2dbc.dao
+
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ColumnTransformer
+
+/**
+ * Class responsible for enabling [R2dbcEntity] field transformations, which may be useful when advanced database
+ * type conversions are necessary for entity mappings.
+ *
+ * Mirrors JDBC's `EntityFieldWithTransform` — duplicated here rather than shared because `exposed-dao` is the
+ * JDBC-only DAO module and `exposed-dao-r2dbc` cannot depend on it.
+ */
+open class EntityFieldWithTransform<Unwrapped, Wrapped>(
+    /** The original column that will be transformed. */
+    val column: Column<Unwrapped>,
+    /** Instance of [ColumnTransformer] with the transformation logic. */
+    private val transformer: ColumnTransformer<Unwrapped, Wrapped>,
+    /**
+     * Whether the original and transformed values should be cached to avoid multiple conversion calls.
+     */
+    protected val cacheResult: Boolean = false
+) : ColumnTransformer<Unwrapped, Wrapped> {
+    private var cache: Pair<Unwrapped, Wrapped>? = null
+
+    override fun unwrap(value: Wrapped): Unwrapped = transformer.unwrap(value)
+
+    /** The function used to transform a value stored in the original column type. */
+    override fun wrap(value: Unwrapped): Wrapped {
+        return if (cacheResult) {
+            val localCache = cache
+            if (localCache != null && localCache.first == value) {
+                localCache.second
+            } else {
+                transformer.wrap(value).also { cache = value to it }
+            }
+        } else {
+            transformer.wrap(value)
+        }
+    }
+}

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntity.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntity.kt
@@ -75,6 +75,21 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
         }
     }
 
+    /**
+     * Property delegate for [EntityFieldWithTransform] — reads the raw column value via [Column.getValue]
+     * and runs it through the transformer's `wrap` function (with optional memoization).
+     */
+    operator fun <Unwrapped, Wrapped> EntityFieldWithTransform<Unwrapped, Wrapped>.getValue(o: R2dbcEntity<ID>, desc: KProperty<*>): Wrapped =
+        wrap(column.getValue(o, desc))
+
+    /**
+     * Property delegate for [EntityFieldWithTransform] — runs the supplied value through the transformer's
+     * `unwrap` function and writes it back to the original column via [Column.setValue].
+     */
+    operator fun <Unwrapped, Wrapped> EntityFieldWithTransform<Unwrapped, Wrapped>.setValue(o: R2dbcEntity<ID>, desc: KProperty<*>, value: Wrapped) {
+        column.setValue(o, desc, unwrap(value))
+    }
+
     @Suppress("UNCHECKED_CAST")
     internal fun writeIdColumnValue(table: IdTable<*>, value: EntityID<*>) {
         (value._value as? CompositeID)?.let { id ->
@@ -134,8 +149,11 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
                 val _writeValues = writeValues.toMap()
                 storeWrittenValues()
 
-                @Suppress("ForbiddenComment")
-                // TODO: Implement entity change tracking when subscriptions are implemented
+                val transaction = TransactionManager.current()
+
+                @Suppress("UNCHECKED_CAST")
+                transaction.registerChange(klass as R2dbcEntityClass<*, R2dbcEntity<*>>, id, EntityChangeType.Updated)
+
                 executeAsPartOfEntityLifecycle {
                     table.update({ table.id eq id }) {
                         for ((c, v) in _writeValues) {
@@ -143,7 +161,6 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
                         }
                     }
                 }
-                // TODO: Implement alertSubscribers when subscriptions are implemented
             } else {
                 batch.addBatch(this)
                 for ((c, v) in writeValues) {
@@ -160,10 +177,14 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
     open suspend fun delete() {
         val table = klass.table
         val entityId = this.id
-        // TODO add register change like in JDBCHello.
         // TODO should we insert before and then remove
-        //  (extra requests, but probablyt correctness could be better)
+        //  (extra requests, but probably correctness could be better)
         if (!isNewEntity()) {
+            val transaction = TransactionManager.current()
+
+            @Suppress("UNCHECKED_CAST")
+            transaction.registerChange(klass as R2dbcEntityClass<*, R2dbcEntity<*>>, entityId, EntityChangeType.Removed)
+
             executeAsPartOfEntityLifecycle {
                 table.deleteWhere { table.id eq entityId }
             }
@@ -212,6 +233,8 @@ open class R2dbcEntity<ID : Any>(val id: EntityID<ID>) {
      *
      * Counterpart of JDBC's `via`. Named `viaSuspend` to match the rest of the R2DBC DAO API.
      */
+    // TODO ALIGN_WITH_JDBC: name diverges from JDBC's `via`; revisit if/when the relationship DSL
+    //  is unified across the JDBC and R2DBC DAO modules.
     infix fun <TID : Any, Target : R2dbcEntity<TID>> R2dbcEntityClass<TID, Target>.viaSuspend(
         table: Table
     ): R2dbcInnerTableLink<ID, R2dbcEntity<ID>, TID, Target> =

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityCache.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.r2dbc.dao
 
 import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.transactions.transactionScope
@@ -26,17 +27,14 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
 
     internal val updates = ConcurrentHashMap<IdTable<*>, MutableSet<R2dbcEntity<*>>>()
 
-    internal val referrers = ConcurrentHashMap<Column<*>, MutableMap<EntityID<*>, Any>>()
+    internal val referrers = ConcurrentHashMap<Column<*>, MutableMap<EntityID<*>, SizedIterable<*>>>()
 
-    fun <ID : Any, T : R2dbcEntity<ID>> find(entityClass: R2dbcEntityClass<ID, T>, id: EntityID<ID>): T? {
-        // `id.value` can not be used, because it can't insert the entity in the case it's null
-        if (id._value == null) {
-            return inserts[entityClass.table]?.firstOrNull { it.id == id } as? T
-                ?: initializingEntities.firstOrNull { it.klass == entityClass && it.id == id } as? T
-        }
-
-        return getMap(entityClass)[id.value] as T?
-    }
+    fun <ID : Any, T : R2dbcEntity<ID>> find(f: R2dbcEntityClass<ID, T>, id: EntityID<ID>): T? =
+        // Mirrors JDBC's `EntityCache.find`. Unlike JDBC we can't dereference `id.value` blindly
+        // (it would throw on an un-flushed entity), so the first lookup is gated by `id._value`.
+        (id._value?.let { getMap(f)[it] as T? })
+            ?: inserts[f.table]?.firstOrNull { it.id == id } as? T
+            ?: initializingEntities.firstOrNull { it.klass == f && it.id == id } as? T
 
     private fun getMap(f: R2dbcEntityClass<*, *>): MutableMap<Any, R2dbcEntity<*>> = getMap(f.table)
 
@@ -59,19 +57,25 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
             }
         }
 
-    fun <ID : Any> store(entity: R2dbcEntity<ID>) {
-        val map = data.getOrPut(entity.klass.table) { ConcurrentHashMap() }
-        map[entity.id.value] = entity
+    /** Stores the specified [R2dbcEntity] in this cache using its associated [R2dbcEntityClass] as the key. */
+    fun <ID : Any, T : R2dbcEntity<ID>> store(f: R2dbcEntityClass<ID, T>, o: T) {
+        getMap(f)[o.id.value] = o
     }
 
-    fun <ID : Any> remove(table: IdTable<ID>, entity: R2dbcEntity<ID>) {
-        // Same as in find(), 'entity.id.value' can not be used directly, because
-        // because the entity could not be fetched in this moment. Another option is to
-        // make 'remove()' suspend
-        if (entity.id._value != null) {
-            data[table]?.remove(entity.id._value)
-        }
-        inserts[table]?.remove(entity)
+    /**
+     * Stores the specified [R2dbcEntity] in this cache.
+     *
+     * The [R2dbcEntityClass] associated with this entity is inferred from its [R2dbcEntity.klass] property.
+     */
+    fun store(o: R2dbcEntity<*>) {
+        getMap(o.klass.table)[o.id.value] = o
+    }
+
+    fun <ID : Any, T : R2dbcEntity<ID>> remove(table: IdTable<ID>, o: T) {
+        // Mirrors JDBC's `EntityCache.remove`. Guard around `id._value`: in R2DBC an un-flushed
+        // entity's `id.value` would throw (no `invokeOnNoValue` flush), so just skip — the entity
+        // can't be in `data` yet.
+        o.id._value?.let { getMap(table).remove(it) }
     }
 
     fun <ID : Any> scheduleUpdate(klass: R2dbcEntityClass<ID, R2dbcEntity<ID>>, entity: R2dbcEntity<ID>) {
@@ -113,6 +117,7 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
         inserts.getOrPut(klass.table) { LinkedIdentityHashSet() }.add(entity)
     }
 
+    // TODO parameters have other order rather tahn in jdbc alternative
     suspend fun <ID : Any, R : R2dbcEntity<ID>> getOrPutReferrers(
         column: Column<*>,
         sourceId: EntityID<*>,
@@ -130,6 +135,18 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
 
     fun removeReferrer(column: Column<*>, entityId: EntityID<*>) {
         referrers[column]?.remove(entityId)
+    }
+
+    suspend fun clear(flush: Boolean = true) {
+        if (flush) flush()
+        data.clear()
+        inserts.clear()
+        updates.clear()
+        clearReferrersCache()
+    }
+
+    fun clearReferrersCache() {
+        referrers.clear()
     }
 
     suspend fun <ID : Any> updateEntities(table: IdTable<ID>) {
@@ -154,43 +171,48 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
     }
 
     suspend fun flush(tables: Iterable<IdTable<*>>) {
-        if (flushingEntities) {
-            return
-        }
-
+        if (flushingEntities) return
         try {
             flushingEntities = true
-
             val insertedTables = inserts.keys
+
             val updateBeforeInsert = SchemaUtils.sortTablesByReferences(insertedTables).filterIsInstance<IdTable<*>>()
-            for (table in updateBeforeInsert) {
-                updateEntities(table)
-            }
+            updateBeforeInsert.forEach { updateEntities(it) }
 
-            val tablesToInsert = SchemaUtils.sortTablesByReferences(insertedTables).filterIsInstance<IdTable<*>>()
-            for (table in tablesToInsert) {
-                flushInserts(table)
-            }
+            SchemaUtils.sortTablesByReferences(tables).filterIsInstance<IdTable<*>>().forEach { flushInserts(it) }
 
-            val updateTheRestTables = tables.toSet() - updateBeforeInsert.toSet()
+            val updateTheRestTables = tables - updateBeforeInsert.toSet()
             for (t in updateTheRestTables) {
                 updateEntities(t)
             }
 
             if (insertedTables.isNotEmpty()) {
-                removeTablesReferrers(insertedTables)
+                removeTablesReferrers(insertedTables, true)
             }
         } finally {
             flushingEntities = false
         }
     }
 
-    fun removeTablesReferrers(tables: Collection<IdTable<*>>) {
-        val columnsToRemove = referrers.keys.filter { column ->
-            tables.any { table -> column.table == table }
+    internal fun removeTablesReferrers(tables: Collection<Table>, isInsert: Boolean) {
+        val insertedTablesSet = tables.toSet()
+        val columnsToInvalidate = tables.flatMapTo(hashSetOf()) { table ->
+            table.columns.mapNotNull { column -> column.takeIf { it.referee != null } }
         }
-        columnsToRemove.forEach { column ->
-            referrers.remove(column)
+
+        columnsToInvalidate.forEach {
+            referrers.remove(it)
+        }
+
+        referrers.keys.filter { refColumn ->
+            when {
+                isInsert -> false
+                refColumn.referee?.table in insertedTablesSet -> true
+                refColumn.table.columns.any { it.referee?.table in tables } -> true
+                else -> false
+            }
+        }.forEach {
+            referrers.remove(it)
         }
     }
 
@@ -243,11 +265,15 @@ class R2dbcEntityCache(private val transaction: R2dbcTransaction) {
             }
 
             store(entity)
+
+            transaction.registerChange(entity.klass, entity.id, EntityChangeType.Created)
         }
 
         for (entity in entitiesWithSelfRefs) {
             entity.flush()
         }
+
+        transaction.alertSubscribers()
     }
 }
 

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityClass.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityClass.kt
@@ -1,17 +1,37 @@
 package org.jetbrains.exposed.r2dbc.dao
 
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.forEach
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.singleOrNull
+import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.r2dbc.dao.exceptions.R2dbcEntityNotFoundException
+import org.jetbrains.exposed.r2dbc.dao.relationships.R2dbcBackReference
+import org.jetbrains.exposed.r2dbc.dao.relationships.R2dbcOptionalBackReference
+import org.jetbrains.exposed.r2dbc.dao.relationships.R2dbcReferrers
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ColumnSet
+import org.jetbrains.exposed.v1.core.ColumnTransformer
+import org.jetbrains.exposed.v1.core.ColumnWithTransform
+import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
+import org.jetbrains.exposed.v1.core.Join
+import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.columnTransformer
+import org.jetbrains.exposed.v1.core.count
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.r2dbc.Query
+import org.jetbrains.exposed.v1.r2dbc.SizedCollection
 import org.jetbrains.exposed.v1.r2dbc.SizedIterable
+import org.jetbrains.exposed.v1.r2dbc.emptySized
 import org.jetbrains.exposed.v1.r2dbc.mapLazy
 import org.jetbrains.exposed.v1.r2dbc.select
 import org.jetbrains.exposed.v1.r2dbc.selectAll
@@ -140,6 +160,8 @@ abstract class R2dbcEntityClass<ID : Any, out T : R2dbcEntity<ID>>(
      * be deprecated, but it sounds like a bad idea in terms of API changes (even on major versions),
      * because it could be used by many users.
      */
+    // TODO ALIGN_WITH_JDBC: no JDBC counterpart — JDBC's `Column.setValue` auto-attaches the entity
+    //  by querying the DB synchronously. Revisit when/if R2DBC gains an equivalent implicit path.
     suspend fun attach(entity: R2dbcEntity<ID>) {
         val cache = warmCache()
         if (cache.find(this, entity.id) != null) return
@@ -168,12 +190,33 @@ abstract class R2dbcEntityClass<ID : Any, out T : R2dbcEntity<ID>>(
         wrapRow(it)
     }
 
+    /**
+     * Wraps the specified [ResultRow] data into an [R2dbcEntity] instance.
+     *
+     * When an entity is already cached, the method performs a **selective merge**: values for
+     * columns present in [row] are used to refresh the entity, while columns absent from [row]
+     * (e.g. a partial SELECT) retain their previously cached values.
+     *
+     * Mirrors JDBC's fix for GitHub issue #1527 — without the merge, a cached entity returned by
+     * `SELECT FOR UPDATE` would silently keep its stale `_readValues`, causing lost updates in
+     * concurrent increment patterns.
+     */
     @Suppress("MemberVisibilityCanBePrivate")
     fun wrapRow(row: ResultRow): T {
         val entity = wrap(row[table.id], row)
+
         if (entity._readValues == null) {
             entity._readValues = row
+            return entity
         }
+
+        val existingKeys = entity.readValues.fieldIndex.keys
+        val fetchedKeys = row.fieldIndex.keys
+        val columnToValue = (existingKeys + fetchedKeys).toSet().associateWith { column ->
+            if (row.hasValue(column)) row[column] else entity._readValues?.get(column)
+        }
+        entity._readValues = ResultRow.createAndFillValues(unwrapColumnValues(columnToValue))
+
         return entity
     }
 
@@ -190,14 +233,268 @@ abstract class R2dbcEntityClass<ID : Any, out T : R2dbcEntity<ID>>(
 
     suspend operator fun get(id: ID): T = get(R2dbcDaoEntityID(id, table))
 
-    @Suppress("ForbiddenComment")
     fun removeFromCache(entity: R2dbcEntity<ID>) {
         val cache = warmCache()
         cache.remove(table, entity)
-        cache.referrers.forEach { (_, referrers) ->
+        // R2DBC's `Entity.delete` skips the round-trip INSERT+DELETE for unflushed entities, so we
+        // also need to drop the entity from the scheduled inserts. JDBC doesn't need this because
+        // the lifecycle interceptor flushes inserts before the DELETE statement.
+        cache.inserts[table]?.remove(entity)
+        cache.referrers.forEach { (col, referrers) ->
+            // Remove references from entity to other entities
             referrers.remove(entity.id)
 
-            // TODO Remove references from other entities to this entity
+            // Remove references from other entities to this entity
+            if (col.table == table) {
+                with(entity) { col.lookup() }?.let { referrers.remove(it as EntityID<*>) }
+            }
         }
     }
+
+    /**
+     * One-to-many reference. R2DBC counterpart of JDBC's `referrersOn`.
+     */
+    // TODO ALIGN_WITH_JDBC: the relationship DSL is suffixed `*Suspend` (referrersOnSuspend,
+    //  optionalReferrersOnSuspend, backReferencedOnSuspend, optionalBackReferencedOnSuspend) to
+    //  disambiguate from the JDBC names that return entities directly. Once a unified naming
+    //  scheme is agreed across modules, drop the suffix here.
+    @Suppress("UNCHECKED_CAST")
+    infix fun <TargetID : Any, Target : R2dbcEntity<TargetID>, REF> R2dbcEntityClass<TargetID, Target>.referrersOnSuspend(
+        column: Column<REF>
+    ): R2dbcReferrers<ID, R2dbcEntity<ID>, TargetID, Target, REF> =
+        R2dbcReferrers(column, this, cache = true)
+
+    /** Two-argument form to control caching behaviour. */
+    fun <TargetID : Any, Target : R2dbcEntity<TargetID>, REF> R2dbcEntityClass<TargetID, Target>.referrersOnSuspend(
+        column: Column<REF>,
+        cache: Boolean
+    ): R2dbcReferrers<ID, R2dbcEntity<ID>, TargetID, Target, REF> =
+        R2dbcReferrers(column, this, cache)
+
+    /**
+     * Optional one-to-many reference. R2DBC counterpart of JDBC's `optionalReferrersOn`.
+     */
+    infix fun <TargetID : Any, Target : R2dbcEntity<TargetID>, REF : Any>
+        R2dbcEntityClass<TargetID, Target>.optionalReferrersOnSuspend(
+            column: Column<REF?>
+        ): R2dbcReferrers<ID, R2dbcEntity<ID>, TargetID, Target, REF?> =
+        R2dbcReferrers(column, this, cache = true)
+
+    /** Two-argument form to control caching behaviour. */
+    fun <TargetID : Any, Target : R2dbcEntity<TargetID>, REF : Any>
+        R2dbcEntityClass<TargetID, Target>.optionalReferrersOnSuspend(
+            column: Column<REF?>,
+            cache: Boolean
+        ): R2dbcReferrers<ID, R2dbcEntity<ID>, TargetID, Target, REF?> =
+        R2dbcReferrers(column, this, cache)
+
+    /**
+     * One-to-one back reference. R2DBC counterpart of JDBC's `backReferencedOn`.
+     */
+    infix fun <TargetID : Any, Target : R2dbcEntity<TargetID>, REF>
+        R2dbcEntityClass<TargetID, Target>.backReferencedOnSuspend(
+            column: Column<REF>
+        ): R2dbcBackReference<TargetID, Target, ID, R2dbcEntity<ID>, REF> =
+        R2dbcBackReference(column, this)
+
+    /**
+     * Optional one-to-one back reference. R2DBC counterpart of JDBC's `optionalBackReferencedOn`.
+     */
+    infix fun <TargetID : Any, Target : R2dbcEntity<TargetID>, REF>
+        R2dbcEntityClass<TargetID, Target>.optionalBackReferencedOnSuspend(
+            column: Column<REF?>
+        ): R2dbcOptionalBackReference<TargetID, Target, ID, R2dbcEntity<ID>, REF> =
+        R2dbcOptionalBackReference(column, this)
+
+    /**
+     * Overload of [optionalBackReferencedOnSuspend] for non-nullable reference columns.
+     * Mirrors JDBC's overloaded `optionalBackReferencedOn(Column<REF>)`.
+     */
+    @Suppress("UNCHECKED_CAST")
+    @JvmName("optionalBackReferencedOnSuspendNonNullable")
+    infix fun <TargetID : Any, Target : R2dbcEntity<TargetID>, REF : Any>
+        R2dbcEntityClass<TargetID, Target>.optionalBackReferencedOnSuspend(
+            column: Column<REF>
+        ): R2dbcOptionalBackReference<TargetID, Target, ID, R2dbcEntity<ID>, REF> =
+        R2dbcOptionalBackReference(column as Column<REF?>, this)
+
+    @Suppress("UNCHECKED_CAST")
+    suspend fun <SID : Any> warmUpLinkedReferences(
+        references: List<EntityID<SID>>,
+        linkTable: Table,
+        forUpdate: Boolean? = null,
+        optimizedLoad: Boolean = false
+    ): List<T> {
+        if (references.isEmpty()) return emptyList()
+
+        val sourceRefColumn = linkTable.columns
+            .singleOrNull { it.referee == references.first().table.id } as? Column<EntityID<SID>>
+            ?: error("Can't detect source reference column")
+        val targetRefColumn = linkTable.columns
+            .singleOrNull { it.referee == table.id } as? Column<EntityID<ID>>
+            ?: error("Can't detect target reference column")
+
+        return warmUpLinkedReferences(references, sourceRefColumn, targetRefColumn, linkTable, forUpdate, optimizedLoad)
+    }
+
+    @Suppress("UNCHECKED_CAST", "ComplexMethod", "LongMethod")
+    suspend fun <SID : Any> warmUpLinkedReferences(
+        references: List<EntityID<SID>>,
+        sourceRefColumn: Column<EntityID<SID>>,
+        targetRefColumn: Column<EntityID<ID>>,
+        linkTable: Table,
+        forUpdate: Boolean? = null,
+        optimizedLoad: Boolean = false
+    ): List<T> {
+        if (references.isEmpty()) return emptyList()
+        val distinctRefIds = references.distinct()
+        val transaction = TransactionManager.current()
+
+        val inCache = transaction.entityCache.referrers[sourceRefColumn]
+            ?.filterKeys { distinctRefIds.contains(it) }
+            ?: emptyMap()
+
+        val loaded = ((distinctRefIds - inCache.keys).takeIf { it.isNotEmpty() } as List<EntityID<SID>>?)?.let { idsToLoad ->
+            val alreadyInJoin = (dependsOnTables as? Join)?.alreadyInJoin(linkTable) ?: false
+            val entityTables = if (alreadyInJoin) dependsOnTables else dependsOnTables.join(linkTable, JoinType.INNER, targetRefColumn, table.id)
+
+            val columns = when {
+                optimizedLoad -> listOf(sourceRefColumn, targetRefColumn)
+                alreadyInJoin -> (dependsOnColumns + sourceRefColumn).distinct()
+                else -> (dependsOnColumns + linkTable.columns + sourceRefColumn).distinct()
+            }
+
+            val query = entityTables.select(columns).where { sourceRefColumn inList idsToLoad }
+            val targetEntities = mutableMapOf<EntityID<ID>, T>()
+            val entitiesWithRefs = when (forUpdate) {
+                true -> query.forUpdate()
+                false -> query.notForUpdate()
+                else -> query
+            }.map {
+                val targetId = it[targetRefColumn]
+                if (!optimizedLoad) {
+                    targetEntities.getOrPut(targetId) { wrapRow(it) }
+                }
+                it[sourceRefColumn] to targetId
+            }
+
+            if (optimizedLoad) {
+                forEntityIds(entitiesWithRefs.map { it.second }.toList()).collect {
+                    targetEntities[it.id] = it
+                }
+            }
+
+            val groupedBySourceId = entitiesWithRefs.toList().groupBy({ it.first }) { targetEntities.getValue(it.second) }
+
+            idsToLoad.forEach {
+                transaction.entityCache.getOrPutReferrers(sourceRefColumn, it) {
+                    SizedCollection(groupedBySourceId[it] ?: emptyList())
+                }
+            }
+            targetEntities.values
+        }
+
+        return inCache.values.flatMap { it.toList() as List<T> } + loaded.orEmpty()
+    }
+
+    open fun forEntityIds(ids: List<EntityID<ID>>): SizedIterable<T> {
+        val distinctIds = ids.distinct()
+        if (distinctIds.isEmpty()) return emptySized()
+
+        val cached = distinctIds.mapNotNull { testCache(it) }
+
+        if (cached.size == distinctIds.size) {
+            return SizedCollection(cached)
+        }
+
+        return wrapRows(searchQuery(table.id inList distinctIds))
+    }
+
+    /**
+     * Returns an [EntityFieldWithTransform] delegate that transforms this stored [Unwrapped] value on every read.
+     *
+     * @param transformer An instance of [ColumnTransformer] to handle the transformations.
+     */
+    fun <Unwrapped, Wrapped> Column<Unwrapped>.transform(
+        transformer: ColumnTransformer<Unwrapped, Wrapped>
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = EntityFieldWithTransform(this, transformer, false)
+
+    /**
+     * Returns an [EntityFieldWithTransform] delegate that transforms this stored [Unwrapped] value on every read.
+     *
+     * @param unwrap A pure function that converts a transformed value to a value that can be stored in this original column type.
+     * @param wrap A pure function that transforms a value stored in this original column type.
+     */
+    fun <Unwrapped, Wrapped> Column<Unwrapped>.transform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = transform(columnTransformer(unwrap, wrap))
+
+    /**
+     * Returns an [EntityFieldWithTransform] that extends transformation of an existing [EntityFieldWithTransform].
+     *
+     * @param unwrap A function that transforms the value to the wrapping type of the previously defined transformation.
+     * @param wrap A function that transforms the value to the wrapping type.
+     */
+    fun <TColumn, Unwrapped, Wrapped> EntityFieldWithTransform<TColumn, Unwrapped>.transform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<TColumn, Wrapped> =
+        EntityFieldWithTransform(this.column, columnTransformer({ this.unwrap(unwrap(it)) }, { wrap(this.wrap(it)) }), false)
+
+    /**
+     * Returns an [EntityFieldWithTransform] delegate that caches the transformed value on first read of
+     * this same stored [Unwrapped] value.
+     *
+     * @param transformer An instance of [ColumnTransformer] to handle the transformations.
+     */
+    fun <Unwrapped, Wrapped> Column<Unwrapped>.memoizedTransform(
+        transformer: ColumnTransformer<Unwrapped, Wrapped>
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = EntityFieldWithTransform(this, transformer, true)
+
+    /**
+     * Returns an [EntityFieldWithTransform] delegate that caches the transformed value on first read of
+     * this same stored [Unwrapped] value.
+     */
+    fun <Unwrapped, Wrapped> Column<Unwrapped>.memoizedTransform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<Unwrapped, Wrapped> = memoizedTransform(columnTransformer(unwrap, wrap))
+
+    /**
+     * Returns an [EntityFieldWithTransform] that extends transformation of an existing [EntityFieldWithTransform]
+     * and caches the transformed value on first read.
+     */
+    fun <TColumn, Unwrapped, Wrapped> EntityFieldWithTransform<TColumn, Unwrapped>.memoizedTransform(
+        unwrap: (Wrapped) -> Unwrapped,
+        wrap: (Unwrapped) -> Wrapped
+    ): EntityFieldWithTransform<TColumn, Wrapped> = EntityFieldWithTransform(
+        this.column,
+        columnTransformer({ this.unwrap(unwrap(it)) }, { wrap(this.wrap(it)) }),
+        true
+    )
+
+    suspend fun count(op: Op<Boolean>? = null): Long {
+        val countExpression = table.idColumns.first().count()
+        val query = table.select(countExpression).notForUpdate()
+        op?.let { query.adjustWhere { op } }
+        return query.first()[countExpression]
+    }
+
+    /**
+     * Returns whether the [entityClass] type is equivalent to or a superclass of this [R2dbcEntityClass] instance's [klass].
+     * Mirrors JDBC's `EntityClass.isAssignableTo`.
+     */
+    fun <ID2 : Any, T2 : R2dbcEntity<ID2>> isAssignableTo(entityClass: R2dbcEntityClass<ID2, T2>) =
+        entityClass.klass.isAssignableFrom(klass)
+}
+
+/**
+ * Unwraps any [ColumnWithTransform] values down to the underlying column type. Used by
+ * [R2dbcEntityClass.wrapRow]'s selective-merge path so transformed columns aren't re-wrapped
+ * when their values are re-stored into [R2dbcEntity._readValues]. Mirrors JDBC's helper.
+ */
+internal fun <T : Expression<*>> unwrapColumnValues(values: Map<T, Any?>): Map<T, Any?> = values.mapValues { (col, value) ->
+    if (col !is ExpressionWithColumnType<*>) return@mapValues value
+    value?.let { (col.columnType as? ColumnWithTransform<Any, Any>)?.unwrapRecursive(it) } ?: value
 }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityHook.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityHook.kt
@@ -1,0 +1,135 @@
+package org.jetbrains.exposed.r2dbc.dao
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.transactions.transactionScope
+import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import java.util.Deque
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * R2DBC counterpart of `EntityChangeType` from `exposed-dao`. The values mirror the JDBC enum;
+ * a separate copy lives in this module because the lifecycle is owned by `R2dbcEntityClass`,
+ * which doesn't share an interface with `EntityClass`.
+ */
+enum class EntityChangeType {
+    /** The entity has been inserted in the database. */
+    Created,
+
+    /** The entity has been updated in the database. */
+    Updated,
+
+    /** The entity has been removed from the database. */
+    Removed
+}
+
+/**
+ * Stores details about a state-change event for an [R2dbcEntity] instance. R2DBC counterpart of
+ * `EntityChange` from `exposed-dao`.
+ */
+// TODO it is almost the same as EntityChange in JDBC DAO, but depends on R2dbcEntityClass and R2dbcEntity
+data class EntityChange(
+    /** The [R2dbcEntityClass] of the changed entity instance. */
+    val entityClass: R2dbcEntityClass<*, R2dbcEntity<*>>,
+    /** The unique [EntityID] associated with the entity instance. */
+    val entityId: EntityID<*>,
+    /** The exact changed state of the event. */
+    val changeType: EntityChangeType,
+    /** The unique id for the [R2dbcTransaction] in which the event took place. */
+    val transactionId: String
+)
+
+/**
+ * Returns the actual [R2dbcEntity] instance associated with [this][EntityChange] event,
+ * or `null` if the entity is not found.
+ */
+@Suppress("UNCHECKED_CAST")
+suspend fun <ID : Any, T : R2dbcEntity<ID>> EntityChange.toEntity(): T? =
+    (entityClass as R2dbcEntityClass<ID, T>).findById(entityId as EntityID<ID>)
+
+/**
+ * Returns the actual [R2dbcEntity] instance associated with [this][EntityChange] event,
+ * or `null` if either its class type is neither equivalent to nor a subclass of [klass],
+ * or if the entity is not found.
+ */
+suspend fun <ID : Any, T : R2dbcEntity<ID>> EntityChange.toEntity(klass: R2dbcEntityClass<ID, T>): T? {
+    if (!entityClass.isAssignableTo(klass)) return null
+    return toEntity<ID, T>()
+}
+
+private val R2dbcTransaction.unprocessedEvents: Deque<EntityChange> by transactionScope { ConcurrentLinkedDeque() }
+private val R2dbcTransaction.entityEvents: Deque<EntityChange> by transactionScope { ConcurrentLinkedDeque() }
+private val entitySubscribers = ConcurrentLinkedQueue<suspend (EntityChange) -> Unit>()
+
+/**
+ * R2DBC counterpart of `EntityHook` from `exposed-dao`. Subscribers are `suspend` because the
+ * R2DBC lifecycle runs inside coroutines.
+ */
+object EntityHook {
+    /**
+     * Registers a specific state-change [action] for alerts and returns the [action].
+     */
+    fun subscribe(action: suspend (EntityChange) -> Unit): suspend (EntityChange) -> Unit {
+        entitySubscribers.add(action)
+        return action
+    }
+
+    /** Unregisters a specific state-change [action] from alerts. */
+    fun unsubscribe(action: suspend (EntityChange) -> Unit) {
+        entitySubscribers.remove(action)
+    }
+}
+
+/** Creates a new [EntityChange] with [this][R2dbcTransaction] id and registers it as an entity event. */
+fun R2dbcTransaction.registerChange(
+    entityClass: R2dbcEntityClass<*, R2dbcEntity<*>>,
+    entityId: EntityID<*>,
+    changeType: EntityChangeType
+) {
+    EntityChange(entityClass, entityId, changeType, transactionId).let {
+        if (unprocessedEvents.peekLast() != it) {
+            unprocessedEvents.addLast(it)
+            entityEvents.addLast(it)
+        }
+    }
+}
+
+private var isProcessingEventsLaunched by transactionScope { false }
+
+/**
+ * Triggers alerts for all unprocessed entity events using any state-change actions previously
+ * registered via [EntityHook.subscribe].
+ */
+suspend fun R2dbcTransaction.alertSubscribers() {
+    if (isProcessingEventsLaunched) return
+    while (true) {
+        try {
+            isProcessingEventsLaunched = true
+            val event = unprocessedEvents.pollFirst() ?: break
+            entitySubscribers.forEach { it(event) }
+        } finally {
+            isProcessingEventsLaunched = false
+        }
+    }
+}
+
+/** Returns a list of all [EntityChange] events that have been registered in this [R2dbcTransaction]. */
+fun R2dbcTransaction.registeredChanges(): List<EntityChange> = entityEvents.toList()
+
+/**
+ * Calls the specified [body] with the given state-change [action], registers the action, and
+ * returns its result.
+ *
+ * The [action] will be unregistered at the end of the call to the [body] block.
+ */
+suspend fun <T> withHook(action: suspend (EntityChange) -> Unit, body: suspend () -> T): T {
+    EntityHook.subscribe(action)
+    return try {
+        body().also {
+            TransactionManager.currentOrNull()?.commit()
+        }
+    } finally {
+        EntityHook.unsubscribe(action)
+    }
+}

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityLifecycleInterceptor.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/R2dbcEntityLifecycleInterceptor.kt
@@ -43,9 +43,9 @@ class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
 
             is DeleteStatement -> {
                 transaction.flushCache()
-                transaction.entityCache.removeTablesReferrers(statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>())
+                transaction.entityCache.removeTablesReferrers(statement.targetsSet.targetTables(), false)
                 if (!isExecutedWithinEntityLifecycle) {
-                    statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>().forEach {
+                    statement.targets.filterIsInstance<IdTable<*>>().forEach {
                         transaction.entityCache.data[it]?.clear()
                     }
                 }
@@ -53,7 +53,7 @@ class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
 
             is UpsertStatement<*>, is BatchUpsertStatement -> {
                 transaction.flushCache()
-                transaction.entityCache.removeTablesReferrers(statement.targets.filterIsInstance<IdTable<*>>())
+                transaction.entityCache.removeTablesReferrers(statement.targets, true)
                 if (!isExecutedWithinEntityLifecycle) {
                     statement.targets.filterIsInstance<IdTable<*>>().forEach {
                         transaction.entityCache.data[it]?.clear()
@@ -63,16 +63,17 @@ class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
 
             is InsertStatement<*> -> {
                 transaction.flushCache()
-                if (statement.table is IdTable<*>) {
-                    transaction.entityCache.removeTablesReferrers(listOf(statement.table as IdTable<*>))
-                }
+                transaction.entityCache.removeTablesReferrers(listOf(statement.table), true)
+            }
+
+            is BatchUpdateStatement -> {
             }
 
             is UpdateStatement -> {
                 transaction.flushCache()
-                transaction.entityCache.removeTablesReferrers(statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>())
+                transaction.entityCache.removeTablesReferrers(statement.targetsSet.targetTables(), false)
                 if (!isExecutedWithinEntityLifecycle) {
-                    statement.targetsSet.targetTables().filterIsInstance<IdTable<*>>().forEach {
+                    statement.targets.filterIsInstance<IdTable<*>>().forEach {
                         transaction.entityCache.data[it]?.clear()
                     }
                 }
@@ -84,28 +85,34 @@ class R2dbcEntityLifecycleInterceptor : GlobalSuspendStatementInterceptor {
         }
     }
 
-    @Suppress("ForbiddenComment")
     override suspend fun afterExecution(
         transaction: R2dbcTransaction,
         contexts: List<StatementContext>,
         executedStatement: R2dbcPreparedStatementApi
     ) {
-        // TODO: Implement alertSubscribers when subscriptions are implemented
+        if (!isExecutedWithinEntityLifecycle || contexts.first().statement !is InsertStatement<*>) {
+            transaction.alertSubscribers()
+        }
     }
 
-    @Suppress("ForbiddenComment")
     override suspend fun beforeCommit(transaction: R2dbcTransaction) {
         transaction.flushCache()
-        // TODO: Implement alertSubscribers and EntityCache.invalidateGlobalCaches when subscriptions are implemented
+        transaction.alertSubscribers()
+        transaction.flushCache()
+        // TODO ALIGN_WITH_JDBC: call `EntityCache.invalidateGlobalCaches(created + createdByHooks)`
+        //  once `ImmutableCachedEntityClass` exists in R2DBC.
     }
 
     override suspend fun beforeRollback(transaction: R2dbcTransaction) {
         val entityCache = transaction.entityCache
-        // Clear referrers cache
-        entityCache.referrers.clear()
+        entityCache.clearReferrersCache()
 
         // Clear writeValues and readValues for all entities before clearing the cache to prevent
-        // stale data from being carried over into a new transaction
+        // stale data from being carried over into a new transaction. Ideally, at this stage,
+        // values from writeValues should not have been transferred to readValues yet, but we clear
+        // both for reliability to ensure complete cleanup.
+        //
+        // TODO ALIGN_WITH_JDBC: when ImmutableCachedEntityClass is ported, preserve its _readValues here.
         entityCache.data.values.forEach { entityMap ->
             entityMap.values.forEach { entity ->
                 entity.writeValues.clear()

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/UIntEntity.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/UIntEntity.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.exposed.r2dbc.dao
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+
+abstract class UIntR2dbcEntity(id: EntityID<UInt>) : R2dbcEntity<UInt>(id)
+
+abstract class UIntR2dbcEntityClass<out E : UIntR2dbcEntity>(
+    table: IdTable<UInt>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<UInt>) -> E)? = null
+) : R2dbcEntityClass<UInt, E>(table, entityType, entityCtor)

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/ULongEntity.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/ULongEntity.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.exposed.r2dbc.dao
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+
+abstract class ULongR2dbcEntity(id: EntityID<ULong>) : R2dbcEntity<ULong>(id)
+
+abstract class ULongR2dbcEntityClass<out E : ULongR2dbcEntity>(
+    table: IdTable<ULong>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<ULong>) -> E)? = null
+) : R2dbcEntityClass<ULong, E>(table, entityType, entityCtor)

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/UuidEntity.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/UuidEntity.kt
@@ -1,0 +1,16 @@
+package org.jetbrains.exposed.r2dbc.dao
+
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class)
+abstract class UuidR2dbcEntity(id: EntityID<Uuid>) : R2dbcEntity<Uuid>(id)
+
+@OptIn(ExperimentalUuidApi::class)
+abstract class UuidR2dbcEntityClass<out E : UuidR2dbcEntity>(
+    table: IdTable<Uuid>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<Uuid>) -> E)? = null
+) : R2dbcEntityClass<Uuid, E>(table, entityType, entityCtor)

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/java/UUIDEntity.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/java/UUIDEntity.kt
@@ -1,0 +1,15 @@
+package org.jetbrains.exposed.r2dbc.dao.java
+
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
+import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import java.util.UUID
+
+abstract class UUIDR2dbcEntity(id: EntityID<UUID>) : R2dbcEntity<UUID>(id)
+
+abstract class UUIDR2dbcEntityClass<out E : UUIDR2dbcEntity>(
+    table: IdTable<UUID>,
+    entityType: Class<E>? = null,
+    entityCtor: ((EntityID<UUID>) -> E)? = null
+) : R2dbcEntityClass<UUID, E>(table, entityType, entityCtor)

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcEagerLoading.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcEagerLoading.kt
@@ -25,7 +25,13 @@ import kotlin.reflect.jvm.isAccessible
  *
  * Returns this [SizedIterable] to allow chaining; the loaded list is also pinned onto any
  * [LazySizedIterable] so subsequent iterations do not re-query the database.
+ *
+ * Note: R2DBC's [SizedIterable] extends `Flow<T>` (not `Iterable<T>` as in JDBC), so we provide
+ * a separate [Iterable.with] overload below — they cannot share one generic receiver.
  */
+// TODO ALIGN_WITH_JDBC: JDBC has a single `Iterable<T>.with` because its SizedIterable is also
+//  an Iterable. R2DBC has to expose two overloads (this one + the Iterable overload below). If
+//  R2DBC's SizedIterable ever stops being `Flow`-only, these can collapse into one.
 suspend fun <SRCID : Any, SRC : R2dbcEntity<SRCID>, REF : R2dbcEntity<*>, L : SizedIterable<SRC>> L.with(
     vararg relations: KProperty1<out REF, Any?>
 ): L {
@@ -41,15 +47,31 @@ suspend fun <SRCID : Any, SRC : R2dbcEntity<SRCID>, REF : R2dbcEntity<*>, L : Si
 }
 
 /**
+ * Eager-loads the specified [relations] for all entities in this in-memory [Iterable] (e.g. a
+ * plain `List<Entity>`). Mirrors JDBC's `Iterable.with`. This overload exists because R2DBC's
+ * [SizedIterable] is a `Flow`, not an `Iterable`, so the two receivers cannot be unified.
+ */
+suspend fun <SRCID : Any, SRC : R2dbcEntity<SRCID>, REF : R2dbcEntity<*>, L : Iterable<SRC>> L.with(
+    vararg relations: KProperty1<out REF, Any?>
+): L {
+    val asList = toList()
+    if (asList.any { it.isNewEntity() }) {
+        TransactionManager.current().flushCache()
+    }
+    asList.preloadRelations(*relations)
+    return this
+}
+
+/**
  * Eager-loads the specified [relations] for this entity. Mirrors JDBC's `Entity.load`.
  */
 suspend fun <SRCID : Any, SRC : R2dbcEntity<SRCID>> SRC.load(
     vararg relations: KProperty1<out R2dbcEntity<*>, Any?>
 ): SRC = apply {
-    SizedCollection(listOf(this)).with(*relations)
+    listOf(this).with(*relations)
 }
 
-@Suppress("UNCHECKED_CAST", "ForbiddenComment")
+@Suppress("UNCHECKED_CAST")
 private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadRelations(
     vararg relations: KProperty1<out R2dbcEntity<*>, Any?>,
     nodesVisited: MutableSet<R2dbcEntityClass<*, *>> = mutableSetOf()
@@ -107,7 +129,19 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadReference(
 
     val referee = reference.referee ?: return emptyList()
     val condition = buildInListCondition(referee, refIds.distinct())
-    return factory.find { condition }.toList()
+    val loadedParents = factory.find { condition }.toList()
+
+    // Mirrors JDBC's `storeReferenceCache`: pin the loaded parent on each child's per-entity
+    // reference cache so reads work after the transaction ends under
+    // `keepLoadedReferencesOutOfTransaction = true`.
+    val parentByKey = loadedParents.indexedByRefereeValue(referee)
+    forEach { child ->
+        val refValue = child.lookupRefValue(reference) ?: return@forEach
+        val parent = parentByKey[normalizeRefKey(refValue)] ?: return@forEach
+        child.storeReferenceInCache(reference, parent)
+    }
+
+    return loadedParents
 }
 
 /**
@@ -120,11 +154,39 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadOptionalReference(
     val reference = accessor.reference as Column<Any?>
     val factory = accessor.factory
     val refIds = mapNotNull { entity -> entity.lookupRefValue(reference) }
-    if (refIds.isEmpty()) return emptyList()
 
     val referee = reference.referee ?: return emptyList()
-    val condition = buildInListCondition(referee, refIds.distinct())
-    return factory.find { condition }.toList()
+    val loadedParents = if (refIds.isEmpty()) {
+        emptyList()
+    } else {
+        val condition = buildInListCondition(referee, refIds.distinct())
+        factory.find { condition }.toList()
+    }
+
+    val parentByKey = loadedParents.indexedByRefereeValue(referee)
+    forEach { child ->
+        val refValue = child.lookupRefValue(reference)
+        if (refValue == null) {
+            child.storeReferenceInCache(reference, null)
+        } else {
+            parentByKey[normalizeRefKey(refValue)]?.let { parent ->
+                child.storeReferenceInCache(reference, parent)
+            }
+        }
+    }
+
+    return loadedParents
+}
+
+private fun normalizeRefKey(value: Any): Any = (value as? EntityID<*>)?.value ?: value
+
+private fun List<R2dbcEntity<*>>.indexedByRefereeValue(referee: Column<*>): Map<Any, R2dbcEntity<*>> {
+    val result = HashMap<Any, R2dbcEntity<*>>(size)
+    for (parent in this) {
+        val raw = parent.lookupRefValue(referee) ?: continue
+        result[normalizeRefKey(raw)] = parent
+    }
+    return result
 }
 
 /**
@@ -166,7 +228,13 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadReferrers(
 
     val refereeValuesToLoad = toLoadMappings.map { it.second }.distinct()
     val condition = buildInListCondition(refColumn, refereeValuesToLoad)
-    val loadedChildren = factory.find { condition }.toList()
+    // Honour any `orderBy` configured on the Referrers delegate (e.g. `referrersOnSuspend X orderBy Y`)
+    // so the bulk-loaded list matches the order the user would see from a single-parent fetch.
+
+    @Suppress("SpreadOperator")
+    val loadedChildren = factory.find { condition }
+        .orderBy(*referrers.getOrderByExpressions())
+        .toList()
 
     val grouped: Map<Any, List<R2dbcEntity<Any>>> = loadedChildren.groupBy { child ->
         @Suppress("UNCHECKED_CAST")
@@ -181,6 +249,13 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadReferrers(
             // later read via `.toList()` (e.g. by transitive preload or by the user).
             SizedCollection(grouped[refereeValue] ?: emptyList())
         }
+    }
+
+    val parentsById: Map<EntityID<*>, R2dbcEntity<ID>> = associateBy { it.id }
+    parentMappings.forEach { (parentId, refereeValue) ->
+        val parent = parentsById[parentId] ?: return@forEach
+        val children = SizedCollection(grouped[refereeValue] ?: emptyList())
+        parent.storeReferenceInCache(refColumn, children)
     }
 
     return loadedChildren
@@ -228,6 +303,12 @@ private suspend fun <ID : Any> List<R2dbcEntity<ID>>.preloadInnerTableLink(
         cache.getOrPutReferrers(sourceColumn, id) {
             SizedCollection(groupedBySourceId[id] ?: emptyList())
         }
+    }
+
+    val parentsById: Map<EntityID<ID>, R2dbcEntity<ID>> = associateBy { it.id }
+    distinctParentIds.forEach { id ->
+        val parent = parentsById[id] ?: return@forEach
+        parent.storeReferenceInCache(sourceColumn, SizedCollection(groupedBySourceId[id] ?: emptyList()))
     }
 
     return pairs.map { it.second }.distinct()

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcInnerTableLink.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcInnerTableLink.kt
@@ -1,10 +1,12 @@
 package org.jetbrains.exposed.r2dbc.dao.relationships
 
 import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.r2dbc.dao.EntityChangeType
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.r2dbc.dao.executeAsPartOfEntityLifecycle
+import org.jetbrains.exposed.r2dbc.dao.registerChange
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
@@ -124,6 +126,17 @@ class R2dbcInnerTableLinkAccessor<SID : Any, Source : R2dbcEntity<SID>, ID : Any
             ) { targetId ->
                 this[link.sourceColumn] = entity.id
                 this[link.targetColumn] = targetId
+            }
+        }
+
+        // current entity updated
+        tx.registerChange(entity.klass as R2dbcEntityClass<*, R2dbcEntity<*>>, entity.id, EntityChangeType.Updated)
+
+        // linked entities updated
+        val targetClass = (value.firstOrNull() ?: oldValue.firstOrNull())?.klass
+        if (targetClass != null) {
+            (existingIds + targetIds).forEach { targetId ->
+                tx.registerChange(targetClass as R2dbcEntityClass<*, R2dbcEntity<*>>, targetId, EntityChangeType.Updated)
             }
         }
     }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcReferrers.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcReferrers.kt
@@ -4,6 +4,10 @@ import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.EntityIDColumnType
+import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.r2dbc.SizedIterable
 import org.jetbrains.exposed.v1.r2dbc.emptySized
@@ -15,68 +19,82 @@ class R2dbcReferrers<ParentID : Any, in Parent : R2dbcEntity<ParentID>, ChildID 
     val factory: R2dbcEntityClass<ChildID, Child>,
     val cache: Boolean
 ) {
-    init {
-        // Validate that reference column points to the parent entity's table
-        val referee = reference.referee ?: error("Column $reference is not a reference")
+    /** The set of columns and their [SortOrder] for ordering referred entities in one-to-many relationship. */
+    private val orderByExpressions = linkedSetOf<Pair<Expression<*>, SortOrder>>()
 
-        // Validate that reference column is on the child entity's table
+    /** Returns the order by expressions as an array. */
+    internal fun getOrderByExpressions(): Array<Pair<Expression<*>, SortOrder>> = orderByExpressions.toTypedArray()
+
+    init {
+        reference.referee ?: error("Column $reference is not a reference")
         if (factory.table != reference.table) {
             error("Column $reference and factory ${factory.table.tableName} point to different tables")
         }
     }
 
-    @Suppress("NestedBlockDepth", "ForbiddenComment")
-    operator fun getValue(thisRef: Parent, property: KProperty<*>): suspend () -> SizedIterable<Child> {
-        // Return a suspend lambda that will load the referrers when invoked
-        return {
-            // Check if entity ID is available
+    @Suppress("NestedBlockDepth", "SpreadOperator")
+    operator fun getValue(thisRef: Parent, property: KProperty<*>): suspend () -> SizedIterable<Child> = {
+        val transaction = TransactionManager.currentOrNull()
+
+        if (transaction == null) {
+            // Out-of-transaction access falls back to the per-entity reference cache populated when
+            // `keepLoadedReferencesOutOfTransaction = true` (or by an eager loader like `with(...)`).
             if (thisRef.id._value == null) {
-                // TODO should it be error?
                 emptySized()
-            } else {
-                val transaction = TransactionManager.currentOrNull()
-
-                // Out-of-transaction access: return cached data
-                if (transaction == null) {
-                    if (thisRef.hasInReferenceCache(reference)) {
-                        val cached = thisRef.getReferenceFromCache<Any?>(reference)
-                        @Suppress("UNCHECKED_CAST")
-                        when (cached) {
-                            is SizedIterable<*> -> cached as SizedIterable<Child>
-                            null -> emptySized()
-                            else -> error("Cached referrer has unexpected type: ${cached::class}")
-                        }
-                    } else {
-                        error("No transaction in context, and referrers not in entity cache for $reference")
-                    }
-                } else {
-                    // Get the parent entity's ID value to use in query
-                    val referee = reference.referee!!
-
-                    @Suppress("UNCHECKED_CAST")
-                    val refValue = with(thisRef) {
-                        referee.lookup()
-                    } as REF
-
-                    // Build the query for child entities
-                    val query: suspend () -> SizedIterable<Child> = {
-                        factory.find { reference eq refValue }
-                    }
-
-                    // Execute query with caching if enabled
-                    val result = if (cache) {
-                        @Suppress("UNCHECKED_CAST")
-                        (transaction.entityCache.getOrPutReferrers(reference, thisRef.id, query))
-                    } else {
-                        query()
-                    }
-
-                    // Store in entity's reference cache for out-of-transaction access
-                    thisRef.storeReferenceInCache(reference, result)
-
-                    result
+            } else if (thisRef.hasInReferenceCache(reference)) {
+                val cached = thisRef.getReferenceFromCache<Any?>(reference)
+                @Suppress("UNCHECKED_CAST")
+                when (cached) {
+                    is SizedIterable<*> -> cached as SizedIterable<Child>
+                    null -> emptySized()
+                    else -> error("Cached referrer has unexpected type: ${cached::class}")
                 }
+            } else {
+                error("No transaction in context, and referrers not in entity cache for $reference")
             }
+        } else {
+            // Mirrors JDBC's implicit flush via `DaoEntityID.invokeOnNoValue` on `id.value` access.
+            if (thisRef.id._value == null) {
+                transaction.entityCache.flush()
+            }
+
+            val referee = reference.referee!!
+            val refereeValue = with(thisRef) { referee.lookup() }
+
+            val needsEntityIdUnwrap = reference.columnType !is EntityIDColumnType<*> &&
+                referee.columnType is EntityIDColumnType<*> && refereeValue is EntityID<*>
+
+            @Suppress("UNCHECKED_CAST")
+            val refValue = if (needsEntityIdUnwrap) refereeValue.value as REF else refereeValue as REF
+
+            val query: suspend () -> SizedIterable<Child> = {
+                factory.find { reference eq refValue }
+                    .orderBy(*orderByExpressions.toTypedArray())
+            }
+
+            val result = if (cache) {
+                @Suppress("UNCHECKED_CAST")
+                transaction.entityCache.getOrPutReferrers(reference, thisRef.id, query)
+            } else {
+                query()
+            }
+
+            thisRef.storeReferenceInCache(reference, result)
+            result
         }
     }
+
+    /** Modifies this reference to sort entities based on multiple columns as specified in [order]. */
+    infix fun orderBy(order: List<Pair<Expression<*>, SortOrder>>) = this.also {
+        orderByExpressions.addAll(order)
+    }
+
+    /** Modifies this reference to sort entities according to the specified [order]. */
+    infix fun orderBy(order: Pair<Expression<*>, SortOrder>) = orderBy(listOf(order))
+
+    /** Modifies this reference to sort entities by a column specified in [expression] using ascending order. */
+    infix fun orderBy(expression: Expression<*>) = orderBy(listOf(expression to SortOrder.ASC))
+
+    /** Modifies this reference to sort entities based on multiple columns as specified in [order]. */
+    fun orderBy(vararg order: Pair<Expression<*>, SortOrder>) = orderBy(order.asList())
 }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcRelationshipExtensions.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/R2dbcRelationshipExtensions.kt
@@ -29,6 +29,10 @@ class OptionalSuspendReference<ID : Any, Parent : R2dbcEntity<ID>, REF : Any>(
     }
 }
 
+// TODO ALIGN_WITH_JDBC: `referencedOnSuspend` / `optionalReferencedOnSuspend` diverge from JDBC's
+//  `referencedOn` / `optionalReferencedOn`. The suffix is intentional today (R2DBC returns a
+//  suspend accessor while JDBC returns an entity directly), but a unified DSL across modules
+//  would drop the suffix.
 infix fun <ID : Any, Parent : R2dbcEntity<ID>, REF : Any> R2dbcEntityClass<ID, Parent>.referencedOnSuspend(
     reference: Column<REF>
 ): SuspendReference<ID, Parent, REF> {
@@ -39,54 +43,4 @@ infix fun <ID : Any, Parent : R2dbcEntity<ID>, REF : Any> R2dbcEntityClass<ID, P
     reference: Column<REF?>
 ): OptionalSuspendReference<ID, Parent, REF> {
     return OptionalSuspendReference(reference, this)
-}
-
-fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF> R2dbcEntityClass<ChildID, Child>.referrersOnSuspend(
-    reference: Column<REF>,
-    cache: Boolean = true
-): R2dbcReferrers<ParentID, Parent, ChildID, Child, REF> {
-    return R2dbcReferrers(reference, this, cache)
-}
-
-infix fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF> R2dbcEntityClass<ChildID, Child>.referrersOnSuspend(
-    reference: Column<REF>
-): R2dbcReferrers<ParentID, Parent, ChildID, Child, REF> {
-    return referrersOnSuspend(reference, cache = true)
-}
-
-fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF : Any>
-    R2dbcEntityClass<ChildID, Child>.optionalReferrersOnSuspend(
-        reference: Column<REF?>,
-        cache: Boolean = true
-    ): R2dbcReferrers<ParentID, Parent, ChildID, Child, REF?> {
-    return R2dbcReferrers(reference, this, cache)
-}
-
-infix fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF : Any>
-    R2dbcEntityClass<ChildID, Child>.optionalReferrersOnSuspend(reference: Column<REF?>): R2dbcReferrers<ParentID, Parent, ChildID, Child, REF?> {
-    return optionalReferrersOnSuspend(reference, cache = true)
-}
-
-infix fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF>
-    R2dbcEntityClass<ParentID, Parent>.backReferencedOnSuspend(reference: Column<REF>): R2dbcBackReference<ParentID, Parent, ChildID, Child, REF> {
-    return R2dbcBackReference(reference, this)
-}
-
-infix fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF>
-    R2dbcEntityClass<ParentID, Parent>.optionalBackReferencedOnSuspend(reference: Column<REF?>): R2dbcOptionalBackReference<ParentID, Parent, ChildID, Child, REF> {
-    return R2dbcOptionalBackReference(reference, this)
-}
-
-/**
- * Overload for referencing a non-nullable column as an optional back reference.
- *
- * The child entity's referencing column is required (non-nullable) but, from the parent
- * side, the relationship is still optional: a child row may or may not exist. This mirrors
- * JDBC's `optionalBackReferencedOn(Column<REF>)` overload.
- */
-@Suppress("UNCHECKED_CAST")
-@JvmName("optionalBackReferencedOnSuspendNonNullable")
-infix fun <ParentID : Any, Parent : R2dbcEntity<ParentID>, ChildID : Any, Child : R2dbcEntity<ChildID>, REF : Any>
-    R2dbcEntityClass<ParentID, Parent>.optionalBackReferencedOnSuspend(reference: Column<REF>): R2dbcOptionalBackReference<ParentID, Parent, ChildID, Child, REF> {
-    return R2dbcOptionalBackReference(reference as Column<REF?>, this)
 }

--- a/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/SuspendAccessor.kt
+++ b/exposed-dao-r2dbc/src/main/kotlin/org/jetbrains/exposed/r2dbc/dao/relationships/SuspendAccessor.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.r2dbc.dao.R2dbcEntity
 import org.jetbrains.exposed.r2dbc.dao.R2dbcEntityClass
 import org.jetbrains.exposed.r2dbc.dao.entityCache
 import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.EntityIDColumnType
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.eq
@@ -85,18 +86,8 @@ class SuspendAccessor<ID : Any, Parent : R2dbcEntity<ID>, REF : Any>(
             ?: (entity._readValues?.let { row -> row[reference] } as? REF)
             ?: error("Reference column ${reference.name} has no value for entity ${entity.id}")
 
-        val parentEntity = when {
-            reference.referee == factory.table.id -> {
-                @Suppress("UNCHECKED_CAST")
-                factory.findById(refValue as EntityID<ID>)
-            }
-            reference.referee?.table == factory.table -> {
-                @Suppress("UNCHECKED_CAST")
-                val refereeColumn = reference.referee!! as Column<Any?>
-                factory.find { refereeColumn eq refValue }.singleOrNull()
-            }
-            else -> error("Reference column ${reference.name} does not point to any column in ${factory.table.tableName}")
-        } ?: error("Referenced entity not found for column ${reference.name} with value $refValue")
+        val parentEntity = lookupParentEntity(factory, reference, refValue)
+            ?: error("Referenced entity not found for column ${reference.name} with value $refValue")
 
         entity.storeReferenceInCache(reference, parentEntity)
 
@@ -172,21 +163,41 @@ class OptionalSuspendAccessor<ID : Any, Parent : R2dbcEntity<ID>, REF : Any>(
             return null
         }
 
-        val parentEntity = when {
-            reference.referee == factory.table.id -> {
-                @Suppress("UNCHECKED_CAST")
-                factory.findById(refValue as EntityID<ID>)
-            }
-            reference.referee?.table == factory.table -> {
-                @Suppress("UNCHECKED_CAST")
-                val refereeColumn = reference.referee!! as Column<Any?>
-                factory.find { refereeColumn eq refValue }.singleOrNull()
-            }
-            else -> error("Reference column ${reference.name} does not point to any column in ${factory.table.tableName}")
-        }
+        val parentEntity = lookupParentEntity(factory, reference, refValue)
 
         entity.storeReferenceInCache(reference, parentEntity)
 
         return parentEntity
+    }
+}
+
+/**
+ * Shared lookup used by [SuspendAccessor.invoke] and [OptionalSuspendAccessor.invoke].
+ *
+ * Mirrors JDBC's `Reference.getValue` / `OptionalReference.getValue` logic from `Entity.kt`:
+ *
+ *   - When the child column already stores an `EntityID` AND the referee is the parent's id,
+ *     hit the cache-friendly `findById` path.
+ *   - Otherwise the child column stores a raw value (e.g. `Column<Long>` referencing
+ *     `Cities.id : Column<EntityID<Long>>`, or a column referencing a non-id unique column).
+ *     Unwrap the referee's column type — if it's `EntityIDColumnType<T>` we need to compare
+ *     against the inner `idColumn` (a raw `Column<T>`) so `eq refValue` type-checks.
+ */
+@Suppress("UNCHECKED_CAST")
+internal suspend fun <ID : Any, Parent : R2dbcEntity<ID>> lookupParentEntity(
+    factory: R2dbcEntityClass<ID, @UnsafeVariance Parent>,
+    reference: Column<*>,
+    refValue: Any
+): Parent? {
+    val referee = reference.referee
+        ?: error("Reference column ${reference.name} does not point to any column in ${factory.table.tableName}")
+
+    return when {
+        refValue is EntityID<*> && referee == factory.table.id ->
+            factory.findById(refValue as EntityID<ID>)
+        else -> {
+            val baseReferee = (referee.columnType as? EntityIDColumnType<Any>)?.idColumn ?: referee
+            factory.find { (baseReferee as Column<Any?>) eq refValue }.singleOrNull()
+        }
     }
 }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/InnerTableLink.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/InnerTableLink.kt
@@ -123,7 +123,7 @@ class InnerTableLink<SID : Any, Source : Entity<SID>, ID : Any, Target : Entity<
         // linked entities updated
         val targetClass = (value.firstOrNull() ?: oldValue.firstOrNull())?.klass
         if (targetClass != null) {
-            existingIds.plus(targetIds).forEach {
+            (existingIds + targetIds).forEach {
                 tx.registerChange(targetClass, it, EntityChangeType.Updated)
             }
         }

--- a/exposed-r2dbc-tests/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/DMLTestsData.kt
+++ b/exposed-r2dbc-tests/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/DMLTestsData.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import java.math.BigDecimal
 
+@Suppress("MagicNumber")
 object DMLTestsData {
     object Cities : Table() {
         val id: Column<Int> = integer("cityId").autoIncrement()
@@ -50,7 +51,7 @@ object DMLTestsData {
     }
 }
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "MagicNumber")
 fun R2dbcDatabaseTestsBase.withCitiesAndUsers(
     exclude: Collection<TestDB> = emptyList(),
     statement: suspend R2dbcTransaction.(
@@ -152,6 +153,7 @@ fun R2dbcDatabaseTestsBase.withSales(
     }
 }
 
+@Suppress("MagicNumber")
 private suspend fun DMLTestsData.Sales.insertSaleData() {
     insertSale(2018, 11, "tea", "550.10")
     insertSale(2018, 12, "coffee", "1500.25")
@@ -171,6 +173,7 @@ private suspend fun DMLTestsData.Sales.insertSale(year: Int, month: Int, product
     }
 }
 
+@Suppress("MagicNumber")
 fun R2dbcDatabaseTestsBase.withSalesAndSomeAmounts(
     excludeSettings: Collection<TestDB> = emptyList(),
     statement: suspend R2dbcTransaction.(

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -31,6 +31,7 @@ import org.jetbrains.exposed.v1.r2dbc.tests.shared.expectException
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
+import java.util.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -185,7 +186,7 @@ class InsertTests : R2dbcDatabaseTestsBase() {
             }
 
             val generatedIds = users.batchInsert(userNamesWithCityIds) { (userName, cityId) ->
-                this[users.id] = java.util.Random().nextInt().toString().take(6)
+                this[users.id] = Random().nextInt().toString().take(6)
                 this[users.name] = userName
                 this[users.cityId] = cityId.toInt()
             }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/demo/dao/SamplesDao.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/demo/dao/SamplesDao.kt
@@ -9,10 +9,8 @@ import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.junit.jupiter.api.Assumptions
-import org.junit.jupiter.api.Tag
 import kotlin.test.Test
 
 object Users : IntIdTable() {
@@ -81,7 +79,6 @@ fun main() {
     }
 }
 
-@Tag(MISSING_R2DBC_TEST)
 class SamplesDao {
     @Test
     fun ensureSamplesDoesntCrash() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/EntityReferenceCacheTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/EntityReferenceCacheTest.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.SizedCollection
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.demo.dao.Cities
 import org.jetbrains.exposed.v1.tests.demo.dao.City
@@ -28,7 +27,6 @@ import org.jetbrains.exposed.v1.tests.shared.entities.VNumber
 import org.jetbrains.exposed.v1.tests.shared.entities.VString
 import org.jetbrains.exposed.v1.tests.shared.entities.ViaTestData
 import org.junit.jupiter.api.Assumptions
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import kotlin.properties.Delegates
 import kotlin.test.assertEquals
@@ -36,7 +34,6 @@ import kotlin.test.assertFails
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-@Tag(MISSING_R2DBC_TEST)
 class EntityReferenceCacheTest : DatabaseTestsBase() {
 
     private val db by lazy {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/MultiDatabaseEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/MultiDatabaseEntityTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.entities.EntityTestsData
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.sql.Connection
 import kotlin.properties.Delegates
@@ -23,7 +21,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-@Tag(MISSING_R2DBC_TEST)
 class MultiDatabaseEntityTest {
 
     private val db1 by lazy {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityCacheRefreshTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityCacheRefreshTests.kt
@@ -13,10 +13,8 @@ import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.jdbc.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.junit.jupiter.api.Assumptions
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.sql.Connection
 import kotlin.test.assertEquals
@@ -30,7 +28,6 @@ import kotlin.test.assertEquals
  *
  * @see <a href="https://github.com/JetBrains/Exposed/issues/1527">GitHub Issue #1527</a>
  */
-@Tag(MISSING_R2DBC_TEST)
 class EntityCacheRefreshTests : DatabaseTestsBase() {
     // Skip databases that don't support SELECT FOR UPDATE
     val excludedDbs = listOf(TestDB.SQLITE, TestDB.SQLSERVER)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityCacheTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityCacheTests.kt
@@ -20,19 +20,16 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.junit.jupiter.api.Assumptions
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.sql.Connection.TRANSACTION_SERIALIZABLE
 import java.sql.SQLException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 
-@Tag(MISSING_R2DBC_TEST)
 class EntityCacheTests : DatabaseTestsBase() {
 
     object TestTable : IntIdTable("TestCache") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityFieldWithTransformTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityFieldWithTransformTest.kt
@@ -7,15 +7,12 @@ import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.assertTrue
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import kotlin.random.Random
 
-@Tag(MISSING_R2DBC_TEST)
 class EntityFieldWithTransformTest : DatabaseTestsBase() {
 
     object TransformationsTable : IntIdTable() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityHookTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityHookTest.kt
@@ -11,10 +11,8 @@ import org.jetbrains.exposed.v1.jdbc.SizedCollection
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 object EntityHookTestData {
@@ -63,7 +61,6 @@ object EntityHookTestData {
     val allTables = arrayOf(Users, Cities, UsersToCities, Countries)
 }
 
-@Tag(MISSING_R2DBC_TEST)
 class EntityHookTest : DatabaseTestsBase() {
 
     private fun <T> trackChanges(statement: JdbcTransaction.() -> T): Triple<T, Collection<EntityChange>, String> {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityWithBlobTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityWithBlobTests.kt
@@ -8,15 +8,12 @@ import org.jetbrains.exposed.v1.dao.Entity
 import org.jetbrains.exposed.v1.dao.EntityClass
 import org.jetbrains.exposed.v1.dao.flushCache
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.entities.EntityTestsData.YTable
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.util.*
 import kotlin.test.assertNull
 
-@Tag(MISSING_R2DBC_TEST)
 class EntityWithBlobTests : DatabaseTestsBase() {
 
     object BlobTable : IdTable<String>("YTable") {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/ForeignIdEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/ForeignIdEntityTest.kt
@@ -12,16 +12,13 @@ import org.jetbrains.exposed.v1.dao.LongEntity
 import org.jetbrains.exposed.v1.dao.LongEntityClass
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertFalse
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import kotlin.test.assertContentEquals
 
 /**
  * A case when a table's primary key is a foreign key to some other table (ProjectConfigs.id -> Project.id)
  */
-@Tag(MISSING_R2DBC_TEST)
 class ForeignIdEntityTest : DatabaseTestsBase() {
 
     object Schema {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/JavaUUIDTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/JavaUUIDTableEntityTest.kt
@@ -10,9 +10,7 @@ import org.jetbrains.exposed.v1.dao.with
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.util.UUID as JavaUUID
 
@@ -66,7 +64,6 @@ object JavaUUIDTables {
     }
 }
 
-@Tag(MISSING_R2DBC_TEST)
 class JavaUUIDTableEntityTest : DatabaseTestsBase() {
     @Test
     fun `create tables`() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/LongIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/LongIdTableEntityTest.kt
@@ -9,9 +9,7 @@ import org.jetbrains.exposed.v1.dao.with
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 object LongIdTables {
@@ -49,7 +47,6 @@ object LongIdTables {
     }
 }
 
-@Tag(MISSING_R2DBC_TEST)
 class LongIdTableEntityTest : DatabaseTestsBase() {
     @Test
     fun `create tables`() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/NonAutoIncEntities.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/NonAutoIncEntities.kt
@@ -10,13 +10,10 @@ import org.jetbrains.exposed.v1.dao.flushCache
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.update
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.util.concurrent.atomic.AtomicInteger
 
-@Tag(MISSING_R2DBC_TEST)
 class NonAutoIncEntities : DatabaseTestsBase() {
 
     abstract class BaseNonAutoIncTable(name: String) : IdTable<Int>(name) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/OrderedReferenceTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/OrderedReferenceTest.kt
@@ -14,17 +14,14 @@ import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.assertTrue
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import kotlin.math.max
 
-@Tag(MISSING_R2DBC_TEST)
 class OrderedReferenceTest : DatabaseTestsBase() {
     object Users : IntIdTable()
 
@@ -206,7 +203,6 @@ class OrderedReferenceTest : DatabaseTestsBase() {
     }
 
     @Test
-    @Tag(MISSING_R2DBC_TEST)
     fun testOrderByWithEagerLoad() {
         withOrderedReferenceTestTables {
             // Clearing cache is not critical, just to be sure that there are no caches from

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/SelfReferenceTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/SelfReferenceTest.kt
@@ -3,15 +3,12 @@ package org.jetbrains.exposed.v1.tests.shared.entities
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.dml.DMLTestsData
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@Tag(MISSING_R2DBC_TEST)
 class SelfReferenceTest {
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/UIntIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/UIntIdTableEntityTest.kt
@@ -9,12 +9,9 @@ import org.jetbrains.exposed.v1.dao.with
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-@Tag(MISSING_R2DBC_TEST)
 class UIntIdTableEntityTest : DatabaseTestsBase() {
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/ULongIdTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/ULongIdTableEntityTest.kt
@@ -9,12 +9,9 @@ import org.jetbrains.exposed.v1.dao.with
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-@Tag(MISSING_R2DBC_TEST)
 class ULongIdTableEntityTest : DatabaseTestsBase() {
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/UuidTableEntityTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/UuidTableEntityTest.kt
@@ -9,11 +9,9 @@ import org.jetbrains.exposed.v1.dao.with
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.tests.shared.assertTrue
 import org.jetbrains.exposed.v1.tests.versionNumber
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import kotlin.uuid.Uuid
 
@@ -83,7 +81,6 @@ object UuidTables {
     }
 }
 
-@Tag(MISSING_R2DBC_TEST)
 class UuidTableEntityTest : DatabaseTestsBase() {
     @Test
     fun `create tables`() {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/ViaTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/ViaTest.kt
@@ -14,11 +14,9 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.inTopLevelTransaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEqualCollections
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.sql.Connection
 import java.util.Objects
@@ -79,7 +77,6 @@ class VString(id: EntityID<Long>) : Entity<Long>(id) {
     companion object : EntityClass<Long, VString>(ViaTestData.StringsTable)
 }
 
-@Tag(MISSING_R2DBC_TEST)
 class ViaTests : DatabaseTestsBase() {
 
     private fun VNumber.testWithBothTables(valuesToSet: List<VString>, body: (ViaTestData.IConnectionTable, List<ResultRow>) -> Unit) {

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/WarmUpLinkedReferencesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/WarmUpLinkedReferencesTests.kt
@@ -5,12 +5,9 @@ import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
-import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-@Tag(MISSING_R2DBC_TEST)
 class WarmUpLinkedReferencesTests : DatabaseTestsBase() {
 
     object Box : IntIdTable() {


### PR DESCRIPTION
#### Description

**Summary of the change**: Ports some JDBC DAO entity test suite to R2DBC

**Detailed description**:
  - 17 JDBC entity tests now have R2DBC counterparts (`R2dbcEntityCacheTests`, `R2dbcEntityFieldWithTransformTest`, `R2dbcEntityWithBlobTests`, `R2dbcForeignIdEntityTest`, `R2dbcJavaUUIDTableEntityTest`, `R2dbcLongIdTableEntityTest`, `R2dbcNonAutoIncEntities`, `R2dbcSelfReferenceTest`, `R2dbcUIntIdTableEntityTest`, `R2dbcULongIdTableEntityTest`, `R2dbcUuidTableEntityTest`, …) plus H2-specific `R2dbcEntityReferenceCacheTest` and `R2dbcMultiDatabaseEntityTest`. Only `CompositeIdTableEntityTest`, `EntityBugsRegressionTest`, and `ImmutableEntityTest` remain unported.
  - Added `EntityFieldWithTransform` + member extensions `transform` / `memoizedTransform` (both `Column<T>` and chainable on `EntityFieldWithTransform`) on `R2dbcEntityClass`, plus matching `getValue`/`setValue` operators on `R2dbcEntity`.
  - Added `Iterable<T>.with(...)` overload alongside the existing `SizedIterable<T>.with(...)` (necessary because R2DBC's `SizedIterable` is a `Flow`, not an `Iterable`).
  - `R2dbcReferrers.getValue` now flushes the parent before issuing the referrer query when the id has not yet been generated (mirrors JDBC's implicit flush via `DaoEntityID.invokeOnNoValue`).
  - `R2dbcEntityCache.removeTablesReferrers` gained an `isInsert` flag and the full JDBC propagation rule (UPDATE/DELETE also invalidates slots whose key column references the affected table). Callers in the lifecycle interceptor and `flushInserts` were updated accordingly.
  - Added `UIntR2dbcEntity` / `ULongR2dbcEntity` / `UuidR2dbcEntity` / `java.util.UUID` and composite-entity base classes; small additions to `R2dbcInnerTableLink` and `SuspendAccessor` for the relationship surface.

