### PR TITLE
fix: EXPOSED-1071 Closing executed statements performance issue

### DIFF
--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/JdbcTransaction.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/JdbcTransaction.kt
@@ -297,7 +297,7 @@ open class JdbcTransaction(
 
     /** Closes all previously executed statements and resets or releases any used database and/or driver resources. */
     fun closeExecutedStatements() {
-        executedStatements.forEach {
+        executedStatements.asReversed().forEach {
             it.closeIfPossible()
         }
         openResultSetsCount = 0

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/JdbcTransactionCloseOrderTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/JdbcTransactionCloseOrderTests.kt
@@ -1,0 +1,88 @@
+package org.jetbrains.exposed.v1.tests.shared
+
+import org.jetbrains.exposed.v1.core.ArrayColumnType
+import org.jetbrains.exposed.v1.core.IColumnType
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.statements.Statement
+import org.jetbrains.exposed.v1.core.statements.StatementResult
+import org.jetbrains.exposed.v1.core.statements.StatementType
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
+import org.jetbrains.exposed.v1.jdbc.statements.BlockingExecutable
+import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
+import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+import java.io.InputStream
+import kotlin.test.assertEquals
+
+class JdbcTransactionCloseOrderTests : DatabaseTestsBase() {
+    @Test
+    fun testExecutedStatementsAreClosedInReverseOrder() {
+        withConnection { database, _ ->
+            Assumptions.assumeTrue(
+                database.supportsMultipleResultSets,
+                "Statement accumulation requires support for multiple result sets"
+            )
+
+            val closeOrder = mutableListOf<Int>()
+
+            transaction(db = database) {
+                repeat(3) { index ->
+                    exec(RecordingExecutable(index + 1, closeOrder))
+                }
+
+                closeExecutedStatements()
+            }
+
+            assertEquals(listOf(3, 2, 1), closeOrder)
+        }
+    }
+
+    private class RecordingExecutable(
+        id: Int,
+        closeOrder: MutableList<Int>
+    ) : Statement<Unit>(StatementType.SELECT, emptyList()), BlockingExecutable<Unit, Statement<Unit>> {
+        override val statement: Statement<Unit>
+            get() = this
+
+        private val preparedStatement = RecordingPreparedStatement(id, closeOrder)
+
+        override fun prepareSQL(transaction: Transaction, prepared: Boolean): String = "SELECT 1"
+
+        override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = emptyList()
+
+        override fun prepared(transaction: JdbcTransaction, sql: String): JdbcPreparedStatementApi = preparedStatement
+
+        override fun JdbcPreparedStatementApi.executeInternal(transaction: JdbcTransaction) = Unit
+    }
+
+    private class RecordingPreparedStatement(
+        private val id: Int,
+        private val closeOrder: MutableList<Int>
+    ) : JdbcPreparedStatementApi {
+        override var fetchSize: Int? = null
+        override var timeout: Int? = null
+        override val resultSet: JdbcResult? = null
+
+        override fun closeIfPossible() {
+            closeOrder += id
+        }
+
+        override fun addBatch(): Unit = unexpectedCall()
+        override fun executeQuery(): JdbcResult = unexpectedCall()
+        override fun executeUpdate(): Int = unexpectedCall()
+        override fun executeMultiple(): List<StatementResult> = unexpectedCall()
+        override fun executeBatch(): List<Int> = unexpectedCall()
+        override fun cancel(): Unit = unexpectedCall()
+        override fun set(index: Int, value: Any, columnType: IColumnType<*>): Unit = unexpectedCall()
+        override fun setNull(index: Int, columnType: IColumnType<*>): Unit = unexpectedCall()
+        override fun setInputStream(index: Int, inputStream: InputStream, setAsBlobObject: Boolean): Unit =
+            unexpectedCall()
+
+        override fun setArray(index: Int, type: ArrayColumnType<*, *>, array: Array<*>): Unit = unexpectedCall()
+
+        private fun unexpectedCall(): Nothing = error("The recording statement should only be closed")
+    }
+}

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/JdbcTransactionCloseOrderTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/JdbcTransactionCloseOrderTests.kt
@@ -12,13 +12,16 @@ import org.jetbrains.exposed.v1.jdbc.statements.api.JdbcPreparedStatementApi
 import org.jetbrains.exposed.v1.jdbc.statements.jdbc.JdbcResult
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import org.jetbrains.exposed.v1.tests.NOT_APPLICABLE_TO_R2DBC
 import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import java.io.InputStream
 import kotlin.test.assertEquals
 
 class JdbcTransactionCloseOrderTests : DatabaseTestsBase() {
     @Test
+    @Tag(NOT_APPLICABLE_TO_R2DBC)
     fun testExecutedStatementsAreClosedInReverseOrder() {
         withConnection { database, _ ->
             Assumptions.assumeTrue(


### PR DESCRIPTION
#### Description

**Summary of the change**: Close executed JDBC statements in reverse order to prevent quadratic transaction cleanup time when using HikariCP.

**Detailed description**:

* **Why**: `JdbcTransaction` previously closed executed statements in FIFO order. HikariCP tracks statements in a collection optimized for removal from the end, so closing a large number of accumulated statements in FIFO order caused repeated linear scans and resulted in quadratic cleanup time. This primarily affected databases reporting `supportsMultipleResultSets = true`, because Exposed retains their statements until transaction cleanup.

---

#### Type of Change

* [x] Bug fix


Affected databases:

* [x] MariaDB
* [x] Mysql5
* [x] Mysql8
* [x] Postgres
* [x] SqlServer

---

#### Related Issues

[EXPOSED-1071](https://youtrack.jetbrains.com/issue/EXPOSED-1071) Closing executed statements performance issue
