### PR TITLE
fix: EXPOSED-644 Can't use Instant.DISTANT_FUTURE as default value

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/datetime/InstantColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/datetime/InstantColumnType.kt
@@ -54,14 +54,14 @@ abstract class InstantColumnType<T> : ColumnType<T>(), IDateColumnType {
                 } else {
                     MYSQL_TIMESTAMP_FORMAT
                 }
-                "'${formatter.format(localDateTime)}'"
+                "'${formatter.formatAndTrimStart(localDateTime)}'"
             }
-            is SQLiteDialect -> "'${ORACLE_SQLITE_TIMESTAMP_FORMAT.format(localDateTime)}'"
+            is SQLiteDialect -> "'${ORACLE_SQLITE_TIMESTAMP_FORMAT.formatAndTrimStart(localDateTime)}'"
             is OracleDialect -> {
-                val formatted = ORACLE_SQLITE_TIMESTAMP_FORMAT.format(localDateTime)
+                val formatted = ORACLE_SQLITE_TIMESTAMP_FORMAT.formatAndTrimStart(localDateTime)
                 "TO_TIMESTAMP('$formatted', 'YYYY-MM-DD HH24:MI:SS.FF3')"
             }
-            else -> "'${DEFAULT_TIMESTAMP_FORMAT.format(localDateTime)}'"
+            else -> "'${DEFAULT_TIMESTAMP_FORMAT.formatAndTrimStart(localDateTime)}'"
         }
     }
 
