### PR TITLE
chore: Configure matching namespace for new exposed-plugin-core module

### DIFF
--- a/exposed-plugin-core/build.gradle.kts
+++ b/exposed-plugin-core/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
     alias(libs.plugins.dokka)
 }
 
+group = "org.jetbrains.exposed.plugin"
+version = "1.3.1"
+description = "Exposed Plugin Core"
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Define a group for the new `exposed-plugin-core`, so it can [match](https://github.com/JetBrains/Exposed/blob/main/exposed-gradle-plugin/build.gradle.kts#L14) the namespace of the published Gradle (& upcoming Maven) plugins.

**Detailed description**:
- **Why**: Current `exposed-gradle-plugin` exists in namespace [org.jetbrains.exposed.plugin](https://central.sonatype.com/namespace/org.jetbrains.exposed.plugin). New `exposed-maven-plugin` is also configured to have this same namespace.

But their common dependency, `exposed-plugin-core` will by default be published in the [org.jetbrains.exposed](https://central.sonatype.com/namespace/org.jetbrains.exposed) namespace.
`publishToMavenLocal` proves this.

Since a direct dependency on the plugin core module should never be required in a project, it would be better to have the 3 modules grouped together under the same namespace from the beginning.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - _Build configuration (publishing)_

#### Checklist

- [X] The build is green (including the Detekt check)

---
