### PR TITLE
feat: Add multi-row values (single statement) batch insert for PostgreSQL with R2DBC

### DIFF
--- a/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
+++ b/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
@@ -141,8 +141,8 @@
                         src="exposed-dsl/src/main/kotlin/org/example/examples/CreateExamples.kt"
                         include-lines="83-95"/>
             <note>
-                The <code>.batchInsert()</code> function will still create multiple <code>INSERT</code> statements when
-                interacting with your database.
+                When using the JDBC driver, the <code>.batchInsert()</code> function will still create multiple
+                <code>INSERT</code> statements when interacting with your database.
                 <p>To convert the <code>INSERT</code> statements into a <code>BULK INSERT</code>, use the
                     <code>rewriteBatchedInserts=true</code>
                     (or <code>rewriteBatchedStatements=true</code>)
@@ -151,6 +151,11 @@
                     href="https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-performance-extensions.html#cj-conn-prop_rewriteBatchedStatements">MySQL</a>
                     and
                     <a href="https://jdbc.postgresql.org/documentation/use/">PostgresSQL</a>.</p>
+                <p>When using the R2DBC driver against PostgreSQL, no such option is needed: <code>.batchInsert()</code>
+                    automatically collapses the batch into a single multi-row <code>INSERT ... VALUES (...), (...), ...</code>
+                    statement, avoiding the per-row round trip that the r2dbc-postgresql driver otherwise performs for
+                    bound statement batches (see
+                    <a href="https://github.com/pgjdbc/r2dbc-postgresql/issues/527">pgjdbc/r2dbc-postgresql#527</a>).</p>
             </note>
 
             <p>
@@ -161,12 +166,14 @@
             </p>
             <p>
                 If you want to check if <code>rewriteBatchedInserts</code> and <code>batchInsert</code> are working
-                correctly, you need to enable JDBC logging for your driver. This is necessary, as Exposed will always
-                show the non-rewritten multiple inserts. For more information, see
+                correctly on JDBC, you need to enable JDBC logging for your driver. This is necessary, as Exposed will
+                always show the non-rewritten multiple inserts. For more information, see
                 <a href="https://jdbc.postgresql.org/documentation/logging/">
                     how to enable logging in PostgresSQL
                 </a>
-                .
+                . On R2DBC with PostgreSQL, the collapsed multi-row statement is visible directly through Exposed's own
+                <code>SqlLogger</code> (for example <code>StdOutSqlLogger</code>), since the rewrite happens in Exposed
+                itself rather than inside the driver.
             </p>
         </chapter>
     </chapter>

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3460,6 +3460,15 @@ public class org/jetbrains/exposed/v1/core/statements/MergeTableStatement : org/
 	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/Transaction;Z)Ljava/lang/String;
 }
 
+public class org/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement : org/jetbrains/exposed/v1/core/statements/BatchInsertStatement {
+	public fun <init> (Lorg/jetbrains/exposed/v1/core/Table;ZZ)V
+	public synthetic fun <init> (Lorg/jetbrains/exposed/v1/core/Table;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun arguments ()Ljava/lang/Iterable;
+	public fun arguments ()Ljava/util/List;
+	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/Transaction;Z)Ljava/lang/String;
+	public fun validateLastBatch ()V
+}
+
 public class org/jetbrains/exposed/v1/core/statements/ReplaceSelectStatement : org/jetbrains/exposed/v1/core/statements/InsertSelectStatement {
 	public fun <init> (Ljava/util/List;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)V
 	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/Transaction;Z)Ljava/lang/String;

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3460,7 +3460,7 @@ public class org/jetbrains/exposed/v1/core/statements/MergeTableStatement : org/
 	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/Transaction;Z)Ljava/lang/String;
 }
 
