### PR TITLE
feat: EXPOSED-1032 Add query timeout as a global configuration 

### DIFF
--- a/documentation-website/Writerside/topics/Transactions.md
+++ b/documentation-website/Writerside/topics/Transactions.md
@@ -353,9 +353,21 @@ transaction(db = db) {
 ### `queryTimeout`
 
 Use `queryTimeout` to set the number of seconds to wait
-for each statement in the block to execute before timing out:
+for each statement in the block to execute before timing out.
+
+If not set, any default value provided in
+[`DatabaseConfig`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-database-config/index.html)
+will be used instead:
 
 ```kotlin
+val db = Database.connect(
+    datasource = datasource,
+    databaseConfig = DatabaseConfig {
+        defaultQueryTimeout = 1
+    }
+)
+
+// property set in transaction block overrides default DatabaseConfig
 transaction {
     queryTimeout = 3
     try {

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -629,6 +629,7 @@ public abstract interface class org/jetbrains/exposed/v1/core/DatabaseConfig {
 	public abstract fun getDefaultMaxAttempts ()I
 	public abstract fun getDefaultMaxRetryDelay ()J
 	public abstract fun getDefaultMinRetryDelay ()J
+	public abstract fun getDefaultQueryTimeout ()I
 	public abstract fun getDefaultReadOnly ()Z
 	public abstract fun getDefaultSchema ()Lorg/jetbrains/exposed/v1/core/Schema;
 	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
@@ -650,6 +651,7 @@ public class org/jetbrains/exposed/v1/core/DatabaseConfig$Builder {
 	public final fun getDefaultMaxAttempts ()I
 	public final fun getDefaultMaxRetryDelay ()J
 	public final fun getDefaultMinRetryDelay ()J
+	public final fun getDefaultQueryTimeout ()I
 	public final fun getDefaultReadOnly ()Z
 	public final fun getDefaultSchema ()Lorg/jetbrains/exposed/v1/core/Schema;
 	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
@@ -667,6 +669,7 @@ public class org/jetbrains/exposed/v1/core/DatabaseConfig$Builder {
 	public final fun setDefaultMaxAttempts (I)V
 	public final fun setDefaultMaxRetryDelay (J)V
 	public final fun setDefaultMinRetryDelay (J)V
+	public final fun setDefaultQueryTimeout (I)V
 	public final fun setDefaultReadOnly (Z)V
 	public final fun setDefaultSchema (Lorg/jetbrains/exposed/v1/core/Schema;)V
 	public final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
@@ -693,6 +696,7 @@ public class org/jetbrains/exposed/v1/core/DatabaseConfigImpl : org/jetbrains/ex
 	public fun getDefaultMaxAttempts ()I
 	public fun getDefaultMaxRetryDelay ()J
 	public fun getDefaultMinRetryDelay ()J
+	public fun getDefaultQueryTimeout ()I
 	public fun getDefaultReadOnly ()Z
 	public fun getDefaultSchema ()Lorg/jetbrains/exposed/v1/core/Schema;
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
@@ -20,6 +20,7 @@ interface DatabaseConfig {
     val defaultMinRetryDelay: Long
     val defaultMaxRetryDelay: Long
     val defaultReadOnly: Boolean
+    val defaultQueryTimeout: Int
     val warnLongQueriesDuration: Long?
     val maxEntitiesToStoreInCachePerEntity: Int
     val keepLoadedReferencesOutOfTransaction: Boolean
@@ -100,6 +101,13 @@ interface DatabaseConfig {
          * Default state is false.
          */
         var defaultReadOnly: Boolean = false
+
+        /**
+         * How many seconds the driver should wait for a statement to execute in a transaction before timing out.
+         * Note that not all drivers implement this limit. For more information, refer to the relevant driver documentation.
+         * Default timeout is 0.
+         */
+        var defaultQueryTimeout: Int = 0
 
         /**
          * Threshold in milliseconds to log queries which exceed the threshold with WARN level.
@@ -215,6 +223,8 @@ open class DatabaseConfigImpl(private val builder: DatabaseConfig.Builder) : Dat
         get() = builder.defaultMaxRetryDelay
     override val defaultReadOnly: Boolean
         get() = builder.defaultReadOnly
+    override val defaultQueryTimeout: Int
+        get() = builder.defaultQueryTimeout
     override val warnLongQueriesDuration: Long?
         get() = builder.warnLongQueriesDuration
     override val maxEntitiesToStoreInCachePerEntity: Int

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
@@ -55,6 +55,7 @@ abstract class Transaction : UserDataHolder(), TransactionInterface {
      * Note that not all drivers implement this limit. For more information, refer to the relevant driver documentation.
      */
     var queryTimeout: Int? = null
+        get() = field ?: db.config.defaultQueryTimeout
 
     /** The unique ID for this transaction. */
     val transactionId by lazy { UUID.randomUUID().toString() }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/QueryTimeoutTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/QueryTimeoutTest.kt
@@ -19,11 +19,12 @@ import kotlin.test.assertTrue
 
 class QueryTimeoutTest : R2dbcDatabaseTestsBase() {
 
+    /** Generates a db-specific statement that delays for [timeout] seconds. The provided [timeout] should not exceed a value of 9. */
     private fun generateTimeoutStatements(db: TestDB, timeout: Int): String {
         return when (db) {
             in TestDB.ALL_MYSQL_MARIADB -> "SELECT 1 = 0 WHERE SLEEP($timeout);"
             in TestDB.ALL_POSTGRES -> "SELECT pg_sleep($timeout);"
-            TestDB.SQLSERVER -> "WAITFOR DELAY '00:00:$timeout';"
+            TestDB.SQLSERVER -> "WAITFOR DELAY '00:00:0$timeout';"
             else -> throw NotImplementedError()
         }
     }
@@ -106,5 +107,36 @@ class QueryTimeoutTest : R2dbcDatabaseTestsBase() {
 
         logCaptor.clearLogs()
         logCaptor.close()
+    }
+
+    @Test
+    fun testTransactionTimeoutWithDefaults() = runTest {
+        Assumptions.assumeTrue(timeoutTestDBList.containsAll(TestDB.enabledDialects()))
+
+        val dialect = TestDB.enabledDialects().first()
+        val db = dialect.connect {
+            defaultQueryTimeout = 1
+        }
+
+        val statementWithDelay = generateTimeoutStatements(dialect, 3)
+
+        // transaction block should use default DatabaseConfig values when no property is set
+        try {
+            suspendTransaction(db = db) {
+                exec(statementWithDelay)
+                Assertions.fail("Should have thrown a timeout or cancelled statement exception")
+            }
+        } catch (cause: ExposedR2dbcException) {
+            assertTrue(cause.cause is R2dbcNonTransientResourceException || cause.cause is R2dbcTimeoutException)
+        }
+
+        // property set in transaction block should override default DatabaseConfig
+        suspendTransaction(db = db) {
+            queryTimeout = 8
+
+            exec(statementWithDelay)
+        }
+
+        TransactionManager.closeAndUnregister(db)
     }
 }

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -276,6 +276,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfigImpl : org/
 	public fun getDefaultMaxAttempts ()I
 	public fun getDefaultMaxRetryDelay ()J
 	public fun getDefaultMinRetryDelay ()J
+	public fun getDefaultQueryTimeout ()I
 	public fun getDefaultR2dbcIsolationLevel ()Lio/r2dbc/spi/IsolationLevel;
 	public fun getDefaultReadOnly ()Z
 	public fun getDefaultSchema ()Lorg/jetbrains/exposed/v1/core/Schema;

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/QueryTimeoutTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/QueryTimeoutTest.kt
@@ -6,11 +6,13 @@ import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.v1.core.exposedLogger
 import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.INCOMPLETE_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.NOT_APPLICABLE_TO_R2DBC
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.postgresql.util.PSQLException
@@ -23,11 +25,12 @@ import java.sql.SQLTimeoutException
  */
 class QueryTimeoutTest : DatabaseTestsBase() {
 
+    /** Generates a db-specific statement that delays for [timeout] seconds. The provided [timeout] should not exceed a value of 9. */
     private fun generateTimeoutStatements(db: TestDB, timeout: Int): String {
         return when (db) {
             in TestDB.ALL_MYSQL_MARIADB -> "SELECT SLEEP($timeout) = 0;"
             in TestDB.ALL_POSTGRES -> "SELECT pg_sleep($timeout);"
-            TestDB.SQLSERVER -> "WAITFOR DELAY '00:00:$timeout';"
+            TestDB.SQLSERVER -> "WAITFOR DELAY '00:00:0$timeout';"
             else -> throw NotImplementedError()
         }
     }
@@ -129,5 +132,33 @@ class QueryTimeoutTest : DatabaseTestsBase() {
 
         logCaptor.clearLogs()
         logCaptor.close()
+    }
+
+    @Test
+    fun testTransactionTimeoutWithDefaults() {
+        Assumptions.assumeTrue(timeoutTestDBList.containsAll(TestDB.enabledDialects()))
+
+        val dialect = TestDB.enabledDialects().first()
+        val db = dialect.connect {
+            defaultQueryTimeout = 1
+        }
+
+        val statementWithDelay = generateTimeoutStatements(dialect, 3)
+
+        // transaction block should use default DatabaseConfig values when no property is set
+        transaction(db = db) {
+            expectException<ExposedSQLException> {
+                exec(statementWithDelay)
+            }
+        }
+
+        // property set in transaction block should override default DatabaseConfig
+        transaction(db = db) {
+            queryTimeout = 8
+
+            exec(statementWithDelay)
+        }
+
+        TransactionManager.closeAndUnregister(db)
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Add `defaultQueryTimeout` property to global `DatabaseConfig` to match existing `Transaction.queryTimeout`.

**Detailed description**:
- **Why**: `Transaction.queryTimeout` was introduced some time ago, but the feature was not extended to global configuration. This has now been requested.

- **How**: Add the necessary `DatabaseConfig` builder properties. The existing transaction property prioritizes its own field, otherwise it uses the global default. Exposed always sets query timeout on the statement level through the JDBC/R2DBC when supported. Any database-level timeout can be set by the user through the database-specific URL connection property.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Affected databases:
- [X] MariaDB
- [X] Mysql8
- [X] Postgres
- [X] SqlServer

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-1032](https://youtrack.jetbrains.com/issue/EXPOSED-1032/Add-query-timeout-as-a-global-configuration)