### PR TITLE
fix: Nullable enumeration columns not handled by r2dbc-postgresql 1.0.5 or older

### DIFF
--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/ddl/EnumerationTests.kt
@@ -23,6 +23,8 @@ import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.r2dbc.update
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+import kotlin.collections.single
 
 class EnumerationTests : R2dbcDatabaseTestsBase() {
     // NOTE: UNSUPPORTED r2dbc-h2
@@ -268,6 +270,25 @@ class EnumerationTests : R2dbcDatabaseTestsBase() {
 
             assertEquals(fooBaz, tester.selectAll().single()[tester.enumNameColumn])
             assertEquals(fooBaz, referenceTable.selectAll().single()[referenceTable.referenceNameColumn])
+        }
+    }
+
+    @Test
+    fun testNullableEnumerationColumns() {
+        val tester = object : Table("nullable_tester") {
+            val enumColumn = enumeration<Foo>("enum_column").nullable()
+            val enumNameColumn = enumerationByName<Foo>("enum_name_column", 32).nullable()
+        }
+
+        withTables(tester, tester) {
+            tester.insert {
+                it[enumColumn] = null
+                it[enumNameColumn] = null
+            }
+
+            val result = tester.selectAll().single()
+            assertNull(result[tester.enumColumn])
+            assertNull(result[tester.enumNameColumn])
         }
     }
 }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/mappers/PrimitiveTypeMapper.kt
@@ -5,7 +5,6 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
 import kotlin.reflect.KClass
-import kotlin.uuid.ExperimentalUuidApi
 
 /**
  * Mapper for primitive types (Int, Long, Float, Double, etc.).
@@ -30,6 +29,8 @@ class PrimitiveTypeMapper : TypeMapper {
         CharacterColumnType::class,
         BasicUuidColumnType::class,
         StringColumnType::class,
+        EnumerationColumnType::class,
+        EnumerationNameColumnType::class,
     )
 
     override fun setValue(
@@ -45,7 +46,6 @@ class PrimitiveTypeMapper : TypeMapper {
             return true
         }
 
-        @OptIn(ExperimentalUuidApi::class)
         val columnValueType = when (columnType) {
             is ByteColumnType -> java.lang.Byte::class.java
             is UByteColumnType -> java.lang.Short::class.java
@@ -63,6 +63,8 @@ class PrimitiveTypeMapper : TypeMapper {
             is CharacterColumnType -> java.lang.String::class.java
             is BooleanColumnType -> java.lang.Boolean::class.java
             is StringColumnType -> java.lang.String::class.java
+            is EnumerationColumnType -> java.lang.Integer::class.java
+            is EnumerationNameColumnType -> java.lang.String::class.java
             else -> return false
         }
         statement.bindNull(index - 1, columnValueType)

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/EnumerationTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/ddl/EnumerationTests.kt
@@ -20,6 +20,7 @@ import org.jetbrains.exposed.v1.tests.currentDialectTest
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 import org.postgresql.util.PGobject
 
 class EnumerationTests : DatabaseTestsBase() {
@@ -216,6 +217,25 @@ class EnumerationTests : DatabaseTestsBase() {
 
             assertEquals(fooBaz, tester.selectAll().single()[tester.enumNameColumn])
             assertEquals(fooBaz, referenceTable.selectAll().single()[referenceTable.referenceNameColumn])
+        }
+    }
+
+    @Test
+    fun testNullableEnumerationColumns() {
+        val tester = object : Table("nullable_tester") {
+            val enumColumn = enumeration<Foo>("enum_column").nullable()
+            val enumNameColumn = enumerationByName<Foo>("enum_name_column", 32).nullable()
+        }
+
+        withTables(tester, tester) {
+            tester.insert {
+                it[enumColumn] = null
+                it[enumNameColumn] = null
+            }
+
+            val result = tester.selectAll().single()
+            assertNull(result[tester.enumColumn])
+            assertNull(result[tester.enumNameColumn])
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Add `EnumerationColumnType` and `EnumerationNameColumnype` to `PrimitiveTypeMapper.setValue()` to ensure they don't reach `DefaultTypeMapper`

**Detailed description**:
- **Why**: Related to PR #2814 . Showed that `r2dbc-postrgresql` driver 1.0.5 or older did not accept binding of null `Object`. This was fixed for any `StringColumnType`. There were no tests using any of the primitive enumeration columns with insertion of null values. And even if there were, they would have passed because driver version 1.0.6.+ now accepts null objects for binding. Temporarily dropping the test driver to version 1.0.5.RELEASE showed that any such null insertions fail with:
```bash
java.lang.IllegalArgumentException: Cannot encode null parameter of type java.lang.Object
```

- **How**: Add coverage of `EnumerationColumnType` and `EnumerationNameColumnype` to `PrimitiveTypeMapper` to make sure `bindNull()` is called with the correct class type (`Int` for enum ordinal input, and `String` for enum name input).

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] Postgres

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-1030](https://youtrack.jetbrains.com/issue/EXPOSED-1030/Nullable-Strings-are-not-handled-by-the-PrimitiveTypeMapper)