-public class org/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement : org/jetbrains/exposed/v1/core/statements/BatchInsertStatement {
+public class org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement : org/jetbrains/exposed/v1/core/statements/BatchInsertStatement {
 	public fun <init> (Lorg/jetbrains/exposed/v1/core/Table;ZZ)V
 	public synthetic fun <init> (Lorg/jetbrains/exposed/v1/core/Table;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun arguments ()Ljava/lang/Iterable;
@@ -3509,7 +3509,9 @@ public abstract class org/jetbrains/exposed/v1/core/statements/Statement {
 
 public abstract interface class org/jetbrains/exposed/v1/core/statements/StatementBuilder {
 	public fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;ZZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
+	public fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;ZZZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
 	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
+	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
 	public fun batchReplace (Lorg/jetbrains/exposed/v1/core/Table;ZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchReplaceStatement;
 	public static synthetic fun batchReplace$default (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/statements/BatchReplaceStatement;
 	public fun batchUpsert (Lorg/jetbrains/exposed/v1/core/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;Ljava/util/List;Lkotlin/jvm/functions/Function0;Z[Lorg/jetbrains/exposed/v1/core/Column;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchUpsertStatement;
@@ -3551,7 +3553,9 @@ public abstract interface class org/jetbrains/exposed/v1/core/statements/Stateme
 
 public final class org/jetbrains/exposed/v1/core/statements/StatementBuilder$DefaultImpls {
 	public static fun batchInsert (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
+	public static fun batchInsert (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZZZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
 	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
+	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
 	public static fun batchReplace (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZLkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchReplaceStatement;
 	public static synthetic fun batchReplace$default (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/statements/BatchReplaceStatement;
 	public static fun batchUpsert (Lorg/jetbrains/exposed/v1/core/statements/StatementBuilder;Lorg/jetbrains/exposed/v1/core/Table;Ljava/util/List;Lkotlin/jvm/functions/Function2;Ljava/util/List;Lkotlin/jvm/functions/Function0;Z[Lorg/jetbrains/exposed/v1/core/Column;Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/exposed/v1/core/statements/BatchUpsertStatement;

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
@@ -21,7 +21,7 @@ private const val POSTGRESQL_PARAMETER_LIMIT = 65535
  * row they belong to. This holds for plain multi-row `VALUES` inserts (no `BEFORE INSERT` trigger reordering)
  * and is the same assumption the JDBC driver's `reWriteBatchedInserts` rewrite relies on.
  */
-open class PostgreSQLBatchInsertStatement(
+open class MultiRowValuesInsertStatement(
     table: Table,
     ignore: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement.kt
@@ -1,0 +1,60 @@
+package org.jetbrains.exposed.v1.core.statements
+
+import org.jetbrains.exposed.v1.core.InternalApi
+import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.Transaction
+
+/** PostgreSQL's hard limit on bind parameters per statement (protocol int16 count field). */
+private const val POSTGRESQL_PARAMETER_LIMIT = 65535
+
+/**
+ * Represents the SQL statement that batch inserts new rows into a table, specifically for the PostgreSQL
+ * database, by rewriting the batch into a single multi-row `INSERT ... VALUES (...), (...), ...` statement
+ * instead of executing one bound statement per row.
+ *
+ * Before adding each new batch, the class validates that PostgreSQL's maximum bind-parameter count (65535)
+ * is not being exceeded.
+ *
+ * Note: collapsing to one multi-row `INSERT ... RETURNING` relies on PostgreSQL returning the `RETURNING`
+ * rows in the same order as the `VALUES` list, so that generated values can be matched back to the input
+ * row they belong to. This holds for plain multi-row `VALUES` inserts (no `BEFORE INSERT` trigger reordering)
+ * and is the same assumption the JDBC driver's `reWriteBatchedInserts` rewrite relies on.
+ */
+open class PostgreSQLBatchInsertStatement(
+    table: Table,
+    ignore: Boolean = false,
+    shouldReturnGeneratedValues: Boolean = true
+) : BatchInsertStatement(table, ignore, shouldReturnGeneratedValues) {
+    @OptIn(InternalApi::class)
+    override fun validateLastBatch() {
+        super.validateLastBatch()
+        val parameterCount = data.size.toLong() * table.columns.size.toLong()
+        if (parameterCount > POSTGRESQL_PARAMETER_LIMIT) {
+            throw BatchDataInconsistentException(
+                "Too many parameters in one batch. Exceeds the PostgreSQL limit of $POSTGRESQL_PARAMETER_LIMIT bind parameters."
+            )
+        }
+    }
+
+    override fun prepareSQL(transaction: Transaction, prepared: Boolean): String {
+        val values = arguments!!
+        val sql = if (values.isEmpty()) {
+            ""
+        } else {
+            QueryBuilder(prepared).apply {
+                values.appendTo(prefix = " VALUES") {
+                    it.appendTo(prefix = "(", postfix = ")") { (col, value) ->
+                        registerArgument(col, value)
+                    }
+                }
+            }.toString()
+        }
+        return transaction.db.dialect.functionProvider.insert(isIgnore, table, values.firstOrNull()?.map { it.first }.orEmpty(), sql, transaction)
+    }
+
+    override fun arguments() = listOfNotNull(
+        @OptIn(InternalApi::class)
+        super.arguments().flatten().takeIf { data.isNotEmpty() }
+    )
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/StatementBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/StatementBuilder.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.v1.core.statements
 
 import org.jetbrains.exposed.v1.core.*
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 
@@ -181,6 +182,19 @@ interface StatementBuilder {
             SQLServerBatchInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
         } else {
             BatchInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
+        }
+    }
+
+    fun <T : Table, E> T.batchInsert(
+        useMultiRowValues: Boolean,
+        ignoreErrors: Boolean = false,
+        shouldReturnGeneratedValues: Boolean = true,
+        body: BatchInsertStatement.(E) -> Unit
+    ): BatchInsertStatement {
+        return if (useMultiRowValues && currentDialect is PostgreSQLDialect) {
+            MultiRowValuesInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
+        } else {
+            batchInsert(ignoreErrors, shouldReturnGeneratedValues, body)
         }
     }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -13,7 +13,11 @@ import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
+import org.jetbrains.exposed.v1.core.statements.PostgreSQLBatchInsertStatement
+import org.jetbrains.exposed.v1.core.statements.StatementContext
+import org.jetbrains.exposed.v1.core.statements.expandArgs
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
 import org.jetbrains.exposed.v1.datetime.XCurrentTimestamp
@@ -33,6 +37,7 @@ import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.fail
@@ -200,6 +205,29 @@ class InsertTests : R2dbcDatabaseTestsBase() {
     }
 
     @Test
+    fun testBatchInsertUsesSingleMultiRowStatementForPostgreSQL() {
+        withCitiesAndUsers(exclude = TestDB.ALL - TestDB.POSTGRESQL) { cities, _, _ ->
+            val executedSql = mutableListOf<String>()
+            val logger = object : SqlLogger {
+                override fun log(context: StatementContext, transaction: Transaction) {
+                    executedSql.add(context.expandArgs(transaction))
+                }
+            }
+            addLogger(logger)
+
+            val cityNames = listOf("Paris", "Moscow", "Helsinki")
+            val allCitiesID = cities.batchInsert(cityNames) { name ->
+                this[cities.name] = name
+            }
+
+            assertEquals(cityNames.size, allCitiesID.size)
+            val insertStatements = executedSql.filter { it.startsWith("INSERT", ignoreCase = true) }
+            assertEquals(1, insertStatements.size, "Expected a single collapsed multi-row INSERT, got: $insertStatements")
+            assertTrue(insertStatements.single().count { it == '(' } >= cityNames.size + 1)
+        }
+    }
+
+    @Test
     fun testBatchInsertWithSequence() {
         val cities = DMLTestsData.Cities
         withTables(cities) { testDb ->
@@ -236,6 +264,30 @@ class InsertTests : R2dbcDatabaseTestsBase() {
         statement.addBatch()
         assertDoesNotThrow("Removing the only batch should not restore values from empty data") {
             statement.removeLastBatch()
+        }
+    }
+
+    @Test
+    fun testPostgreSQLBatchInsertRejectsBatchExceedingParameterLimit() {
+        // DMLTestsData.Cities has 2 columns, so the 65535 PostgreSQL bind-parameter limit
+        // is exceeded once more than 32767 rows are batched.
+        // validateLastBatch() requires a transaction in context, but the statement is never executed.
+        withTables(DMLTestsData.Cities) {
+            val statement = PostgreSQLBatchInsertStatement(DMLTestsData.Cities)
+
+            repeat(32767) {
+                statement[DMLTestsData.Cities.name] = "City$it"
+                statement.addBatch()
+            }
+            assertDoesNotThrow("Batch at the parameter limit should not throw") {
+                statement[DMLTestsData.Cities.name] = "City32767"
+                statement.addBatch()
+            }
+
+            assertFailsWith<BatchDataInconsistentException>("Batch exceeding the parameter limit should throw") {
+                statement[DMLTestsData.Cities.name] = "OneRowTooMany"
+                statement.addBatch()
+            }
         }
     }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
+import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
@@ -15,9 +16,7 @@ import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
-import org.jetbrains.exposed.v1.core.statements.PostgreSQLBatchInsertStatement
-import org.jetbrains.exposed.v1.core.statements.StatementContext
-import org.jetbrains.exposed.v1.core.statements.expandArgs
+import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
 import org.jetbrains.exposed.v1.datetime.XCurrentTimestamp
@@ -207,23 +206,22 @@ class InsertTests : R2dbcDatabaseTestsBase() {
     @Test
     fun testBatchInsertUsesSingleMultiRowStatementForPostgreSQL() {
         withCitiesAndUsers(exclude = TestDB.ALL - TestDB.POSTGRESQL) { cities, _, _ ->
-            val executedSql = mutableListOf<String>()
-            val logger = object : SqlLogger {
-                override fun log(context: StatementContext, transaction: Transaction) {
-                    executedSql.add(context.expandArgs(transaction))
-                }
-            }
-            addLogger(logger)
+            val logCaptor = LogCaptor.forName(exposedLogger.name)
+            logCaptor.setLogLevelToDebug()
 
             val cityNames = listOf("Paris", "Moscow", "Helsinki")
-            val allCitiesID = cities.batchInsert(cityNames) { name ->
+            val allCitiesID = cities.batchInsert(cityNames, useMultiRowValues = true) { name ->
                 this[cities.name] = name
             }
 
             assertEquals(cityNames.size, allCitiesID.size)
-            val insertStatements = executedSql.filter { it.startsWith("INSERT", ignoreCase = true) }
-            assertEquals(1, insertStatements.size, "Expected a single collapsed multi-row INSERT, got: $insertStatements")
-            assertTrue(insertStatements.single().count { it == '(' } >= cityNames.size + 1)
+            val insertLogs = logCaptor.debugLogs.filter { it.startsWith("INSERT ", ignoreCase = true) }
+            assertEquals(1, insertLogs.size, "Expected a single collapsed multi-row INSERT, got: $insertLogs")
+            assertTrue(insertLogs.single().count { it == '(' } >= cityNames.size + 1)
+
+            logCaptor.clearLogs()
+            logCaptor.resetLogLevel()
+            logCaptor.close()
         }
     }
 
@@ -273,7 +271,7 @@ class InsertTests : R2dbcDatabaseTestsBase() {
         // is exceeded once more than 32767 rows are batched.
         // validateLastBatch() requires a transaction in context, but the statement is never executed.
         withTables(DMLTestsData.Cities) {
-            val statement = PostgreSQLBatchInsertStatement(DMLTestsData.Cities)
+            val statement = MultiRowValuesInsertStatement(DMLTestsData.Cities)
 
             repeat(32767) {
                 statement[DMLTestsData.Cities.name] = "City$it"

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -98,9 +98,13 @@ public final class org/jetbrains/exposed/v1/r2dbc/MetadataQueriesKt {
 
 public final class org/jetbrains/exposed/v1/r2dbc/QueriesKt {
 	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun batchReplace (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun batchReplace (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun batchReplace$default (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZLkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -721,11 +725,11 @@ public class org/jetbrains/exposed/v1/r2dbc/statements/MergeSuspendExecutable : 
 	public fun prepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public class org/jetbrains/exposed/v1/r2dbc/statements/PostgreSQLBatchInsertSuspendExecutable : org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable {
-	public fun <init> (Lorg/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement;)V
+public class org/jetbrains/exposed/v1/r2dbc/statements/MultiRowValuesInsertSuspendExecutable : org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable {
+	public fun <init> (Lorg/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement;)V
 	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
 	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/InsertStatement;
-	public fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement;
+	public fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement;
 	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/Statement;
 	public fun isAlwaysBatch ()Z
 }

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -721,6 +721,15 @@ public class org/jetbrains/exposed/v1/r2dbc/statements/MergeSuspendExecutable : 
 	public fun prepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public class org/jetbrains/exposed/v1/r2dbc/statements/PostgreSQLBatchInsertSuspendExecutable : org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable {
+	public fun <init> (Lorg/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement;)V
+	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
+	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/InsertStatement;
+	public fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/PostgreSQLBatchInsertStatement;
+	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/Statement;
+	public fun isAlwaysBatch ()Z
+}
+
 public final class org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl : org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcExposedConnection {
 	public fun <init> (Lorg/reactivestreams/Publisher;Ljava/lang/String;Lorg/jetbrains/exposed/v1/r2dbc/mappers/R2dbcTypeMapping;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
@@ -6,8 +6,6 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.statements.*
-import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
-import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.r2dbc.statements.*
@@ -321,7 +319,15 @@ suspend fun <T : Table, E> T.batchInsert(
     ignore: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
-): List<ResultRow> = batchInsert(data.iterator(), ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+
+suspend fun <T : Table, E> T.batchInsert(
+    data: Iterable<E>,
+    useMultiRowValues: Boolean,
+    ignore: Boolean = false,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchInsertStatement.(E) -> Unit
+): List<ResultRow> = batchInsert(data.iterator(), useMultiRowValues, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
 /**
  * Represents the SQL statement that batch inserts new rows into a table.
@@ -344,22 +350,24 @@ suspend fun <T : Table, E> T.batchInsert(
     ignore: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
-): List<ResultRow> = batchInsert(data.iterator(), ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+
+suspend fun <T : Table, E> T.batchInsert(
+    data: Sequence<E>,
+    useMultiRowValues: Boolean,
+    ignore: Boolean = false,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchInsertStatement.(E) -> Unit
+): List<ResultRow> = batchInsert(data.iterator(), useMultiRowValues, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
 private suspend fun <T : Table, E> T.batchInsert(
     data: Iterator<E>,
+    useMultiRowValues: Boolean,
     ignoreErrors: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> = executeBatch(data, body) {
-    val stmt = buildStatement {
-        when (currentDialect) {
-            is SQLServerDialect if autoIncColumn != null ->
-                SQLServerBatchInsertStatement(this@batchInsert, ignoreErrors, shouldReturnGeneratedValues)
-            is PostgreSQLDialect -> PostgreSQLBatchInsertStatement(this@batchInsert, ignoreErrors, shouldReturnGeneratedValues)
-            else -> BatchInsertStatement(this@batchInsert, ignoreErrors, shouldReturnGeneratedValues)
-        }
-    }
+    val stmt = buildStatement { batchInsert(useMultiRowValues, ignoreErrors, shouldReturnGeneratedValues, body) }
     stmt.executable()
 }
 

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
@@ -6,6 +6,8 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
 import org.jetbrains.exposed.v1.core.statements.*
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.r2dbc.statements.*
@@ -308,6 +310,10 @@ fun <T : Table> T.insertReturning(
  * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
  * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
  * @return A list of [ResultRow] representing data from each newly inserted row.
+ *
+ * **Note** Against PostgreSQL, the batch is sent as a single multi-row `INSERT ... VALUES (...), (...), ...`
+ * statement instead of one bound statement per row, avoiding the per-row round trip that r2dbc-postgresql
+ * otherwise performs for statement-level batches.
  * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsert01
  */
 suspend fun <T : Table, E> T.batchInsert(
@@ -326,6 +332,11 @@ suspend fun <T : Table, E> T.batchInsert(
  * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
  * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
  * @return A list of [ResultRow] representing data from each newly inserted row.
+ *
+ * **Note** Against PostgreSQL, the batch is sent as a single multi-row `INSERT ... VALUES (...), (...), ...`
+ * statement instead of one bound statement per row, avoiding the per-row round trip that r2dbc-postgresql
+ * otherwise performs for statement-level batches (see
+ * [pgjdbc/r2dbc-postgresql#527](https://github.com/pgjdbc/r2dbc-postgresql/issues/527)).
  * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsertWithSequence
  */
 suspend fun <T : Table, E> T.batchInsert(
@@ -341,7 +352,14 @@ private suspend fun <T : Table, E> T.batchInsert(
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> = executeBatch(data, body) {
-    val stmt = buildStatement { batchInsert(ignoreErrors, shouldReturnGeneratedValues, body) }
+    val stmt = buildStatement {
+        when (currentDialect) {
+            is SQLServerDialect if autoIncColumn != null ->
+                SQLServerBatchInsertStatement(this@batchInsert, ignoreErrors, shouldReturnGeneratedValues)
+            is PostgreSQLDialect -> PostgreSQLBatchInsertStatement(this@batchInsert, ignoreErrors, shouldReturnGeneratedValues)
+            else -> BatchInsertStatement(this@batchInsert, ignoreErrors, shouldReturnGeneratedValues)
+        }
+    }
     stmt.executable()
 }
 

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.v1.r2dbc.statements
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
+import org.jetbrains.exposed.v1.core.statements.PostgreSQLBatchInsertStatement
 import org.jetbrains.exposed.v1.core.statements.SQLServerBatchInsertStatement
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcPreparedStatementApi
@@ -48,10 +49,21 @@ open class SQLServerBatchInsertSuspendExecutable(
     }
 }
 
+/**
+ * Represents the execution logic for an SQL statement that batch inserts new rows into a table,
+ * specifically for the PostgreSQL database, using a single multi-row INSERT statement.
+ */
+open class PostgreSQLBatchInsertSuspendExecutable(
+    override val statement: PostgreSQLBatchInsertStatement
+) : BatchInsertSuspendExecutable<PostgreSQLBatchInsertStatement>(statement) {
+    override val isAlwaysBatch: Boolean = false
+}
+
 @Suppress("Unchecked_Cast")
 internal fun <S : BatchInsertStatement> S.executable(): BatchInsertSuspendExecutable<S> {
     return when (this) {
         is SQLServerBatchInsertStatement -> SQLServerBatchInsertSuspendExecutable(this)
+        is PostgreSQLBatchInsertStatement -> PostgreSQLBatchInsertSuspendExecutable(this)
         else -> BatchInsertSuspendExecutable(this)
     } as BatchInsertSuspendExecutable<S>
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
@@ -3,7 +3,7 @@ package org.jetbrains.exposed.v1.r2dbc.statements
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
-import org.jetbrains.exposed.v1.core.statements.PostgreSQLBatchInsertStatement
+import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
 import org.jetbrains.exposed.v1.core.statements.SQLServerBatchInsertStatement
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcPreparedStatementApi
@@ -53,9 +53,9 @@ open class SQLServerBatchInsertSuspendExecutable(
  * Represents the execution logic for an SQL statement that batch inserts new rows into a table,
  * specifically for the PostgreSQL database, using a single multi-row INSERT statement.
  */
-open class PostgreSQLBatchInsertSuspendExecutable(
-    override val statement: PostgreSQLBatchInsertStatement
-) : BatchInsertSuspendExecutable<PostgreSQLBatchInsertStatement>(statement) {
+open class MultiRowValuesInsertSuspendExecutable(
+    override val statement: MultiRowValuesInsertStatement
+) : BatchInsertSuspendExecutable<MultiRowValuesInsertStatement>(statement) {
     override val isAlwaysBatch: Boolean = false
 }
 
@@ -63,7 +63,7 @@ open class PostgreSQLBatchInsertSuspendExecutable(
 internal fun <S : BatchInsertStatement> S.executable(): BatchInsertSuspendExecutable<S> {
     return when (this) {
         is SQLServerBatchInsertStatement -> SQLServerBatchInsertSuspendExecutable(this)
-        is PostgreSQLBatchInsertStatement -> PostgreSQLBatchInsertSuspendExecutable(this)
+        is MultiRowValuesInsertStatement -> MultiRowValuesInsertSuspendExecutable(this)
         else -> BatchInsertSuspendExecutable(this)
     } as BatchInsertSuspendExecutable<S>
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable.kt
@@ -103,6 +103,7 @@ fun <T : Any, S : Statement<T>> S.toExecutable(): SuspendExecutable<T, S> {
         is BatchUpsertStatement -> BatchUpsertSuspendExecutable(this)
         is UpsertStatement<*> -> UpsertSuspendExecutable(this as UpsertStatement<T>)
         is SQLServerBatchInsertStatement -> SQLServerBatchInsertSuspendExecutable(this)
+        is PostgreSQLBatchInsertStatement -> PostgreSQLBatchInsertSuspendExecutable(this)
         is BatchInsertStatement -> BatchInsertSuspendExecutable(this)
         is InsertStatement<*> -> InsertSuspendExecutable(this as InsertStatement<T>)
         is BatchUpdateStatement -> BatchUpdateSuspendExecutable(this)

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/SuspendExecutable.kt
@@ -103,7 +103,7 @@ fun <T : Any, S : Statement<T>> S.toExecutable(): SuspendExecutable<T, S> {
         is BatchUpsertStatement -> BatchUpsertSuspendExecutable(this)
         is UpsertStatement<*> -> UpsertSuspendExecutable(this as UpsertStatement<T>)
         is SQLServerBatchInsertStatement -> SQLServerBatchInsertSuspendExecutable(this)
-        is PostgreSQLBatchInsertStatement -> PostgreSQLBatchInsertSuspendExecutable(this)
+        is MultiRowValuesInsertStatement -> MultiRowValuesInsertSuspendExecutable(this)
         is BatchInsertStatement -> BatchInsertSuspendExecutable(this)
         is InsertStatement<*> -> InsertSuspendExecutable(this as InsertStatement<T>)
         is BatchUpdateStatement -> BatchUpdateSuspendExecutable(this)


### PR DESCRIPTION
#### Description

**Summary of the change**: Adds batch insert support for the postgresql dialect of r2dbc.

**Detailed description**:
- **Why**: https://github.com/pgjdbc/r2dbc-postgresql/issues/527 Provides the background context but the tl;dr is that currently r2dbc with postgres has to duplicate the entire query, for every single item in a batch insert rather than having the query once and then the list of items being inserted.
- **What**: A `PostgreSQLBatchInsertStatement` has been created which provides this batching functionality, transforming the SQL so the query statement is included just once for the entire batch, rather than being copied for each item. This `PostgreSQLBatchInsertStatement` is instantiated only on the PostgreSQL dialect
- **How**: The implementation is almost entirely based off of the already existing `SQLServerBatchInsertStatement`. A test has been added to verify that it works

---

#### Type of Change

Please mark the relevant options with an "X":
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [X] Postgres
- [ ] SqlServer
- [ ] H2
- [ ] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
