### PR TITLE
docs: EXPOSED-976 Add mentions and links to the Exposed plugin 

### DIFF
--- a/documentation-website/Writerside/hi.tree
+++ b/documentation-website/Writerside/hi.tree
@@ -57,6 +57,7 @@
     </toc-element>
     <toc-element toc-title="Tools">
         <toc-element topic="Exposed-gradle-plugin.md"/>
+        <toc-element toc-title="Exposed IntelliJ IDEA plugin" href="https://www.jetbrains.com/help/idea/exposed.html" />
     </toc-element>
     <toc-element topic="Spring-Boot-integration.md"/>
     <toc-element toc-title="Releases">

--- a/documentation-website/Writerside/topics/DAO-Entity-definition.topic
+++ b/documentation-website/Writerside/topics/DAO-Entity-definition.topic
@@ -22,6 +22,13 @@
         <code>Entity</code>. This is because every database record in this table needs to be mapped to an
         <code>Entity</code> instance, identified by its primary key.
     </p>
+    <!-- TODO Add link to IDEA docs -->
+    <note>
+        In IntelliJ IDEA Ultimate, you can use
+        <a href="https://plugins.jetbrains.com/plugin/24367-exposed">the Exposed plugin</a> to generate
+        entities from your table definitions. For more information, see
+        the <a href="">Exposed plugin documentation</a>.
+    </note>
     <chapter id="defining-entity-class" title="Defining an Entity">
         <p>
             You define an entity by creating a class.

--- a/documentation-website/Writerside/topics/DAO-Entity-definition.topic
+++ b/documentation-website/Writerside/topics/DAO-Entity-definition.topic
@@ -22,12 +22,6 @@
         <code>Entity</code>. This is because every database record in this table needs to be mapped to an
         <code>Entity</code> instance, identified by its primary key.
     </p>
-    <note>
-        In IntelliJ IDEA Ultimate, you can use
-        <a href="https://plugins.jetbrains.com/plugin/24367-exposed">the Exposed plugin</a> to generate
-        entities from your table definitions. For more information, see
-        the <a href="https://www.jetbrains.com/help/idea/exposed.html">Exposed plugin documentation</a>.
-    </note>
     <chapter id="defining-entity-class" title="Defining an Entity">
         <p>
             You define an entity by creating a class.
@@ -42,6 +36,12 @@
                 <include from="DAO-Table-Types.topic" element-id="StarWarsFilmsTable-dao-code-block"/>
             </tab>
         </tabs>
+        <note>
+            In IntelliJ IDEA Ultimate, you can use
+            <a href="https://plugins.jetbrains.com/plugin/24367-exposed">the Exposed plugin</a> to generate
+            entities from your table definitions. For more information, see
+            the <a href="https://www.jetbrains.com/help/idea/exposed.html">Exposed plugin documentation</a>.
+        </note>
         <chapter id="entity-type" title="Entity type">
             <p>
                 The entity type determines how the <code>Entity</code> class interacts with the table’s primary key.

--- a/documentation-website/Writerside/topics/DAO-Entity-definition.topic
+++ b/documentation-website/Writerside/topics/DAO-Entity-definition.topic
@@ -22,12 +22,11 @@
         <code>Entity</code>. This is because every database record in this table needs to be mapped to an
         <code>Entity</code> instance, identified by its primary key.
     </p>
-    <!-- TODO Add link to IDEA docs -->
     <note>
         In IntelliJ IDEA Ultimate, you can use
         <a href="https://plugins.jetbrains.com/plugin/24367-exposed">the Exposed plugin</a> to generate
         entities from your table definitions. For more information, see
-        the <a href="">Exposed plugin documentation</a>.
+        the <a href="https://www.jetbrains.com/help/idea/exposed.html">Exposed plugin documentation</a>.
     </note>
     <chapter id="defining-entity-class" title="Defining an Entity">
         <p>

--- a/documentation-website/Writerside/topics/Get-Started-with-Exposed.topic
+++ b/documentation-website/Writerside/topics/Get-Started-with-Exposed.topic
@@ -39,22 +39,24 @@
             </li>
             <li>A <a href="https://www.oracle.com/java/technologies/downloads/">Java Development Kit (JDK)</a>, version 8 or higher.</li>
             <li>An integrated development environment (IDE), such as <a href="https://www.jetbrains.com/idea/">
-                IntelliJ IDEA Ultimate
-            </a>.  <p>
+                IntelliJ IDEA
+            </a>.
+                <note>
                 We recommend that you install
                 <a href="https://www.jetbrains.com/idea/">
                     IntelliJ IDEA Ultimate
                 </a>
-                which comes with built-in
+                , which comes with built-in
                 <a href="https://www.jetbrains.com/pages/intellij-idea-databases/">
                     database tools
                 </a>
-                and the
+                and supports
                 <a href="https://plugins.jetbrains.com/plugin/24367-exposed">
-                    Exposed plugin
+                    the Exposed plugin
                 </a>
