### PR TITLE
fix: GH-2407 Release JDBC statements as soon as their result is consumed

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/ExplainBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/ExplainBlockingExecutable.kt
@@ -11,7 +11,6 @@ import org.jetbrains.exposed.v1.jdbc.statements.StatementIterator
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
-import java.sql.ResultSet
 
 /**
  * Represents the execution logic for an SQL statement that obtains information about a statement execution plan.
@@ -27,7 +26,7 @@ open class ExplainBlockingExecutable(
         return Iterable { resultIterator }.iterator()
     }
 
-    private class ResultIterator(rs: ResultSet) : StatementIterator<String, ExplainResultRow>(rs) {
+    private class ResultIterator(rs: JdbcResult) : StatementIterator<String, ExplainResultRow>(rs) {
         override val fieldIndex: Map<String, Int> = List(result.metaData.columnCount) { i ->
             result.metaData.getColumnName(i + 1) to i
         }.toMap()
@@ -36,7 +35,7 @@ open class ExplainBlockingExecutable(
             hasNext = result.next()
         }
 
-        override fun createResultRow(): ExplainResultRow = ExplainResultRow.create(JdbcResult(result), fieldIndex)
+        override fun createResultRow(): ExplainResultRow = ExplainResultRow.create(jdbcResult, fieldIndex)
     }
 }
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/JdbcTransaction.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/JdbcTransaction.kt
@@ -73,7 +73,13 @@ open class JdbcTransaction(
     /** Whether this [JdbcTransaction] should prevent any statement execution from proceeding. */
     internal var blockStatementExecution: Boolean = false
 
-    internal val executedStatements: MutableList<JdbcPreparedStatementApi> = arrayListOf()
+    /**
+     * Statements whose result set may still be open, in execution order.
+     *
+     * A statement is registered when its execution hands out a result set, and is removed once that result is
+     * released. Anything still registered when the transaction ends is closed by [closeExecutedStatements].
+     */
+    internal val executedStatements: MutableSet<JdbcPreparedStatementApi> = LinkedHashSet()
 
     internal var openResultSetsCount: Int = 0
 
@@ -292,7 +298,7 @@ open class JdbcTransaction(
         body((it as JdbcResult).result)
     }
 
-    internal fun execQuery(query: BlockingExecutable<ResultApi, *>): ResultSet = execQuery(query) { it }
+    internal fun execQuery(query: BlockingExecutable<ResultApi, *>): JdbcResult = exec(stmt = query) { it as JdbcResult }
         ?: error("A ResultSet was expected, but none was retrieved from the database")
 
     /** Closes all previously executed statements and resets or releases any used database and/or driver resources. */
@@ -302,6 +308,36 @@ open class JdbcTransaction(
         }
         openResultSetsCount = 0
         executedStatements.clear()
