### PR TITLE
fix: Apply inProperCase() to CHECK constraint names

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Constraints.kt
@@ -237,14 +237,14 @@ data class CheckConstraint(
     }
 
     companion object {
+        @OptIn(InternalApi::class)
         fun from(table: Table, name: String, op: Op<Boolean>): CheckConstraint {
             require(name.isNotBlank()) { "Check constraint name cannot be blank" }
-            @OptIn(InternalApi::class)
             val tr = currentTransaction()
             val identifierManager = tr.db.identifierManager
             val tableName = tr.identity(table)
             val checkOpSQL = op.toString().replace("$tableName.", "")
-            return CheckConstraint(tableName, identifierManager.cutIfNecessaryAndQuote(name), checkOpSQL)
+            return CheckConstraint(tableName, identifierManager.cutIfNecessaryAndQuote(name).inProperCase(), checkOpSQL)
         }
     }
 }

--- a/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DefaultsTest.kt
+++ b/exposed-java-time/src/test/kotlin/org/jetbrains/exposed/v1/javatime/DefaultsTest.kt
@@ -293,10 +293,10 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT ${"chk_t_signed_long_l".inProperCase()} CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"
@@ -452,7 +452,7 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE, TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeDefaultsTest.kt
+++ b/exposed-jodatime/src/test/kotlin/org/jetbrains/exposed/v1/jodatime/JodaTimeDefaultsTest.kt
@@ -216,10 +216,10 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
                 "${"t6".inProperCase()} $timeType${testTable.t6.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT ${"chk_t_signed_long_l".inProperCase()} CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"
@@ -429,7 +429,7 @@ class JodaTimeDefaultsTest : DatabaseTestsBase() {
                 "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentDateTime.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE, TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
@@ -282,10 +282,10 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t12".inProperCase()} $timestampType${testTable.t12.constraintNamePart()} ${tsLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT ${"chk_t_signed_long_l".inProperCase()} CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"
@@ -450,7 +450,7 @@ class DefaultsTest : DatabaseTestsBase() {
                 "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
                 when (testDb) {
                     TestDB.SQLITE, TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/DatabaseMigrationTests.kt
@@ -640,4 +640,30 @@ class DatabaseMigrationTests : DatabaseTestsBase() {
             }
         }
     }
+
+    object MixedCaseUIntTable : Table() {
+        val unsignedCol = uinteger("unsignedCol")
+    }
+
+    @OptIn(InternalApi::class)
+    @Test
+    fun testUnsignedCheckConstraintNameCaseRegression() {
+        withDb(excludeSettings = TestDB.ALL_MYSQL_MARIADB) {
+            val previousConstraintName = "chk_MixedCaseUInt_unsigned_integer_unsignedCol"
+            val currentDdl = MixedCaseUIntTable.createStatement().single()
+            val currentCheckClause = currentDdl.substringAfter("CHECK ")
+            val previousDdl =
+                "${currentDdl.substringBefore(" CONSTRAINT ")} CONSTRAINT $previousConstraintName CHECK $currentCheckClause"
+
+            try {
+                exec(previousDdl)
+                commit()
+
+                val rerun = MigrationUtils.statementsRequiredForDatabaseMigration(MixedCaseUIntTable, withLogs = false)
+                assertTrue(rerun.isEmpty())
+            } finally {
+                SchemaUtils.drop(MixedCaseUIntTable)
+            }
+        }
+    }
 }

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/DatabaseMigrationTests.kt
@@ -616,4 +616,30 @@ class DatabaseMigrationTests : R2dbcDatabaseTestsBase() {
             }
         }
     }
+
+    object MixedCaseUIntTable : Table() {
+        val unsignedCol = uinteger("unsignedCol")
+    }
+
+    @OptIn(InternalApi::class)
+    @Test
+    fun testUnsignedCheckConstraintNameCaseRegression() {
+        withDb(excludeSettings = TestDB.ALL_MYSQL_MARIADB) {
+            val previousConstraintName = "chk_MixedCaseUInt_unsigned_integer_unsignedCol"
+            val currentDdl = MixedCaseUIntTable.createStatement().single()
+            val currentCheckClause = currentDdl.substringAfter("CHECK ")
+            val previousDdl =
+                "${currentDdl.substringBefore(" CONSTRAINT ")} CONSTRAINT $previousConstraintName CHECK $currentCheckClause"
+
+            try {
+                exec(previousDdl)
+                commit()
+
+                val rerun = MigrationUtils.statementsRequiredForDatabaseMigration(MixedCaseUIntTable, withLogs = false)
+                assertTrue(rerun.isEmpty())
+            } finally {
+                SchemaUtils.drop(MixedCaseUIntTable)
+            }
+        }
+    }
 }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/DefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/javatime/DefaultsTest.kt
