### PR TITLE
fix: EXPOSED-1061 DDL generation for column defaults using Op [MariaDB] and Function [SQLite]

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MariaDBDialect.kt
@@ -14,9 +14,9 @@ internal object MariaDBDataTypeProvider : MysqlDataTypeProvider() {
         throw UnsupportedByDialectException("This vendor does not support timestamp with time zone data type", currentDialect)
     }
 
-    override fun processForDefaultValue(e: Expression<*>): String = when {
-        e is LiteralOp<*> -> (e.columnType as IColumnType<Any?>).valueAsDefaultString(e.value)
-        e is Function<*> || currentDialect is MariaDBDialect -> "$e"
+    override fun processForDefaultValue(e: Expression<*>): String = when (e) {
+        is LiteralOp<*> -> (e.columnType as IColumnType<Any?>).valueAsDefaultString(e.value)
+        is Function<*> -> "$e"
         else -> "($e)"
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
@@ -27,6 +27,22 @@ internal object SQLiteDataTypeProvider : DataTypeProvider() {
         return if (currentVersion.covers(supportedVersion)) blobType() else super.jsonBType()
     }
 
+    override fun processForDefaultValue(e: Expression<*>): String = when (e) {
+        is LiteralOp<*> -> (e.columnType as IColumnType<Any?>).valueAsDefaultString(e.value)
+        // The default value specified in a DEFAULT clause can be a literal constant or an expression. With one
+        // exception, enclose expression default values within parentheses to distinguish them from literal constant
+        // default values. The exception is that, for TIMESTAMP and DATETIME columns, you can specify any of the
+        // built-in time constant functions as the default, without enclosing parentheses.
+        is ExpressionWithColumnType<*> if (
+            e.columnType is IDateColumnType && acceptableDateTimeDefaults.any { e.toString().startsWith(it) }
+            ) ->
+            super.processForDefaultValue(e)
+        !is LiteralOp<*> -> "(${super.processForDefaultValue(e)})"
+        else -> super.processForDefaultValue(e)
+    }
+
+    private val acceptableDateTimeDefaults = mutableListOf("CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP")
+
     override fun hexToDb(hexString: String): String = "X'$hexString'"
 }
 

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/functions/MathFunctionTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/functions/MathFunctionTests.kt
@@ -2,17 +2,15 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.functions
 
 import io.r2dbc.spi.R2dbcException
 import kotlinx.coroutines.flow.single
+import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
-import org.jetbrains.exposed.v1.core.decimalLiteral
-import org.jetbrains.exposed.v1.core.div
-import org.jetbrains.exposed.v1.core.doubleLiteral
-import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.functions.math.*
-import org.jetbrains.exposed.v1.core.intLiteral
 import org.jetbrains.exposed.v1.r2dbc.insertAndGetId
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertFalse
+import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertTrue
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.expectException
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
@@ -172,6 +170,8 @@ class MathFunctionTests : FunctionsTestBase() {
             val defaultDecimal3 = decimal("defaultDecimal3", 3, 0).nullable().defaultExpression(RoundFunction(double, 0))
             val defaultInt3 = integer("defaultInt3").nullable().defaultExpression(SignFunction(integer))
             val defaultDecimal4 = decimal("defaultDecimal4", 3, 0).nullable().defaultExpression(SqrtFunction(defaultDecimal2))
+            val defaultInt4 = integer("defaultInt4").defaultExpression(defaultInt plus intLiteral(1))
+            val defaultBoolean = bool("defaultBoolean").defaultExpression(defaultDecimal.isNull())
         }
 
         // MySQL and MariaDB are the only supported databases that allow referencing another column in a default expression
@@ -185,12 +185,63 @@ class MathFunctionTests : FunctionsTestBase() {
             val result = foo.selectAll().where { foo.id eq id }.single()
 
             assertEquals(100, result[foo.defaultInt])
+            assertEquals(1, result[foo.defaultInt2])
             assertEquals(BigDecimal("2.718281828459"), result[foo.defaultDecimal])
             assertEquals(100, result[foo.defaultLong])
             assertEquals(BigDecimal(100), result[foo.defaultDecimal2])
             assertEquals(BigDecimal(101), result[foo.defaultDecimal3])
             assertEquals(-1, result[foo.defaultInt3])
             assertEquals(BigDecimal(10), result[foo.defaultDecimal4])
+            assertEquals(101, result[foo.defaultInt4])
+            assertFalse(result[foo.defaultBoolean])
+        }
+    }
+
+    @Test
+    fun testConstantFunctionsInDefaultExpression() {
+        val tester = object : IntIdTable("tester") {
+            val absolute = integer("absolute").defaultExpression(AbsFunction(intLiteral(-100)))
+            val length = integer("length").nullable().defaultExpression(stringLiteral("TEST").charLength())
+            val conditional = integer("conditional").defaultExpression(
+                Case().When(Op.TRUE, intLiteral(1) times intLiteral(10)).Else(intLiteral(0))
+            )
+        }
+
+        // MySQL 5 does not support functions in default values.
+        withTables(excludeSettings = listOf(TestDB.MYSQL_V5), tester) {
+            val id = tester.insertAndGetId { }
+            val result = tester.selectAll().where { tester.id eq id }.single()
+
+            assertEquals(100, result[tester.absolute])
+            assertEquals(4, result[tester.length])
+            assertEquals(10, result[tester.conditional])
+        }
+    }
+
+    @Test
+    fun testArithmeticExpressionsInDefaultExpression() {
+        val tester = object : IntIdTable("tester") {
+            // CustomOperator example (extends Function)
+            val addition = integer("addition").defaultExpression(intLiteral(2) plus intLiteral(3))
+
+            // ComparisonOp example (extends Op)
+            val comparison = bool("comparison").defaultExpression(intLiteral(2) less intLiteral(3))
+
+            // Mixed Function example
+            val extraLength = integer("extra_length").nullable().defaultExpression(
+                stringLiteral("TEST").charLength() plus intLiteral(1)
+            )
+        }
+
+        // SQL Server & Oracle only allow 3 column defaults: constants/literals, scalar/deterministic functions, system functions;
+        // MySQL 5 does not support functions in default values;
+        withTables(excludeSettings = TestDB.ALL_ORACLE_LIKE + TestDB.SQLSERVER + TestDB.MYSQL_V5, tester) {
+            val id = tester.insertAndGetId { }
+            val result = tester.selectAll().where { tester.id eq id }.single()
+
+            assertEquals(5, result[tester.addition])
+            assertTrue(result[tester.comparison])
+            assertEquals(5, result[tester.extraLength])
         }
     }
 }

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/functions/MathFunctionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/functions/MathFunctionTests.kt
@@ -1,16 +1,14 @@
 package org.jetbrains.exposed.v1.tests.shared.functions
 
