### PR TITLE
fix: EXPOSED-1027 cast binary parameter in MERGE upsert to preserve high bytes

### DIFF
--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -165,6 +165,8 @@ public class org/jetbrains/exposed/v1/core/BasicBinaryColumnType : org/jetbrains
 	public fun <init> ()V
 	public synthetic fun nonNullValueToString (Ljava/lang/Object;)Ljava/lang/String;
 	public fun nonNullValueToString ([B)Ljava/lang/String;
+	public synthetic fun parameterMarker (Ljava/lang/Object;)Ljava/lang/String;
+	public fun parameterMarker ([B)Ljava/lang/String;
 	public fun sqlType ()Ljava/lang/String;
 	public synthetic fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)[B

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
@@ -949,8 +949,8 @@ open class LargeTextColumnType(
 open class BasicBinaryColumnType : ColumnType<ByteArray>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.binaryType()
 
-    override fun parameterMarker(value: ByteArray?): String = when (currentDialect) {
-        is H2Dialect -> "cast(? as ${sqlType()})"
+    override fun parameterMarker(value: ByteArray?): String = when (val dialect = currentDialect) {
+        is H2Dialect -> "cast(? as ${dialect.originalDataTypeProvider.binaryType()})"
         else -> super.parameterMarker(value)
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
@@ -949,6 +949,11 @@ open class LargeTextColumnType(
 open class BasicBinaryColumnType : ColumnType<ByteArray>() {
     override fun sqlType(): String = currentDialect.dataTypeProvider.binaryType()
 
+    override fun parameterMarker(value: ByteArray?): String = when (currentDialect) {
+        is H2Dialect -> "cast(? as ${sqlType()})"
+        else -> super.parameterMarker(value)
+    }
+
     override fun valueFromDB(value: Any): ByteArray = when (value) {
         is Blob -> value.binaryStream.use { it.readBytes() }
         is InputStream -> value.use { it.readBytes() }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/UpsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/UpsertTests.kt
@@ -42,6 +42,7 @@ import org.jetbrains.exposed.v1.r2dbc.upsert
 import org.junit.jupiter.api.Test
 import java.lang.Integer.parseInt
 import kotlin.properties.Delegates
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -959,6 +960,54 @@ class UpsertTests : R2dbcDatabaseTestsBase() {
 
             assertTesterName(1, "tester1")
             assertTesterName(2, "tester2-modified")
+        }
+    }
+
+    @Test
+    fun testUpsertBinaryValuePreservesHighBytes() {
+        val tester = object : Table("binary_upsert") {
+            val id = integer("id")
+            val data = binary("data", 32).nullable()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val highBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+
+        withTables(tester) {
+            tester.upsert {
+                it[id] = 1
+                it[data] = highBytes
+            }
+
+            assertContentEquals(highBytes, tester.selectAll().single()[tester.data])
+        }
+    }
+
+    @Test
+    fun testBatchUpsertBinaryValuePreservesHighBytes() {
+        val tester = object : Table("binary_batch_upsert") {
+            val id = integer("id")
+            val data = binary("data", 32).nullable()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val rows = listOf(
+            1 to byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+            2 to byteArrayOf(0xFF.toByte(), 0x00, 0xC3.toByte(), 0x28)
+        )
+
+        withTables(tester) {
+            tester.batchUpsert(rows) { (rowId, bytes) ->
+                this[tester.id] = rowId
+                this[tester.data] = bytes
+            }
+
+            rows.forEach { (rowId, bytes) ->
+                val stored = tester.selectAll().where { tester.id eq rowId }.single()[tester.data]
+                assertContentEquals(bytes, stored)
+            }
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/UpsertTests.kt
@@ -38,6 +38,7 @@ import org.jetbrains.exposed.v1.tests.shared.expectException
 import org.junit.jupiter.api.Test
 import java.lang.Integer.parseInt
 import kotlin.properties.Delegates
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
@@ -956,6 +957,54 @@ class UpsertTests : DatabaseTestsBase() {
 
             assertTesterName(1, "tester1")
             assertTesterName(2, "tester2-modified")
+        }
+    }
+
+    @Test
+    fun testUpsertBinaryValuePreservesHighBytes() {
+        val tester = object : Table("binary_upsert") {
+            val id = integer("id")
+            val data = binary("data", 32).nullable()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val highBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+
+        withTables(tester) {
+            tester.upsert {
+                it[id] = 1
+                it[data] = highBytes
+            }
+
+            assertContentEquals(highBytes, tester.selectAll().single()[tester.data])
+        }
+    }
+
+    @Test
+    fun testBatchUpsertBinaryValuePreservesHighBytes() {
+        val tester = object : Table("binary_batch_upsert") {
+            val id = integer("id")
+            val data = binary("data", 32).nullable()
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val rows = listOf(
+            1 to byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+            2 to byteArrayOf(0xFF.toByte(), 0x00, 0xC3.toByte(), 0x28)
+        )
+
+        withTables(tester) {
+            tester.batchUpsert(rows) { (rowId, bytes) ->
+                this[tester.id] = rowId
+                this[tester.data] = bytes
+            }
+
+            rows.forEach { (rowId, bytes) ->
+                val stored = tester.selectAll().where { tester.id eq rowId }.single()[tester.data]
+                assertContentEquals(bytes, stored)
+            }
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/BinaryColumnTypeTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/types/BinaryColumnTypeTests.kt
@@ -1,0 +1,44 @@
+package org.jetbrains.exposed.v1.tests.shared.types
+
+import org.jetbrains.exposed.v1.core.StdOutSqlLogger
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import org.jetbrains.exposed.v1.tests.TestDB
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class BinaryColumnTypeTests : DatabaseTestsBase() {
+
+    private object BinaryTestTable : Table("binary_cast_simple") {
+        val id = integer("id")
+        val data = binary("data", 4)
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    @Test
+    fun testLongerValueDoesNotMatchStoredValue() {
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_H2_V2, BinaryTestTable) {
+            addLogger(StdOutSqlLogger)
+            BinaryTestTable.insert {
+                it[id] = 1
+                it[data] = byteArrayOf(1, 2, 3, 4)
+            }
+
+            // A different value that merely starts with the same four bytes.
+            val longerValue = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8)
+
+            val matches = BinaryTestTable.selectAll().where { BinaryTestTable.data eq longerValue }.count()
+
+            assertEquals(
+                0L,
+                matches,
+                "an 8-byte value matched the stored 4-byte row - the comparison argument was " +
+                    "truncated to its first 4 bytes by cast(? as VARBINARY(4))"
+            )
+        }
+    }
+}


### PR DESCRIPTION

#### Description

**Summary of the change**: Fixes silent corruption of binary column values on upsert/batchUpsert under H2 by explicitly typing the binary parameter in the generated `MERGED ... USING (VALUES (?))`

**Detailed description**:
- **Why**: This is sort-of fixed in main already: the PR https://github.com/JetBrains/Exposed/issues/2834 switched how a default timeout is set, which triggers H2 metadata to be updated which happens to fix the reported problem. The problem is still present for R2DBC though. The root cause is that H2 casts this to char when it doesn't have the type info, which can mess up bytes higher than the char type allows. Casting it to binary fixes this. 
  - Added tests for JDBC that pass in main
  - Added tests for R2DBC that fail in main
  - Updated `BasicBinaryColumnType` to provide the sql type info to prevent the bug in the first place.

---

#### Type of Change

Please mark the relevant options with an "X":
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] SqlServer
- [x] H2
- [ ] SQLite

#### Checklist

- [x] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [x] All public methods affected by my PR has up to date API docs
- [x] Documentation for my change is up to date

---

#### Related Issues

[EXPOSED-1027](https://youtrack.jetbrains.com/issue/EXPOSED-1027/upsert-corrupts-binary-column-values-in-H2-PostgreSQL-mode-MERGE-INTO-...-USING-VALUES-...-mangles-high-bytes)
[EXPOSED-1032](https://github.com/JetBrains/Exposed/issues/2834)