### PR TITLE
fix: EXPOSED-169 Schedule DAO updates independently of the entity cache

### DIFF
--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/Entity.kt
@@ -87,22 +87,20 @@ open class Entity<ID : Any>(val id: EntityID<ID>) {
 
     private val referenceCache by lazy { HashMap<Column<*>, Any?>() }
 
-    internal fun isNewEntity(): Boolean {
-        val cache = TransactionManager.current().entityCache
+    internal fun isNewEntity(cache: EntityCache = TransactionManager.current().entityCache): Boolean {
         return cache.inserts[klass.table]?.contains(this) ?: false
     }
 
     /**
-     * Whether this entity maps to a row that already exists in the database of the current transaction.
+     * Whether this entity maps to a row that already exists in the database of the provided [transaction].
      *
      * The result is `false` for an entity that belongs to a different [Database], that has not been assigned an
      * id value, that is scheduled for insert, or that is still running its initialization block and so has not
      * been scheduled yet.
      */
-    internal fun isPersistedInCurrentTransaction(): Boolean {
-        val transaction = TransactionManager.current()
+    internal fun isPersistedIn(transaction: Transaction, cache: EntityCache): Boolean {
         if (transaction.db != db || id._value == null) return false
-        return !isNewEntity() && !transaction.entityCache.isEntityInInitializationState(this)
+        return !isNewEntity(cache) && !cache.isEntityInInitializationState(this)
     }
 
     /**
@@ -313,7 +311,8 @@ open class Entity<ID : Any>(val id: EntityID<ID>) {
         klass.invalidateEntityInCache(o)
         val currentValue = _readValues?.getOrNull(this)
         if (writeValues.containsKey(this as Column<out Any?>) || currentValue != value) {
-            val entityCache = TransactionManager.current().entityCache
+            val transaction = TransactionManager.current()
+            val entityCache = transaction.entityCache
             if (referee != null) {
                 if (value is EntityID<*> && value.table == referee!!.table) value.value // flush
 
@@ -323,7 +322,7 @@ open class Entity<ID : Any>(val id: EntityID<ID>) {
             }
             val valueTypeMismatch = value is EntityID<*> && value.table is CompositeIdTable && this.columnType !is EntityIDColumnType<*>
             writeValues[this as Column<Any?>] = if (valueTypeMismatch) (value as EntityID<*>)._value else value
-            if (o.isPersistedInCurrentTransaction()) {
+            if (o.isPersistedIn(transaction, entityCache)) {
                 entityCache.scheduleUpdate(klass, o)
             }
         }

--- a/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/Entity.kt
+++ b/exposed-dao/src/main/kotlin/org/jetbrains/exposed/v1/dao/Entity.kt
@@ -93,6 +93,19 @@ open class Entity<ID : Any>(val id: EntityID<ID>) {
     }
 
     /**
+     * Whether this entity maps to a row that already exists in the database of the current transaction.
+     *
+     * The result is `false` for an entity that belongs to a different [Database], that has not been assigned an
+     * id value, that is scheduled for insert, or that is still running its initialization block and so has not
+     * been scheduled yet.
+     */
+    internal fun isPersistedInCurrentTransaction(): Boolean {
+        val transaction = TransactionManager.current()
+        if (transaction.db != db || id._value == null) return false
+        return !isNewEntity() && !transaction.entityCache.isEntityInInitializationState(this)
+    }
+
+    /**
      * Updates the fields of this [Entity] instance with values retrieved from the database.
      * Override this function to refresh some additional state, if any.
      *
@@ -310,7 +323,7 @@ open class Entity<ID : Any>(val id: EntityID<ID>) {
             }
             val valueTypeMismatch = value is EntityID<*> && value.table is CompositeIdTable && this.columnType !is EntityIDColumnType<*>
             writeValues[this as Column<Any?>] = if (valueTypeMismatch) (value as EntityID<*>)._value else value
-            if (entityCache.data[table].orEmpty().contains(o.id._value)) {
+            if (o.isPersistedInCurrentTransaction()) {
                 entityCache.scheduleUpdate(klass, o)
             }
         }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityCacheTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/entities/EntityCacheTests.kt
@@ -337,4 +337,47 @@ class EntityCacheTests : DatabaseTestsBase() {
             }
         }
     }
+
+    /* EXPOSED-169 a disabled entity cache silently dropped every DAO update */
+    @Test
+    @Tag(MISSING_R2DBC_TEST)
+    fun updatesArePersistedWhenTheCacheIsDisabledByConfig() {
+        Assumptions.assumeTrue(TestDB.H2_V2 in TestDB.enabledDialects())
+        val db = TestDB.H2_V2.connect {
+            maxEntitiesToStoreInCachePerEntity = 0
+        }
+
+        try {
+            val id = transaction(db) {
+                SchemaUtils.create(TestTable)
+                TestEntity.new { value = 1 }.id
+            }
+
+            transaction(db) {
+                TestEntity.findById(id)!!.value = 2
+            }
+
+            transaction(db) {
+                assertEquals(2, TestEntity.findById(id)!!.value)
+            }
+        } finally {
+            transaction(db) { SchemaUtils.drop(TestTable) }
+        }
+    }
+
+    /* EXPOSED-169 a disabled entity cache silently dropped every DAO update */
+    @Test
+    @Tag(MISSING_R2DBC_TEST)
+    fun updatesArePersistedWhenTheCacheIsDisabledMidTransaction() {
+        withTables(TestTable) {
+            val entity = TestEntity.new { value = 1 }
+            entityCache.flush()
+
+            entityCache.maxEntitiesToStore = 0
+            entity.value = 2
+            entityCache.flush()
+
+            assertEquals(2, TestTable.selectAll().single()[TestTable.value])
+        }
+    }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: A DAO update is no longer silently dropped when the entity cache is disabled with `maxEntitiesToStoreInCachePerEntity = 0`.

**Detailed description**:

- **Why**: Assigning to an entity property only scheduled an update when the entity was found in the cache:

  ```kotlin
  if (entityCache.data[table].orEmpty().contains(o.id._value)) {
      entityCache.scheduleUpdate(klass, o)
  }
  ```

Whether an entity is cached says nothing about whether a change to it still has to be written — the cache is size-limited and can be configured to hold nothing at all. 

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix


Affected databases:
- [X] All

---

#### Related Issues

[EXPOSED-169](https://youtrack.jetbrains.com/issue/EXPOSED-169) DAO writes are lost with maxEntitiesToStoreInCachePerEntity=0 in SQLite
