### PR TITLE
feat: EXPOSED-1053 Add DatabaseConfig flag to allow dropping of indexes when only name differs

### DIFF
--- a/documentation-website/Writerside/topics/Migrations.md
+++ b/documentation-website/Writerside/topics/Migrations.md
@@ -320,7 +320,9 @@ Any detected changes to table and column constraints generally result in the gen
 The type of change that generates these migration statements depends on the type of constraint:
 
 - [`ForeignKeyConstraint`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-foreign-key-constraint/index.html) detects mismatches in name, update rule, or delete rule.
-- [`Index`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-index/index.html) detects mismatches in name, uniqueness, or columns involved. Differences in index type, index function, or filter conditions will not be detected.
+- [`Index`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-index/index.html) detects mismatches in uniqueness or columns involved. Differences in index type, index function, or filter conditions will not be detected.
+  By default, a mismatch in index name alone is also detected, but it is only logged (if logs are enabled during migration script generation).
+  To generate statement pairs for an index that only differs by name, ensure that the global `DatabaseConfig` flag `modifyIndexIfOnlyNameDiffers = true`.
 - [`CheckConstraint`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-check-constraint/index.html) detects mismatches in name only. Differences in the boolean expression or condition used by this constraint will not be detected.
 
 ### Column change detection

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -637,6 +637,7 @@ public abstract interface class org/jetbrains/exposed/v1/core/DatabaseConfig {
 	public abstract fun getKeepLoadedReferencesOutOfTransaction ()Z
 	public abstract fun getLogTooMuchResultSetsThreshold ()I
 	public abstract fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public abstract fun getModifyIndexIfOnlyNameDiffers ()Z
 	public abstract fun getPreserveIdentifierCasing ()Z
 	public abstract fun getPreserveKeywordCasing ()Z
 	public abstract fun getSqlLogger ()Lorg/jetbrains/exposed/v1/core/SqlLogger;
@@ -659,6 +660,7 @@ public class org/jetbrains/exposed/v1/core/DatabaseConfig$Builder {
 	public final fun getKeepLoadedReferencesOutOfTransaction ()Z
 	public final fun getLogTooMuchResultSetsThreshold ()I
 	public final fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public final fun getModifyIndexIfOnlyNameDiffers ()Z
 	public final fun getPreserveIdentifierCasing ()Z
 	public final fun getPreserveKeywordCasing ()Z
 	public final fun getSqlLogger ()Lorg/jetbrains/exposed/v1/core/SqlLogger;
@@ -677,6 +679,7 @@ public class org/jetbrains/exposed/v1/core/DatabaseConfig$Builder {
 	public final fun setKeepLoadedReferencesOutOfTransaction (Z)V
 	public final fun setLogTooMuchResultSetsThreshold (I)V
 	public final fun setMaxEntitiesToStoreInCachePerEntity (I)V
+	public final fun setModifyIndexIfOnlyNameDiffers (Z)V
 	public final fun setPreserveIdentifierCasing (Z)V
 	public final fun setPreserveKeywordCasing (Z)V
 	public final fun setSqlLogger (Lorg/jetbrains/exposed/v1/core/SqlLogger;)V
@@ -704,6 +707,7 @@ public class org/jetbrains/exposed/v1/core/DatabaseConfigImpl : org/jetbrains/ex
 	public fun getKeepLoadedReferencesOutOfTransaction ()Z
 	public fun getLogTooMuchResultSetsThreshold ()I
 	public fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public fun getModifyIndexIfOnlyNameDiffers ()Z
 	public fun getPreserveIdentifierCasing ()Z
 	public fun getPreserveKeywordCasing ()Z
 	public fun getSqlLogger ()Lorg/jetbrains/exposed/v1/core/SqlLogger;
@@ -2099,7 +2103,7 @@ public abstract class org/jetbrains/exposed/v1/core/SchemaUtilityApi {
 	protected final fun filterAndLogExcessConstraints (Ljava/util/Map;Z)Ljava/util/List;
 	protected final fun filterAndLogExcessIndices (Ljava/util/Map;Z)Ljava/util/List;
 	protected final fun filterAndLogMissingAndUnmappedCheckConstraints (Ljava/util/Map;Z[Lorg/jetbrains/exposed/v1/core/Table;)Lkotlin/Pair;
-	protected final fun filterAndLogMissingAndUnmappedIndices (Ljava/util/Map;Ljava/util/Set;ZZ[Lorg/jetbrains/exposed/v1/core/Table;)Lkotlin/Pair;
+	protected final fun filterAndLogMissingAndUnmappedIndices (Ljava/util/Map;Ljava/util/Set;ZZZ[Lorg/jetbrains/exposed/v1/core/Table;)Lkotlin/Pair;
 	protected final fun hasCycle (Ljava/util/List;)Z
 	protected final fun log (Ljava/util/Collection;Ljava/lang/String;Z)V
 	protected final fun logTimeSpent (Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)Ljava/lang/Object;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Constraints.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Constraints.kt
@@ -285,7 +285,7 @@ data class Index(
                 if (columns.isNotEmpty()) append('_')
                 append(f.joinToString("_") { it.toString().substringBefore("(").lowercase() })
             }
-            if (unique) {
+            if (unique && currentDialect !is SQLiteDialect) {
                 append("_unique")
             }
         }.inProperCase()

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/DatabaseConfig.kt
@@ -29,6 +29,7 @@ interface DatabaseConfig {
     val logTooMuchResultSetsThreshold: Int
     val preserveKeywordCasing: Boolean
     val preserveIdentifierCasing: Boolean
+    val modifyIndexIfOnlyNameDiffers: Boolean
 
     /**
      * The [CoroutineDispatcher] to be used when determining the scope of Exposed transaction if
@@ -185,6 +186,16 @@ interface DatabaseConfig {
         var preserveIdentifierCasing: Boolean = false
 
         /**
+         * When migration methods compare an index in a database with an index defined in a table object,
+         * any that have the same columns and uniqueness, but a different name, do not trigger generation of
+         * CREATE/ALTER/DROP SQL statements. By default, details of the index mismatch are only logged.
+         *
+         * Toggling this setting to `true` will additionally generate the appropriate SQL to drop the index with the
+         * old name and create an equivalent index with the new name.
+         */
+        var modifyIndexIfOnlyNameDiffers: Boolean = false
+
+        /**
          * The [CoroutineDispatcher] to be used when determining the scope of Exposed transaction if
          * It is run in a context with no dispatcher. It could be, for instance, a Ktor route or a standalone Kotlin script.
          *
@@ -246,4 +257,7 @@ open class DatabaseConfigImpl(private val builder: DatabaseConfig.Builder) : Dat
 
     override val preserveIdentifierCasing: Boolean
         get() = builder.preserveIdentifierCasing
+
+    override val modifyIndexIfOnlyNameDiffers: Boolean
+        get() = builder.modifyIndexIfOnlyNameDiffers
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
@@ -209,14 +209,16 @@ abstract class SchemaUtilityApi {
      * in a table object. and returns those that are defined on a table with more than one of this constraint.
      * If [withLogs] is `true`, the corresponding statements for these indices will also be logged.
      *
-     * @return Pair of CREATE statements for missing indices and, if [withDropIndices] is `true`, DROP statements ofr
-     * unmapped indices; if [withDropIndices] is `false`, the second value will be an empty list.
+     * @return Pair of CREATE statements for missing indices and, if [withDropIndices] is `true`, DROP statements for
+     * unmapped indices; if [withDropIndices] is `false`, the second value will be an empty list. Any generated DROP
+     * statements will include those for indexes that differ only by name, only if [withModifyOnNameDiffer] is `true`.
      * @suppress
      */
     @InternalApi
     protected fun Map<Table, List<Index>>.filterAndLogMissingAndUnmappedIndices(
         existingFKConstraints: Set<Pair<Table, LinkedHashSet<Column<*>>>>,
         withDropIndices: Boolean,
+        withModifyOnNameDiffer: Boolean,
         withLogs: Boolean,
         vararg tables: Table
     ): Pair<List<Index>, List<Index>> {
@@ -233,6 +235,14 @@ abstract class SchemaUtilityApi {
             this
         }
 
+        // H2: named indexes retrieved from metadata are appended with a suffix like "_INDEX_5"
+        // Oracle: custom index name undergoes upper-case folding by db
+        fun Index.nameOnlyDiffersByDBChange(other: Index): Boolean = when (currentDialect) {
+            is H2Dialect -> indexName.substringBeforeLast("_INDEX_").inProperCase() == other.indexName.inProperCase()
+            is OracleDialect -> indexName == other.indexName.inProperCase()
+            else -> false
+        }
+
         fun Table.existingIndices() = this@filterAndLogMissingAndUnmappedIndices[this].orEmpty()
             .filterForeignKeys()
             .filterInternalIndices()
@@ -240,6 +250,7 @@ abstract class SchemaUtilityApi {
         fun Table.mappedIndices() = this.indices.filterForeignKeys().filterInternalIndices()
         val missingIndices = HashSet<Index>()
         val unMappedIndices = HashMap<String, MutableSet<Index>>()
+        // stores indexes that will be ignored from create/drop lists, because they only differ in name equality
         val nameDiffers = HashSet<Index>()
         tables.forEach { table ->
             val existingTableIndices = table.existingIndices()
@@ -252,8 +263,12 @@ abstract class SchemaUtilityApi {
                             "-> in mapping ${mappedIndex.indexName}"
                     )
                 }
-                nameDiffers.add(index)
-                nameDiffers.add(mappedIndex)
+                if (!withModifyOnNameDiffer || index.nameOnlyDiffersByDBChange(mappedIndex)) {
+                    // add/ignore indexes where only name differs, only if global flag is set to not modify these indexes;
+                    // always ignore H2 indexes where name only differs by extra suffix
+                    nameDiffers.add(index)
+                    nameDiffers.add(mappedIndex)
+                }
             }
             unMappedIndices
                 .getOrPut(table.nameInDatabaseCase()) { hashSetOf() }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/SchemaUtils.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/SchemaUtils.kt
@@ -397,7 +397,11 @@ object SchemaUtils : SchemaUtilityApi() {
 
         @OptIn(InternalApi::class)
         return existingIndices.filterAndLogMissingAndUnmappedIndices(
-            foreignKeyConstraints, withDropIndices = false, withLogs, tables = tables
+            foreignKeyConstraints,
+            withDropIndices = false,
+            withModifyOnNameDiffer = false,
+            withLogs,
+            tables = tables
         ).first
     }
 

--- a/exposed-migration-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/jdbc/MigrationUtils.kt
+++ b/exposed-migration-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/jdbc/MigrationUtils.kt
@@ -196,11 +196,13 @@ object MigrationUtils : MigrationUtilityApi() {
 
         val foreignKeyConstraints = currentDialectMetadata.columnConstraints(*tables).keys
         val existingIndices = currentDialectMetadata.existingIndices(*tables)
+        val modifyIndexIfOnlyNameDiffers = TransactionManager.current().db.config.modifyIndexIfOnlyNameDiffers
 
         @OptIn(InternalApi::class)
         val toDrop = existingIndices.filterAndLogMissingAndUnmappedIndices(
             foreignKeyConstraints,
             withDropIndices = true,
+            withModifyOnNameDiffer = modifyIndexIfOnlyNameDiffers,
             withLogs = withLogs,
             tables = tables
         ).second
@@ -248,9 +250,14 @@ object MigrationUtils : MigrationUtilityApi() {
         } else {
             emptyMap()
         }
+        val modifyIndexIfOnlyNameDiffers = TransactionManager.current().db.config.modifyIndexIfOnlyNameDiffers
 
         val filteredIndices = existingIndices.filterAndLogMissingAndUnmappedIndices(
-            foreignKeyConstraints.keys, withDropIndices = true, withLogs, tables = tables
+            foreignKeyConstraints.keys,
+            withDropIndices = true,
+            withModifyOnNameDiffer = modifyIndexIfOnlyNameDiffers,
+            withLogs,
+            tables = tables
         )
         val (createMissing, dropUnmapped) = filteredIndices
 

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/IndexConstraintsTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/IndexConstraintsTests.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.exposed.v1.migration.jdbc
 
+import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.exposedLogger
 import org.jetbrains.exposed.v1.core.like
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -193,6 +195,46 @@ class IndexConstraintsTests : DatabaseTestsBase() {
             assertEquals(2, statements.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" indexOnlyInDbIdx".lowercase()) }.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" columnWithIndexOnlyInDbIdx".lowercase()) }.size)
+        }
+    }
+
+    @Test
+    fun testIndexWithSameColumnsButDifferentName() {
+        val oldTester = object : Table("index_tester") {
+            val firstName = varchar("first_name", 32)
+            val lastName = varchar("last_name", 32)
+            val codeName = varchar("code_name", 32).uniqueIndex("custom_code_name_idx")
+            init {
+                uniqueIndex(firstName, lastName)
+            }
+        }
+        val newTester = object : Table("index_tester") {
+            val firstName = varchar("first_name", 32)
+            val lastName = varchar("last_name", 32)
+            val codeName = varchar("code_name", 32).uniqueIndex("new_code_name_idx")
+            init {
+                uniqueIndex("custom_full_name_idx", firstName, lastName)
+            }
+        }
+
+        val logCaptor = LogCaptor.forName(exposedLogger.name)
+        // default config retains original behavior of only logging that there is an index name mismatch
+        withTables(oldTester) {
+            assertTrue(MigrationUtils.statementsRequiredForDatabaseMigration(oldTester, withLogs = false).isEmpty())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(newTester, withLogs = true)
+            assertTrue(statements.isEmpty())
+            assertEquals(2, logCaptor.infoLogs.count { it.contains("differs only in name") })
+        }
+        logCaptor.clearLogs()
+        logCaptor.close()
+
+        withTables(oldTester, configure = { modifyIndexIfOnlyNameDiffers = true }) {
+            assertTrue(MigrationUtils.statementsRequiredForDatabaseMigration(oldTester, withLogs = false).isEmpty())
+
+            // name changes should now trigger add + drop pairs for both indexes
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(newTester, withLogs = false)
+            assertEquals(4, statements.size)
         }
     }
 }

--- a/exposed-migration-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/MigrationUtils.kt
+++ b/exposed-migration-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/MigrationUtils.kt
@@ -195,11 +195,13 @@ object MigrationUtils : MigrationUtilityApi() {
 
         val foreignKeyConstraints = currentDialectMetadata.columnConstraints(*tables).keys
         val existingIndices = currentDialectMetadata.existingIndices(*tables)
+        val modifyIndexIfOnlyNameDiffers = TransactionManager.current().db.config.modifyIndexIfOnlyNameDiffers
 
         @OptIn(InternalApi::class)
         val toDrop = existingIndices.filterAndLogMissingAndUnmappedIndices(
             existingFKConstraints = foreignKeyConstraints,
             withDropIndices = true,
+            withModifyOnNameDiffer = modifyIndexIfOnlyNameDiffers,
             withLogs = withLogs,
             tables = tables
         ).second
@@ -247,9 +249,14 @@ object MigrationUtils : MigrationUtilityApi() {
         } else {
             emptyMap()
         }
+        val modifyIndexIfOnlyNameDiffers = TransactionManager.current().db.config.modifyIndexIfOnlyNameDiffers
 
         val filteredIndices = existingIndices.filterAndLogMissingAndUnmappedIndices(
-            foreignKeyConstraints.keys, withDropIndices = true, withLogs, tables = tables
+            foreignKeyConstraints.keys,
+            withDropIndices = true,
+            withModifyOnNameDiffer = modifyIndexIfOnlyNameDiffers,
+            withLogs,
+            tables = tables
         )
         val (createMissing, dropUnmapped) = filteredIndices
 

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/IndexConstraintsTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/IndexConstraintsTests.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.exposed.v1.migration.r2dbc
 
+import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.exposedLogger
 import org.jetbrains.exposed.v1.core.like
 import org.jetbrains.exposed.v1.r2dbc.exists
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -11,6 +13,7 @@ import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.test.expect
+import kotlin.text.contains
 
 class IndexConstraintsTests : R2dbcDatabaseTestsBase() {
     @Test
@@ -193,6 +196,46 @@ class IndexConstraintsTests : R2dbcDatabaseTestsBase() {
             assertEquals(2, statements.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" indexOnlyInDbIdx".lowercase()) }.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" columnWithIndexOnlyInDbIdx".lowercase()) }.size)
+        }
+    }
+
+    @Test
+    fun testIndexWithSameColumnsButDifferentName() {
+        val oldTester = object : Table("index_tester") {
+            val firstName = varchar("first_name", 32)
+            val lastName = varchar("last_name", 32)
+            val codeName = varchar("code_name", 32).uniqueIndex("custom_code_name_idx")
+            init {
+                uniqueIndex(firstName, lastName)
+            }
+        }
+        val newTester = object : Table("index_tester") {
+            val firstName = varchar("first_name", 32)
+            val lastName = varchar("last_name", 32)
+            val codeName = varchar("code_name", 32).uniqueIndex("new_code_name_idx")
+            init {
+                uniqueIndex("custom_full_name_idx", firstName, lastName)
+            }
+        }
+
+        val logCaptor = LogCaptor.forName(exposedLogger.name)
+        // default config retains original behavior of only logging that there is an index name mismatch
+        withTables(oldTester) {
+            assertTrue(MigrationUtils.statementsRequiredForDatabaseMigration(oldTester, withLogs = false).isEmpty())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(newTester, withLogs = true)
+            assertTrue(statements.isEmpty())
+            assertEquals(2, logCaptor.infoLogs.count { it.contains("differs only in name") })
+        }
+        logCaptor.clearLogs()
+        logCaptor.close()
+
+        withTables(oldTester, configure = { modifyIndexIfOnlyNameDiffers = true }) {
+            assertTrue(MigrationUtils.statementsRequiredForDatabaseMigration(oldTester, withLogs = false).isEmpty())
+
+            // name changes should now trigger add + drop pairs for both indexes
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(newTester, withLogs = false)
+            assertEquals(4, statements.size)
         }
     }
 }

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -285,6 +285,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/R2dbcDatabaseConfigImpl : org/
 	public fun getKeepLoadedReferencesOutOfTransaction ()Z
 	public fun getLogTooMuchResultSetsThreshold ()I
 	public fun getMaxEntitiesToStoreInCachePerEntity ()I
