### PR TITLE
fix(r2dbc): EXPOSED-1047 Release R2DBC connection on failure of beginTransaction()

### DIFF
--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ConnectionLeakTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ConnectionLeakTests.kt
@@ -1,0 +1,179 @@
+package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared
+
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactories
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryMetadata
+import io.r2dbc.spi.IsolationLevel
+import io.r2dbc.spi.R2dbcTransientException
+import io.r2dbc.spi.TransactionDefinition
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.core.vendors.H2Dialect
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import java.util.TimeZone
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+/**
+ * Tests that a connection handed over by the driver is always released, even if it cannot be used because
+ * starting a transaction on it fails.
+ */
+class ConnectionLeakTests {
+    init {
+        // these tests open H2 connections without extending R2dbcDatabaseTestsBase, so the same default time zone
+        // has to be set here, otherwise H2 sessions opened by this class would break time zone sensitive tests
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    }
+
+    private class ConnectionSpy(
+        private val connection: Connection,
+        private val beginBehaviour: (real: () -> Publisher<Void?>) -> Publisher<Void?>
+    ) : Connection by connection {
+        @Volatile
+        var closeCalled = false
+
+        override fun beginTransaction(): Publisher<Void?> = beginBehaviour { connection.beginTransaction() }
+
+        override fun beginTransaction(definition: TransactionDefinition): Publisher<Void?> =
+            beginBehaviour { connection.beginTransaction(definition) }
+
+        override fun close(): Publisher<Void?> {
+            closeCalled = true
+            return connection.close()
+        }
+    }
+
+    private class WrappingConnectionFactory(
+        private val testDB: TestDB,
+        private val connectionDecorator: (Connection) -> ConnectionSpy
+    ) : ConnectionFactory {
+        val connections = CopyOnWriteArrayList<ConnectionSpy>()
+
+        override fun create(): Publisher<out Connection?> = Mono.defer {
+            Mono
+                .from(ConnectionFactories.get(testDB.connection()).create())
+                .map { connection ->
+                    connectionDecorator(connection).also { connections.add(it) }
+                }
+        }
+
+        override fun getMetadata(): ConnectionFactoryMetadata {
+            throw NotImplementedError()
+        }
+    }
+
+    private class BeginException : R2dbcTransientException()
+
+    private fun connect(connectionFactory: ConnectionFactory) = R2dbcDatabase.connect(
+        connectionFactory = connectionFactory,
+        databaseConfig = R2dbcDatabaseConfig { explicitDialect = H2Dialect() }
+    )
+
+    private fun WrappingConnectionFactory.assertNoConnectionLeaked() {
+        assertTrue(connections.isNotEmpty(), "No connection was ever acquired, so nothing was actually tested")
+        val leaked = connections.withIndex().filterNot { it.value.closeCalled }.map { it.index }
+        assertTrue(leaked.isEmpty(), "Connections $leaked of the ${connections.size} acquired were never closed")
+    }
+
+    @Test
+    fun testConnectionIsReleasedWhenBeginTransactionFails() = runTest {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+
+        val connectionFactory = WrappingConnectionFactory(TestDB.H2_V2) { connection ->
+            ConnectionSpy(connection) { Mono.error(BeginException()) }
+        }
+        val db = connect(connectionFactory)
+
+        try {
+            val cause = assertFails {
+                suspendTransaction(db = db, transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                    maxAttempts = 1
+                    exec("SELECT 1;")
+                }
+            }
+            assertTrue(
+                generateSequence(cause) { it.cause }.take(10).any { it is BeginException },
+                "Expected ${BeginException::class.simpleName} to be reported but got $cause"
+            )
+
+            connectionFactory.assertNoConnectionLeaked()
+        } finally {
+            TransactionManager.closeAndUnregister(db)
+        }
+    }
+
+    @Test
+    fun testConnectionIsReleasedWhenCancelledDuringBeginTransaction() = runTest {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+
+        val beginStarted = CompletableDeferred<Unit>()
+        val firstBegin = AtomicBoolean(true)
+        // only the first BEGIN stalls, so any cleanup path that acquires another connection still completes
+        val connectionFactory = WrappingConnectionFactory(TestDB.H2_V2) { connection ->
+            ConnectionSpy(connection) { real ->
+                if (firstBegin.getAndSet(false)) {
+                    beginStarted.complete(Unit)
+                    Mono.never()
+                } else {
+                    real()
+                }
+            }
+        }
+        val db = connect(connectionFactory)
+
+        try {
+            val job = launch {
+                suspendTransaction(db = db, transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                    maxAttempts = 1
+                    exec("SELECT 1;")
+                }
+            }
+            beginStarted.await()
+            job.cancelAndJoin()
+
+            connectionFactory.assertNoConnectionLeaked()
+        } finally {
+            TransactionManager.closeAndUnregister(db)
+        }
+    }
+
+    @Test
+    fun testFailedConnectionAttemptsAreNotRetainedOnRetry() = runTest {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+
+        val attempts = 3
+        val connectionFactory = WrappingConnectionFactory(TestDB.H2_V2) { connection ->
+            ConnectionSpy(connection) { Mono.error(BeginException()) }
+        }
+        val db = connect(connectionFactory)
+
+        try {
+            assertFails {
+                suspendTransaction(db = db, transactionIsolation = IsolationLevel.SERIALIZABLE) {
+                    maxAttempts = attempts
+                    exec("SELECT 1;")
+                }
+            }
+
+            // every retry must start from a fresh connection & none of them may be left behind
+            assertEquals(attempts, connectionFactory.connections.size)
+            connectionFactory.assertNoConnectionLeaked()
+        } finally {
+            TransactionManager.closeAndUnregister(db)
+        }
+    }
+}

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
@@ -7,6 +7,7 @@ import io.r2dbc.spi.RowMetadata
 import io.r2dbc.spi.Statement
 import io.r2dbc.spi.TransactionDefinition
 import io.r2dbc.spi.ValidationDepth
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.awaitFirstOrNull
@@ -15,6 +16,7 @@ import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.reactive.collect
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.statements.api.ExposedSavepoint
@@ -110,9 +112,12 @@ class R2dbcConnectionImpl(
     }
 
     override suspend fun close() {
-        withConnection { close().awaitFirstOrNull() }
-        localConnection = null
-        transactionDefinition = null
+        localConnectionLock.withLock {
+            localConnection.also {
+                localConnection = null
+                transactionDefinition = null
+            }
+        }?.let { releaseConnection(it) }
     }
 
     override suspend fun prepareStatement(
@@ -228,32 +233,43 @@ class R2dbcConnectionImpl(
 
     private suspend fun <T> withConnection(body: suspend Connection.() -> T): T {
         val acquiredConnection = localConnectionLock.withLock {
-            localConnection ?: connection.awaitLast().also { cx ->
-                // beginTransaction() starts an explicit transaction with autoCommit mode off
-                transactionDefinition
-                    ?.let { originalDefinition ->
-                        when (val definition = originalDefinition as? R2dbcTransactionDefinition) {
-                            is R2dbcTransactionDefinition if metadataProvider is OracleMetadata && definition.readOnly != null -> {
-                                // Oracle does not allow both isolation level + mutability to be set implicitly together;
-                                // instead it requires a specific order, with transaction isolation always set first.
-                                cx.beginTransaction(definition.toOracleDefinition()).awaitFirstOrNull()
-                                cx.executeSQL(metadataProvider.setReadOnlyMode(definition.readOnly))
+            localConnection ?: withContext(NonCancellable) { connection.awaitLast() }.also { cx ->
+                runCatching {
+                    // beginTransaction() starts an explicit transaction with autoCommit mode off
+                    transactionDefinition
+                        ?.let { originalDefinition ->
+                            when (val definition = originalDefinition as? R2dbcTransactionDefinition) {
+                                is R2dbcTransactionDefinition if metadataProvider is OracleMetadata && definition.readOnly != null -> {
+                                    // Oracle does not allow both isolation level + mutability to be set implicitly together;
+                                    // instead it requires a specific order, with transaction isolation always set first.
+                                    cx.beginTransaction(definition.toOracleDefinition()).awaitFirstOrNull()
+                                    cx.executeSQL(metadataProvider.setReadOnlyMode(definition.readOnly))
+                                }
+                                is R2dbcTransactionDefinition if metadataProvider is MySQLMetadata && definition.isolationLevel != null -> {
+                                    // MySQL/MariaDB driver would set level only on next-next transaction, not the 1 about to start
+                                    cx.executeSQL(metadataProvider.setCurrentTransactionIsolation(definition.isolationLevel))
+                                    cx.beginTransaction(definition).awaitFirstOrNull()
+                                }
+                                else -> cx.beginTransaction(originalDefinition).awaitFirstOrNull()
                             }
-                            is R2dbcTransactionDefinition if metadataProvider is MySQLMetadata && definition.isolationLevel != null -> {
-                                // MySQL/MariaDB driver would set level only on next-next transaction, not the 1 about to start
-                                cx.executeSQL(metadataProvider.setCurrentTransactionIsolation(definition.isolationLevel))
-                                cx.beginTransaction(definition).awaitFirstOrNull()
-                            }
-                            else -> cx.beginTransaction(originalDefinition).awaitFirstOrNull()
                         }
-                    }
-                    ?: cx.beginTransaction().awaitFirstOrNull()
+                        ?: cx.beginTransaction().awaitFirstOrNull()
 
-                localConnection = cx
-                transactionDefinition = null
+                    localConnection = cx
+                    transactionDefinition = null
+                }
+                    .onFailure {
+                        releaseConnection(cx)
+                    }.getOrThrow()
             }
         }
         return acquiredConnection.body()
+    }
+
+    private suspend fun releaseConnection(connection: Connection) {
+        withContext(NonCancellable) {
+            runCatching { connection.close().awaitFirstOrNull() }
+        }
     }
 }
 

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.core.InternalApi
+import org.jetbrains.exposed.v1.core.exposedLogger
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.statements.api.ExposedSavepoint
 import org.jetbrains.exposed.v1.core.transactions.withThreadLocalTransaction
@@ -107,9 +108,9 @@ class R2dbcConnectionImpl(
         withConnection { rollbackTransaction().awaitFirstOrNull() }
     }
 
-    override suspend fun isClosed(): Boolean = withConnection {
+    override suspend fun isClosed(): Boolean = localConnectionLock.withLock { localConnection }?.run {
         !validate(ValidationDepth.LOCAL).awaitSingle() || !validate(ValidationDepth.REMOTE).awaitSingle()
-    }
+    } ?: true
 
     override suspend fun close() {
         localConnectionLock.withLock {
@@ -231,10 +232,11 @@ class R2dbcConnectionImpl(
     private val localConnectionLock = Mutex()
     private var localConnection: Connection? = null
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun <T> withConnection(body: suspend Connection.() -> T): T {
         val acquiredConnection = localConnectionLock.withLock {
             localConnection ?: withContext(NonCancellable) { connection.awaitLast() }.also { cx ->
-                runCatching {
+                try {
                     // beginTransaction() starts an explicit transaction with autoCommit mode off
                     transactionDefinition
                         ?.let { originalDefinition ->
@@ -257,18 +259,23 @@ class R2dbcConnectionImpl(
 
                     localConnection = cx
                     transactionDefinition = null
+                } catch (cause: Throwable) {
+                    releaseConnection(cx)
+                    throw cause
                 }
-                    .onFailure {
-                        releaseConnection(cx)
-                    }.getOrThrow()
             }
         }
         return acquiredConnection.body()
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun releaseConnection(connection: Connection) {
         withContext(NonCancellable) {
-            runCatching { connection.close().awaitFirstOrNull() }
+            try {
+                connection.close().awaitFirstOrNull()
+            } catch (cause: Exception) {
+                exposedLogger.warn("Failed to release connection: ${cause.message}", cause)
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**:  

Fixes a connection leak in R2dbcConnectionImpl.withConnection when acquisition succeeds but beginTransaction() fails — including coroutine cancellation, transient BEGIN errors, or any other failure on the begin path.

**Detailed description**:
- **Why**:  If beginTransaction() throws or the coroutine is cancelled during BEGIN, the lambda aborts before assignment. localConnection stays null, cx goes out of scope, and the connection is leaked.

- **What**:  Acquire under NonCancellable so cancellation cannot strand a connection between awaitLast() and BEGIN; Wrap the begin/assign block in runCatching; on failure, call releaseConnection(cx) before rethrowing; Add releaseConnection() — NonCancellable + runCatching { connection.close() } — as the single release path; Change close() to atomically take-and-null localConnection under the lock, then release outside the lock (no re-entry into withConnection when nothing is held).

- **How**: withConnection now acquires under NonCancellable, wraps begin/assign in runCatching, and calls a new releaseConnection(cx) in onFailure before rethrowing. close() takes and nulls localConnection under the existing lock, then releases outside the lock — it no longer calls withConnection when nothing is held.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] R2dbc drivers

#### Checklist

- [ ] Unit tests are in place
- [ ] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

https://youtrack.jetbrains.com/issue/EXPOSED-1047/Connection-leak-when-beginTransaction-throws-during-R2dbcConnectionImpl.withConnection