### PR TITLE
docs: Fix dependency issue of mysql-connector-j

### DIFF
--- a/documentation-website/Writerside/topics/Working-with-DataSource.md
+++ b/documentation-website/Writerside/topics/Working-with-DataSource.md
@@ -28,7 +28,7 @@ val config = HikariConfig().apply {
 }
 
 // Gradle
-implementation "mysql:mysql-connector-java:8.0.33"
+implementation "mysql:mysql-connector-j:8.0.33"
 implementation "com.zaxxer:HikariCP:4.0.3"
 ```
 Then instantiate a `HikariDataSource` with this configuration class and provide it to `Database.connect()`:

--- a/documentation-website/Writerside/topics/Working-with-Database.md
+++ b/documentation-website/Writerside/topics/Working-with-Database.md
@@ -173,7 +173,7 @@ Add the required dependency:
 <tabs group="connectivity">
     <tab id="jdbc-mysql" title="JDBC" group-key="jdbc">
         <code-block lang="kotlin">
-            implementation("mysql:mysql-connector-java:%mysql%")
+            implementation("mysql:mysql-connector-j:%mysql%")
         </code-block>
     </tab>
     <tab id="r2dbc-mysql" title="R2DBC" group-key="r2dbc">


### PR DESCRIPTION
#### Description


While I was trying to follow the documentation of exposed, I came across the issue that the existing documentation of mysql db-connection has an error in it.
The error being the dependency linked in the docs website
https://www.jetbrains.com/help/exposed/working-with-database.html#mysql
the part with "java" in
**mysql:mysql-connector-java:8.4.0**
is wrong. the correction of it would be 
this
implementation("com.mysql:mysql-connector-j:8.4.0")
According to
https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.4.0?__cf_chl_f_tk=Ko.R3hXmpzBrnn1ZgElnDoySXdug1aj3PmsTYwqt7cM-1783280089-1.0.1.1-JdFIhkw0Fc0Nlrl9MjunfeVrRT_QbmkBqGlUmT8Bbhg


---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [x] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [x] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues
