### PR TITLE
fix(plugin): GH-2897 Prevent timestamp migration version collisions with generateMigrations

### DIFF
--- a/exposed-plugin-core/src/main/kotlin/org/jetbrains/exposed/v1/plugin/core/migration/VersionFormat.kt
+++ b/exposed-plugin-core/src/main/kotlin/org/jetbrains/exposed/v1/plugin/core/migration/VersionFormat.kt
@@ -13,15 +13,17 @@ import kotlin.time.Clock
 enum class VersionFormat {
     /**
      * Uses the format `<prefix>YYYYMMDDHHMMSS<separator><description><extension>`
+     * and appends `.<index>` to subsequent migrations generated in the same run.
      *
-     * For example, V20260417195521__create_table_users.sql
+     * For example, V20260417195521__create_table_users.sql or V20260417195521.1__create_table_cities.sql
      */
     TIMESTAMP_ONLY,
 
     /**
      * Uses the format `<prefix>YYYYMMDDHHMM<separator><description><extension>`
+     * and appends `.<index>` to subsequent migrations generated in the same run.
      *
-     * For example, V202604171955__create_table_users.sql
+     * For example, V202604171955__create_table_users.sql or V202604171955.1__create_table_cities.sql
      */
     TIMESTAMP_WITHOUT_SECONDS,
 
@@ -71,11 +73,13 @@ internal fun VersionFormat.nextVersion(
     separator: String,
 ): (Int) -> String {
     return when (this) {
-        VersionFormat.TIMESTAMP_ONLY -> { _: Int ->
-            "$prefix${getCurrentTimestamp(clock, withSeconds = true)}$separator"
+        VersionFormat.TIMESTAMP_ONLY -> { index: Int ->
+            val indexSuffix = if (index > 0) ".$index" else ""
+            "$prefix${getCurrentTimestamp(clock, withSeconds = true)}$indexSuffix$separator"
         }
-        VersionFormat.TIMESTAMP_WITHOUT_SECONDS -> { _: Int ->
-            "$prefix${getCurrentTimestamp(clock, withSeconds = false)}$separator"
+        VersionFormat.TIMESTAMP_WITHOUT_SECONDS -> { index: Int ->
+            val indexSuffix = if (index > 0) ".$index" else ""
+            "$prefix${getCurrentTimestamp(clock, withSeconds = false)}$indexSuffix$separator"
         }
         VersionFormat.MAJOR_TIMESTAMP -> { _: Int ->
             val majorPadded = findNextMajor(migrationsDirectory, prefix, separator)

--- a/exposed-plugin-core/src/test/kotlin/org/jetbrains/exposed/v1/plugin/core/migration/collision/MigrationGeneratorCollisionTest.kt
+++ b/exposed-plugin-core/src/test/kotlin/org/jetbrains/exposed/v1/plugin/core/migration/collision/MigrationGeneratorCollisionTest.kt
@@ -1,0 +1,79 @@
+package org.jetbrains.exposed.v1.plugin.core.migration.collision
+
+import org.jetbrains.exposed.v1.core.InternalApi
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.plugin.core.migration.MigrationConfig
+import org.jetbrains.exposed.v1.plugin.core.migration.MigrationGenerator
+import org.jetbrains.exposed.v1.plugin.core.migration.MigrationLogger
+import org.jetbrains.exposed.v1.plugin.core.migration.VersionFormat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.UUID
+import kotlin.test.assertEquals
+
+object Parent : Table("issue_2897_parent") {
+    val id = integer("id")
+    override val primaryKey = PrimaryKey(id)
+}
+
+object ChildOne : Table("issue_2897_child_one") {
+    val id = integer("id")
+    val parentId = integer("parent_id").references(Parent.id)
+    override val primaryKey = PrimaryKey(id)
+}
+
+object ChildTwo : Table("issue_2897_child_two") {
+    val id = integer("id")
+    val parentId = integer("parent_id").references(Parent.id)
+    override val primaryKey = PrimaryKey(id)
+}
+
+object Alpha : Table("issue_2897_alpha") {
+    val id = integer("id")
+    override val primaryKey = PrimaryKey(id)
+}
+
+@OptIn(InternalApi::class)
+class MigrationGeneratorCollisionTest {
+    @field:TempDir
+    private lateinit var migrationsDirectory: File
+
+    @Test
+    fun testDependentTablesDoNotOverwriteGeneratedMigrations() {
+        val generator = MigrationGenerator(
+            config = MigrationConfig(
+                tablesPackage = this::class.java.packageName,
+                classpathUrls = listOf(this::class.java.protectionDomain.codeSource.location),
+                fileDirectory = migrationsDirectory,
+                fileVersionFormat = VersionFormat.TIMESTAMP_WITHOUT_SECONDS,
+                databaseUrl = "jdbc:h2:mem:${UUID.randomUUID()}",
+                databaseUser = "",
+                databasePassword = "",
+            ),
+            logger = object : MigrationLogger {
+                override fun lifecycle(message: String) = Unit
+                override fun debug(message: String) = Unit
+                override val isDebugEnabled: Boolean = false
+            },
+        )
+
+        val generated = generator.generate()
+        val expectedTables = setOf(
+            Parent.tableName,
+            ChildOne.tableName,
+            ChildTwo.tableName,
+            Alpha.tableName,
+        )
+        val generatedFiles = migrationsDirectory.listFiles().orEmpty()
+        val createTableRegex = Regex("""CREATE TABLE(?: IF NOT EXISTS)?\s+\"?([\w.]+)\"?""", RegexOption.IGNORE_CASE)
+        val createdTables = generatedFiles
+            .flatMap { file -> createTableRegex.findAll(file.readText()).map { it.groupValues[1] }.toList() }
+            .map { it.substringAfterLast('.').lowercase() }
+            .toSet()
+
+        assertEquals(expectedTables.size, generated.size, "All table migrations must be preserved: $generated")
+        assertEquals(expectedTables.size, generatedFiles.size)
+        assertEquals(expectedTables, createdTables, "All table DDL must be preserved")
+    }
+}

--- a/exposed-plugin-core/src/test/kotlin/org/jetbrains/exposed/v1/plugin/core/migration/migrations/FileVersionGeneratorTest.kt
+++ b/exposed-plugin-core/src/test/kotlin/org/jetbrains/exposed/v1/plugin/core/migration/migrations/FileVersionGeneratorTest.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.exposed.v1.plugin.core.migration.migrations
 
+import org.flywaydb.core.api.MigrationVersion
 import org.jetbrains.exposed.v1.plugin.core.migration.VersionFormat
 import org.jetbrains.exposed.v1.plugin.core.migration.nextVersion
 import org.junit.jupiter.api.BeforeEach
@@ -41,16 +42,66 @@ class FileVersionGeneratorTest {
     }
 
     @Test
-    fun testTimestampOnlyFormatsIgnoreExistingFilesAndArgs() {
-        val version1 = VersionFormat.TIMESTAMP_ONLY.nextVersion(testFilePath, testClock, filePrefix, fileSeparator).invoke(1)
+    fun testTimestampOnlyFormatsIgnoreExistingFilesForFirstMigration() {
+        val version1 = VersionFormat.TIMESTAMP_ONLY.nextVersion(testFilePath, testClock, filePrefix, fileSeparator).invoke(0)
         val match1 = versionTsPattern.matchEntire(version1)
         assertNotNull(match1)
         assertTrue { match1.groupValues[1].length == 14 }
 
-        val version2 = VersionFormat.TIMESTAMP_WITHOUT_SECONDS.nextVersion(testFilePath, testClock, filePrefix, fileSeparator).invoke(1)
+        val version2 = VersionFormat.TIMESTAMP_WITHOUT_SECONDS.nextVersion(testFilePath, testClock, filePrefix, fileSeparator).invoke(0)
         val match2 = versionTsPattern.matchEntire(version2)
         assertNotNull(match2)
         assertTrue { match2.groupValues[1].length == 12 }
+    }
+
+    @Test
+    fun testTimestampOnlyFormatGeneratesUniqueVersionsForEachIndex() {
+        val nextVersion = VersionFormat.TIMESTAMP_ONLY.nextVersion(testFilePath, testClock, filePrefix, fileSeparator)
+        val versions = (0..2).map(nextVersion)
+
+        assertEquals(listOf("V20260417221043__", "V20260417221043.1__", "V20260417221043.2__"), versions)
+        assertFlywayVersionsAreUniqueAndOrdered(versions, fileSeparator)
+    }
+
+    @Test
+    fun testTimestampWithoutSecondsFormatGeneratesUniqueVersionsForEachIndex() {
+        val nextVersion = VersionFormat.TIMESTAMP_WITHOUT_SECONDS.nextVersion(
+            testFilePath,
+            testClock,
+            filePrefix,
+            fileSeparator
+        )
+        val versions = (0..2).map(nextVersion)
+
+        assertEquals(listOf("V202604172210__", "V202604172210.1__", "V202604172210.2__"), versions)
+        assertFlywayVersionsAreUniqueAndOrdered(versions, fileSeparator)
+    }
+
+    @Test
+    fun testTimestampOnlyFormatGeneratesUniqueVersionsWithSingleUnderscoreSeparator() {
+        val separator = "_"
+        val nextVersion = VersionFormat.TIMESTAMP_ONLY.nextVersion(testFilePath, testClock, filePrefix, separator)
+        val versions = (0..2).map(nextVersion)
+
+        assertEquals("V20260417221043_", versions.first())
+        assertFlywayVersionsAreUniqueAndOrdered(versions, separator)
+        assertEquals(listOf("V20260417221043_", "V20260417221043.1_", "V20260417221043.2_"), versions)
+    }
+
+    @Test
+    fun testTimestampWithoutSecondsFormatGeneratesUniqueVersionsWithSingleUnderscoreSeparator() {
+        val separator = "_"
+        val nextVersion = VersionFormat.TIMESTAMP_WITHOUT_SECONDS.nextVersion(
+            testFilePath,
+            testClock,
+            filePrefix,
+            separator
+        )
+        val versions = (0..2).map(nextVersion)
+
+        assertEquals("V202604172210_", versions.first())
+        assertFlywayVersionsAreUniqueAndOrdered(versions, separator)
+        assertEquals(listOf("V202604172210_", "V202604172210.1_", "V202604172210.2_"), versions)
     }
 
     @Test
@@ -134,5 +185,14 @@ class FileVersionGeneratorTest {
         val (major, minor) = version.substringAfter(filePrefix).substringBefore(fileSeparator).split('_')
         assertEquals(currentMajor + 1, major.toInt())
         assertEquals(1, minor.toInt())
+    }
+
+    private fun assertFlywayVersionsAreUniqueAndOrdered(versions: List<String>, separator: String) {
+        assertEquals(versions.size, versions.distinct().size, "Migration versions must be unique: $versions")
+        val flywayVersions = versions.map {
+            MigrationVersion.fromVersion(it.removePrefix(filePrefix).substringBefore(separator))
+        }
+        assertEquals(flywayVersions.size, flywayVersions.distinct().size, "Flyway versions must be unique: $versions")
+        assertEquals(flywayVersions.sorted(), flywayVersions, "Flyway versions must preserve migration order: $versions")
     }
 }


### PR DESCRIPTION
Description

Summary of the change: Ensure timestamp-based migration versions remain unique within a single migration generation run, preventing generated migration files from being overwritten and avoiding duplicate Flyway versions.

Detailed description:

* Why: TIMESTAMP_ONLY and TIMESTAMP_WITHOUT_SECONDS could generate identical versions for multiple migrations created in the same run. When descriptions also matched, generated files could overwrite each other and silently lose migration DDL. Even when filenames differed, Flyway could reject multiple migrations with the same version.
* What: Updated the timestamp-based version formats to append the migration index to subsequent migrations while preserving the existing format for the first migration. Added regression coverage for duplicate migration versions and dependent-table migration loss.
* How: Reused the existing migration index passed to VersionFormat.nextVersion(...). The first migration keeps the original timestamp-only version, while later migrations append _<index>. Tests verify that Flyway interprets the generated versions as unique and ordered, and that all expected table DDL remains present across generated migration files.

⸻

Type of Change

Please mark the relevant options with an “X”:

* Bug fix
* New feature
* Documentation update

Updates/remove existing public API methods:

* Is breaking change

Affected databases:

* MariaDB
* Mysql5
* Mysql8
* Oracle
* Postgres
* SqlServer
* H2
* SQLite

Checklist

* Unit tests are in place
* The build is green (including the Detekt check)
* All public methods affected by my PR has up to date API docs
* Documentation for my change is up to date

⸻

Related Issues

Fixes #2897