### PR TITLE
docs: Add `route` to import statements in ProjectRoutes configuration for exposed-ktor-r2dbc sample

### DIFF
--- a/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/project/ProjectRoutes.kt
+++ b/samples/exposed-ktor-r2dbc/src/main/kotlin/domain/project/ProjectRoutes.kt
@@ -11,6 +11,7 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
+import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 
 suspend fun Application.projectRoutes() {


### PR DESCRIPTION



#### Description

**Summary of the change**: Add missing `route` to import statements in ProjectRoutes configuration for exposed-ktor-r2dbc sample

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

---

#### Related Issues