+    }
+
+    /**
+     * Registers a [statement] whose result set is still open, so that it is closed by [closeExecutedStatements]
+     * unless it has been released by [releaseStatement] before then.
+     */
+    internal fun registerStatement(statement: JdbcPreparedStatementApi) {
+        val threshold = db.config.logTooMuchResultSetsThreshold
+        if (threshold > 0 && threshold < openResultSetsCount) {
+            val message = "Current opened result sets size $openResultSetsCount exceeds $threshold threshold for transaction $transactionId "
+            exposedLogger.error(Exception(message).stackTraceToString())
+        }
+        if (executedStatements.add(statement)) openResultSetsCount++
+    }
+
+    /** Closes a [statement] and removes it from the registered statements, if it was registered. */
+    internal fun releaseStatement(statement: JdbcPreparedStatementApi) {
+        if (executedStatements.remove(statement)) openResultSetsCount--
+        statement.closeIfPossible()
+    }
+
+    /** Closes a [result] and releases the statement that produced it. */
+    internal fun releaseResult(result: JdbcResult) {
+        val resultSet = result.result
+        val owner = result.owner
+        // Read the fallback before closing: some drivers reject getStatement() on a closed result set.
+        val unregisteredStatement = if (owner == null && !resultSet.isClosed) resultSet.statement else null
+        // The result set is closed before its statement so that pools such as Agroal do not report a leak (EXPOSED-373).
+        if (!resultSet.isClosed) resultSet.close()
+        if (owner != null) releaseStatement(owner) else unregisteredStatement?.close()
     }
 
     final override fun addLogger(vararg logger: SqlLogger): CompositeSqlLogger {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Query.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Query.kt
@@ -9,7 +9,6 @@ import org.jetbrains.exposed.v1.jdbc.statements.StatementIterator
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
-import java.sql.ResultSet
 
 /** Class representing an SQL `SELECT` statement on which query clauses can be built. */
 open class Query(
@@ -252,12 +251,13 @@ open class Query(
         } else {
             try {
                 count = true
-                transaction.execQuery(this) { rs ->
+                val rs = transaction.execQuery(this)
+                try {
                     rs.next()
-                    rs.getLong(1).also {
-                        rs.close()
-                    }
-                }!!
+                    rs.result.getLong(1)
+                } finally {
+                    transaction.releaseResult(rs)
+                }
             } finally {
                 count = false
             }
@@ -273,8 +273,12 @@ open class Query(
         val oldLimit = limit
         try {
             if (!isForUpdate()) limit = 1
-            val resultSet = transaction.execQuery(this)
-            return !resultSet.next().also { resultSet.close() }
+            val rs = transaction.execQuery(this)
+            return try {
+                !rs.next()
+            } finally {
+                transaction.releaseResult(rs)
+            }
         } finally {
             limit = oldLimit
         }
@@ -308,7 +312,7 @@ open class Query(
         }
     }
 
-    private inner class ResultIterator(rs: ResultSet) : StatementIterator<Expression<*>, ResultRow>(rs) {
+    private inner class ResultIterator(rs: JdbcResult) : StatementIterator<Expression<*>, ResultRow>(rs) {
         override val fieldIndex = set.realFields.toSet()
             .mapIndexed { index, expression -> expression to index }
             .toMap()
@@ -319,25 +323,13 @@ open class Query(
 
         init {
             hasNext = result.next()
-            if (hasNext) trackResultSet(transaction)
         }
 
         @OptIn(InternalApi::class)
-        override fun createResultRow(): ResultRow = ResultRow.create(JdbcResult(result), fieldIndex, columnTypes)
+        override fun createResultRow(): ResultRow = ResultRow.create(jdbcResult, fieldIndex, columnTypes)
     }
 
-    companion object {
-        private fun trackResultSet(transaction: JdbcTransaction) {
-            val threshold = transaction.db.config.logTooMuchResultSetsThreshold
-            if (threshold > 0 && threshold < transaction.openResultSetsCount) {
-                val message =
-                    "Current opened result sets size ${transaction.openResultSetsCount} exceeds $threshold threshold for transaction ${transaction.transactionId} "
-                val stackTrace = Exception(message).stackTraceToString()
-                exposedLogger.error(stackTrace)
-            }
-            transaction.openResultSetsCount++
-        }
-    }
+    companion object
 }
 
 /**

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/SetOperations.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/SetOperations.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.v1.jdbc.statements.StatementIterator
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
-import java.sql.ResultSet
 
 /**
  * Represents an SQL operation that combines the results of multiple queries into a single result.
@@ -74,12 +73,13 @@ sealed class SetOperation(
     override fun count(): Long {
         try {
             count = true
-            return transaction.execQuery(this) { rs ->
+            val rs = transaction.execQuery(this)
+            return try {
                 rs.next()
-                rs.getLong(1).also {
-                    rs.close()
-                }
-            }!!
+                rs.result.getLong(1)
+            } finally {
+                transaction.releaseResult(rs)
+            }
         } finally {
             count = false
         }
@@ -91,7 +91,11 @@ sealed class SetOperation(
         try {
             limit = 1
             val rs = transaction.execQuery(this)
-            return !rs.next().also { rs.close() }
+            return try {
+                !rs.next()
+            } finally {
+                transaction.releaseResult(rs)
+            }
         } finally {
             limit = oldLimit
         }
@@ -163,7 +167,7 @@ sealed class SetOperation(
         }
     }
 
-    private inner class ResultIterator(rs: ResultSet) : StatementIterator<Expression<*>, ResultRow>(rs) {
+    private inner class ResultIterator(rs: JdbcResult) : StatementIterator<Expression<*>, ResultRow>(rs) {
         override val fieldIndex = set.realFields.toSet()
             .mapIndexed { index, expression -> expression to index }
             .toMap()
@@ -174,25 +178,13 @@ sealed class SetOperation(
 
         init {
             hasNext = result.next()
-            if (hasNext) trackResultSet(transaction)
         }
 
         @OptIn(InternalApi::class)
-        override fun createResultRow(): ResultRow = ResultRow.create(JdbcResult(result), fieldIndex, columnTypes)
+        override fun createResultRow(): ResultRow = ResultRow.create(jdbcResult, fieldIndex, columnTypes)
     }
 
-    companion object {
-        private fun trackResultSet(transaction: JdbcTransaction) {
-            val threshold = transaction.db.config.logTooMuchResultSetsThreshold
-            if (threshold > 0 && threshold < transaction.openResultSetsCount) {
-                val message = "Current opened result sets size ${transaction.openResultSetsCount} " +
-                    "exceeds $threshold threshold for transaction ${transaction.transactionId} "
-                val stackTrace = Exception(message).stackTraceToString()
-                exposedLogger.error(stackTrace)
-            }
-            transaction.openResultSetsCount++
-        }
-    }
+    companion object
 }
 
 /** Represents an SQL operation that combines all results from two queries, without any duplicates. */

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/BlockingExecutable.kt
@@ -1,10 +1,13 @@
 package org.jetbrains.exposed.v1.jdbc.statements
 
 import org.jetbrains.exposed.v1.core.InternalApi
+import org.jetbrains.exposed.v1.core.exposedLogger
 import org.jetbrains.exposed.v1.core.statements.*
+import org.jetbrains.exposed.v1.core.statements.api.ResultApi
 import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
 import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
+import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import java.sql.SQLException
 
 internal object DefaultValueMarker {
@@ -152,15 +155,37 @@ internal fun <T, S : Statement<T>> BlockingExecutable<T, S>.executeIn(
 
     transaction.currentStatement = statement
     transaction.interceptors.forEach { it.afterStatementPrepared(transaction, statement) }
+    var executed = false
     val result = try {
-        statement.executeInternal(transaction)
+        statement.executeInternal(transaction).also { executed = true }
     } catch (cause: SQLException) {
         throw ExposedSQLException(cause, contexts, transaction)
+    } finally {
+        // A failed statement is never handed to anyone, so nothing else would close it.
+        if (!executed) statement.closeQuietly()
     }
     transaction.currentStatement = null
-    transaction.executedStatements.add(statement)
 
-    JdbcTransaction.globalInterceptors.forEach { it.afterExecution(transaction, contexts, statement) }
-    transaction.interceptors.forEach { it.afterExecution(transaction, contexts, statement) }
+    // Only a statement that hands out a result set must outlive its execution: it stays registered with the
+    // transaction until that result is released. Every other statement is closed once the interceptors have seen it.
+    val retainsResultSet = result is ResultApi
+    if (retainsResultSet) {
+        (result as? JdbcResult)?.owner = statement
+        transaction.registerStatement(statement)
+    }
+    try {
+        JdbcTransaction.globalInterceptors.forEach { it.afterExecution(transaction, contexts, statement) }
+        transaction.interceptors.forEach { it.afterExecution(transaction, contexts, statement) }
+    } finally {
+        if (!retainsResultSet) statement.closeIfPossible()
+    }
     return result to contexts
+}
+
+private fun JdbcPreparedStatementApi.closeQuietly() {
+    try {
+        closeIfPossible()
+    } catch (cause: SQLException) {
+        exposedLogger.debug("Failed to close a statement after a failed execution", cause)
+    }
 }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/ReturningBlockingExecutable.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/ReturningBlockingExecutable.kt
@@ -9,7 +9,6 @@ import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
-import java.sql.ResultSet
 
 /**
  * Represents the execution logic for an underlying SQL statement that returns a result with data from any modified rows.
@@ -25,7 +24,7 @@ open class ReturningBlockingExecutable(
         return Iterable { resultIterator }.iterator()
     }
 
-    private inner class ResultIterator(rs: ResultSet) : StatementIterator<Expression<*>, ResultRow>(rs) {
+    private inner class ResultIterator(rs: JdbcResult) : StatementIterator<Expression<*>, ResultRow>(rs) {
         override val fieldIndex = statement.returningExpressions.withIndex()
             .associateBy({ it.value }, { it.index })
 
@@ -38,6 +37,6 @@ open class ReturningBlockingExecutable(
         }
 
         @OptIn(InternalApi::class)
-        override fun createResultRow(): ResultRow = ResultRow.create(JdbcResult(result), fieldIndex, columnTypes)
+        override fun createResultRow(): ResultRow = ResultRow.create(jdbcResult, fieldIndex, columnTypes)
     }
 }

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/StatementIterator.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/StatementIterator.kt
@@ -1,23 +1,25 @@
 package org.jetbrains.exposed.v1.jdbc.statements
 
+import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import java.sql.ResultSet
 
 internal abstract class StatementIterator<T, RR>(
-    protected val result: ResultSet
+    protected val jdbcResult: JdbcResult
 ) : Iterator<RR> {
+    protected val result: ResultSet
+        get() = jdbcResult.result
+
     protected abstract val fieldIndex: Map<T, Int>
 
     protected abstract fun createResultRow(): RR
 
+    /** Whether another row can be read. Setting this to `false` releases the result set and the statement behind it. */
     protected var hasNext = false
         set(value) {
             field = value
             if (!field) {
-                val statement = result.statement
-                result.close()
-                statement?.close()
-                TransactionManager.current().openResultSetsCount--
+                TransactionManager.current().releaseResult(jdbcResult)
             }
         }
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcPreparedStatementImpl.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcPreparedStatementImpl.kt
@@ -25,11 +25,18 @@ class JdbcPreparedStatementImpl(
     val statement: PreparedStatement,
     val wasGeneratedKeysRequested: Boolean
 ) : JdbcPreparedStatementApi {
+    /** Statement used to read generated keys where the driver cannot return them itself (SQLite); closed with this one. */
+    private var generatedKeysStatement: PreparedStatement? = null
+
     override val resultSet: JdbcResult?
         get() = when {
             !wasGeneratedKeysRequested -> statement.resultSet?.let { JdbcResult(it) }
             currentDialect is SQLiteDialect -> {
-                statement.connection.prepareStatement("select last_insert_rowid();").executeQuery()?.let { JdbcResult(it) }
+                generatedKeysStatement?.close()
+                statement.connection.prepareStatement("select last_insert_rowid();")
+                    .also { generatedKeysStatement = it }
+                    .executeQuery()
+                    ?.let { JdbcResult(it) }
             }
             else -> statement.generatedKeys?.let { JdbcResult(it) }
         }
@@ -94,6 +101,8 @@ class JdbcPreparedStatementImpl(
     }
 
     override fun closeIfPossible() {
+        generatedKeysStatement?.let { if (!it.isClosed) it.close() }
+        generatedKeysStatement = null
         if (!statement.isClosed) statement.close()
     }
 

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcResult.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import org.jetbrains.exposed.v1.core.statements.api.ResultApi
 import org.jetbrains.exposed.v1.core.statements.api.RowApi
+import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import java.sql.ResultSet
 
 /**
@@ -15,6 +16,12 @@ class JdbcResult(
     val result: ResultSet
 ) : ResultApi, RowApi {
     private var consumed = false
+
+    /**
+     * The prepared statement that produced this result. It is registered with the transaction for as long as this
+     * result may still be read, and is released together with it. `null` for results created outside of statement execution.
+     */
+    internal var owner: JdbcPreparedStatementApi? = null
 
     override fun <T> mapRows(block: (RowApi) -> T?): Flow<T?> {
         if (consumed) error("Result is already consumed")

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/StatementReleaseTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/StatementReleaseTests.kt
@@ -1,0 +1,168 @@
+package org.jetbrains.exposed.v1.tests.shared
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.statements.StatementContext
+import org.jetbrains.exposed.v1.core.statements.StatementInterceptor
+import org.jetbrains.exposed.v1.core.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
+import org.jetbrains.exposed.v1.jdbc.batchInsert
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcPreparedStatementImpl
+import org.jetbrains.exposed.v1.jdbc.update
+import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import org.junit.jupiter.api.Test
+import java.sql.PreparedStatement
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that a JDBC statement is closed as soon as nothing can read from it anymore, instead of being kept
+ * until the transaction ends (GitHub #2407).
+ */
+class StatementReleaseTests : DatabaseTestsBase() {
+    object Items : Table("statement_release_items") {
+        val id = integer("id")
+        val name = varchar("name", 50)
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    /** Records the JDBC statement behind every execution, so that its state can be checked afterwards. */
+    private class StatementCapture : StatementInterceptor {
+        val statements = mutableListOf<PreparedStatement>()
+
+        val last: PreparedStatement
+            get() = statements.last()
+
+        override fun afterExecution(transaction: Transaction, contexts: List<StatementContext>, executedStatement: PreparedStatementApi) {
+            (executedStatement as? JdbcPreparedStatementImpl)?.let { statements += it.statement }
+        }
+    }
+
+    private fun JdbcTransaction.captureStatements(): StatementCapture = StatementCapture().also { registerInterceptor(it) }
+
+    @Test
+    fun testStatementsWithoutResultSetAreClosedAfterExecution() {
+        withTables(Items) {
+            val capture = captureStatements()
+
+            Items.insert {
+                it[id] = 1
+                it[name] = "one"
+            }
+            assertTrue(capture.last.isClosed, "insert")
+
+            Items.update({ Items.id eq 1 }) { it[name] = "uno" }
+            assertTrue(capture.last.isClosed, "update")
+
+            Items.batchInsert(2..4) {
+                this[Items.id] = it
+                this[Items.name] = "n$it"
+            }
+            assertTrue(capture.last.isClosed, "batch insert")
+
+            Items.deleteWhere { Items.id eq 1 }
+            assertTrue(capture.last.isClosed, "delete")
+
+            val count = exec("SELECT COUNT(*) FROM ${Items.nameInDatabaseCase()}") { rs ->
+                rs.next()
+                rs.getLong(1)
+            }
+            assertEquals(3, count)
+            assertTrue(capture.last.isClosed, "exec with transform")
+        }
+    }
+
+    @Test
+    fun testQueryStatementIsClosedOnceItsResultIsConsumed() {
+        withTables(Items) {
+            Items.batchInsert(1..5) {
+                this[Items.id] = it
+                this[Items.name] = "n$it"
+            }
+            val capture = captureStatements()
+
+            assertEquals(5, Items.selectAll().toList().size)
+            assertTrue(capture.last.isClosed, "fully iterated")
+
+            assertEquals(5, Items.selectAll().count())
+            assertTrue(capture.last.isClosed, "count")
+
+            assertFalse(Items.selectAll().empty())
+            assertTrue(capture.last.isClosed, "empty")
+
+            assertTrue(Items.selectAll().where { Items.id eq 99 }.empty())
+            assertTrue(capture.last.isClosed, "empty result")
+        }
+    }
+
+    @Test
+    fun testPartiallyConsumedQueryStaysOpenUntilExhaustedOrReleased() {
+        withTables(Items) {
+            Items.batchInsert(1..5) {
+                this[Items.id] = it
+                this[Items.name] = "n$it"
+            }
+            val capture = captureStatements()
+
+            val exhausted = Items.selectAll().iterator()
+            val exhaustedStatement = capture.last
+            exhausted.next()
+            if (db.supportsMultipleResultSets) {
+                assertFalse(exhaustedStatement.isClosed, "one row read")
+            }
+            while (exhausted.hasNext()) exhausted.next()
+            assertTrue(exhaustedStatement.isClosed, "exhausted")
+
+            val abandoned = Items.selectAll().iterator()
+            val abandonedStatement = capture.last
+            abandoned.next()
+            closeExecutedStatements()
+            assertTrue(abandonedStatement.isClosed, "abandoned then released by the transaction")
+        }
+    }
+
+    @Test
+    fun testFailedStatementIsClosed() {
+        withTables(Items) {
+            Items.insert {
+                it[id] = 1
+                it[name] = "one"
+            }
+
+            assertFailAndRollback("duplicate primary key") {
+                Items.insert {
+                    it[id] = 1
+                    it[name] = "again"
+                }
+            }
+
+            val failed = (currentStatement as JdbcPreparedStatementImpl).statement
+            assertTrue(failed.isClosed, "failed statement")
+        }
+    }
+
+    @Test
+    fun testStatementsDoNotAccumulateInLongTransaction() {
+        withTables(Items) {
+            val capture = captureStatements()
+
+            repeat(200) { i ->
+                Items.insert {
+                    it[id] = i
+                    it[name] = "n$i"
+                }
+                assertEquals(1, Items.selectAll().where { Items.id eq i }.count())
+                Items.update({ Items.id eq i }) { it[name] = "m$i" }
+            }
+
+            assertEquals(600, capture.statements.size)
+            assertTrue(capture.statements.all { it.isClosed }, "every statement released before the transaction ended")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2407.

### Problem

Every executed statement was kept in the transaction's **executedStatements** list until the transaction ended, and a query's statement was only closed when its iterator reached the last row. A long-running transaction therefore accumulated one **PreparedStatement** per executed statement. Causing the memory usage to grow considerably.


### Description

**Description Summary:** executedStatements now holds only statements that still own an open result set.

**Detailed description**:
- **Why**: the only way an executable can hand an open cursor to a caller is by returning a ResultApi
- **What**: 

1. **ResultSet -> JdbcResult change**: releasing a statement needs to know which statement wrapper to release, and a raw java.sql.ResultSet can't tell you that. We need to use the JdbcResult wrapper instead which gives us the ability to call releaseResult()
2. **trackResultSet (multiple copies consolidated) -> JdbcTransaction.registerStatement**: The counter has to be incremented at the first event and decremented at the second. Both events happen inside JdbcTransaction, so that's where the common code was put.
3. **replace the unconditional transaction.executedStatements.add(statement).**: We need to enhance the JdbcResult with owner, so that we can release it later. But, this only makes sense when we have a ResultApi.

- **How**: BlockingExecutable.executeIn closes a statement right after the afterExecution interceptors run, unless executeInternal returned a ResultApi. Insert, update, delete, merge, batch statements, and exec(sql) { rs -> } are closed immediately.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] MariaDB
- [X] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [X] SqlServer
- [X] H2
- [X] SQLite

#### Checklist

- [X] Unit tests are in place
- [x] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
