### PR TITLE
build: Bump SpringFramework from 7.0.1 to 7.0.8 and SpringBoot from 4.0.0 to 4.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,9 +31,9 @@ postgresql-r2dbc = "1.1.2.RELEASE"
 sqlserver-r2dbc = "1.0.5.RELEASE"
 
 springFramework6 = "6.2.19"
-springFramework7 = "7.0.1"
+springFramework7 = "7.0.8"
 springBoot3 = "3.5.8"
-springBoot4 = "4.0.0"
+springBoot4 = "4.1.0"
 
 spring-security-crypto = "7.0.0"
 joda-time = "2.14.2"


### PR DESCRIPTION
#### Description

**Summary of the change**: Bump `springFramework7` and `springBoot4` to latest versions.

**Detailed description**:
- **Why**: The [libs.versions.toml](https://github.com/JetBrains/Exposed/blob/main/gradle/libs.versions.toml#L33) holds 2 major versions of the same dependencies simultaneously (Spring Framework 6+7, Spring Boot 3+4). Dependabot does not seem capable of maintaining minor versions or patches for 2 major versions. Instead, it keeps attempting to bump all dependencies to the latest version 7.x or 4.x. For example, #2653 

This is a known dependabot limitation: [dependabot-core/issues/14040](https://github.com/dependabot/dependabot-core/issues/14040), [dependabot/dependabot-core/issues/14974](https://github.com/dependabot/dependabot-core/issues/14974)

[Successful](https://github.com/emaarco/metamorphmagus/pull/31) [workarounds](https://github.com/micrometer-metrics/micrometer/pull/7621) involve moving some or all of the conflicting dependencies out of the `.toml`, and directly declaring them in a subproject's build config, then updating the root scan path accordingly in `dependabot.yaml`.

❓ We could open a ticket to pursue more concrete options, especially if we change our minds about support Spring Boot 3 in V2. But for now, I'm just manually bumping the latest versions when prompted.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Other - _Dependency bump_

#### Checklist

- [X] The build is green (including the Detekt check)

---