### PR TITLE
fix: EXPOSED-798 Declare both offending beans as role infrastructure

### DIFF
--- a/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/v1/spring/boot/autoconfigure/ExposedAutoConfiguration.kt
+++ b/exposed-spring-boot-starter/src/main/kotlin/org/jetbrains/exposed/v1/spring/boot/autoconfigure/ExposedAutoConfiguration.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.v1.spring.boot.DatabaseInitializer
 import org.jetbrains.exposed.v1.spring.transaction.ExposedSpringTransactionAttributeSource
 import org.jetbrains.exposed.v1.spring.transaction.SpringTransactionManager
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -12,6 +13,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Role
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import javax.sql.DataSource
 
@@ -30,6 +32,7 @@ import javax.sql.DataSource
  * @property applicationContext The Spring ApplicationContext container responsible for managing beans.
  */
 @AutoConfiguration(after = [DataSourceAutoConfiguration::class])
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 @EnableTransactionManagement
 open class ExposedAutoConfiguration(private val applicationContext: ApplicationContext) {
 
@@ -79,6 +82,7 @@ open class ExposedAutoConfiguration(private val applicationContext: ApplicationC
      * than enable when use '@EnableTransactionManagement'
      */
     @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Primary
     open fun exposedSpringTransactionAttributeSource(): ExposedSpringTransactionAttributeSource {
         return ExposedSpringTransactionAttributeSource()

--- a/exposed-spring-boot4-starter/src/main/kotlin/org/jetbrains/exposed/v1/spring/boot4/autoconfigure/ExposedAutoConfiguration.kt
+++ b/exposed-spring-boot4-starter/src/main/kotlin/org/jetbrains/exposed/v1/spring/boot4/autoconfigure/ExposedAutoConfiguration.kt
@@ -5,6 +5,7 @@ import org.jetbrains.exposed.v1.spring.boot4.DatabaseInitializer
 import org.jetbrains.exposed.v1.spring7.transaction.ExposedSpringTransactionAttributeSource
 import org.jetbrains.exposed.v1.spring7.transaction.SpringTransactionManager
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -12,6 +13,7 @@ import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Role
 import org.springframework.transaction.annotation.EnableTransactionManagement
 import javax.sql.DataSource
 
@@ -30,6 +32,7 @@ import javax.sql.DataSource
  * @property applicationContext The Spring ApplicationContext container responsible for managing beans.
  */
 @AutoConfiguration(after = [DataSourceAutoConfiguration::class])
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 @EnableTransactionManagement
 open class ExposedAutoConfiguration(private val applicationContext: ApplicationContext) {
 
@@ -79,6 +82,7 @@ open class ExposedAutoConfiguration(private val applicationContext: ApplicationC
      * than enable when use '@EnableTransactionManagement'
      */
     @Bean
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Primary
     open fun exposedSpringTransactionAttributeSource(): ExposedSpringTransactionAttributeSource {
         return ExposedSpringTransactionAttributeSource()


### PR DESCRIPTION
This fixes the warnings about the bean post processing when adding both the exposed spring boot and the spring boot actuator starters by declaring both offending beans with `@Role(BeanDefinition.ROLE_INFRASTRUCTURE`.

---

#### Related Issues

[EXPOSED-798](https://youtrack.jetbrains.com/issue/EXPOSED-798/Warning-about-ExposedAutoConfiguration-in-a-Spring-Boot-Application)