### PR TITLE
docs: Fix documentation typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,7 +346,7 @@ Docs:
 * docs: Update KDocs @sample to use correct v1 package paths by @bog-walk in https://github.com/JetBrains/Exposed/pull/2541
 
 Bug fixes:
-* fix: EXPOSED-827 forUpdate() query method doesn't add actual `FOR UDPATE` modifier by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2548
+* fix: EXPOSED-827 forUpdate() query method doesn't add actual `FOR UPDATE` modifier by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2548
 
 # 1.0.0-beta-3
 
@@ -719,7 +719,7 @@ Bug fixes:
 * fix: EXPOSED-474 Unexpected value of type when using a ColumnTransfor… by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2191
 * fix: EXPOSED-472 Alias IdTable fails with isNull and eq ops by @bog-walk in https://github.com/JetBrains/Exposed/pull/2189
 * fix: EXPOSED-467 Decimal type precision and scale not checked by SchemaUtils by @bog-walk in https://github.com/JetBrains/Exposed/pull/2192
-* EXPOSED-203 Lightweight DAO insert with encryptedVarchar attemtps to … by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2194
+* EXPOSED-203 Lightweight DAO insert with encryptedVarchar attempts to … by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2194
 * fix: EXPOSED-481 Bug with batch-flushing of CompositeID entities by @bystam in https://github.com/JetBrains/Exposed/pull/2196
 * fix: EXPOSED-492 Eq/Neq op with partial CompositeID unwrapped value fails by @bog-walk in https://github.com/JetBrains/Exposed/pull/2205
 * fix: EXPOSED-485 ClassCastException when eager loading referrersOn with uuid().references() by @bog-walk in https://github.com/JetBrains/Exposed/pull/2198
@@ -1202,7 +1202,7 @@ Features:
 * feat: EXPOSED-68 Add more json/json(b) column functions by @bog-walk in https://github.com/JetBrains/Exposed/pull/1770
 * #623 Add support of window functions in Exposed DSL by @Legohuman in https://github.com/JetBrains/Exposed/pull/1651
 * feat: EXPOSED-89 Support functions in Create Index by @bog-walk in https://github.com/JetBrains/Exposed/pull/1788
-* feat: Add spring mutli container support by @FullOfOrange in https://github.com/JetBrains/Exposed/pull/1781
+* feat: Add spring multi container support by @FullOfOrange in https://github.com/JetBrains/Exposed/pull/1781
 * feat: EXPOSED-43 Add support for timestamp with time zone by @joc-a in https://github.com/JetBrains/Exposed/pull/1787
 
 Bug fixes:
@@ -1279,7 +1279,7 @@ Feature:
       Lambdas previously using an implicit `it` reference from an outer scope will also need to introduce an explicit name to access that binding.
 * New `mediumText` and `largeText` columns were introduced by [Alex Shubert](https://github.com/lure) to allow use more suitable data types for databases where they are supported.
 * `ForUpdateOption` (like `ForUpdateOption.PostgreSQL.ForKeyShare`) added for more flexible management of locks in your `SELECT` queries. You can set it as a parameter via `Query.forUpdate` function. Another kudos goes to [Alex Shubert](https://github.com/lure)
-* Preserve a colection type for `Iterable.with()` function 
+* Preserve a collection type for `Iterable.with()` function
 * `LazySizedCollection` can be checked for loaded data with `LazySizedCollection.isLoaded()`. Added by [unbearables](https://github.com/unbearables)
 
 Bug Fixes:
@@ -1332,7 +1332,7 @@ Bug Fixes:
 * Argument value error acquires when `REPLACE` used with expressions under MySQL. Founded and fixed by [Tiscs](https://github.com/Tiscs)
 * `EntityClass#wramUpReferences` doesn't store the cached values. Resolved by [Joddev](https://github.com/Joddev)
 * Creating tables with composite primary key and defined schema doesn't work. Fixed by [davidwheeler123](https://github.com/davidwheeler123)
-* Eager loading of Parent-Child relations doen't work ([#1363](https://github.com/JetBrains/Exposed/issues/1363))
+* Eager loading of Parent-Child relations doesn't work ([#1363](https://github.com/JetBrains/Exposed/issues/1363))
 * Possible StackOverflowError when processing entities hooks which executes flush
 
 # 0.38.2
@@ -1710,7 +1710,7 @@ Bug fixes:
 # 0.28.1
 Breaking Changes:
 * `referrersOn`/`optionalReferrersOn` is now have `cache=true` by default [1046](https://github.com/JetBrains/Exposed/issues/1046). 
-  It should help to prevent excessive queries when reading referenced values withing the same transaction but may require more memory to store the cached values.
+  It should help to prevent excessive queries when reading referenced values within the same transaction but may require more memory to store the cached values.
 * Default isolation level for PostgreSQL now set to `READ_COMMITTED`. PR by [uryyyyyyy](https://github.com/uryyyyyyy)  
 * [Oracle] Binary column type without length prohibited in favour to blob
 
@@ -1914,7 +1914,7 @@ Features:
 * New way to define primary keys on tables were implemented by [hfazai](https://github.com/hfazai) to support custom primary key constraint keys. 
 If have to use `override val primaryKey: PrimaryKey?` on your table if you want to define a custom name. 
 For all users of predefined `IntIdTable`/`LongIdTable`/`UUIDTable` nothing changed. 
-Old `Column.primaryKey` function was depricated and will be removed in the future releases.
+Old `Column.primaryKey` function was deprecated and will be removed in the future releases.
 * `java.time.Instant` supported with `timestamp` column type (`exposed-java-time` module only) ([#724](https://github.com/JetBrains/Exposed/issues/724)). Many thanks to [Lukáš Křečan](https://github.com/lukas-krecan).
 * Support for unsized binary columns (Oracle and PostgreSQL dialects) ([#716](https://github.com/JetBrains/Exposed/issues/716)). Another great PR from [hfazai](https://github.com/hfazai).
 * A unique identifier for `Transaction` instance introduced and supported in EntityHooks/EntityEvents by [mpe85](https://github.com/mpe85).
@@ -2305,7 +2305,7 @@ Bug fixes:
 # 0.10.3
 Features:
 * Floating point columns
-* Check constraint functionallity (kudos to @SackCastellon)
+* Check constraint functionality (kudos to @SackCastellon)
 * Possibility to provide custom names for contraints and indexes (thanks to @mduesterhoeft)
 * Added support to delete with limit and offset (thanks  @Mon_chi for initial PR)
 * Full SQL will be now logged on any SQLException ([#288](https://github.com/JetBrains/Exposed/issues/288) [Suggestion] Log the SQL query when an exception is thrown)


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `CHANGELOG.md`

## Testing
I run `git diff --check`.