+import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.dao.id.IntIdTable
-import org.jetbrains.exposed.v1.core.decimalLiteral
-import org.jetbrains.exposed.v1.core.div
-import org.jetbrains.exposed.v1.core.doubleLiteral
-import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.functions.math.*
-import org.jetbrains.exposed.v1.core.intLiteral
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.tests.TestDB
 import org.jetbrains.exposed.v1.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.tests.shared.assertFalse
+import org.jetbrains.exposed.v1.tests.shared.assertTrue
 import org.jetbrains.exposed.v1.tests.shared.expectException
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
@@ -175,6 +173,8 @@ class MathFunctionTests : FunctionsTestBase() {
             val defaultDecimal3 = decimal("defaultDecimal3", 3, 0).nullable().defaultExpression(RoundFunction(double, 0))
             val defaultInt3 = integer("defaultInt3").nullable().defaultExpression(SignFunction(integer))
             val defaultDecimal4 = decimal("defaultDecimal4", 3, 0).nullable().defaultExpression(SqrtFunction(defaultDecimal2))
+            val defaultInt4 = integer("defaultInt4").defaultExpression(defaultInt plus intLiteral(1))
+            val defaultBoolean = bool("defaultBoolean").defaultExpression(defaultDecimal.isNull())
         }
 
         // MySQL and MariaDB are the only supported databases that allow referencing another column in a default expression
