### PR TITLE
feat: EXPOSED-924 Extend multi-row values batch insert to all DB and drivers

### DIFF
--- a/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
+++ b/documentation-website/Writerside/topics/DSL-CRUD-operations.topic
@@ -140,23 +140,6 @@
             <code-block lang="kotlin"
                         src="exposed-dsl/src/main/kotlin/org/example/examples/CreateExamples.kt"
                         include-lines="83-95"/>
-            <note>
-                When using the JDBC driver, the <code>.batchInsert()</code> function will still create multiple
-                <code>INSERT</code> statements when interacting with your database.
-                <p>To convert the <code>INSERT</code> statements into a <code>BULK INSERT</code>, use the
-                    <code>rewriteBatchedInserts=true</code>
-                    (or <code>rewriteBatchedStatements=true</code>)
-                    option of your relevant JDBC driver.</p>
-                <p>For more information, see the documentation for this option for <a
-                    href="https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-performance-extensions.html#cj-conn-prop_rewriteBatchedStatements">MySQL</a>
-                    and
-                    <a href="https://jdbc.postgresql.org/documentation/use/">PostgresSQL</a>.</p>
-                <p>When using the R2DBC driver against PostgreSQL, no such option is needed: <code>.batchInsert()</code>
-                    automatically collapses the batch into a single multi-row <code>INSERT ... VALUES (...), (...), ...</code>
-                    statement, avoiding the per-row round trip that the r2dbc-postgresql driver otherwise performs for
-                    bound statement batches (see
-                    <a href="https://github.com/pgjdbc/r2dbc-postgresql/issues/527">pgjdbc/r2dbc-postgresql#527</a>).</p>
-            </note>
 
             <p>
                 If you don't need to get the newly generated values, such as the auto-incremented ID, set the
@@ -164,17 +147,56 @@
                 performance of batch inserts by batching them in chunks, instead of always waiting for the database to
                 synchronize the newly inserted object state.
             </p>
+            <note>
+                When using the JDBC driver, the <code>.batchInsert()</code> function will by default prepare a single
+                parameterized <code>PreparedStatement</code> and repeatedly call <code>.addBatch()</code> before periodically
+                flushing each batch to the database.
+                <p>To convert this statement-level batching into a true <code>BULK INSERT</code>, use
+                    connection configuration parameters, such as PostgreSQL's <code>reWriteBatchedInserts=true</code>
+                    or MySQL's <code>rewriteBatchedStatements=true</code>, from supporting JDBC drivers.
+                    Even if these flags are set to <code>true</code>, the Exposed logger will always show non-rewritten
+                    multiple insert SQL lines.
+                </p>
+            </note>
+            <note>
+                <p>When using the R2DBC driver, connection parameters similar to the above JDBC flags do not exist
+                    for most databases, forcing a reliance on the driver's underlying batch statement performance.
+                    Certain databases propose using the multiple-row values constructor syntax instead, to avoid these
+                    per-row round trips. And Exposed provides a <code>.batchInsert()</code> overload that enables this
+                    specific syntax when <code>useMultiRowValues=true</code>.
+                </p>
+            </note>
+
             <p>
-                If you want to check if <code>rewriteBatchedInserts</code> and <code>batchInsert</code> are working
+                If you want to check whether <code>.batchInsert()</code> is working with your connection configuration
                 correctly on JDBC, you need to enable JDBC logging for your driver. This is necessary, as Exposed will
                 always show the non-rewritten multiple inserts. For more information, see
                 <a href="https://jdbc.postgresql.org/documentation/logging/">
-                    how to enable logging in PostgresSQL
+                    how to enable logging in PostgreSQL
                 </a>
-                . On R2DBC with PostgreSQL, the collapsed multi-row statement is visible directly through Exposed's own
-                <code>SqlLogger</code> (for example <code>StdOutSqlLogger</code>), since the rewrite happens in Exposed
-                itself rather than inside the driver.
+                . For more information on these connection flags, see the documentation for these options for <a
+                href="https://dev.mysql.com/doc/connector-j/en/connector-j-connp-props-performance-extensions.html#cj-conn-prop_rewriteBatchedStatements">MySQL</a>
+                and
+                <a href="https://jdbc.postgresql.org/documentation/use/">PostgresSQL</a>.
             </p>
+
+            <p>
+                Regardless of which driver you are using, you can manually ensure that your batch inserts always
+                automatically collapse the batch into a single multi-row <code>INSERT ... VALUES (...), (...), ...</code>
+                statement, by using the dedicated <code>.batchInsert()</code> with the parameter <code>useMultiRowValues=true</code>.
+                This avoids any potential driver batching performance limitations. The logger will always show a single
+                insert SQL line because the rewrite happens by Exposed before the statement is prepared and sent to the database:
+            </p>
+            <code-block lang="kotlin"><![CDATA[
+                val cityNames = listOf("Paris", "Moscow", "Helsinki")
+
+                CitiesTable.batchInsert(
+                    cityNames,
+                    useMultiRowValues = true
+                ) { name ->
+                    this[CitiesTable.name] = name
+                }
+            ]]></code-block>
         </chapter>
     </chapter>
     <chapter title="Read" id="read">

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -4316,6 +4316,7 @@ public abstract class org/jetbrains/exposed/v1/core/vendors/FunctionProvider {
 	public fun groupConcat (Lorg/jetbrains/exposed/v1/core/GroupConcat;Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
 	public fun hour (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
 	public fun insert (ZLorg/jetbrains/exposed/v1/core/Table;Ljava/util/List;Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/Transaction;)Ljava/lang/String;
+	public fun insertMultiRowValues (ZLorg/jetbrains/exposed/v1/core/Table;Ljava/util/List;Ljava/lang/String;ILorg/jetbrains/exposed/v1/core/Transaction;)Ljava/lang/String;
 	public fun insertValue (Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
 	public fun jsonCast (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/IColumnType;Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
 	public fun jsonContains (Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/IColumnType;Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
@@ -4,9 +4,14 @@ import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.QueryBuilder
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
+import org.jetbrains.exposed.v1.core.vendors.currentDialect
 
-/** PostgreSQL's hard limit on bind parameters per statement (protocol int16 count field). */
-private const val POSTGRESQL_PARAMETER_LIMIT = 65535
+/** The documented hard limit on bind parameters per statement (protocol int16 count field) for most supported databases. */
+private const val DEFAULT_PARAMETER_LIMIT = 65535
+
+/** The documented hard limit on bind parameters per statement for SQLite. */
+private const val SQLITE_PARAMETER_LIMIT = 32766
 
 /**
  * Represents the SQL statement that batch inserts new rows into a table by using a single multi-row
@@ -23,9 +28,10 @@ open class MultiRowValuesInsertStatement(
     override fun validateLastBatch() {
         super.validateLastBatch()
         val parameterCount = data.size.toLong() * table.columns.size.toLong()
-        if (parameterCount > POSTGRESQL_PARAMETER_LIMIT) {
+        val limit = if (currentDialect is SQLiteDialect) SQLITE_PARAMETER_LIMIT else DEFAULT_PARAMETER_LIMIT
+        if (parameterCount > limit) {
             throw BatchDataInconsistentException(
-                "Too many parameters in one batch. Exceeds the database's limit of $POSTGRESQL_PARAMETER_LIMIT bind parameters."
+                "Too many parameters in one batch. Exceeds the database's limit of $limit bind parameters."
             )
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
@@ -49,8 +49,9 @@ open class MultiRowValuesInsertStatement(
                 }
             }.toString()
         }
+        val columnsToUse = values.firstOrNull()?.map { it.first }.orEmpty()
         return transaction.db.dialect.functionProvider
-            .insert(isIgnore, table, values.firstOrNull()?.map { it.first }.orEmpty(), sql, transaction)
+            .insertMultiRowValues(isIgnore, table, columnsToUse, sql, values.size, transaction)
     }
 
     override fun arguments() = listOfNotNull(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement.kt
@@ -9,17 +9,10 @@ import org.jetbrains.exposed.v1.core.Transaction
 private const val POSTGRESQL_PARAMETER_LIMIT = 65535
 
 /**
- * Represents the SQL statement that batch inserts new rows into a table, specifically for the PostgreSQL
- * database, by rewriting the batch into a single multi-row `INSERT ... VALUES (...), (...), ...` statement
- * instead of executing one bound statement per row.
+ * Represents the SQL statement that batch inserts new rows into a table by using a single multi-row
+ * `INSERT ... VALUES (...), (...), ...` statement instead of executing one bound statement per row.
  *
- * Before adding each new batch, the class validates that PostgreSQL's maximum bind-parameter count (65535)
- * is not being exceeded.
- *
- * Note: collapsing to one multi-row `INSERT ... RETURNING` relies on PostgreSQL returning the `RETURNING`
- * rows in the same order as the `VALUES` list, so that generated values can be matched back to the input
- * row they belong to. This holds for plain multi-row `VALUES` inserts (no `BEFORE INSERT` trigger reordering)
- * and is the same assumption the JDBC driver's `reWriteBatchedInserts` rewrite relies on.
+ * Before adding each new batch, the class validates that the database's maximum bind-parameter count is not being exceeded.
  */
 open class MultiRowValuesInsertStatement(
     table: Table,
@@ -32,7 +25,7 @@ open class MultiRowValuesInsertStatement(
         val parameterCount = data.size.toLong() * table.columns.size.toLong()
         if (parameterCount > POSTGRESQL_PARAMETER_LIMIT) {
             throw BatchDataInconsistentException(
-                "Too many parameters in one batch. Exceeds the PostgreSQL limit of $POSTGRESQL_PARAMETER_LIMIT bind parameters."
+                "Too many parameters in one batch. Exceeds the database's limit of $POSTGRESQL_PARAMETER_LIMIT bind parameters."
             )
         }
     }
@@ -43,14 +36,15 @@ open class MultiRowValuesInsertStatement(
             ""
         } else {
             QueryBuilder(prepared).apply {
-                values.appendTo(prefix = " VALUES") {
+                values.appendTo(prefix = "VALUES ") {
                     it.appendTo(prefix = "(", postfix = ")") { (col, value) ->
                         registerArgument(col, value)
                     }
                 }
             }.toString()
         }
-        return transaction.db.dialect.functionProvider.insert(isIgnore, table, values.firstOrNull()?.map { it.first }.orEmpty(), sql, transaction)
+        return transaction.db.dialect.functionProvider
+            .insert(isIgnore, table, values.firstOrNull()?.map { it.first }.orEmpty(), sql, transaction)
     }
 
     override fun arguments() = listOfNotNull(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/StatementBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/StatementBuilder.kt
@@ -164,7 +164,8 @@ interface StatementBuilder {
     }
 
     /**
-     * Represents the SQL statement that batch inserts new rows into a table.
+     * Represents the SQL statement that batch inserts new rows into a table, relying entirely on the underlying driver
+     * mechanisms to perform the batching operation.
      *
      * @param ignoreErrors Whether to ignore errors or not.
      * **Note** [ignoreErrors] is not supported by all vendors. Please check the documentation.
@@ -184,6 +185,17 @@ interface StatementBuilder {
         }
     }
 
+    /**
+     * Represents the SQL statement that batch inserts new rows into a table.
+     *
+     * @param useMultiRowValues Whether to return a single INSERT statement that uses multi-row values constructor,
+     * like `INSERT ... VALUES (...), (...), ...`; if `false`, a regular statement will be prepared for driver batching.
+     * @param ignoreErrors Whether to ignore errors or not.
+     * **Note** [ignoreErrors] is not supported by all vendors. Please check the documentation.
+     * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
+     * should be returned.
+     * @return A [BatchInsertStatement] that can be executed.
+     */
     fun <T : Table, E> T.batchInsert(
         useMultiRowValues: Boolean,
         ignoreErrors: Boolean = false,
@@ -191,7 +203,7 @@ interface StatementBuilder {
         body: BatchInsertStatement.(E) -> Unit
     ): BatchInsertStatement {
         return when {
-            !useMultiRowValues -> this.batchInsert(ignoreErrors, shouldReturnGeneratedValues, body)
+            !useMultiRowValues -> batchInsert(ignoreErrors, shouldReturnGeneratedValues, body)
             currentDialect is SQLServerDialect && autoIncColumn != null -> SQLServerBatchInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
             else -> MultiRowValuesInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/StatementBuilder.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/StatementBuilder.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.exposed.v1.core.statements
 
 import org.jetbrains.exposed.v1.core.*
-import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.SQLServerDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 
@@ -191,10 +190,10 @@ interface StatementBuilder {
         shouldReturnGeneratedValues: Boolean = true,
         body: BatchInsertStatement.(E) -> Unit
     ): BatchInsertStatement {
-        return if (useMultiRowValues && currentDialect is PostgreSQLDialect) {
-            MultiRowValuesInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
-        } else {
-            batchInsert(ignoreErrors, shouldReturnGeneratedValues, body)
+        return when {
+            !useMultiRowValues -> this.batchInsert(ignoreErrors, shouldReturnGeneratedValues, body)
+            currentDialect is SQLServerDialect && autoIncColumn != null -> SQLServerBatchInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
+            else -> MultiRowValuesInsertStatement(this, ignoreErrors, shouldReturnGeneratedValues)
         }
     }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
@@ -483,30 +483,13 @@ abstract class FunctionProvider {
 
         val nextValExpression = autoIncColumn?.autoIncColumnType?.nextValExpression?.takeIf { autoIncColumn !in columns }
         val isInsertFromSelect = columns.isNotEmpty() && expr.isNotEmpty() && !expr.startsWith("VALUES")
-        val isOracle = transaction.db.dialect is OracleDialect
-        val isOracleLike = isOracle || (transaction.db.dialect as? H2Dialect)?.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
 
         val (columnsToInsert, valuesExpr) = when {
             isInsertFromSelect -> columns to expr
-            nextValExpression != null && columns.isNotEmpty() -> {
-                val multiRowValuesCount = if (!isOracleLike || !expr.startsWith("VALUES")) {
-                    0
-                } else {
-                    Regex("""\(([^)]+)\)""").findAll(expr).count()
-                }
-                val newExpr = if (multiRowValuesCount <= 1) {
-                    expr.dropLast(1) + ", $nextValExpression)"
-                } else {
-                    // Oracle requires special handling of sequence.NEXTVAL since Exposed does not map these to IDENTITY columns;
-                    // otherwise Oracle 12c+ could use INSERT ALL INTO ... INTO ... INTO ...
-                    val exprColumns = columns.joinToString { transaction.identity(it) }
-                    "SELECT DATA.*, $nextValExpression FROM ($expr) DATA($exprColumns)"
-                }
-                (columns + autoIncColumn) to newExpr
-            }
+            nextValExpression != null && columns.isNotEmpty() -> (columns + autoIncColumn) to expr.dropLast(1) + ", $nextValExpression)"
             nextValExpression != null -> listOf(autoIncColumn) to "VALUES ($nextValExpression)"
             columns.isNotEmpty() -> columns to expr
-            isOracle -> {
+            currentDialect is OracleDialect -> {
                 val oracleDefaults = table.columns.joinToString(prefix = "VALUES(", postfix = ")") { "DEFAULT" }
                 emptyList<Column<*>>() to oracleDefaults
             }
@@ -515,6 +498,30 @@ abstract class FunctionProvider {
         val columnsExpr = columnsToInsert.takeIf { it.isNotEmpty() }?.joinToString(prefix = "(", postfix = ")") { transaction.identity(it) } ?: ""
 
         return "INSERT INTO ${transaction.identity(table)} $columnsExpr $valuesExpr"
+    }
+
+    /**
+     * Returns the SQL command that inserts a new row into a table, specifically using the multi-row values syntax,
+     * like `INSERT ... VALUES (...), (...), ...`.
+     *
+     * **Note:** The `ignore` parameter is not supported by all vendors, please check the documentation.
+     *
+     * @param ignore Whether to ignore errors or not.
+     * @param table Table to insert the new row into.
+     * @param columns Columns to insert the values into.
+     * @param expr Expression with the values to insert.
+     * @param valuesSize The amount of rows included as part of the `VALUES` clause.
+     * @param transaction Transaction where the operation is executed.
+     */
+    open fun insertMultiRowValues(
+        ignore: Boolean,
+        table: Table,
+        columns: List<Column<*>>,
+        expr: String,
+        valuesSize: Int,
+        transaction: Transaction
+    ): String {
+        return insert(ignore, table, columns, expr, transaction)
     }
 
     /**

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
@@ -489,10 +489,16 @@ abstract class FunctionProvider {
         val (columnsToInsert, valuesExpr) = when {
             isInsertFromSelect -> columns to expr
             nextValExpression != null && columns.isNotEmpty() -> {
-                val multiRowValuesCount = if (!expr.startsWith("VALUES")) 0 else Regex("""\(([^)]+)\)""").findAll(expr).count()
-                val newExpr = if (multiRowValuesCount <= 1 || !isOracleLike) {
+                val multiRowValuesCount = if (!isOracleLike || !expr.startsWith("VALUES")) {
+                    0
+                } else {
+                    Regex("""\(([^)]+)\)""").findAll(expr).count()
+                }
+                val newExpr = if (multiRowValuesCount <= 1) {
                     expr.dropLast(1) + ", $nextValExpression)"
                 } else {
+                    // Oracle requires special handling of sequence.NEXTVAL since Exposed does not map these to IDENTITY columns;
+                    // otherwise Oracle 12c+ could use INSERT ALL INTO ... INTO ... INTO ...
                     val exprColumns = columns.joinToString { transaction.identity(it) }
                     "SELECT DATA.*, $nextValExpression FROM ($expr) DATA($exprColumns)"
                 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
@@ -483,13 +483,24 @@ abstract class FunctionProvider {
 
         val nextValExpression = autoIncColumn?.autoIncColumnType?.nextValExpression?.takeIf { autoIncColumn !in columns }
         val isInsertFromSelect = columns.isNotEmpty() && expr.isNotEmpty() && !expr.startsWith("VALUES")
+        val isOracle = transaction.db.dialect is OracleDialect
+        val isOracleLike = isOracle || (transaction.db.dialect as? H2Dialect)?.h2Mode == H2Dialect.H2CompatibilityMode.Oracle
 
         val (columnsToInsert, valuesExpr) = when {
             isInsertFromSelect -> columns to expr
-            nextValExpression != null && columns.isNotEmpty() -> (columns + autoIncColumn) to expr.dropLast(1) + ", $nextValExpression)"
+            nextValExpression != null && columns.isNotEmpty() -> {
+                val multiRowValuesCount = if (!expr.startsWith("VALUES")) 0 else Regex("""\(([^)]+)\)""").findAll(expr).count()
+                val newExpr = if (multiRowValuesCount <= 1 || !isOracleLike) {
+                    expr.dropLast(1) + ", $nextValExpression)"
+                } else {
+                    val exprColumns = columns.joinToString { transaction.identity(it) }
+                    "SELECT DATA.*, $nextValExpression FROM ($expr) DATA($exprColumns)"
+                }
+                (columns + autoIncColumn) to newExpr
+            }
             nextValExpression != null -> listOf(autoIncColumn) to "VALUES ($nextValExpression)"
             columns.isNotEmpty() -> columns to expr
-            currentDialect is OracleDialect -> {
+            isOracle -> {
                 val oracleDefaults = table.columns.joinToString(prefix = "VALUES(", postfix = ")") { "DEFAULT" }
                 emptyList<Column<*>>() to oracleDefaults
             }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
@@ -94,6 +94,7 @@ internal object OracleDataTypeProvider : DataTypeProvider() {
     override fun hexToDb(hexString: String): String = "HEXTORAW('$hexString')"
 }
 
+@Suppress("TooManyFunctions")
 internal object OracleFunctionProvider : FunctionProvider() {
 
     /**
@@ -253,6 +254,29 @@ internal object OracleFunctionProvider : FunctionProvider() {
             }
             append(")")
         }
+    }
+
+    override fun insertMultiRowValues(
+        ignore: Boolean,
+        table: Table,
+        columns: List<Column<*>>,
+        expr: String,
+        valuesSize: Int,
+        transaction: Transaction
+    ): String {
+        val standardInsert = insert(ignore, table, columns, expr, transaction)
+        if (valuesSize <= 1 || columns.isEmpty()) return standardInsert
+
+        val autoIncColumn = table.autoIncColumn
+        val nextValExpression = autoIncColumn?.autoIncColumnType?.nextValExpression?.takeIf { autoIncColumn !in columns }
+        if (nextValExpression == null) return standardInsert
+
+        // Oracle requires special handling of sequence.NEXTVAL since Exposed does not map these to IDENTITY columns;
+        // otherwise Oracle 12c+ could use INSERT ALL INTO ... INTO ... INTO ...
+        val exprColumns = columns.joinToString { transaction.identity(it) }
+        val newExpr = "SELECT DATA.*, $nextValExpression FROM ($expr) DATA($exprColumns)"
+
+        return "${standardInsert.substringBefore(" VALUES ")} $newExpr"
     }
 
     override fun update(

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -528,6 +528,7 @@ public class org/jetbrains/exposed/v1/jdbc/statements/MultiRowValuesInsertBlocki
 	public fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement;
 	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/Statement;
 	public fun isAlwaysBatch ()Z
+	public fun prepared (Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/jdbc/statements/api/JdbcPreparedStatementApi;
 }
 
 public class org/jetbrains/exposed/v1/jdbc/statements/ReturningBlockingExecutable : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, org/jetbrains/exposed/v1/jdbc/statements/BlockingExecutable {

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -177,9 +177,13 @@ public final class org/jetbrains/exposed/v1/jdbc/MetadataQueriesKt {
 
 public final class org/jetbrains/exposed/v1/jdbc/QueriesKt {
 	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZLkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZZLkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZLkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static final fun batchInsert (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZZLkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun batchInsert$default (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun batchReplace (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZLkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static final fun batchReplace (Lorg/jetbrains/exposed/v1/core/Table;Lkotlin/sequences/Sequence;ZLkotlin/jvm/functions/Function2;)Ljava/util/List;
 	public static synthetic fun batchReplace$default (Lorg/jetbrains/exposed/v1/core/Table;Ljava/lang/Iterable;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
@@ -515,6 +519,15 @@ public class org/jetbrains/exposed/v1/jdbc/statements/MergeBlockingExecutable : 
 	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/Statement;
 	public fun isAlwaysBatch ()Z
 	public fun prepared (Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/jdbc/statements/api/JdbcPreparedStatementApi;
+}
+
+public class org/jetbrains/exposed/v1/jdbc/statements/MultiRowValuesInsertBlockingExecutable : org/jetbrains/exposed/v1/jdbc/statements/BatchInsertBlockingExecutable {
+	public fun <init> (Lorg/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement;)V
+	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/BatchInsertStatement;
+	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/InsertStatement;
+	public fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement;
+	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/Statement;
+	public fun isAlwaysBatch ()Z
 }
 
 public class org/jetbrains/exposed/v1/jdbc/statements/ReturningBlockingExecutable : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, org/jetbrains/exposed/v1/jdbc/statements/BlockingExecutable {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Queries.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Queries.kt
@@ -309,6 +309,16 @@ fun <T : Table> T.insertReturning(
 /**
  * Represents the SQL statement that batch inserts new rows into a table.
  *
+ * A single INSERT statement will be prepared and parameterized with new bindings for each row in [data],
+ * relying entirely on the underlying driver's statement-level batching mechanisms. Certain drivers, like for
+ * MySQL and PostgreSQL, may automatically rewrite a batched statement to use the optimized multi-row values
+ * constructor syntax. This behavior is usually dependent on the value set on specific connection configuration
+ * parameters. Regardless, the Exposed logger will still represent this batching operation by logging a new
+ * INSERT SQL line per row.
+ *
+ * Alternatively, a single INSERT statement that uses multi-row values constructor for batch inserting
+ * can be created by Exposed by setting `useMultiRowValues = true`.
+ *
  * @param data Collection of values to use in the batch insert.
  * @param ignore Whether to ignore errors or not.
  * **Note** [ignore] is not supported by all vendors. Please check the documentation.
@@ -324,6 +334,23 @@ fun <T : Table, E> T.batchInsert(
     body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
+/**
+ * Represents the SQL statement that batch inserts new rows into a table, either by using a single multi-row
+ * `INSERT ... VALUES (...), (...), ...` statement, or by executing one bound statement per row.
+ *
+ * Relying on this specific INSERT syntax instead of the driver's statement-level batching mechanisms may be
+ * recommended by certain drivers for improved performance optimization.
+ *
+ * @param data Collection of values to use in the batch insert.
+ * @param useMultiRowValues Whether to return a single INSERT statement that uses multi-row values constructor,
+ * like `INSERT ... VALUES (...), (...), ...`; if `false`, a regular statement will be prepared for driver batching.
+ * @param ignore Whether to ignore errors or not.
+ * **Note** [ignore] is not supported by all vendors. Please check the documentation.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
+ * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @return A list of [ResultRow] representing data from each newly inserted row.
+ * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsert01
+ */
 fun <T : Table, E> T.batchInsert(
     data: Iterable<E>,
     useMultiRowValues: Boolean,
@@ -334,6 +361,16 @@ fun <T : Table, E> T.batchInsert(
 
 /**
  * Represents the SQL statement that batch inserts new rows into a table.
+ *
+ * A single INSERT statement will be prepared and parameterized with new bindings for each row in [data],
+ * relying entirely on the underlying driver's statement-level batching mechanisms. Certain drivers, like for
+ * MySQL and PostgreSQL, may automatically rewrite a batched statement to use the optimized multi-row values
+ * constructor syntax. This behavior is usually dependent on the value set on specific connection configuration
+ * parameters. Regardless, the Exposed logger will still represent this batching operation by logging a new
+ * INSERT SQL line per row.
+ *
+ * Alternatively, a single INSERT statement that uses multi-row values constructor for batch inserting
+ * can be created by Exposed by setting `useMultiRowValues = true`.
  *
  * @param data Sequence of values to use in the batch insert.
  * @param ignore Whether to ignore errors or not.
@@ -350,6 +387,23 @@ fun <T : Table, E> T.batchInsert(
     body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
+/**
+ * Represents the SQL statement that batch inserts new rows into a table, either by using a single multi-row
+ * `INSERT ... VALUES (...), (...), ...` statement, or by executing one bound statement per row.
+ *
+ * Relying on this specific INSERT syntax instead of the driver's statement-level batching mechanisms may be
+ * recommended by certain drivers for improved performance optimization.
+ *
+ * @param data Sequence of values to use in the batch insert.
+ * @param useMultiRowValues Whether to return a single INSERT statement that uses multi-row values constructor,
+ * like `INSERT ... VALUES (...), (...), ...`; if `false`, a regular statement will be prepared for driver batching.
+ * @param ignore Whether to ignore errors or not.
+ * **Note** [ignore] is not supported by all vendors. Please check the documentation.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
+ * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @return A list of [ResultRow] representing data from each newly inserted row.
+ * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsert01
+ */
 fun <T : Table, E> T.batchInsert(
     data: Sequence<E>,
     useMultiRowValues: Boolean,

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Queries.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Queries.kt
@@ -322,7 +322,15 @@ fun <T : Table, E> T.batchInsert(
     ignore: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
-): List<ResultRow> = batchInsert(data.iterator(), ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+
+fun <T : Table, E> T.batchInsert(
+    data: Iterable<E>,
+    useMultiRowValues: Boolean,
+    ignore: Boolean = false,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchInsertStatement.(E) -> Unit
+): List<ResultRow> = batchInsert(data.iterator(), useMultiRowValues, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
 /**
  * Represents the SQL statement that batch inserts new rows into a table.
@@ -340,15 +348,24 @@ fun <T : Table, E> T.batchInsert(
     ignore: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
-): List<ResultRow> = batchInsert(data.iterator(), ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
+
+fun <T : Table, E> T.batchInsert(
+    data: Sequence<E>,
+    useMultiRowValues: Boolean,
+    ignore: Boolean = false,
+    shouldReturnGeneratedValues: Boolean = true,
+    body: BatchInsertStatement.(E) -> Unit
+): List<ResultRow> = batchInsert(data.iterator(), useMultiRowValues, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
 private fun <T : Table, E> T.batchInsert(
     data: Iterator<E>,
+    useMultiRowValues: Boolean,
     ignoreErrors: Boolean = false,
     shouldReturnGeneratedValues: Boolean = true,
     body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> = executeBatch(data, body) {
-    val stmt = buildStatement { batchInsert(ignoreErrors, shouldReturnGeneratedValues, body) }
+    val stmt = buildStatement { batchInsert(useMultiRowValues, ignoreErrors, shouldReturnGeneratedValues, body) }
     stmt.executable()
 }
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BatchInsertBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BatchInsertBlockingExecutable.kt
@@ -5,6 +5,9 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
 import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
 import org.jetbrains.exposed.v1.core.statements.SQLServerBatchInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
+import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import java.sql.ResultSet
@@ -55,6 +58,19 @@ open class MultiRowValuesInsertBlockingExecutable(
     override val statement: MultiRowValuesInsertStatement
 ) : BatchInsertBlockingExecutable<MultiRowValuesInsertStatement>(statement) {
     override val isAlwaysBatch: Boolean = false
+
+    override fun prepared(transaction: JdbcTransaction, sql: String): JdbcPreparedStatementApi {
+        // [MariaDB] jdbc returnGeneratedValues() does not support adding RETURNING clause automatically
+        val needsManualReturning = autoIncColumns.isNotEmpty() && currentDialect is MariaDBDialect
+        return if (needsManualReturning) {
+            @OptIn(InternalApi::class)
+            val generatedColumns = autoIncColumns.map { it.name.inProperCase() }.toTypedArray()
+            val replaceReturning = "$sql RETURNING ${generatedColumns.joinToString()}"
+            transaction.connection.prepareStatement(replaceReturning, false)
+        } else {
+            super.prepared(transaction, sql)
+        }
+    }
 }
 
 @Suppress("Unchecked_Cast")

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BatchInsertBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BatchInsertBlockingExecutable.kt
@@ -61,7 +61,9 @@ open class MultiRowValuesInsertBlockingExecutable(
 
     override fun prepared(transaction: JdbcTransaction, sql: String): JdbcPreparedStatementApi {
         // [MariaDB] jdbc returnGeneratedValues() does not support adding RETURNING clause automatically
-        val needsManualReturning = autoIncColumns.isNotEmpty() && currentDialect is MariaDBDialect
+        val needsManualReturning = statement.shouldReturnGeneratedValues &&
+            autoIncColumns.isNotEmpty() &&
+            currentDialect is MariaDBDialect
         return if (needsManualReturning) {
             @OptIn(InternalApi::class)
             val generatedColumns = autoIncColumns.map { it.name.inProperCase() }.toTypedArray()

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BatchInsertBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BatchInsertBlockingExecutable.kt
@@ -3,6 +3,7 @@ package org.jetbrains.exposed.v1.jdbc.statements
 import org.jetbrains.exposed.v1.core.InternalApi
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
+import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
 import org.jetbrains.exposed.v1.core.statements.SQLServerBatchInsertStatement
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
@@ -46,10 +47,21 @@ open class SQLServerBatchInsertBlockingExecutable(
     }
 }
 
+/**
+ * Represents the execution logic for an SQL statement that batch inserts new rows into a table,
+ * specifically using a single multi-row value INSERT statement.
+ */
+open class MultiRowValuesInsertBlockingExecutable(
+    override val statement: MultiRowValuesInsertStatement
+) : BatchInsertBlockingExecutable<MultiRowValuesInsertStatement>(statement) {
+    override val isAlwaysBatch: Boolean = false
+}
+
 @Suppress("Unchecked_Cast")
 internal fun <S : BatchInsertStatement> S.executable(): BatchInsertBlockingExecutable<S> {
     return when (this) {
         is SQLServerBatchInsertStatement -> SQLServerBatchInsertBlockingExecutable(this)
+        is MultiRowValuesInsertStatement -> MultiRowValuesInsertBlockingExecutable(this)
         else -> BatchInsertBlockingExecutable(this)
     } as BatchInsertBlockingExecutable<S>
 }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BlockingExecutable.kt
@@ -103,6 +103,7 @@ fun <T : Any, S : Statement<T>> S.toExecutable(): BlockingExecutable<T, S> {
         is BatchUpsertStatement -> BatchUpsertBlockingExecutable(this)
         is UpsertStatement<*> -> UpsertBlockingExecutable(this as UpsertStatement<T>)
         is SQLServerBatchInsertStatement -> SQLServerBatchInsertBlockingExecutable(this)
+        is MultiRowValuesInsertStatement -> MultiRowValuesInsertBlockingExecutable(this)
         is BatchInsertStatement -> BatchInsertBlockingExecutable(this)
         is InsertStatement<*> -> InsertBlockingExecutable(this as InsertStatement<T>)
         is BatchUpdateStatement -> BatchUpdateBlockingExecutable(this)

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
@@ -69,18 +69,9 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
             transaction.connection.prepareStatement(sql, true)
 
         autoIncColumns.isNotEmpty() -> {
-            // [MariaDB] jdbc returnGeneratedValues() does not support adding RETURNING clause to multi-row values insert, so it only returns key for first row
-            val needsManualReturning = (statement is MultiRowValuesInsertStatement) && currentDialect is MariaDBDialect
-
+            // http://viralpatel.net/blogs/oracle-java-jdbc-get-primary-key-insert-sql/
             @OptIn(InternalApi::class)
-            val generatedColumns = autoIncColumns.map { it.name.inProperCase() }.toTypedArray()
-            if (needsManualReturning) {
-                val replaceReturning = "$sql RETURNING ${generatedColumns.joinToString()}"
-                transaction.connection.prepareStatement(replaceReturning, false)
-            } else {
-                // http://viralpatel.net/blogs/oracle-java-jdbc-get-primary-key-insert-sql/
-                transaction.connection.prepareStatement(sql, generatedColumns)
-            }
+            transaction.connection.prepareStatement(sql, autoIncColumns.map { it.name.inProperCase() }.toTypedArray())
         }
 
         else -> transaction.connection.prepareStatement(sql, false)

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
@@ -27,15 +27,32 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
      */
     private var affectedRowCounts: List<Int>? = null
 
-    @Suppress("MagicNumber")
-    private val mariaDBResult = -99
+    /**
+     * Number of rows affected, only set if the statement returns a `ResultSet` that is actively processed.
+     * When the `ResultSet` is iterated over, this property will be set with either a manual count of the result set rows,
+     * or the affected row count returned by `executeUpdate()` or `executeBatch()`.
+     */
+    private var processedAffectedRowCount: Int? = null
 
     protected open fun JdbcPreparedStatementApi.execInsertFunction(): Pair<Int, ResultSet?> {
         val inserted = if (statement.arguments().count() > 1 || isAlwaysBatch) {
             executeBatch().also { affectedRowCounts = it }.sum()
-        } else if (statement is MultiRowValuesInsertStatement && currentDialect is MariaDBDialect && autoIncColumns.isNotEmpty()) {
-            executeQuery()
-            mariaDBResult
+        } else if (
+            (statement as? MultiRowValuesInsertStatement)?.shouldReturnGeneratedValues == true &&
+            autoIncColumns.isNotEmpty() &&
+            currentDialect is MariaDBDialect
+        ) {
+            executeQuery().also {
+                // since MariaDB in this case must return a ResultSet (empty or not),
+                // Exposed must process it early to return a non-null (or non-placeholder) Int value
+                @OptIn(InternalApi::class)
+                statement.resultedValues = processResults(it.result, null)
+                statement.insertedCount = statement.resultedValues?.size ?: 0
+                it.result.close()
+            }
+            // because the ResultSet is processed early, it is also closed early;
+            // so nothing will be returned, to prevent attempts to read the ResultSet after cursor already moved to end.
+            return statement.insertedCount to null
         } else {
             executeUpdate()
         }
@@ -53,8 +70,10 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
         val (inserted, rs) = execInsertFunction()
         @OptIn(InternalApi::class)
         return inserted.apply {
-            statement.resultedValues = processResults(rs, this)
-            statement.insertedCount = if (this != mariaDBResult) this else statement.resultedValues?.size ?: 0
+            if (statement.resultedValues == null) {
+                statement.insertedCount = this
+                statement.resultedValues = processResults(rs, this)
+            }
             rs?.close()
         }
     }
@@ -91,11 +110,16 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
             }
         }
 
-    private fun processResults(rs: ResultSet?, inserted: Int): List<ResultRow> {
+    private fun processResults(rs: ResultSet?, inserted: Int?): List<ResultRow> {
         val allResultSetsValues = rs?.returnedValues(inserted)
 
+        // parameter 'inserted' will only be null when executeQuery() was called for INSERT;
+        // in which case returnedValues() will have performed a manual count (if a non-empty result set was used)
+        // and passed this count to processedAffectedRowCount by now.
+        val insertedToUse = inserted ?: processedAffectedRowCount ?: 0
+
         @Suppress("UNCHECKED_CAST")
-        return statement.arguments!!.insertedOnly(inserted, affectedRowCounts)
+        return statement.arguments!!.insertedOnly(insertedToUse, affectedRowCounts)
             // Join the values from ResultSet with arguments
             .mapIndexed { index, columnValues ->
                 val resultSetValues = allResultSetsValues?.getOrNull(index) ?: hashMapOf()
@@ -148,8 +172,11 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
     }
 
     @Suppress("NestedBlockDepth", "TooGenericExceptionCaught")
-    private fun ResultSet.returnedValues(inserted: Int): ArrayList<MutableMap<Column<*>, Any?>> {
+    private fun ResultSet.returnedValues(inserted: Int?): ArrayList<MutableMap<Column<*>, Any?>> {
         if (inserted == 0) return arrayListOf()
+        // parameter 'inserted' will only be null when executeQuery() was called for INSERT;
+        // since default ResultSet is not scrollable, the affected row count can only be attained during processing
+        var processedInserted = inserted ?: 0
 
         val resultSetsValues = arrayListOf<MutableMap<Column<*>, Any?>>()
 
@@ -166,6 +193,8 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
                         returnedValues[firstAutoIncColumn] = getObject(1)
                     }
                     resultSetsValues.add(returnedValues)
+                    // local var should only ever be incremented if argument provided to method was null (i.e. result of executeQuery)
+                    if (inserted == null) processedInserted++
                 } catch (cause: ArrayIndexOutOfBoundsException) {
                     // EXPOSED-191 Flaky Oracle test on TC build
                     // this try/catch should help to get information about the flaky test.
@@ -190,12 +219,12 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
                 }
             }
 
-            if (inserted > 1 && firstAutoIncColumn != null && resultSetsValues.isNotEmpty() && !currentDialect.supportsMultipleGeneratedKeys) {
+            if (processedInserted > 1 && firstAutoIncColumn != null && resultSetsValues.isNotEmpty() && !currentDialect.supportsMultipleGeneratedKeys) {
                 // H2/SQLite only returns one last generated key...
                 (resultSetsValues[0][firstAutoIncColumn] as? Number)?.toLong()?.let {
                     var id = it
 
-                    while (resultSetsValues.size < inserted) {
+                    while (resultSetsValues.size < processedInserted) {
                         id -= 1
                         resultSetsValues.add(0, mutableMapOf(firstAutoIncColumn to id))
                     }
@@ -203,11 +232,13 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
             }
 
             assert(
-                this@InsertBlockingExecutable.statement.isIgnore || resultSetsValues.isEmpty() || resultSetsValues.size == inserted ||
+                this@InsertBlockingExecutable.statement.isIgnore || resultSetsValues.isEmpty() || resultSetsValues.size == processedInserted ||
                     currentDialect.supportsTernaryAffectedRowValues
             ) {
-                "Number of autoincs (${resultSetsValues.size}) doesn't match number of batch entries ($inserted)"
+                "Number of autoincs (${resultSetsValues.size}) doesn't match number of batch entries ($processedInserted)"
             }
+
+            processedAffectedRowCount = processedInserted
         }
 
         return resultSetsValues

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/InsertBlockingExecutable.kt
@@ -3,6 +3,8 @@ package org.jetbrains.exposed.v1.jdbc.statements
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
 import org.jetbrains.exposed.v1.core.statements.InsertStatement
+import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
@@ -25,9 +27,15 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
      */
     private var affectedRowCounts: List<Int>? = null
 
+    @Suppress("MagicNumber")
+    private val mariaDBResult = -99
+
     protected open fun JdbcPreparedStatementApi.execInsertFunction(): Pair<Int, ResultSet?> {
         val inserted = if (statement.arguments().count() > 1 || isAlwaysBatch) {
             executeBatch().also { affectedRowCounts = it }.sum()
+        } else if (statement is MultiRowValuesInsertStatement && currentDialect is MariaDBDialect && autoIncColumns.isNotEmpty()) {
+            executeQuery()
+            mariaDBResult
         } else {
             executeUpdate()
         }
@@ -45,8 +53,8 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
         val (inserted, rs) = execInsertFunction()
         @OptIn(InternalApi::class)
         return inserted.apply {
-            statement.insertedCount = this
             statement.resultedValues = processResults(rs, this)
+            statement.insertedCount = if (this != mariaDBResult) this else statement.resultedValues?.size ?: 0
             rs?.close()
         }
     }
@@ -61,9 +69,18 @@ open class InsertBlockingExecutable<Key : Any, S : InsertStatement<Key>>(
             transaction.connection.prepareStatement(sql, true)
 
         autoIncColumns.isNotEmpty() -> {
-            // http://viralpatel.net/blogs/oracle-java-jdbc-get-primary-key-insert-sql/
+            // [MariaDB] jdbc returnGeneratedValues() does not support adding RETURNING clause to multi-row values insert, so it only returns key for first row
+            val needsManualReturning = (statement is MultiRowValuesInsertStatement) && currentDialect is MariaDBDialect
+
             @OptIn(InternalApi::class)
-            transaction.connection.prepareStatement(sql, autoIncColumns.map { it.name.inProperCase() }.toTypedArray())
+            val generatedColumns = autoIncColumns.map { it.name.inProperCase() }.toTypedArray()
+            if (needsManualReturning) {
+                val replaceReturning = "$sql RETURNING ${generatedColumns.joinToString()}"
+                transaction.connection.prepareStatement(replaceReturning, false)
+            } else {
+                // http://viralpatel.net/blogs/oracle-java-jdbc-get-primary-key-insert-sql/
+                transaction.connection.prepareStatement(sql, generatedColumns)
+            }
         }
 
         else -> transaction.connection.prepareStatement(sql, false)

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -15,9 +15,8 @@ import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.java.javaUUID
-import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
-import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
@@ -41,7 +40,6 @@ import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.fail
@@ -209,18 +207,21 @@ class InsertTests : R2dbcDatabaseTestsBase() {
     }
 
     @Test
-    fun testBatchInsertUsingMultiRowValue() {
-        withCitiesAndUsers { cities, _, _ ->
+    fun testBatchInsertUsingMultiRowValues() {
+        withCitiesAndUsers { cities, users, _ ->
             val logCaptor = LogCaptor.forName(exposedLogger.name)
             logCaptor.setLogLevelToDebug()
 
-            val cityNames = listOf("Paris", "Moscow", "Helsinki")
             // Oracle driver tries to append RETURNING if keys must be generated, which is not compatible with any table value constructor syntax;
-            // MySQL does not allow RETURNING clause
+            // MySQL does not allow RETURNING clause & only ever retrieves first generated key
+            val dialect = currentDialectTest
+            val canReturnKeys = dialect !is OracleDialect && (dialect !is MysqlDialect || dialect is MariaDBDialect)
+
+            val cityNames = listOf("Paris", "Moscow", "Helsinki")
             val allCitiesID = cities.batchInsert(
                 cityNames,
                 useMultiRowValues = true,
-                shouldReturnGeneratedValues = currentDialectTest !is OracleDialect && currentDialectTest !is MysqlDialect
+                shouldReturnGeneratedValues = canReturnKeys,
             ) { name ->
                 this[cities.name] = name
             }
@@ -233,6 +234,28 @@ class InsertTests : R2dbcDatabaseTestsBase() {
             logCaptor.clearLogs()
             logCaptor.resetLogLevel()
             logCaptor.close()
+
+            // now make sure the generated keys were returned properly even with the new syntax
+            if (canReturnKeys) {
+                val userNamesWithCityIds = allCitiesID.mapIndexed { index, id ->
+                    "UserFrom${cityNames[index]}" to id[cities.id] as Number
+                }
+
+                val generatedIds = users.batchInsert(
+                    userNamesWithCityIds,
+                    useMultiRowValues = true,
+                ) { (userName, cityId) ->
+                    this[users.id] = java.util.Random().nextInt().toString().take(6)
+                    this[users.name] = userName
+                    this[users.cityId] = cityId.toInt()
+                }
+
+                assertEquals(userNamesWithCityIds.size, generatedIds.size)
+                assertEquals(
+                    userNamesWithCityIds.size.toLong(),
+                    users.selectAll().where { users.name inList userNamesWithCityIds.map { it.first } }.count()
+                )
+            }
         }
     }
 
@@ -319,30 +342,6 @@ class InsertTests : R2dbcDatabaseTestsBase() {
         statement.addBatch()
         assertDoesNotThrow("Removing the only batch should not restore values from empty data") {
             statement.removeLastBatch()
-        }
-    }
-
-    @Test
-    fun testPostgreSQLBatchInsertRejectsBatchExceedingParameterLimit() {
-        // DMLTestsData.Cities has 2 columns, so the 65535 PostgreSQL bind-parameter limit
-        // is exceeded once more than 32767 rows are batched.
-        // validateLastBatch() requires a transaction in context, but the statement is never executed.
-        withTables(DMLTestsData.Cities) {
-            val statement = MultiRowValuesInsertStatement(DMLTestsData.Cities)
-
-            repeat(32767) {
-                statement[DMLTestsData.Cities.name] = "City$it"
-                statement.addBatch()
-            }
-            assertDoesNotThrow("Batch at the parameter limit should not throw") {
-                statement[DMLTestsData.Cities.name] = "City32767"
-                statement.addBatch()
-            }
-
-            assertFailsWith<BatchDataInconsistentException>("Batch exceeding the parameter limit should throw") {
-                statement[DMLTestsData.Cities.name] = "OneRowTooMany"
-                statement.addBatch()
-            }
         }
     }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -39,7 +39,9 @@ import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.fail
@@ -193,7 +195,7 @@ class InsertTests : R2dbcDatabaseTestsBase() {
             }
 
             val generatedIds = users.batchInsert(userNamesWithCityIds) { (userName, cityId) ->
-                this[users.id] = java.util.Random().nextInt().toString().take(6)
+                this[users.id] = userName.substringAfter("UserFrom")
                 this[users.name] = userName
                 this[users.cityId] = cityId.toInt()
             }
@@ -208,6 +210,8 @@ class InsertTests : R2dbcDatabaseTestsBase() {
 
     @Test
     fun testBatchInsertUsingMultiRowValues() {
+        fun String.trimOracleSyntax(): String = if (currentTestDB in TestDB.ALL_ORACLE_LIKE) substringBefore(") DATA(\"name\")") else this
+
         withCitiesAndUsers { cities, users, _ ->
             val logCaptor = LogCaptor.forName(exposedLogger.name)
             logCaptor.setLogLevelToDebug()
@@ -218,7 +222,7 @@ class InsertTests : R2dbcDatabaseTestsBase() {
             val canReturnKeys = dialect !is OracleDialect && (dialect !is MysqlDialect || dialect is MariaDBDialect)
 
             val cityNames = listOf("Paris", "Moscow", "Helsinki")
-            val allCitiesID = cities.batchInsert(
+            val allCities = cities.batchInsert(
                 cityNames,
                 useMultiRowValues = true,
                 shouldReturnGeneratedValues = canReturnKeys,
@@ -226,10 +230,13 @@ class InsertTests : R2dbcDatabaseTestsBase() {
                 this[cities.name] = name
             }
 
-            assertEquals(cityNames.size, allCitiesID.size)
+            assertEquals(cityNames.size, allCities.size)
             val insertLogs = logCaptor.debugLogs.filter { it.startsWith("INSERT ", ignoreCase = true) }
             assertEquals(1, insertLogs.size, "Expected a single collapsed multi-row INSERT, got: $insertLogs")
-            assertTrue(insertLogs.single().count { it == '(' } >= cityNames.size + 1)
+            assertEquals(
+                cityNames.joinToString { "('$it')" },
+                insertLogs.single().substringAfter("VALUES").trim().trimOracleSyntax()
+            )
 
             logCaptor.clearLogs()
             logCaptor.resetLogLevel()
@@ -237,7 +244,7 @@ class InsertTests : R2dbcDatabaseTestsBase() {
 
             // now make sure the generated keys were returned properly even with the new syntax
             if (canReturnKeys) {
-                val userNamesWithCityIds = allCitiesID.mapIndexed { index, id ->
+                val userNamesWithCityIds = allCities.mapIndexed { index, id ->
                     "UserFrom${cityNames[index]}" to id[cities.id] as Number
                 }
 
@@ -245,7 +252,7 @@ class InsertTests : R2dbcDatabaseTestsBase() {
                     userNamesWithCityIds,
                     useMultiRowValues = true,
                 ) { (userName, cityId) ->
-                    this[users.id] = java.util.Random().nextInt().toString().take(6)
+                    this[users.id] = userName.substringAfter("UserFrom")
                     this[users.name] = userName
                     this[users.cityId] = cityId.toInt()
                 }
@@ -256,6 +263,44 @@ class InsertTests : R2dbcDatabaseTestsBase() {
                     users.selectAll().where { users.name inList userNamesWithCityIds.map { it.first } }.count()
                 )
             }
+        }
+    }
+
+    @Test
+    fun testBatchInsertWithoutGeneratedValues() {
+        withCitiesAndUsers { cities, _, _ ->
+            val cityNames = listOf("Paris", "Moscow", "Helsinki")
+            val allCities = cities.batchInsert(
+                cityNames,
+                shouldReturnGeneratedValues = false,
+            ) { name ->
+                this[cities.name] = name
+            }
+
+            assertEquals(cityNames.size, allCities.size)
+            // Stored InsertStatement (batched results) will only hold client-side provided row results
+            assertEqualLists(allCities.map { it[cities.name] }, cityNames)
+            val exception1 = assertFailsWith<IllegalStateException> {
+                allCities.map { it[cities.id] }
+            }
+            assertContains(exception1.message.orEmpty(), "not in record set")
+
+            val moreCityNames = listOf("Berlin", "Amsterdam")
+            val moreCities = cities.batchInsert(
+                moreCityNames,
+                useMultiRowValues = true,
+                shouldReturnGeneratedValues = false,
+            ) { name ->
+                this[cities.name] = name
+            }
+
+            assertEquals(moreCityNames.size, moreCities.size)
+            // Stored InsertStatement (multi-row values result) will only hold client-side provided row results
+            assertEqualLists(moreCities.map { it[cities.name] }, moreCityNames)
+            val exception2 = assertFailsWith<IllegalStateException> {
+                moreCities.map { it[cities.id] }
+            }
+            assertContains(exception2.message.orEmpty(), "not in record set")
         }
     }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/InsertTests.kt
@@ -18,6 +18,8 @@ import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
 import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
+import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.datetime.CurrentTimestamp
 import org.jetbrains.exposed.v1.datetime.XCurrentTimestamp
@@ -27,6 +29,7 @@ import org.jetbrains.exposed.v1.r2dbc.*
 import org.jetbrains.exposed.v1.r2dbc.statements.toExecutable
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.tests.currentDialectTest
 import org.jetbrains.exposed.v1.r2dbc.tests.currentTestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
@@ -206,13 +209,19 @@ class InsertTests : R2dbcDatabaseTestsBase() {
     }
 
     @Test
-    fun testBatchInsertUsesSingleMultiRowStatementForPostgreSQL() {
-        withCitiesAndUsers(exclude = TestDB.ALL - TestDB.POSTGRESQL) { cities, _, _ ->
+    fun testBatchInsertUsingMultiRowValue() {
+        withCitiesAndUsers { cities, _, _ ->
             val logCaptor = LogCaptor.forName(exposedLogger.name)
             logCaptor.setLogLevelToDebug()
 
             val cityNames = listOf("Paris", "Moscow", "Helsinki")
-            val allCitiesID = cities.batchInsert(cityNames, useMultiRowValues = true) { name ->
+            // Oracle driver tries to append RETURNING if keys must be generated, which is not compatible with any table value constructor syntax;
+            // MySQL does not allow RETURNING clause
+            val allCitiesID = cities.batchInsert(
+                cityNames,
+                useMultiRowValues = true,
+                shouldReturnGeneratedValues = currentDialectTest !is OracleDialect && currentDialectTest !is MysqlDialect
+            ) { name ->
                 this[cities.name] = name
             }
 

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -732,6 +732,7 @@ public class org/jetbrains/exposed/v1/r2dbc/statements/MultiRowValuesInsertSuspe
 	public fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/MultiRowValuesInsertStatement;
 	public synthetic fun getStatement ()Lorg/jetbrains/exposed/v1/core/statements/Statement;
 	public fun isAlwaysBatch ()Z
+	public fun prepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl : org/jetbrains/exposed/v1/r2dbc/statements/api/R2dbcExposedConnection {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Queries.kt
@@ -302,6 +302,13 @@ fun <T : Table> T.insertReturning(
 /**
  * Represents the SQL statement that batch inserts new rows into a table.
  *
+ * A single INSERT statement will be prepared and parameterized with new bindings for each row in [data],
+ * relying entirely on the underlying driver's statement-level batching mechanisms. The Exposed logger will still
+ * represent this batching operation by logging a new INSERT SQL line per row.
+ *
+ * Alternatively, a single INSERT statement that uses multi-row values constructor for batch inserting
+ * can be created by Exposed by setting `useMultiRowValues = true`.
+ *
  * **Note:** On most databases, a batch with [ignore] enabled that inserts only some of its rows returns only the rows
  * that were successfully inserted. However, on H2 and MariaDB, such a batch returns a row for every value in [data]
  * rather than only the inserted ones, and pairs the values the database generated with the wrong rows. This occurs
@@ -314,10 +321,6 @@ fun <T : Table> T.insertReturning(
  * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
  * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
  * @return A list of [ResultRow] representing data from each newly inserted row.
- *
- * **Note** Against PostgreSQL, the batch is sent as a single multi-row `INSERT ... VALUES (...), (...), ...`
- * statement instead of one bound statement per row, avoiding the per-row round trip that r2dbc-postgresql
- * otherwise performs for statement-level batches.
  * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsert01
  */
 suspend fun <T : Table, E> T.batchInsert(
@@ -327,6 +330,30 @@ suspend fun <T : Table, E> T.batchInsert(
     body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
+/**
+ * Represents the SQL statement that batch inserts new rows into a table, either by using a single multi-row
+ * `INSERT ... VALUES (...), (...), ...` statement, or by executing one bound statement per row.
+ *
+ * Relying on this specific INSERT syntax instead of the driver's statement-level batching mechanisms may be
+ * recommended by certain drivers for improved performance optimization. Some databases, like Oracle and MySQL, may
+ * not support returning multiple generated key values when this insert syntax is used.
+ *
+ * **Note:** On most databases, a batch with [ignore] enabled that inserts only some of its rows returns only the rows
+ * that were successfully inserted. However, on H2 and MariaDB, such a batch returns a row for every value in [data]
+ * rather than only the inserted ones, and pairs the values the database generated with the wrong rows. This occurs
+ * because their drivers report no update count per statement, leaving nothing to tell the skipped rows apart by.
+ * Any batch that inserts no rows at all returns an empty list on every database.
+ *
+ * @param data Collection of values to use in the batch insert.
+ * @param useMultiRowValues Whether to return a single INSERT statement that uses multi-row values constructor,
+ * like `INSERT ... VALUES (...), (...), ...`; if `false`, a regular statement will be prepared for driver batching.
+ * @param ignore Whether to ignore errors or not.
+ * **Note** [ignore] is not supported by all vendors. Please check the documentation.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
+ * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @return A list of [ResultRow] representing data from each newly inserted row.
+ * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsert01
+ */
 suspend fun <T : Table, E> T.batchInsert(
     data: Iterable<E>,
     useMultiRowValues: Boolean,
@@ -337,6 +364,13 @@ suspend fun <T : Table, E> T.batchInsert(
 
 /**
  * Represents the SQL statement that batch inserts new rows into a table.
+ *
+ * A single INSERT statement will be prepared and parameterized with new bindings for each row in [data],
+ * relying entirely on the underlying driver's statement-level batching mechanisms. The Exposed logger will still
+ * represent this batching operation by logging a new INSERT SQL line per row.
+ *
+ * Alternatively, a single INSERT statement that uses multi-row values constructor for batch inserting
+ * can be created by Exposed by setting `useMultiRowValues = true`.
  *
  * **Note:** On most databases, a batch with [ignore] enabled that inserts only some of its rows returns only the rows
  * that were successfully inserted. However, on H2 and MariaDB, such a batch returns a row for every value in [data]
@@ -350,11 +384,6 @@ suspend fun <T : Table, E> T.batchInsert(
  * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
  * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
  * @return A list of [ResultRow] representing data from each newly inserted row.
- *
- * **Note** Against PostgreSQL, the batch is sent as a single multi-row `INSERT ... VALUES (...), (...), ...`
- * statement instead of one bound statement per row, avoiding the per-row round trip that r2dbc-postgresql
- * otherwise performs for statement-level batches (see
- * [pgjdbc/r2dbc-postgresql#527](https://github.com/pgjdbc/r2dbc-postgresql/issues/527)).
  * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsertWithSequence
  */
 suspend fun <T : Table, E> T.batchInsert(
@@ -364,6 +393,30 @@ suspend fun <T : Table, E> T.batchInsert(
     body: BatchInsertStatement.(E) -> Unit
 ): List<ResultRow> = batchInsert(data.iterator(), false, ignoreErrors = ignore, shouldReturnGeneratedValues, body)
 
+/**
+ * Represents the SQL statement that batch inserts new rows into a table, either by using a single multi-row
+ * `INSERT ... VALUES (...), (...), ...` statement, or by executing one bound statement per row.
+ *
+ * Relying on this specific INSERT syntax instead of the driver's statement-level batching mechanisms may be
+ * recommended by certain drivers for improved performance optimization. Some databases, like Oracle and MySQL, may
+ * not support returning multiple generated key values when this insert syntax is used.
+ *
+ * **Note:** On most databases, a batch with [ignore] enabled that inserts only some of its rows returns only the rows
+ * that were successfully inserted. However, on H2 and MariaDB, such a batch returns a row for every value in [data]
+ * rather than only the inserted ones, and pairs the values the database generated with the wrong rows. This occurs
+ * because their drivers report no update count per statement, leaving nothing to tell the skipped rows apart by.
+ * Any batch that inserts no rows at all returns an empty list on every database.
+ *
+ * @param data Sequence of values to use in the batch insert.
+ * @param useMultiRowValues Whether to return a single INSERT statement that uses multi-row values constructor,
+ * like `INSERT ... VALUES (...), (...), ...`; if `false`, a regular statement will be prepared for driver batching.
+ * @param ignore Whether to ignore errors or not.
+ * **Note** [ignore] is not supported by all vendors. Please check the documentation.
+ * @param shouldReturnGeneratedValues Specifies whether newly generated values (for example, auto-incremented IDs)
+ * should be returned. See [Batch Insert](https://github.com/JetBrains/Exposed/wiki/DSL#batch-insert) for more details.
+ * @return A list of [ResultRow] representing data from each newly inserted row.
+ * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertTests.testBatchInsert01
+ */
 suspend fun <T : Table, E> T.batchInsert(
     data: Sequence<E>,
     useMultiRowValues: Boolean,

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
@@ -5,6 +5,9 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
 import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
 import org.jetbrains.exposed.v1.core.statements.SQLServerBatchInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
+import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcPreparedStatementApi
 import org.jetbrains.exposed.v1.r2dbc.statements.api.R2dbcResult
@@ -57,6 +60,19 @@ open class MultiRowValuesInsertSuspendExecutable(
     override val statement: MultiRowValuesInsertStatement
 ) : BatchInsertSuspendExecutable<MultiRowValuesInsertStatement>(statement) {
     override val isAlwaysBatch: Boolean = false
+
+    override suspend fun prepared(transaction: R2dbcTransaction, sql: String): R2dbcPreparedStatementApi {
+        // [MariaDB] r2dbc returnGeneratedValues() does not support adding RETURNING clause automatically
+        val needsManualReturning = autoIncColumns.isNotEmpty() && currentDialect is MariaDBDialect
+        return if (needsManualReturning) {
+            @OptIn(InternalApi::class)
+            val generatedColumns = autoIncColumns.map { it.name.inProperCase() }.toTypedArray()
+            val replaceReturning = "$sql RETURNING ${generatedColumns.joinToString()}"
+            transaction.connection().prepareStatement(replaceReturning, false)
+        } else {
+            super.prepared(transaction, sql)
+        }
+    }
 }
 
 @Suppress("Unchecked_Cast")

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
@@ -63,7 +63,9 @@ open class MultiRowValuesInsertSuspendExecutable(
 
     override suspend fun prepared(transaction: R2dbcTransaction, sql: String): R2dbcPreparedStatementApi {
         // [MariaDB] r2dbc returnGeneratedValues() does not support adding RETURNING clause automatically
-        val needsManualReturning = autoIncColumns.isNotEmpty() && currentDialect is MariaDBDialect
+        val needsManualReturning = statement.shouldReturnGeneratedValues &&
+            autoIncColumns.isNotEmpty() &&
+            currentDialect is MariaDBDialect
         return if (needsManualReturning) {
             @OptIn(InternalApi::class)
             val generatedColumns = autoIncColumns.map { it.name.inProperCase() }.toTypedArray()

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/BatchInsertSuspendExecutable.kt
@@ -51,7 +51,7 @@ open class SQLServerBatchInsertSuspendExecutable(
 
 /**
  * Represents the execution logic for an SQL statement that batch inserts new rows into a table,
- * specifically for the PostgreSQL database, using a single multi-row INSERT statement.
+ * specifically using a single multi-row value INSERT statement.
  */
 open class MultiRowValuesInsertSuspendExecutable(
     override val statement: MultiRowValuesInsertStatement

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
+import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.dao.IntEntity
 import org.jetbrains.exposed.v1.dao.IntEntityClass
@@ -23,6 +24,7 @@ import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
 import org.jetbrains.exposed.v1.tests.MISSING_R2DBC_TEST
 import org.jetbrains.exposed.v1.tests.NOT_APPLICABLE_TO_R2DBC
 import org.jetbrains.exposed.v1.tests.TestDB
+import org.jetbrains.exposed.v1.tests.currentDialectTest
 import org.jetbrains.exposed.v1.tests.currentTestDB
 import org.jetbrains.exposed.v1.tests.shared.assertEqualLists
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
@@ -200,6 +202,37 @@ class InsertTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testBatchInsertUsingMultiRowValue() {
+        withCitiesAndUsers { cities, users, _ ->
+            val cityNames = listOf("Paris", "Moscow", "Helsinki")
+
+            // Oracle driver tries to append RETURNING if keys must be generated, which is not compatible with any table value constructor syntax
+            val allCitiesID = cities.batchInsert(cityNames, useMultiRowValues = true, shouldReturnGeneratedValues = currentDialectTest !is OracleDialect) { name ->
+                this[cities.name] = name
+            }
+            assertEquals(cityNames.size, allCitiesID.size)
+
+            if (currentDialectTest !is OracleDialect) {
+                val userNamesWithCityIds = allCitiesID.mapIndexed { index, id ->
+                    "UserFrom${cityNames[index]}" to id[cities.id] as Number
+                }
+
+                val generatedIds = users.batchInsert(userNamesWithCityIds, useMultiRowValues = true) { (userName, cityId) ->
+                    this[users.id] = java.util.Random().nextInt().toString().take(6)
+                    this[users.name] = userName
+                    this[users.cityId] = cityId.toInt()
+                }
+
+                assertEquals(userNamesWithCityIds.size, generatedIds.size)
+                assertEquals(
+                    userNamesWithCityIds.size.toLong(),
+                    users.selectAll().where { users.name inList userNamesWithCityIds.map { it.first } }.count()
+                )
+            }
+        }
+    }
+
+    @Test
     fun testBatchInsertWithSequence() {
         val cities = DMLTestsData.Cities
         withTables(cities) {
@@ -217,7 +250,7 @@ class InsertTests : DatabaseTestsBase() {
         val cities = DMLTestsData.Cities
         withTables(cities) {
             val names = emptySequence<String>()
-            cities.batchInsert(names) { name -> this[cities.name] = name }
+            cities.batchInsert(names, useMultiRowValues = true) { name -> this[cities.name] = name }
 
             val batchesSize = cities.selectAll().count()
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.sql.SQLException
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -193,7 +194,7 @@ class InsertTests : DatabaseTestsBase() {
             }
 
             val generatedIds = users.batchInsert(userNamesWithCityIds) { (userName, cityId) ->
-                this[users.id] = java.util.Random().nextInt().toString().take(6)
+                this[users.id] = userName.substringAfter("UserFrom")
                 this[users.name] = userName
                 this[users.cityId] = cityId.toInt()
             }
@@ -208,6 +209,8 @@ class InsertTests : DatabaseTestsBase() {
 
     @Test
     fun testBatchInsertUsingMultiRowValues() {
+        fun String.trimOracleSyntax(): String = if (currentTestDB in TestDB.ALL_ORACLE_LIKE) substringBefore(") DATA(\"name\")") else this
+
         withCitiesAndUsers { cities, users, _ ->
             val logCaptor = LogCaptor.forName(exposedLogger.name)
             logCaptor.setLogLevelToDebug()
@@ -216,7 +219,7 @@ class InsertTests : DatabaseTestsBase() {
             val canReturnKeys = currentDialectTest !is OracleDialect
 
             val cityNames = listOf("Paris", "Moscow", "Helsinki")
-            val allCitiesID = cities.batchInsert(
+            val allCities = cities.batchInsert(
                 cityNames,
                 useMultiRowValues = true,
                 shouldReturnGeneratedValues = canReturnKeys,
@@ -224,10 +227,13 @@ class InsertTests : DatabaseTestsBase() {
                 this[cities.name] = name
             }
 
-            assertEquals(cityNames.size, allCitiesID.size)
+            assertEquals(cityNames.size, allCities.size)
             val insertLogs = logCaptor.debugLogs.filter { it.startsWith("INSERT ", ignoreCase = true) }
             assertEquals(1, insertLogs.size, "Expected a single collapsed multi-row INSERT, got: $insertLogs")
-            assertTrue(insertLogs.single().count { it == '(' } >= cityNames.size + 1)
+            assertEquals(
+                cityNames.joinToString { "('$it')" },
+                insertLogs.single().substringAfter("VALUES").trim().trimOracleSyntax()
+            )
 
             logCaptor.clearLogs()
             logCaptor.resetLogLevel()
@@ -235,7 +241,7 @@ class InsertTests : DatabaseTestsBase() {
 
             // now make sure the generated keys were returned properly even with the new syntax
             if (canReturnKeys) {
-                val userNamesWithCityIds = allCitiesID.mapIndexed { index, id ->
+                val userNamesWithCityIds = allCities.mapIndexed { index, id ->
                     "UserFrom${cityNames[index]}" to id[cities.id] as Number
                 }
 
@@ -243,7 +249,7 @@ class InsertTests : DatabaseTestsBase() {
                     userNamesWithCityIds,
                     useMultiRowValues = true,
                 ) { (userName, cityId) ->
-                    this[users.id] = java.util.Random().nextInt().toString().take(6)
+                    this[users.id] = userName.substringAfter("UserFrom")
                     this[users.name] = userName
                     this[users.cityId] = cityId.toInt()
                 }
@@ -281,6 +287,44 @@ class InsertTests : DatabaseTestsBase() {
                 statement[DMLTestsData.Cities.name] = "OneRowTooMany"
                 statement.addBatch()
             }
+        }
+    }
+
+    @Test
+    fun testBatchInsertWithoutGeneratedValues() {
+        withCitiesAndUsers { cities, _, _ ->
+            val cityNames = listOf("Paris", "Moscow", "Helsinki")
+            val allCities = cities.batchInsert(
+                cityNames,
+                shouldReturnGeneratedValues = false,
+            ) { name ->
+                this[cities.name] = name
+            }
+
+            assertEquals(cityNames.size, allCities.size)
+            // Stored InsertStatement (batched results) will only hold client-side provided row results
+            assertEqualLists(allCities.map { it[cities.name] }, cityNames)
+            val exception1 = assertFailsWith<IllegalStateException> {
+                allCities.map { it[cities.id] }
+            }
+            assertContains(exception1.message.orEmpty(), "not in record set")
+
+            val moreCityNames = listOf("Berlin", "Amsterdam")
+            val moreCities = cities.batchInsert(
+                moreCityNames,
+                useMultiRowValues = true,
+                shouldReturnGeneratedValues = false,
+            ) { name ->
+                this[cities.name] = name
+            }
+
+            assertEquals(moreCityNames.size, moreCities.size)
+            // Stored InsertStatement (multi-row values result) will only hold client-side provided row results
+            assertEqualLists(moreCities.map { it[cities.name] }, moreCityNames)
+            val exception2 = assertFailsWith<IllegalStateException> {
+                moreCities.map { it[cities.id] }
+            }
+            assertContains(exception2.message.orEmpty(), "not in record set")
         }
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/InsertTests.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.exposed.v1.tests.shared.dml
 
 import kotlinx.coroutines.runBlocking
+import nl.altindag.log.LogCaptor
 import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
@@ -8,7 +9,9 @@ import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.java.UUIDColumnType
 import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.core.statements.BatchDataInconsistentException
 import org.jetbrains.exposed.v1.core.statements.BatchInsertStatement
+import org.jetbrains.exposed.v1.core.statements.MultiRowValuesInsertStatement
 import org.jetbrains.exposed.v1.core.vendors.OracleDialect
 import org.jetbrains.exposed.v1.core.vendors.inProperCase
 import org.jetbrains.exposed.v1.dao.IntEntity
@@ -38,12 +41,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.sql.SQLException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.fail
 import kotlin.uuid.Uuid
 import java.util.UUID as JavaUUID
 
+@Suppress("LargeClass")
 class InsertTests : DatabaseTestsBase() {
     @Test
     fun testInsertAndGetId01() {
@@ -202,22 +207,42 @@ class InsertTests : DatabaseTestsBase() {
     }
 
     @Test
-    fun testBatchInsertUsingMultiRowValue() {
+    fun testBatchInsertUsingMultiRowValues() {
         withCitiesAndUsers { cities, users, _ ->
-            val cityNames = listOf("Paris", "Moscow", "Helsinki")
+            val logCaptor = LogCaptor.forName(exposedLogger.name)
+            logCaptor.setLogLevelToDebug()
 
-            // Oracle driver tries to append RETURNING if keys must be generated, which is not compatible with any table value constructor syntax
-            val allCitiesID = cities.batchInsert(cityNames, useMultiRowValues = true, shouldReturnGeneratedValues = currentDialectTest !is OracleDialect) { name ->
+            // Oracle driver tries to append RETURNING if keys must be generated, which is not compatible with any table value constructor syntax;
+            val canReturnKeys = currentDialectTest !is OracleDialect
+
+            val cityNames = listOf("Paris", "Moscow", "Helsinki")
+            val allCitiesID = cities.batchInsert(
+                cityNames,
+                useMultiRowValues = true,
+                shouldReturnGeneratedValues = canReturnKeys,
+            ) { name ->
                 this[cities.name] = name
             }
-            assertEquals(cityNames.size, allCitiesID.size)
 
-            if (currentDialectTest !is OracleDialect) {
+            assertEquals(cityNames.size, allCitiesID.size)
+            val insertLogs = logCaptor.debugLogs.filter { it.startsWith("INSERT ", ignoreCase = true) }
+            assertEquals(1, insertLogs.size, "Expected a single collapsed multi-row INSERT, got: $insertLogs")
+            assertTrue(insertLogs.single().count { it == '(' } >= cityNames.size + 1)
+
+            logCaptor.clearLogs()
+            logCaptor.resetLogLevel()
+            logCaptor.close()
+
+            // now make sure the generated keys were returned properly even with the new syntax
+            if (canReturnKeys) {
                 val userNamesWithCityIds = allCitiesID.mapIndexed { index, id ->
                     "UserFrom${cityNames[index]}" to id[cities.id] as Number
                 }
 
-                val generatedIds = users.batchInsert(userNamesWithCityIds, useMultiRowValues = true) { (userName, cityId) ->
+                val generatedIds = users.batchInsert(
+                    userNamesWithCityIds,
+                    useMultiRowValues = true,
+                ) { (userName, cityId) ->
                     this[users.id] = java.util.Random().nextInt().toString().take(6)
                     this[users.name] = userName
                     this[users.cityId] = cityId.toInt()
@@ -228,6 +253,33 @@ class InsertTests : DatabaseTestsBase() {
                     userNamesWithCityIds.size.toLong(),
                     users.selectAll().where { users.name inList userNamesWithCityIds.map { it.first } }.count()
                 )
+            }
+        }
+    }
+
+    @Tag(NOT_APPLICABLE_TO_R2DBC)
+    @Test
+    fun testMultiRowValuesInsertRejectsBatchExceedingParameterLimit() {
+        // DMLTestsData.Cities has 2 columns, so the 65535 bind-parameter limit
+        // is exceeded once more than 32767 rows are batched (for all db except SQLite).
+        // SQLite would be exceeded once more than 16383 rows are batched.
+        // validateLastBatch() requires a transaction in context, but the statement is never executed.
+        withTables(excludeSettings = listOf(TestDB.SQLSERVER), DMLTestsData.Cities) { testDb ->
+            val limit = if (testDb == TestDB.SQLITE) 16383 else 32767
+            val statement = MultiRowValuesInsertStatement(DMLTestsData.Cities)
+
+            repeat(limit) {
+                statement[DMLTestsData.Cities.name] = "City$it"
+                statement.addBatch()
+            }
+            assertDoesNotThrow("Batch at the parameter limit should not throw") {
+                statement[DMLTestsData.Cities.name] = "City32767"
+                statement.addBatch()
+            }
+
+            assertFailsWith<BatchDataInconsistentException>("Batch exceeding the parameter limit should throw") {
+                statement[DMLTestsData.Cities.name] = "OneRowTooMany"
+                statement.addBatch()
             }
         }
     }


### PR DESCRIPTION
#### Description

**Summary of the change**: Extend recent `MultiRowValuesInsertStatement` to `exposed-jdbc` and all other databases (beyond initial PostgreSQL).

**Detailed description**:
- **Why**: PR #2880 laid the ground work for this feature, by introducing the ability to use this `INSERT` syntax for PostgreSQL + R2DBC (since JDBC's `reWriteBatchedInserts` does not exist for R2DBC).

Even if connection flags exist in JDBC, the multi-row values constructor syntax is valid for all INSERT statements, so users might like the option to use this an alternative to the traditional statement-level batching.

- **What**:
    - Update documentation and KDocs
    - Update `MultiRowValuesInsertStatement` parameter limit and syntax logic to cover all databases
    - Add Oracle-specific logic to `FunctionProvider.insert()`
    - Add the same 2 `.batchInser(useMultiRowValues)` overloads to `exposed-jdbc`
    - Add equivalent `MultiRowValuesInsertBlockingExecutable` to `exposed-jdbc`
    - Cover MariaDB specific logi

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] New feature

Affected databases:
- [X] All

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-924](https://youtrack.jetbrains.com/issue/EXPOSED-924/batch-insert-doesnt-work-with-r2dbc-postgres)