-                for code completion and inspections. However, you can use another IDE of your choice.
-            </p></li>
+                . The Exposed plugin provides code completion, inspections, and allows you to generate tables and
+                entities from an existing schema.
+            </note></li>
         </list>
 
     </chapter>

--- a/documentation-website/Writerside/topics/Get-Started-with-Exposed.topic
+++ b/documentation-website/Writerside/topics/Get-Started-with-Exposed.topic
@@ -51,7 +51,7 @@
                     database tools
                 </a>
                 and supports
-                <a href="https://plugins.jetbrains.com/plugin/24367-exposed">
+                <a href="https://www.jetbrains.com/help/idea/exposed.html">
                     the Exposed plugin
                 </a>
                 . The Exposed plugin provides code completion, inspections, and allows you to generate tables and

--- a/documentation-website/Writerside/topics/Get-Started-with-Exposed.topic
+++ b/documentation-website/Writerside/topics/Get-Started-with-Exposed.topic
@@ -43,7 +43,7 @@
             </a>.
                 <note>
                 We recommend that you install
-                <a href="https://www.jetbrains.com/idea/">
+                <a href="https://www.jetbrains.com/idea/buy/">
                     IntelliJ IDEA Ultimate
                 </a>
                 , which comes with built-in

--- a/documentation-website/Writerside/topics/Working-with-Tables.topic
+++ b/documentation-website/Writerside/topics/Working-with-Tables.topic
@@ -19,6 +19,13 @@
         </chapter>
     </chapter>
     <chapter title="Defining tables" id="defining-tables">
+        <!-- TODO Add link to IDEA docs -->
+        <note>
+            In IntelliJ IDEA Ultimate, you can use
+            <a href="https://plugins.jetbrains.com/plugin/24367-exposed">the Exposed plugin</a> to generate
+            table definitions from an existing database schema. For more information, see
+            the <a href="">Exposed plugin documentation</a>.
+        </note>
         <p>
             A database table is represented by an object inherited from a <code>Table</code> class.
         </p>
@@ -657,5 +664,4 @@
             This will generate the SQL necessary to create the table based on your definition.
         </p>
     </chapter>
-
 </topic>

--- a/documentation-website/Writerside/topics/Working-with-Tables.topic
+++ b/documentation-website/Writerside/topics/Working-with-Tables.topic
@@ -19,12 +19,6 @@
         </chapter>
     </chapter>
     <chapter title="Defining tables" id="defining-tables">
-        <note>
-            In IntelliJ IDEA Ultimate, you can use the
-            <a href="https://plugins.jetbrains.com/plugin/24367-exposed">Exposed plugin</a> to generate
-            table definitions from an existing database schema. For more information, see
-            the <a href="https://www.jetbrains.com/help/idea/exposed.html">Exposed plugin documentation</a>.
-        </note>
         <p>
             A database table is represented by an object inherited from a <code>Table</code> class.
         </p>
@@ -72,6 +66,12 @@
                 <include from="DAO-Table-Types.topic" element-id="StarWarsFilmsTable-dao-sql" />
             </tab>
         </tabs>
+        <note>
+            In IntelliJ IDEA Ultimate, you can use the
+            <a href="https://plugins.jetbrains.com/plugin/24367-exposed">Exposed plugin</a> to generate
+            table definitions from an existing database schema. For more information, see
+            the <a href="https://www.jetbrains.com/help/idea/exposed.html">Exposed plugin documentation</a>.
+        </note>
         <chapter title="Configuring a custom table name" id="name-from-object">
             <p>
                 By default, Exposed generates the table name from the full class name.

--- a/documentation-website/Writerside/topics/Working-with-Tables.topic
+++ b/documentation-website/Writerside/topics/Working-with-Tables.topic
@@ -19,12 +19,11 @@
         </chapter>
     </chapter>
     <chapter title="Defining tables" id="defining-tables">
-        <!-- TODO Add link to IDEA docs -->
         <note>
-            In IntelliJ IDEA Ultimate, you can use
-            <a href="https://plugins.jetbrains.com/plugin/24367-exposed">the Exposed plugin</a> to generate
+            In IntelliJ IDEA Ultimate, you can use the
+            <a href="https://plugins.jetbrains.com/plugin/24367-exposed">Exposed plugin</a> to generate
             table definitions from an existing database schema. For more information, see
-            the <a href="">Exposed plugin documentation</a>.
+            the <a href="https://www.jetbrains.com/help/idea/exposed.html">Exposed plugin documentation</a>.
         </note>
         <p>
             A database table is represented by an object inherited from a <code>Table</code> class.


### PR DESCRIPTION
- Add a new page linking to the IntelliJ IDEA docs for the Exposed plugin.
- Mention table and entity generation in the "Get started with Exposed" tutorial.
- Add notes with links in the Table definition and Entity topics.

#### Type of Change

- [x] Documentation update

#### Related Issues

[EXPOSED-976](https://youtrack.jetbrains.com/issue/EXPOSED-976) 
