### PR TITLE
fix: EXPOSED-1059 Regression in ExposedSpringTransactionAttributeSource

### DIFF
--- a/spring-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring/transaction/ExposedSpringTransactionAttributeSource.kt
+++ b/spring-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring/transaction/ExposedSpringTransactionAttributeSource.kt
@@ -29,7 +29,11 @@ class ExposedSpringTransactionAttributeSource(
         // The delegate (e.g. AnnotationTransactionAttributeSource) caches the returned attribute,
         // so mutating it here would be a data race across concurrent callers. Make a defensive
         // copy and only modify the copy.
-        val copy = RuleBasedTransactionAttribute(original)
+        val copy = RuleBasedTransactionAttribute(original).apply {
+            qualifier = original.qualifier
+            descriptor = original.descriptor
+            labels = original.labels
+        }
         val rules = copy.rollbackRules.toMutableList()
         rollbackExceptions.forEach { exception ->
             val containsException = rules.any {

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring/transaction/NamedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring/transaction/NamedTransactionManagerTest.kt
@@ -32,7 +32,7 @@ import javax.sql.DataSource
         SecondaryTransactionConfig::class,
     ]
 )
-open class Exposed1059Test {
+open class NamedTransactionManagerTest {
     @Autowired
     lateinit var playerService: PlayerService
 

--- a/spring-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring/transaction/NamedTransactionManagerTest.kt
+++ b/spring-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring/transaction/NamedTransactionManagerTest.kt
@@ -1,0 +1,108 @@
+package org.jetbrains.exposed.v1.spring.transaction
+
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.atomic.AtomicInteger
+import javax.sql.DataSource
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(
+    classes = [
+        ExposedAutoConfigurationCopy::class,
+        SecondaryTransactionConfig::class,
+    ]
+)
+open class Exposed1059Test {
+    @Autowired
+    lateinit var playerService: PlayerService
+
+    @Autowired
+    lateinit var recordingTransactionManager: RecordingTransactionManager
+
+    @BeforeEach
+    open fun beforeTest() {
+        transaction {
+            SchemaUtils.create(Players)
+
+            Players.insert { }
+        }
+    }
+
+    @Test
+    fun `should not use differently named transaction manager`() {
+        assertEquals(
+            1,
+            playerService.countPlayers()
+        )
+
+        assertEquals(
+            0,
+            recordingTransactionManager.invocations.get(),
+            "recordingTransactionManager was used even though springTransactionManager was requested"
+        )
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+@EnableTransactionManagement
+class ExposedAutoConfigurationCopy {
+    @Bean
+    fun dataSource(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName(
+        "embeddedTest"
+    ).setType(EmbeddedDatabaseType.H2).build()
+
+    @Bean
+    fun springTransactionManager(dataSource: DataSource): SpringTransactionManager = SpringTransactionManager(dataSource)
+
+    @Bean
+    @Primary
+    fun exposedSpringTransactionAttributeSource(): ExposedSpringTransactionAttributeSource = ExposedSpringTransactionAttributeSource()
+}
+
+@Configuration(proxyBeanMethods = false)
+@EnableTransactionManagement(proxyTargetClass = true)
+class SecondaryTransactionConfig {
+
+    @Bean @Primary
+    fun recordingTransactionManager(dataSource: DataSource): RecordingTransactionManager =
+        RecordingTransactionManager(dataSource)
+
+    @Bean
+    fun playerService(): PlayerService = PlayerService()
+}
+
+class RecordingTransactionManager(dataSource: DataSource) : DataSourceTransactionManager(dataSource) {
+    val invocations = AtomicInteger(0)
+
+    override fun doBegin(transaction: Any, definition: TransactionDefinition) {
+        invocations.incrementAndGet()
+        super.doBegin(transaction, definition)
+    }
+}
+
+open class PlayerService {
+    @Transactional(transactionManager = "springTransactionManager")
+    open fun countPlayers(): Long = Players.selectAll().count()
+}
+
+private object Players : LongIdTable("players")

--- a/spring7-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring7/transaction/ExposedSpringTransactionAttributeSource.kt
+++ b/spring7-transaction/src/main/kotlin/org/jetbrains/exposed/v1/spring7/transaction/ExposedSpringTransactionAttributeSource.kt
@@ -29,7 +29,11 @@ class ExposedSpringTransactionAttributeSource(
         // The delegate (e.g. AnnotationTransactionAttributeSource) caches the returned attribute,
         // so mutating it here would be a data race across concurrent callers. Make a defensive
         // copy and only modify the copy.
-        val copy = RuleBasedTransactionAttribute(original)
+        val copy = RuleBasedTransactionAttribute(original).apply {
+            qualifier = original.qualifier
+            descriptor = original.descriptor
+            labels = original.labels
+        }
         val rules = copy.rollbackRules.toMutableList()
         rollbackExceptions.forEach { exception ->
             val containsException = rules.any {

--- a/spring7-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring7/transaction/NamedTransactionManagerTest.kt
+++ b/spring7-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring7/transaction/NamedTransactionManagerTest.kt
@@ -32,7 +32,7 @@ import javax.sql.DataSource
         SecondaryTransactionConfig::class,
     ]
 )
-open class Exposed1059Test {
+open class NamedTransactionManagerTest {
     @Autowired
     lateinit var playerService: PlayerService
 

--- a/spring7-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring7/transaction/NamedTransactionManagerTest.kt
+++ b/spring7-transaction/src/test/kotlin/org/jetbrains/exposed/v1/spring7/transaction/NamedTransactionManagerTest.kt
@@ -1,0 +1,108 @@
+package org.jetbrains.exposed.v1.spring7.transaction
+
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.atomic.AtomicInteger
+import javax.sql.DataSource
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(
+    classes = [
+        ExposedAutoConfigurationCopy::class,
+        SecondaryTransactionConfig::class,
+    ]
+)
+open class Exposed1059Test {
+    @Autowired
+    lateinit var playerService: PlayerService
+
+    @Autowired
+    lateinit var recordingTransactionManager: RecordingTransactionManager
+
+    @BeforeEach
+    open fun beforeTest() {
+        transaction {
+            SchemaUtils.create(Players)
+
+            Players.insert { }
+        }
+    }
+
+    @Test
+    fun `should not use differently named transaction manager`() {
+        assertEquals(
+            1,
+            playerService.countPlayers()
+        )
+
+        assertEquals(
+            0,
+            recordingTransactionManager.invocations.get(),
+            "recordingTransactionManager was used even though springTransactionManager was requested"
+        )
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+@EnableTransactionManagement
+class ExposedAutoConfigurationCopy {
+    @Bean
+    fun dataSource(): EmbeddedDatabase = EmbeddedDatabaseBuilder().setName(
+        "embeddedTest"
+    ).setType(EmbeddedDatabaseType.H2).build()
+
+    @Bean
+    fun springTransactionManager(dataSource: DataSource): SpringTransactionManager = SpringTransactionManager(dataSource)
+
+    @Bean
+    @Primary
+    fun exposedSpringTransactionAttributeSource(): ExposedSpringTransactionAttributeSource = ExposedSpringTransactionAttributeSource()
+}
+
+@Configuration(proxyBeanMethods = false)
+@EnableTransactionManagement(proxyTargetClass = true)
+class SecondaryTransactionConfig {
+
+    @Bean @Primary
+    fun recordingTransactionManager(dataSource: DataSource): RecordingTransactionManager =
+        RecordingTransactionManager(dataSource)
+
+    @Bean
+    fun playerService(): PlayerService = PlayerService()
+}
+
+class RecordingTransactionManager(dataSource: DataSource) : DataSourceTransactionManager(dataSource) {
+    val invocations = AtomicInteger(0)
+
+    override fun doBegin(transaction: Any, definition: TransactionDefinition) {
+        invocations.incrementAndGet()
+        super.doBegin(transaction, definition)
+    }
+}
+
+open class PlayerService {
+    @Transactional(transactionManager = "springTransactionManager")
+    open fun countPlayers(): Long = Players.selectAll().count()
+}
+
+private object Players : LongIdTable("players")


### PR DESCRIPTION
#### Description

**Summary of the change**: This fixes a regression introduced in 1.4.0 where the qualifier of a transaction was not getting copied over, causing the wrong transaction manager to be used in Spring. Note: although I did tinker on this myself, I did refer to the zip file the ticket submitter had on the ticket (Youtrack user `Prototype` :bow:) so I can't take full credit for the code here.

**Detailed description**:
- **What**: The copying inside `ExposedSpringTransactionAttributeSource.getTransactionAttribute` was updated to also copy qualifier, descriptor and labels.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- Not applicable

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-1059](https://youtrack.jetbrains.com/issue/EXPOSED-1059/)
[EXPOSED-1028](https://youtrack.jetbrains.com/issue/EXPOSED-1059/) suspected that the bug was introduced here