@@ -188,12 +188,63 @@ class MathFunctionTests : FunctionsTestBase() {
             val result = foo.selectAll().where { foo.id eq id }.single()
 
             assertEquals(100, result[foo.defaultInt])
+            assertEquals(1, result[foo.defaultInt2])
             assertEquals(BigDecimal("2.718281828459"), result[foo.defaultDecimal])
             assertEquals(100, result[foo.defaultLong])
             assertEquals(BigDecimal(100), result[foo.defaultDecimal2])
             assertEquals(BigDecimal(101), result[foo.defaultDecimal3])
             assertEquals(-1, result[foo.defaultInt3])
             assertEquals(BigDecimal(10), result[foo.defaultDecimal4])
+            assertEquals(101, result[foo.defaultInt4])
+            assertFalse(result[foo.defaultBoolean])
+        }
+    }
+
+    @Test
+    fun testConstantFunctionsInDefaultExpression() {
+        val tester = object : IntIdTable("tester") {
+            val absolute = integer("absolute").defaultExpression(AbsFunction(intLiteral(-100)))
+            val length = integer("length").nullable().defaultExpression(stringLiteral("TEST").charLength())
+            val conditional = integer("conditional").defaultExpression(
+                Case().When(Op.TRUE, intLiteral(1) times intLiteral(10)).Else(intLiteral(0))
+            )
+        }
+
+        // MySQL 5 does not support functions in default values.
+        withTables(excludeSettings = listOf(TestDB.MYSQL_V5), tester) {
+            val id = tester.insertAndGetId { }
+            val result = tester.selectAll().where { tester.id eq id }.single()
+
+            assertEquals(100, result[tester.absolute])
+            assertEquals(4, result[tester.length])
+            assertEquals(10, result[tester.conditional])
+        }
+    }
+
+    @Test
+    fun testArithmeticExpressionsInDefaultExpression() {
+        val tester = object : IntIdTable("tester") {
+            // CustomOperator example (extends Function)
+            val addition = integer("addition").defaultExpression(intLiteral(2) plus intLiteral(3))
+
+            // ComparisonOp example (extends Op)
+            val comparison = bool("comparison").defaultExpression(intLiteral(2) less intLiteral(3))
+
+            // Mixed Function example
+            val extraLength = integer("extra_length").nullable().defaultExpression(
+                stringLiteral("TEST").charLength() plus intLiteral(1)
+            )
+        }
+
+        // SQL Server & Oracle only allow 3 column defaults: constants/literals, scalar/deterministic functions, system functions;
+        // MySQL 5 does not support functions in default values;
+        withTables(excludeSettings = TestDB.ALL_ORACLE_LIKE + TestDB.SQLSERVER + TestDB.MYSQL_V5, tester) {
+            val id = tester.insertAndGetId { }
+            val result = tester.selectAll().where { tester.id eq id }.single()
+
+            assertEquals(5, result[tester.addition])
+            assertTrue(result[tester.comparison])
+            assertEquals(5, result[tester.extraLength])
         }
     }
 }


### PR DESCRIPTION
#### Description

**Summary of the change**: Refactor `DataTypeProvider.processForDefaultValue()` overrides in `MariaDBDialect` and `SQLiteDialect` to avoid syntax errors when certain expressions are used in `Column.defaultExpression()`.

**Detailed description**:
- **Why**: With MariaDB, attempting to use any class extending `Op` in `defaultExpression()` fails, for example:
```kt
bool("comparison").defaultExpression(intLiteral(2) less intLiteral(3))

bool("defaultBoolean").defaultExpression(defaultDecimal.isNull())
```

With SQLite, attempting to use any class extending `Function` in `defaultExpression()` fails, for example:
```kt
integer("absolute").defaultExpression(AbsFunction(intLiteral(-100)))
```

- **How**:
    - Remove dialect check from second branch in `MariaDBDataTypeProvider.processForDefaultValue()`
    - Add  `SQLiteDataTypeProvider.processForDefaultValue()` that wraps all `Function`s except datetime constants
    - Add unit tests

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix

Affected databases:
- [X] MariaDB
- [X] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues
[EXPOSED-1061](https://youtrack.jetbrains.com/issue/EXPOSED-1061)