### PR TITLE
docs: EXPOSED-1035 Fix UuidTable KDoc parameter mismatch

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/dao/id/IdTable.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/dao/id/IdTable.kt
@@ -116,7 +116,7 @@ open class ULongIdTable(name: String = "", columnName: String = "id", sequenceNa
  *
  * **Note** The specific UUID column type used depends on the database.
  * The stored identity value will be auto-generated on the client side, just before insertion of a new row,
- * by calling `Uuid.generateV4()`. If version 7 is wanted instead, use `UuidTable(useGenerateV7 = true)`.
+ * by calling `Uuid.generateV4()`. If version 7 is wanted instead, use `UuidTable(uuidVersion = UuidVersion.V7)`.
  *
  * @param name Table name. By default, this will be resolved from any class name with a "Table" suffix removed (if present).
  * @param columnName Name for the primary key column. By default, "id" is used.


### PR DESCRIPTION
#### Description

This PR fixes a mismatch between the class-level KDoc and the actual constructor implementation in the `UuidTable` class.

The class-level KDoc previously guided users to use `UuidTable(useGenerateV7 = true)`. However, there is no such boolean parameter in the constructors. Instead, the secondary constructor accepts a `uuidVersion` parameter of type `UuidVersion`.

I have updated the documentation to correctly instruct users to use `UuidTable(uuidVersion = UuidVersion.V7)`.


---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues
- Fixes https://youtrack.jetbrains.com/issue/EXPOSED-1035