@@ -201,8 +201,8 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
                 "${"t10".inProperCase()} $timeType${testTable.t10.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT ${"chk_t_signed_long_l".inProperCase()} CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
 
                     else -> ""
                 } +
@@ -364,7 +364,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
                 "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
                 when (testDb) {
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
 
                     else -> ""
                 } +

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/jodatime/JodaTimeDefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/jodatime/JodaTimeDefaultsTest.kt
@@ -141,8 +141,8 @@ class JodaTimeDefaultsTest : R2dbcDatabaseTestsBase() {
                 "${"t6".inProperCase()} $timeType${testTable.t6.constraintNamePart()} ${tLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT ${"chk_t_signed_long_l".inProperCase()} CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"
@@ -320,7 +320,7 @@ class JodaTimeDefaultsTest : R2dbcDatabaseTestsBase() {
                 "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentDateTime.itOrNull()}" +
                 when (testDb) {
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
@@ -201,8 +201,8 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
                 "${"t12".inProperCase()} $timestampType${testTable.t12.constraintNamePart()} ${tsLiteral.itOrNull()}" +
                 when (testDb) {
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                            ", CONSTRAINT chk_t_signed_long_l CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                            ", CONSTRAINT ${"chk_t_signed_long_l".inProperCase()} CHECK (L BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"
@@ -367,7 +367,7 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
                 "${"t3".inProperCase()} $timestampWithTimeZoneType${testTable.t3.constraintNamePart()} ${CurrentTimestampWithTimeZone.itOrNull()}" +
                 when (testDb) {
                     TestDB.ORACLE ->
-                        ", CONSTRAINT chk_t_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_t_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                     else -> ""
                 } +
                 ")"

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/DDLTests.kt
@@ -112,6 +112,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
         )
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testKeywordIdentifiersWithoutOptOut() {
         val keywords = listOf("data", "public", "key", "constraint")
@@ -137,7 +138,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
             @Suppress("MaximumLineLength")
             val expectedCreate =
                 "CREATE TABLE ${addIfNotExistsIfSupported()}$tableName (" + "$publicName ${keywordTable.public.columnType.sqlType()} NOT NULL, " + "$dataName ${keywordTable.data.columnType.sqlType()} NOT NULL, " + "$constraintName ${keywordTable.constraint.columnType.sqlType()} NOT NULL" + when (testDb) {
-                    TestDB.ORACLE -> """, CONSTRAINT chk_data_signed_integer_key CHECK ("key" BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"""
+                    TestDB.ORACLE -> """, CONSTRAINT ${"chk_data_signed_integer_key".inProperCase()} CHECK ("key" BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"""
                     else -> ""
                 } + ")"
             assertEquals(expectedCreate, keywordTable.ddl.single())
@@ -172,6 +173,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun unnamedTableWithQuotesSQL() {
         withTables(tables = arrayOf(unnamedTable)) { testDb ->
             val q = db.identifierManager.quoteString
@@ -190,7 +192,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
                     "$tableName " +
                     "(${"id".inProperCase()} $integerType PRIMARY KEY, $q${"name".inProperCase()}$q $varCharType NOT NULL" +
                     when (testDb) {
-                        TestDB.ORACLE -> ", CONSTRAINT chk_unnamedTable$1_signed_integer_id CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        TestDB.ORACLE -> ", CONSTRAINT ${"chk_unnamedTable$1_signed_integer_id".inProperCase()} CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } + ")",
                 unnamedTable.ddl
@@ -234,6 +236,7 @@ class DDLTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun tableWithDifferentColumnTypesSQL02() {
         val testTable = object : Table("with_different_column_types") {
             val id = integer("id")
@@ -253,8 +256,8 @@ class DDLTests : R2dbcDatabaseTestsBase() {
             val primaryKeyConstraint = "CONSTRAINT pk_with_different_column_types PRIMARY KEY (${"id".inProperCase()}, $q${"name".inProperCase()}$q)"
             val checkConstraint = when (testDb) {
                 TestDB.ORACLE ->
-                    ", CONSTRAINT chk_with_different_column_types_signed_integer_id CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                        ", CONSTRAINT chk_with_different_column_types_signed_integer_age CHECK (AGE BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                    ", CONSTRAINT ${"chk_with_different_column_types_signed_integer_id".inProperCase()} CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                        ", CONSTRAINT ${"chk_with_different_column_types_signed_integer_age".inProperCase()} CHECK (AGE BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                 else -> ""
             }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/CreateTableTests.kt
@@ -150,6 +150,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun testCreateTableWithSingleColumnPrimaryKey() {
         val stringPKTable = object : Table("string_pk_table") {
             val column1 = varchar("column_1", 30)
@@ -179,7 +180,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     intColumnDescription +
                     when (testDb) {
                         TestDB.ORACLE ->
-                            ", CONSTRAINT chk_int_pk_table_signed_integer_column_1 CHECK (${"column_1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_int_pk_table_signed_integer_column_1".inProperCase()} CHECK (${"column_1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")",
@@ -190,6 +191,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun primaryKeyCreateTableTest() {
         val account = object : Table("Account") {
             val id1 = integer("id1")
@@ -208,8 +210,8 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     "CONSTRAINT pk_$tableName PRIMARY KEY ($id1ProperName, $id2ProperName)" +
                     when (testDb) {
                         TestDB.ORACLE ->
-                            ", CONSTRAINT chk_Account_signed_integer_id1 CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_Account_signed_integer_id2 CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_Account_signed_integer_id1".inProperCase()} CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_Account_signed_integer_id2".inProperCase()} CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")",
@@ -220,6 +222,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun primaryKeyWithConstraintNameCreateTableTest() {
         val pkConstraintName = "PKConstraintName"
 
@@ -235,8 +238,8 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     "CONSTRAINT $pkConstraintName PRIMARY KEY ($id1ProperName, $id2ProperName)" +
                     when (testDb) {
                         TestDB.ORACLE ->
-                            ", CONSTRAINT chk_Person_signed_integer_id1 CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_Person_signed_integer_id2 CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_Person_signed_integer_id1".inProperCase()} CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_Person_signed_integer_id2".inProperCase()} CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")",
@@ -353,6 +356,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName1() {
         val fkName = "MyForeignKey1"
         val parent = object : LongIdTable("parent1") {}
@@ -375,7 +379,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.id)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child1_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child1_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -404,7 +408,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                 " FOREIGN KEY (${this.identity(child.parentId)})" +
                 " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
                 if (testDb == TestDB.ORACLE) {
-                    ", CONSTRAINT chk_Child_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    ", CONSTRAINT ${"chk_Child_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                 } else {
                     ""
                 } +
@@ -432,7 +436,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                 " FOREIGN KEY (${this.identity(child.parentId)})" +
                 " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
                 if (testDb == TestDB.ORACLE) {
-                    ", CONSTRAINT chk_Child2_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    ", CONSTRAINT ${"chk_Child2_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                 } else {
                     ""
                 } +
@@ -443,6 +447,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName2() {
         val fkName = "MyForeignKey2"
         val parent = object : LongIdTable("parent2") {
@@ -467,7 +472,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.uniqueId)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child2_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child2_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -479,6 +484,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName3() {
         val fkName = "MyForeignKey3"
         val parent = object : LongIdTable("parent3") {}
@@ -501,7 +507,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.id)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child3_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child3_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -513,6 +519,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName4() {
         val fkName = "MyForeignKey4"
         val parent = object : LongIdTable() {
@@ -538,7 +545,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.uniqueId)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child4_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child4_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -550,6 +557,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitCompositeForeignKeyName1() {
         val fkName = "MyForeignKey1"
         val parent = object : Table("parent1") {
@@ -584,8 +592,8 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     " ON DELETE CASCADE$updateCascadePart" +
                     when (testDb) {
                         TestDB.ORACLE ->
-                            ", CONSTRAINT chk_child1_signed_integer_id_a CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_child1_signed_integer_id_b CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_child1_signed_integer_id_a".inProperCase()} CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_child1_signed_integer_id_b".inProperCase()} CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")"
@@ -596,6 +604,7 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitCompositeForeignKeyName2() {
         val fkName = "MyForeignKey2"
         val parent = object : Table("parent2") {
@@ -630,8 +639,8 @@ class CreateTableTests : R2dbcDatabaseTestsBase() {
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.idA)}, ${t.identity(parent.idB)})" +
                     when (testDb) {
                         TestDB.ORACLE ->
-                            ", CONSTRAINT chk_child2_signed_integer_id_a CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_child2_signed_integer_id_b CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_child2_signed_integer_id_a".inProperCase()} CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_child2_signed_integer_id_b".inProperCase()} CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")"

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/types/NumericColumnTypesTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/types/NumericColumnTypesTests.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.types
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.functions.math.RoundFunction
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.select
 import org.jetbrains.exposed.v1.r2dbc.selectAll
@@ -290,6 +291,8 @@ class NumericColumnTypesTests : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
+    @Suppress("MaximumLineLength")
     @Test
     fun testCustomCheckConstraintName() {
         val tester = object : Table("tester") {
@@ -310,12 +313,12 @@ class NumericColumnTypesTests : R2dbcDatabaseTestsBase() {
                     "${tester.ushort.nameInDatabaseCase()} ${tester.ushort.columnType} NOT NULL, " +
                     "${tester.integer.nameInDatabaseCase()} ${tester.integer.columnType} NOT NULL, " +
                     "${tester.uinteger.nameInDatabaseCase()} ${tester.uinteger.columnType} NOT NULL, " +
-                    "CONSTRAINT custom_byte_check CHECK (${tester.byte.nameInDatabaseCase()} BETWEEN ${Byte.MIN_VALUE} AND ${Byte.MAX_VALUE}), " +
-                    "CONSTRAINT custom_ubyte_check CHECK (${tester.ubyte.nameInDatabaseCase()} BETWEEN 0 AND ${UByte.MAX_VALUE}), " +
-                    "CONSTRAINT custom_short_check CHECK (${tester.short.nameInDatabaseCase()} BETWEEN ${Short.MIN_VALUE} AND ${Short.MAX_VALUE}), " +
-                    "CONSTRAINT custom_ushort_check CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
-                    "CONSTRAINT custom_integer_check CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
-                    "CONSTRAINT custom_uinteger_check CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}))",
+                    "CONSTRAINT ${"custom_byte_check".inProperCase()} CHECK (${tester.byte.nameInDatabaseCase()} BETWEEN ${Byte.MIN_VALUE} AND ${Byte.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_ubyte_check".inProperCase()} CHECK (${tester.ubyte.nameInDatabaseCase()} BETWEEN 0 AND ${UByte.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_short_check".inProperCase()} CHECK (${tester.short.nameInDatabaseCase()} BETWEEN ${Short.MIN_VALUE} AND ${Short.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_ushort_check".inProperCase()} CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_integer_check".inProperCase()} CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_uinteger_check".inProperCase()} CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}))",
                 tester.ddl
             )
         }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -3,11 +3,13 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.types
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.selectAll
@@ -21,6 +23,13 @@ import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
 import org.junit.jupiter.api.Test
 
 class UnsignedColumnTypeTests : R2dbcDatabaseTestsBase() {
+    // Table without explicit name — Kotlin class name "MixedCaseUIntTable" is used
+    // (resolved to "MixedCaseUInt" after Table suffix removal),
+    // which has mixed casing to verify CHECK constraint names use inProperCase().
+    object MixedCaseUIntTable : Table() {
+        val unsignedCol = uinteger("unsignedCol")
+    }
+
     object UByteTable : Table("ubyte_table") {
         val unsignedByte = ubyte("ubyte")
     }
@@ -227,6 +236,20 @@ class UnsignedColumnTypeTests : R2dbcDatabaseTestsBase() {
                 val outOfRangeValue = UInt.MAX_VALUE.toLong() + 1L
                 exec("""INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)""")
             }
+        }
+    }
+
+    @OptIn(InternalApi::class)
+    @Test
+    fun testUnsignedCheckConstraintNameUsesProperCase() {
+        // MySQL/MariaDB use the UNSIGNED type instead of a CHECK constraint
+        withTables(excludeSettings = TestDB.ALL_MYSQL_MARIADB, MixedCaseUIntTable) {
+            val checkConstraints = MixedCaseUIntTable.checkConstraints()
+            val checkName = checkConstraints.single().checkName
+            val expectedName = "chk_MixedCaseUInt_unsigned_integer_unsignedCol".inProperCase()
+            // Constraint name may be quoted by cutIfNecessaryAndQuote, so strip quotes for comparison
+            val unquotedCheckName = checkName.trim('"', '\'', '`')
+            assertEquals(expectedName, unquotedCheckName)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/DDLTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/DDLTests.kt
@@ -116,6 +116,7 @@ class DDLTests : DatabaseTestsBase() {
         )
     }
 
+    @OptIn(InternalApi::class)
     @Test
     fun testKeywordIdentifiersWithoutOptOut() {
         val keywords = listOf("data", "public", "key", "constraint")
@@ -144,7 +145,7 @@ class DDLTests : DatabaseTestsBase() {
                 "$constraintName ${keywordTable.constraint.columnType.sqlType()} NOT NULL" +
                 when (testDb) {
                     TestDB.SQLITE, TestDB.ORACLE ->
-                        """, CONSTRAINT chk_data_signed_integer_key CHECK ("key" BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"""
+                        """, CONSTRAINT ${"chk_data_signed_integer_key".inProperCase()} CHECK ("key" BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"""
                     else -> ""
                 } +
                 ")"
@@ -180,6 +181,7 @@ class DDLTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun unnamedTableWithQuotesSQL() {
         withTables(excludeSettings = listOf(TestDB.SQLITE), tables = arrayOf(unnamedTable)) { testDb ->
             val q = db.identifierManager.quoteString
@@ -196,7 +198,7 @@ class DDLTests : DatabaseTestsBase() {
                 "CREATE TABLE " + addIfNotExistsIfSupported() + "$tableName " +
                     "(${"id".inProperCase()} $integerType PRIMARY KEY, $q${"name".inProperCase()}$q $varCharType NOT NULL" +
                     when (testDb) {
-                        TestDB.ORACLE -> ", CONSTRAINT chk_unnamedTable$1_signed_integer_id CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                        TestDB.ORACLE -> ", CONSTRAINT ${"chk_unnamedTable$1_signed_integer_id".inProperCase()} CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")",
@@ -261,6 +263,7 @@ class DDLTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun tableWithDifferentColumnTypesSQL02() {
         val testTable = object : Table("with_different_column_types") {
             val id = integer("id")
@@ -280,8 +283,8 @@ class DDLTests : DatabaseTestsBase() {
             val primaryKeyConstraint = "CONSTRAINT pk_with_different_column_types PRIMARY KEY (${"id".inProperCase()}, $q${"name".inProperCase()}$q)"
             val checkConstraint = when (testDb) {
                 TestDB.ORACLE ->
-                    ", CONSTRAINT chk_with_different_column_types_signed_integer_id CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                        ", CONSTRAINT chk_with_different_column_types_signed_integer_age CHECK (AGE BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                    ", CONSTRAINT ${"chk_with_different_column_types_signed_integer_id".inProperCase()} CHECK (ID BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                        ", CONSTRAINT ${"chk_with_different_column_types_signed_integer_age".inProperCase()} CHECK (AGE BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                 else -> ""
             }
 
@@ -291,6 +294,7 @@ class DDLTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun tableWithDifferentColumnTypesInSQLite() {
         val testTable = object : Table("with_different_column_types") {
             val id = integer("id")
@@ -311,8 +315,8 @@ class DDLTests : DatabaseTestsBase() {
 
             assertEquals(
                 "$tableDescription ($idDescription, $nameDescription, $ageDescription, $constraint," +
-                    " CONSTRAINT chk_with_different_column_types_signed_integer_id CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})," +
-                    " CONSTRAINT chk_with_different_column_types_signed_integer_age CHECK (${"age".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}))",
+                    " CONSTRAINT ${"chk_with_different_column_types_signed_integer_id".inProperCase()} CHECK (${"id".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})," +
+                    " CONSTRAINT ${"chk_with_different_column_types_signed_integer_age".inProperCase()} CHECK (${"age".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}))",
                 testTable.ddl
             )
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateTableTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/CreateTableTests.kt
@@ -144,6 +144,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun testCreateTableWithSingleColumnPrimaryKey() {
         val stringPKTable = object : Table("string_pk_table") {
             val column1 = varchar("column_1", 30)
@@ -173,7 +174,7 @@ class CreateTableTests : DatabaseTestsBase() {
                     intColumnDescription +
                     when (testDb) {
                         TestDB.SQLITE, TestDB.ORACLE ->
-                            ", CONSTRAINT chk_int_pk_table_signed_integer_column_1 CHECK (${"column_1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_int_pk_table_signed_integer_column_1".inProperCase()} CHECK (${"column_1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")",
@@ -184,6 +185,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun primaryKeyCreateTableTest() {
         val account = object : Table("Account") {
             val id1 = integer("id1")
@@ -202,8 +204,8 @@ class CreateTableTests : DatabaseTestsBase() {
                     "CONSTRAINT pk_$tableName PRIMARY KEY ($id1ProperName, $id2ProperName)" +
                     when (testDb) {
                         TestDB.SQLITE, TestDB.ORACLE ->
-                            ", CONSTRAINT chk_Account_signed_integer_id1 CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_Account_signed_integer_id2 CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_Account_signed_integer_id1".inProperCase()} CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_Account_signed_integer_id2".inProperCase()} CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")",
@@ -214,6 +216,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun primaryKeyWithConstraintNameCreateTableTest() {
         val pkConstraintName = "PKConstraintName"
 
@@ -229,8 +232,8 @@ class CreateTableTests : DatabaseTestsBase() {
                     "CONSTRAINT $pkConstraintName PRIMARY KEY ($id1ProperName, $id2ProperName)" +
                     when (testDb) {
                         TestDB.SQLITE, TestDB.ORACLE ->
-                            ", CONSTRAINT chk_Person_signed_integer_id1 CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_Person_signed_integer_id2 CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_Person_signed_integer_id1".inProperCase()} CHECK (${"id1".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_Person_signed_integer_id2".inProperCase()} CHECK (${"id2".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")",
@@ -348,6 +351,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName1() {
         val fkName = "MyForeignKey1"
         val parent = object : LongIdTable("parent1") {}
@@ -370,7 +374,7 @@ class CreateTableTests : DatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.id)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child1_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child1_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -399,7 +403,7 @@ class CreateTableTests : DatabaseTestsBase() {
                 " FOREIGN KEY (${this.identity(child.parentId)})" +
                 " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
                 if (testDb == TestDB.ORACLE) {
-                    ", CONSTRAINT chk_Child_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    ", CONSTRAINT ${"chk_Child_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                 } else {
                     ""
                 } +
@@ -427,7 +431,7 @@ class CreateTableTests : DatabaseTestsBase() {
                 " FOREIGN KEY (${this.identity(child.parentId)})" +
                 " REFERENCES ${this.identity(parent)}(${this.identity(parent.id)})" +
                 if (testDb == TestDB.ORACLE) {
-                    ", CONSTRAINT chk_Child2_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                    ", CONSTRAINT ${"chk_Child2_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                 } else {
                     ""
                 } +
@@ -438,6 +442,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName2() {
         val fkName = "MyForeignKey2"
         val parent = object : LongIdTable("parent2") {
@@ -462,7 +467,7 @@ class CreateTableTests : DatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.uniqueId)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child2_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child2_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -474,6 +479,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName3() {
         val fkName = "MyForeignKey3"
         val parent = object : LongIdTable("parent3") {}
@@ -496,7 +502,7 @@ class CreateTableTests : DatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.id)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child3_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child3_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -508,6 +514,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitForeignKeyName4() {
         val fkName = "MyForeignKey4"
         val parent = object : LongIdTable() {
@@ -533,7 +540,7 @@ class CreateTableTests : DatabaseTestsBase() {
                     " FOREIGN KEY (${t.identity(child.parentId)})" +
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.uniqueId)})" +
                     if (testDb == TestDB.ORACLE) {
-                        ", CONSTRAINT chk_child4_signed_long_id CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
+                        ", CONSTRAINT ${"chk_child4_signed_long_id".inProperCase()} CHECK (${this.identity(parent.id)} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE})"
                     } else {
                         ""
                     } +
@@ -545,6 +552,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitCompositeForeignKeyName1() {
         val fkName = "MyForeignKey1"
         val parent = object : Table("parent1") {
@@ -579,8 +587,8 @@ class CreateTableTests : DatabaseTestsBase() {
                     " ON DELETE CASCADE$updateCascadePart" +
                     when (testDb) {
                         TestDB.SQLITE, TestDB.ORACLE ->
-                            ", CONSTRAINT chk_child1_signed_integer_id_a CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_child1_signed_integer_id_b CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_child1_signed_integer_id_a".inProperCase()} CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_child1_signed_integer_id_b".inProperCase()} CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")"
@@ -591,6 +599,7 @@ class CreateTableTests : DatabaseTestsBase() {
 
     @OptIn(InternalApi::class)
     @Test
+    @Suppress("MaximumLineLength")
     fun createTableWithExplicitCompositeForeignKeyName2() {
         val fkName = "MyForeignKey2"
         val parent = object : Table("parent2") {
@@ -625,8 +634,8 @@ class CreateTableTests : DatabaseTestsBase() {
                     " REFERENCES ${t.identity(parent)}(${t.identity(parent.idA)}, ${t.identity(parent.idB)})" +
                     when (testDb) {
                         TestDB.SQLITE, TestDB.ORACLE ->
-                            ", CONSTRAINT chk_child2_signed_integer_id_a CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_child2_signed_integer_id_b CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_child2_signed_integer_id_a".inProperCase()} CHECK (${"id_a".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_child2_signed_integer_id_b".inProperCase()} CHECK (${"id_b".inProperCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")"
@@ -648,8 +657,8 @@ class CreateTableTests : DatabaseTestsBase() {
                     " ON DELETE SET DEFAULT" +
                     when (testDb) {
                         TestDB.SQLITE ->
-                            ", CONSTRAINT chk_Item_signed_integer_id CHECK (id BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
-                                ", CONSTRAINT chk_Item_signed_integer_categoryId CHECK (categoryId BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
+                            ", CONSTRAINT ${"chk_Item_signed_integer_id".inProperCase()} CHECK (id BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})" +
+                                ", CONSTRAINT ${"chk_Item_signed_integer_categoryId".inProperCase()} CHECK (categoryId BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE})"
                         else -> ""
                     } +
                     ")"

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/NumericColumnTypesTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/NumericColumnTypesTests.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.v1.tests.shared.types
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.functions.math.RoundFunction
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -294,6 +295,8 @@ class NumericColumnTypesTests : DatabaseTestsBase() {
         }
     }
 
+    @OptIn(InternalApi::class)
+    @Suppress("MaximumLineLength")
     @Test
     fun testCustomCheckConstraintName() {
         val tester = object : Table("tester") {
@@ -316,13 +319,13 @@ class NumericColumnTypesTests : DatabaseTestsBase() {
                     "${tester.integer.nameInDatabaseCase()} ${tester.integer.columnType} NOT NULL, " +
                     "${tester.uinteger.nameInDatabaseCase()} ${tester.uinteger.columnType} NOT NULL, " +
                     "${tester.long.nameInDatabaseCase()} ${tester.long.columnType} NOT NULL, " +
-                    "CONSTRAINT custom_byte_check CHECK (${tester.byte.nameInDatabaseCase()} BETWEEN ${Byte.MIN_VALUE} AND ${Byte.MAX_VALUE}), " +
-                    "CONSTRAINT custom_ubyte_check CHECK (${tester.ubyte.nameInDatabaseCase()} BETWEEN 0 AND ${UByte.MAX_VALUE}), " +
-                    "CONSTRAINT custom_short_check CHECK (${tester.short.nameInDatabaseCase()} BETWEEN ${Short.MIN_VALUE} AND ${Short.MAX_VALUE}), " +
-                    "CONSTRAINT custom_ushort_check CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
-                    "CONSTRAINT custom_integer_check CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
-                    "CONSTRAINT custom_uinteger_check CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}), " +
-                    "CONSTRAINT custom_long_check CHECK (${tester.long.nameInDatabaseCase()} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE}))",
+                    "CONSTRAINT ${"custom_byte_check".inProperCase()} CHECK (${tester.byte.nameInDatabaseCase()} BETWEEN ${Byte.MIN_VALUE} AND ${Byte.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_ubyte_check".inProperCase()} CHECK (${tester.ubyte.nameInDatabaseCase()} BETWEEN 0 AND ${UByte.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_short_check".inProperCase()} CHECK (${tester.short.nameInDatabaseCase()} BETWEEN ${Short.MIN_VALUE} AND ${Short.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_ushort_check".inProperCase()} CHECK (${tester.ushort.nameInDatabaseCase()} BETWEEN 0 AND ${UShort.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_integer_check".inProperCase()} CHECK (${tester.integer.nameInDatabaseCase()} BETWEEN ${Int.MIN_VALUE} AND ${Int.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_uinteger_check".inProperCase()} CHECK (${tester.uinteger.nameInDatabaseCase()} BETWEEN 0 AND ${UInt.MAX_VALUE}), " +
+                    "CONSTRAINT ${"custom_long_check".inProperCase()} CHECK (${tester.long.nameInDatabaseCase()} BETWEEN ${Long.MIN_VALUE} AND ${Long.MAX_VALUE}))",
                 tester.ddl
             )
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -1,10 +1,12 @@
 package org.jetbrains.exposed.v1.tests.shared.types
 
+import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -18,6 +20,13 @@ import org.jetbrains.exposed.v1.tests.shared.assertTrue
 import org.junit.jupiter.api.Test
 
 class UnsignedColumnTypeTests : DatabaseTestsBase() {
+    // Table without explicit name — Kotlin class name "MixedCaseUIntTable" is used
+    // (resolved to "MixedCaseUInt" after Table suffix removal),
+    // which has mixed casing to verify CHECK constraint names use inProperCase().
+    object MixedCaseUIntTable : Table() {
+        val unsignedCol = uinteger("unsignedCol")
+    }
+
     object UByteTable : Table("ubyte_table") {
         val unsignedByte = ubyte("ubyte")
     }
@@ -227,6 +236,20 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
                 val outOfRangeValue = UInt.MAX_VALUE.toLong() + 1L
                 exec("""INSERT INTO $tableName ($columnName) VALUES ($outOfRangeValue)""")
             }
+        }
+    }
+
+    @OptIn(InternalApi::class)
+    @Test
+    fun testUnsignedCheckConstraintNameUsesProperCase() {
+        withTables(MixedCaseUIntTable) {
+            if (currentDialectTest is MysqlDialect) return@withTables // MySQL uses UNSIGNED type instead of CHECK
+            val checkConstraints = MixedCaseUIntTable.checkConstraints()
+            val checkName = checkConstraints.single().checkName
+            val expectedName = "chk_MixedCaseUInt_unsigned_integer_unsignedCol".inProperCase()
+            // Constraint name may be quoted by cutIfNecessaryAndQuote, so strip quotes for comparison
+            val unquotedCheckName = checkName.trim('"', '\'', '`')
+            assertEquals(expectedName, unquotedCheckName)
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/UnsignedColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/UnsignedColumnTypeTests.kt
@@ -242,8 +242,8 @@ class UnsignedColumnTypeTests : DatabaseTestsBase() {
     @OptIn(InternalApi::class)
     @Test
     fun testUnsignedCheckConstraintNameUsesProperCase() {
-        withTables(MixedCaseUIntTable) {
-            if (currentDialectTest is MysqlDialect) return@withTables // MySQL uses UNSIGNED type instead of CHECK
+        // MySQL/MariaDB use the UNSIGNED type instead of a CHECK constraint
+        withTables(excludeSettings = TestDB.ALL_MYSQL_MARIADB, MixedCaseUIntTable) {
             val checkConstraints = MixedCaseUIntTable.checkConstraints()
             val checkName = checkConstraints.single().checkName
             val expectedName = "chk_MixedCaseUInt_unsigned_integer_unsignedCol".inProperCase()


### PR DESCRIPTION
## Problem

CHECK constraint names generated for unsigned/signed integer columns (e.g. `uinteger()`, `ushort()`, `ubyte()`, `ulong()`) use `tableNameWithSchemaSanitized`, which preserves the raw Kotlin class name casing. On PostgreSQL, unquoted identifiers are folded to lowercase on storage, so mixed-case constraint names in DDL don't match what `pg_constraint.conname` stores.

For example, `uinteger("onboardingStates")` on `OrgMemberModel` generates:
```
chk_OrgMemberModel_unsigned_integer_onboardingStates
```
but PostgreSQL stores it as `chk_orgmembermodel_unsigned_integer_onboardingstates`.

This causes problems for any migration tooling that checks `pg_constraint.conname` for idempotent `IF NOT EXISTS` guards — the mixed-case lookup fails to find the existing constraint.

## Root Cause

Other constraint types already handle casing correctly:

- **FK constraints** (`ForeignKeyConstraint.fkName`, line 118-123): applies `cutIfNecessaryAndQuote(...).inProperCase()`
- **Index names** (`Index.indexName`, line 280-291): applies `buildString { ... }.inProperCase()`
- **CHECK constraints** (`CheckConstraint.from`, line 247): only applies `cutIfNecessaryAndQuote(name)` — **missing `.inProperCase()`**

The CHECK constraint name is built from `generatedUnsignedCheckPrefix` / `generatedSignedCheckPrefix`, which use `tableNameWithSchemaSanitized` (raw `tableName.unquoted()`) without any casing normalization.

## Fix

Apply `.inProperCase()` to the CHECK constraint name in `CheckConstraint.from()`, matching the pattern already used for FK and Index constraints:

```kotlin
// Before
CheckConstraint(tableName, identifierManager.cutIfNecessaryAndQuote(name), checkOpSQL)

// After  
CheckConstraint(tableName, identifierManager.cutIfNecessaryAndQuote(name).inProperCase(), checkOpSQL)
```

Also added a test with a mixed-case table name (`MixedCaseUIntTable`) that verifies the CHECK constraint name uses `inProperCase()`. Test passes on H2 (uppercase) and will pass on PostgreSQL (lowercase).

Fixes #2825