@@ -106,15 +106,15 @@ abstract class InstantColumnType<T> : ColumnType<T>(), IDateColumnType {
         @OptIn(InternalApi::class)
         @Suppress("MagicNumber")
         return when (val dialect = currentDialect) {
-            is SQLiteDialect -> ORACLE_SQLITE_TIMESTAMP_FORMAT.format(localDateTime)
+            is SQLiteDialect -> ORACLE_SQLITE_TIMESTAMP_FORMAT.formatAndTrimStart(localDateTime)
             is MysqlDialect if (
                 dialect !is MariaDBDialect &&
                     !currentTransaction().db.version.covers(8, 0)
                 ) -> {
                 if (dialect.isFractionDateTimeSupported()) {
-                    MYSQL_TIMESTAMP_FRACTION_FORMAT.format(localDateTime)
+                    MYSQL_TIMESTAMP_FRACTION_FORMAT.formatAndTrimStart(localDateTime)
                 } else {
-                    MYSQL_TIMESTAMP_FORMAT.format(localDateTime)
+                    MYSQL_TIMESTAMP_FORMAT.formatAndTrimStart(localDateTime)
                 }
             }
             else -> localDateTime.toSqlTimestamp()
@@ -128,14 +128,16 @@ abstract class InstantColumnType<T> : ColumnType<T>(), IDateColumnType {
 
         return when {
             dialect is PostgreSQLDialect -> {
-                val formatted = ORACLE_SQLITE_TIMESTAMP_FORMAT.format(localDateTime)
+                val formatted = ORACLE_SQLITE_TIMESTAMP_FORMAT.formatAndTrimStart(localDateTime)
                 "'${formatted.trimEnd('0').trimEnd('.')}'::timestamp without time zone"
             }
             dialect.h2Mode == H2Dialect.H2CompatibilityMode.Oracle -> {
-                val formatted = ORACLE_SQLITE_TIMESTAMP_FORMAT.format(localDateTime)
+                val formatted = ORACLE_SQLITE_TIMESTAMP_FORMAT.formatAndTrimStart(localDateTime)
                 "'${formatted.trimEnd('0').trimEnd('.')}'"
             }
             else -> super.nonNullValueAsDefaultString(value)
         }
     }
+
+    private fun DateTimeFormat<LocalDateTime>.formatAndTrimStart(value: LocalDateTime): String = format(value).trimStart('+')
 }

--- a/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
+++ b/exposed-kotlin-datetime/src/test/kotlin/org/jetbrains/exposed/v1/datetime/DefaultsTest.kt
@@ -12,6 +12,7 @@ import org.jetbrains.exposed.v1.dao.EntityClass
 import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
 import org.jetbrains.exposed.v1.dao.flushCache
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
 import org.jetbrains.exposed.v1.jdbc.*
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
@@ -670,6 +671,39 @@ class DefaultsTest : DatabaseTestsBase() {
             val timestamp = DefaultTimestampTable.selectAll().first()[DefaultTimestampTable.timestamp]
 
             assertEquals(timestamp, entity[DefaultTimestampTable.timestamp])
+        }
+    }
+
+    @Test
+    fun testTimestampWithDistantFutureDefault() {
+        val tester = object : Table("tester") {
+            // Kotlin DISTANT_FUTURE == +100000-01-01T00:00:00Z
+            val status_end = timestamp("status_end").default(Instant.DISTANT_FUTURE)
+            val activity_end = timestamp("activity_end").clientDefault { Instant.DISTANT_FUTURE }
+        }
+
+        withDb { testDb ->
+            // Stored range for these DB (& SQL Server) has maximum year 9999
+            if (testDb == TestDB.ORACLE || testDb in TestDB.ALL_MYSQL_MARIADB) {
+                // Out-of-range TS value not even acceptable as just default value
+                expectException<ExposedSQLException> { SchemaUtils.create(tester) }
+            } else {
+                SchemaUtils.create(tester)
+
+                if (testDb == TestDB.SQLSERVER) {
+                    // TS value is only checked whether out-of-range on insert
+                    expectException<ExposedSQLException> { tester.insert { } }
+                } else {
+                    tester.insert { }
+
+                    val results = tester.selectAll().singleOrNull()
+                    assertNotNull(results)
+                    assertEquals(Instant.DISTANT_FUTURE, results[tester.status_end])
+                    assertEquals(Instant.DISTANT_FUTURE, results[tester.activity_end])
+                }
+
+                SchemaUtils.drop(tester)
+            }
         }
     }
 }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/kotlindatetime/DefaultsTest.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.kotlindatetime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.datetime.*
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
@@ -569,6 +570,39 @@ class DefaultsTest : R2dbcDatabaseTestsBase() {
             val timestamp = DefaultTimestampTable.selectAll().first()[DefaultTimestampTable.timestamp]
 
             assertEquals(timestamp, entity[DefaultTimestampTable.timestamp])
+        }
+    }
+
+    @Test
+    fun testTimestampWithDistantFutureDefault() {
+        val tester = object : Table("tester") {
+            // Kotlin DISTANT_FUTURE == +100000-01-01T00:00:00Z
+            val status_end = timestamp("status_end").default(Instant.DISTANT_FUTURE)
+            val activity_end = timestamp("activity_end").clientDefault { Instant.DISTANT_FUTURE }
+        }
+
+        withDb { testDb ->
+            // Stored range for these DB (& SQL Server) has maximum year 9999
+            if (testDb == TestDB.ORACLE || testDb in TestDB.ALL_MYSQL_MARIADB) {
+                // Out-of-range TS value not even acceptable as just default value
+                expectException<ExposedR2dbcException> { SchemaUtils.create(tester) }
+            } else {
+                SchemaUtils.create(tester)
+
+                if (testDb == TestDB.SQLSERVER) {
+                    // TS value is only checked whether out-of-range on insert
+                    expectException<ExposedR2dbcException> { tester.insert { } }
+                } else {
+                    tester.insert { }
+
+                    val results = tester.selectAll().singleOrNull()
+                    assertNotNull(results)
+                    assertEquals(Instant.DISTANT_FUTURE, results[tester.status_end])
+                    assertEquals(Instant.DISTANT_FUTURE, results[tester.activity_end])
+                }
+
+                SchemaUtils.drop(tester)
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: `timestamp()` columns now handle `Instant.DISTANT_FUTURE` passed as default value for databases that allow storing very large datetime values.

**Detailed description**:
- **Why**: `Instant.DISTANT_FUTURE` is represented as a very large value that starts with '+' -> `+100000-01-01T00:00:00Z`. The databases that allow storing a value greater than 9999 are either unable to parse this type of string or incorrectly assume the value following '+' is part of a timezone, leading to syntax errors.

- **What**: Basic `.format()` is replaced by a version that also trims unneeded '+' from `LocalDateTime`. Databases that don't allow large values continue to fail with "value out-of-range" errors, while databases that do allow large values, now accepts and returns this constant.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED_644](https://youtrack.jetbrains.com/issue/EXPOSED-644/Cannot-use-Instant.DISTANTFUTURE-as-default-value-in-postgresql)