### PR TITLE
fix: Use thread-safe lazy initialization for JDBC Database capability flags

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Database.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Database.kt
@@ -68,21 +68,13 @@ class Database private constructor(
 
     override val fullVersion: String by lazy { metadata { databaseProductVersion } }
 
-    override val supportsAlterTableWithAddColumn: Boolean by lazy(
-        LazyThreadSafetyMode.NONE
-    ) { metadata { supportsAlterTableWithAddColumn } }
+    override val supportsAlterTableWithAddColumn: Boolean by lazy { metadata { supportsAlterTableWithAddColumn } }
 
-    override val supportsAlterTableWithDropColumn: Boolean by lazy(
-        LazyThreadSafetyMode.NONE
-    ) { metadata { supportsAlterTableWithDropColumn } }
+    override val supportsAlterTableWithDropColumn: Boolean by lazy { metadata { supportsAlterTableWithDropColumn } }
 
-    override val supportsMultipleResultSets: Boolean by lazy(
-        LazyThreadSafetyMode.NONE
-    ) { metadata { supportsMultipleResultSets } }
+    override val supportsMultipleResultSets: Boolean by lazy { metadata { supportsMultipleResultSets } }
 
-    override val supportsSelectForUpdate: Boolean by lazy(
-        LazyThreadSafetyMode.NONE
-    ) { metadata { supportsSelectForUpdate } }
+    override val supportsSelectForUpdate: Boolean by lazy { metadata { supportsSelectForUpdate } }
 
     override val identifierManager: IdentifierManagerApi by lazy { metadata { identifierManager } }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/DatabaseMetadataConcurrencyTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/DatabaseMetadataConcurrencyTest.kt
@@ -1,0 +1,101 @@
+package org.jetbrains.exposed.v1.tests.h2
+
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.tests.LogDbInTestName
+import org.jetbrains.exposed.v1.tests.TestDB
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+import java.sql.DriverManager
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for issue #2813.
+ *
+ * The [Database] capability flags [Database.supportsAlterTableWithAddColumn],
+ * [Database.supportsAlterTableWithDropColumn], [Database.supportsMultipleResultSets] and
+ * [Database.supportsSelectForUpdate] were declared with `lazy(LazyThreadSafetyMode.NONE)`.
+ * A `Database` is shared across every transaction / coroutine, so when several threads trigger
+ * the first read at once, `UnsafeLazyImpl` has no memory barrier: it runs the initializer on
+ * every racing thread (and, on weak memory models such as ARM, can throw `NullPointerException`).
+ * Each initializer opens a metadata connection, so an unsafe flag turns a startup burst into a
+ * connection storm.
+ *
+ * This test connects a `Database` whose initializer counts connections, warms up the unrelated
+ * lazies, then races the first read of the four flags from a thread pool. A thread-safe flag must
+ * initialize exactly once, i.e. open exactly one connection per flag, no matter how many threads
+ * race the first access.
+ */
+class DatabaseMetadataConcurrencyTest : LogDbInTestName() {
+
+    @Test
+    fun testConcurrentFirstAccessInitializesFlagsOnce() {
+        Assumptions.assumeTrue(dialect == TestDB.H2_V2.name)
+
+        val threadCount = 32
+        val connections = AtomicInteger(0)
+        val delayConnections = AtomicBoolean(false)
+        val db = Database.connect(
+            getNewConnection = {
+                connections.incrementAndGet()
+                // Widen the initialization window so an unsafe (LazyThreadSafetyMode.NONE) flag is
+                // observably initialized by many racing threads instead of exactly one.
+                if (delayConnections.get()) Thread.sleep(WINDOW_MILLIS)
+                DriverManager.getConnection("jdbc:h2:mem:metadataRace;DB_CLOSE_DELAY=-1;", "root", "")
+            }
+        )
+        // Initialize every lazy that isn't under test so only the four flags open connections
+        // once the workers are released.
+        db.dialect
+
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(threadCount)
+        val errors = ConcurrentLinkedQueue<Throwable>()
+        val observed = ConcurrentLinkedQueue<List<Boolean>>()
+        val pool = Executors.newFixedThreadPool(threadCount)
+        try {
+            repeat(threadCount) {
+                pool.execute {
+                    try {
+                        start.await()
+                        observed += listOf(
+                            db.supportsAlterTableWithAddColumn,
+                            db.supportsAlterTableWithDropColumn,
+                            db.supportsMultipleResultSets,
+                            db.supportsSelectForUpdate,
+                        )
+                    } catch (cause: Throwable) {
+                        errors += cause
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+            delayConnections.set(true)
+            connections.set(0)
+            start.countDown()
+            assertTrue(done.await(1, TimeUnit.MINUTES), "Workers did not finish")
+        } finally {
+            pool.shutdownNow()
+        }
+
+        assertTrue(errors.isEmpty(), "Concurrent first access threw: ${errors.firstOrNull()}")
+        assertEquals(1, observed.toSet().size, "Workers observed inconsistent flags: ${observed.toSet()}")
+        assertEquals(
+            FLAG_COUNT,
+            connections.get(),
+            "Each capability flag must initialize exactly once, but the four flags opened ${connections.get()} connections"
+        )
+    }
+
+    private companion object {
+        const val FLAG_COUNT = 4
+        const val WINDOW_MILLIS = 25L
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/DatabaseMetadataConcurrencyTest.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/h2/DatabaseMetadataConcurrencyTest.kt
@@ -2,8 +2,10 @@ package org.jetbrains.exposed.v1.tests.h2
 
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.tests.LogDbInTestName
+import org.jetbrains.exposed.v1.tests.NOT_APPLICABLE_TO_R2DBC
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.sql.DriverManager
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -32,6 +34,7 @@ import kotlin.test.assertTrue
  * initialize exactly once, i.e. open exactly one connection per flag, no matter how many threads
  * race the first access.
  */
+@Tag(NOT_APPLICABLE_TO_R2DBC)
 class DatabaseMetadataConcurrencyTest : LogDbInTestName() {
 
     @Test


### PR DESCRIPTION
#### Description

**Summary of the change**: `Database.supportsAlterTableWithAddColumn`, `supportsAlterTableWithDropColumn`, `supportsMultipleResultSets` and `supportsSelectForUpdate` were declared with `lazy(LazyThreadSafetyMode.NONE)`, which is unsafe when a shared `Database` is read concurrently. Switch them to the default (synchronized) `lazy { }`.

**Detailed description**:
- **Why**: A `Database` is shared across every transaction and coroutine. `LazyThreadSafetyMode.NONE` (`UnsafeLazyImpl`) has no memory barrier, so when several threads trigger the first read at once it runs the initializer on every racing thread — each opening a metadata connection — and on weak memory models such as ARM it can throw `NullPointerException` from `UnsafeLazyImpl.getValue` (a stale `_value == UNINITIALIZED_VALUE` observed together with an already-nulled `initializer`). This is what #2813 reports: an intermittent NPE right after startup, when a burst of coroutines hit their first `suspendedTransaction` before any single read has completed.
- **What**: Remove the explicit `LazyThreadSafetyMode.NONE` from the four capability flags so they use the default synchronized `lazy { }`. The issue reports two of them; the same race affects all four. The neighboring flags (`url`, `vendor`, `dialect`, `version`, `identifierManager`) and the r2dbc `R2dbcDatabase` already initialize these safely, so this just makes the JDBC flags consistent.
- **How**: `by lazy(LazyThreadSafetyMode.NONE) { ... }` → `by lazy { ... }`. Added `DatabaseMetadataConcurrencyTest`, which connects a `Database` whose connector counts the connections it opens, then races the first read of the four flags from 32 threads. A thread-safe flag initializes exactly once (4 connections total); with the old `NONE` version every racing thread re-ran the initializer, opening 128 connections (32 × 4) and failing the test.

---

#### Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases: the flags live on the shared JDBC `Database` and the change is dialect-independent; the regression test runs on H2.

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check) — `detekt` and `apiCheck` pass locally (no public API change)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

Fixes #2813

---

This change was written with AI assistance (Claude). I've reviewed every line and can walk through the reasoning.