+	public fun getModifyIndexIfOnlyNameDiffers ()Z
 	public fun getPreserveIdentifierCasing ()Z
 	public fun getPreserveKeywordCasing ()Z
 	public fun getSqlLogger ()Lorg/jetbrains/exposed/v1/core/SqlLogger;

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/SchemaUtils.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/SchemaUtils.kt
@@ -389,7 +389,11 @@ object SchemaUtils : SchemaUtilityApi() {
 
         @OptIn(InternalApi::class)
         return existingIndices.filterAndLogMissingAndUnmappedIndices(
-            foreignKeyConstraints, withDropIndices = false, withLogs, tables = tables
+            foreignKeyConstraints,
+            withDropIndices = false,
+            withModifyOnNameDiffer = false,
+            withLogs,
+            tables = tables
         ).first
     }
 


### PR DESCRIPTION
#### Description

**Summary of the change**: Add `DatabaseConfig.modifyIndexIfOnlyNameDiffers` flag to enable generation of DROP/CREATE statements when migration methods detect an index that has only changed its name.

**Detailed description**:
- **Why**: If a table's index keeps the same columns and uniqueness, but only changes its name, an empty list is returned by calling `MigrationUtils.statementsRequiredForDatabaseMigration(NewTable, withLogs = true)`. The method only logs to INFO level something like, to prompt the user to manually drop the index if they want:
```bash
Index on table 'tester' differs only in name: in db first_name_last_name_index -> in mapping custom_full_name_idx
```

This design choice and the logic supporting it seems very intentional, although the full reasons are yet unclear.

Historically, there have been no raised issues about this and no requests for a change to this behavior. So rather than changing this behavior, this PR aims to support both expectations and improve documentation about it.

- **How**:
    - Add `DatabaseConfig.modifyIndexIfOnlyNameDiffers` that defaults to `false` to retain original migration behavior
    - Pass this flag's value to internal schema util `filterAndLogMissingAndUnmappedIndices()`
    - If the flag is `true`, indexes with only a name-change are no longer excluded from SQL generation
        - Which means we need to now account for name-changes that are done internally by the database
    - Update migration docs 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature - _To avoid breaking behavioral change_

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-1053](https://youtrack.jetbrains.com/issue/EXPOSED-1053/Index-on-table-with-a-changed-name-does-not-trigger-generation-of-migration-SQL)