### PR TITLE
docs: Edit index migrations docs to specify what changes trigger SQL generation

### DIFF
--- a/documentation-website/Writerside/topics/Migrations.md
+++ b/documentation-website/Writerside/topics/Migrations.md
@@ -320,7 +320,8 @@ Any detected changes to table and column constraints generally result in the gen
 The type of change that generates these migration statements depends on the type of constraint:
 
 - [`ForeignKeyConstraint`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-foreign-key-constraint/index.html) detects mismatches in name, update rule, or delete rule.
-- [`Index`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-index/index.html) detects mismatches in name, uniqueness, or columns involved. Differences in index type, index function, or filter conditions will not be detected.
+- [`Index`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-index/index.html) detects mismatches in uniqueness or columns involved. Differences in index type, index function, or filter conditions will not be detected.
+  By default, a mismatch in index name alone is also detected, but it is only logged (if logs are enabled during migration script generation).
 - [`CheckConstraint`](https://jetbrains.github.io/Exposed/api/exposed-core/org.jetbrains.exposed.v1.core/-check-constraint/index.html) detects mismatches in name only. Differences in the boolean expression or condition used by this constraint will not be detected.
 
 ### Column change detection


### PR DESCRIPTION
#### Description

See PR #2867 

**Summary of the change**: Update `Migrations.md` section about what changes to index constraints trigger SQL statement generation.

**Detailed description**:
- **Why**: A user recently brought up that an index name change does not trigger any SQL statements when calling `MigrationUtils` methods. This was initially thought to be a bug, but after assessing the internal logic, log statements, and attempted solutions, it was decided that this must be intentional and resolving it requires more steps that simply adding a new flag.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Documentation update

---

#### Related Issues
[EXPOSED-1053](https://youtrack.jetbrains.com/issue/EXPOSED-1053/Index-on-table-with-a-changed-name-does-not-trigger-generation-of-migration-SQL)