### PR TITLE
fix: Prevent NoSuchElementException when removing the only batch from BatchInsertStatement

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/BatchInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/BatchInsertStatement.kt
@@ -63,7 +63,7 @@ open class BatchInsertStatement(
         allColumnsInDataSet.clear()
         data.flatMapTo(allColumnsInDataSet) { it.keys }
         values.clear()
-        values.putAll(data.last())
+        data.lastOrNull()?.let(values::putAll)
         arguments = null
         hasBatchedValues = data.isNotEmpty()
     }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -31,6 +31,7 @@ import org.jetbrains.exposed.v1.r2dbc.tests.shared.expectException
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -224,6 +225,17 @@ class InsertTests : R2dbcDatabaseTestsBase() {
             val batchesSize = cities.selectAll().count()
 
             assertEquals(0, batchesSize)
+        }
+    }
+
+    @Test
+    fun testRemoveOnlyBatch() {
+        val statement = BatchInsertStatement(DMLTestsData.Cities)
+
+        statement[DMLTestsData.Cities.name] = "Test"
+        statement.addBatch()
+        assertDoesNotThrow("Removing the only batch should not restore values from empty data") {
+            statement.removeLastBatch()
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -32,6 +32,7 @@ import org.jetbrains.exposed.v1.tests.shared.expectException
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import java.sql.SQLException
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -229,7 +230,9 @@ class InsertTests : DatabaseTestsBase() {
 
         statement[DMLTestsData.Cities.name] = "Test"
         statement.addBatch()
-        statement.removeLastBatch()
+        assertDoesNotThrow("Removing the only batch should not restore values from empty data") {
+            statement.removeLastBatch()
+        }
     }
 
     @Test

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -224,6 +224,15 @@ class InsertTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testRemoveOnlyBatch() {
+        val statement = BatchInsertStatement(DMLTestsData.Cities)
+
+        statement[DMLTestsData.Cities.name] = "Test"
+        statement.addBatch()
+        statement.removeLastBatch()
+    }
+
+    @Test
     fun testGeneratedKey01() {
         withTables(DMLTestsData.Cities) {
             val id = DMLTestsData.Cities.insert {


### PR DESCRIPTION
#### Description

**Summary of the change**:
Fix `BatchInsertStatement.removeLastBatch()` so removing the only batch no longer throws `NoSuchElementException`, and add a regression test covering this case.

**Detailed description**:
- **Why**: Calling `removeLastBatch()` after adding a single batch leaves the internal batch list empty, causing `data.last()` to throw `NoSuchElementException`.
- **What**:
  - Replace `data.last()` with `data.lastOrNull()` when restoring the current values after removing a batch.
  - Add a regression test covering the single-batch removal scenario.
- **How**:
  - Restore `values` only when another batch remains.
  - Verify the fix with a regression test that reproduces the original failure.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [x] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [ ] All public methods affected by my PR has up to date API docs
- [ ] Documentation for my change is up to date

---

#### Related Issues

Closes #2858