### PR TITLE
feat: EXPOSED-868 Add common table expression support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Infrastructure:
 * Flyway 13.3.0
 
 Features:
+* feat: EXPOSED-868 Add common table expression support for JDBC and R2DBC
+* fix: Preserve `Except` when copying JDBC and R2DBC set operations
 * feat: EXPOSED-1049 Support hashing algorithms for the Crypt module by @obabichevjb in https://github.com/JetBrains/Exposed/pull/2876
 * feat: Add multi-row values (single statement) batch insert for PostgreSQL with R2DBC by @mdedetrich in https://github.com/JetBrains/Exposed/pull/2880
 * feat: Add Amazon Redshift JDBC support by @hugoncosta in https://github.com/JetBrains/Exposed/pull/2883

--- a/documentation-website/Writerside/hi.tree
+++ b/documentation-website/Writerside/hi.tree
@@ -47,6 +47,7 @@
         <toc-element topic="DSL-CRUD-operations.topic"/>
         <toc-element topic="Working-with-Sequence.topic"/>
         <toc-element topic="DSL-Querying-data.topic"/>
+        <toc-element topic="Common-table-expressions.md"/>
         <toc-element topic="DSL-Statement-Builder.md"/>
     </toc-element>
     <toc-element toc-title="Deep Dive into DAO">

--- a/documentation-website/Writerside/topics/Common-table-expressions.md
+++ b/documentation-website/Writerside/topics/Common-table-expressions.md
@@ -1,0 +1,127 @@
+# Common table expressions
+
+Exposed supports ordinary and recursive common table expressions (CTEs) in both the JDBC and R2DBC DSLs.
+A CTE is a named query result that you can select from, join, and reference from later CTE definitions.
+
+## Create an ordinary CTE
+
+Create a CTE with `asCte()`, map its output fields, and attach it to the outermost query with `withCtes()`:
+
+```kotlin
+val activeUsers = Users
+    .select(Users.id, Users.name)
+    .where { Users.active eq true }
+    .asCte("active_users")
+
+val userId = activeUsers[Users.id]
+val userName = activeUsers[Users.name]
+
+val query = activeUsers
+    .select(userId, userName)
+    .withCtes(activeUsers)
+
+query.forEach { row ->
+    println("${row[userId]}: ${row[userName]}")
+}
+```
+
+The same query construction API is available with R2DBC. Consume the result as a flow:
+
+```kotlin
+activeUsers
+    .select(userId, userName)
+    .withCtes(activeUsers)
+    .collect { row -> println(row[userName]) }
+```
+
+Use the fields returned by the CTE, such as `userId` and `userName`, when reading a `ResultRow`.
+The original table fields identify the corresponding CTE output, but they are not interchangeable in the final result row.
+
+Every computed output must have an explicit alias before it is used in a CTE:
+
+```kotlin
+val total = Orders.amount.sum().alias("total")
+val totals = Orders.select(Orders.region, total).asCte("regional_totals")
+val cteTotal = totals[total]
+```
+
+## Use multiple and dependent CTEs
+
+Pass CTEs to `withCtes()` in dependency order. Exposed preserves this order and does not reorder definitions automatically:
+
+```kotlin
+val total = Orders.amount.sum().alias("total")
+val regionalSales = Orders
+    .select(Orders.region, total)
+    .groupBy(Orders.region)
+    .asCte("regional_sales")
+
+val region = regionalSales[Orders.region]
+val regionalTotal = regionalSales[total]
+
+val topRegions = regionalSales
+    .select(region, regionalTotal)
+    .where { regionalTotal greater BigDecimal("1000") }
+    .asCte("top_regions")
+
+val query = topRegions
+    .selectAll()
+    .withCtes(regionalSales, topRegions)
+```
+
+A CTE can also be joined to a table or another CTE because `CommonTableExpression` is a `ColumnSet`.
+
+## Create a recursive CTE
+
+Recursive CTEs require an explicit output schema so the definition can refer to itself:
+
+```kotlin
+val number = intLiteral(1).alias("number")
+
+val numbers = recursiveCte("numbers", listOf(number)) { self ->
+    val current = self[number]
+    val seed = Table.Dual.select(number)
+    val next = (current + intLiteral(1)).alias("number")
+    val recursiveMember = self.select(next).where { current less 5 }
+
+    seed.unionAll(recursiveMember)
+}
+
+val result = numbers[number]
+val query = numbers
+    .select(result)
+    .withCtes(numbers)
+    .orderBy(result)
+```
+
+Exposed emits `WITH RECURSIVE` only for dialects that require the keyword. SQL Server and Oracle use `WITH` for recursive CTEs.
+
+## Keep the WITH clause outermost
+
+Attach all CTEs to the outermost executable query. A query that owns a `WITH` clause cannot be embedded as a query alias, scalar subquery, predicate subquery, set-operation operand, or insert/select source.
+
+```kotlin
+val source = Users.select(Users.id).asCte("source")
+val sourceId = source[Users.id]
+
+// Correct: the final executable query owns the WITH clause.
+val query = source.select(sourceId).withCtes(source)
+```
+
+CTE definitions are snapshotted when `asCte()` or `recursiveCte()` returns, so later mutation of the source query does not change the CTE.
+
+## Dialect support
+
+| Dialect | Ordinary CTEs | Recursive CTEs | Recursive declaration |
+|---|---:|---:|---|
+| H2 | Yes | Yes | `WITH RECURSIVE` |
+| PostgreSQL | Yes | Yes | `WITH RECURSIVE` |
+| Redshift | Yes | Yes | `WITH RECURSIVE` |
+| SQLite | Yes | Yes | `WITH RECURSIVE` |
+| MySQL 8 and later | Yes | Yes | `WITH RECURSIVE` |
+| MariaDB 10.2 and later | Yes | Yes | `WITH RECURSIVE` |
+| SQL Server | Yes | Yes | `WITH` |
+| Oracle | Yes | Yes | `WITH` |
+
+Unsupported versions fail with `UnsupportedByDialectException` before the statement is executed.
+The initial CTE API supports `SELECT` queries. Data-modifying CTE definitions and top-level `WITH` clauses on `INSERT`, `UPDATE`, `DELETE`, or `MERGE` are not supported.

--- a/exposed-core/api/exposed-core.api
+++ b/exposed-core/api/exposed-core.api
@@ -3,6 +3,8 @@ public abstract class org/jetbrains/exposed/v1/core/AbstractQuery : org/jetbrain
 	public final fun adjustComments (Lorg/jetbrains/exposed/v1/core/AbstractQuery$CommentPosition;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public static synthetic fun adjustComments$default (Lorg/jetbrains/exposed/v1/core/AbstractQuery;Lorg/jetbrains/exposed/v1/core/AbstractQuery$CommentPosition;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public final fun adjustHaving (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
+	protected final fun appendCommonTableExpressions (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
+	protected final fun appendStatementPreamble (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
 	public synthetic fun arguments ()Ljava/lang/Iterable;
 	public fun arguments ()Ljava/util/List;
 	public final fun comment (Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/AbstractQuery$CommentPosition;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
@@ -23,9 +25,12 @@ public abstract class org/jetbrains/exposed/v1/core/AbstractQuery : org/jetbrain
 	public abstract fun getSet ()Lorg/jetbrains/exposed/v1/core/FieldSet;
 	public final fun getWhere ()Lorg/jetbrains/exposed/v1/core/Op;
 	public final fun groupBy ([Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
+	protected final fun hasCommonTableExpressions ()Z
 	public final fun hasCustomForUpdateState ()Z
 	public final fun having (Lkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public final fun isForUpdate ()Z
+	public fun isGeneratedCteField (I)Z
+	public final fun prepareAsSubquerySQL (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)Ljava/lang/String;
 	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)Ljava/lang/String;
 	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/Transaction;Z)Ljava/lang/String;
 	protected final fun setCount (Z)V
@@ -35,6 +40,10 @@ public abstract class org/jetbrains/exposed/v1/core/AbstractQuery : org/jetbrain
 	protected final fun setLimit (Ljava/lang/Integer;)V
 	protected final fun setOffset (J)V
 	protected final fun setWhere (Lorg/jetbrains/exposed/v1/core/Op;)V
+	public fun snapshotForCte ()Lorg/jetbrains/exposed/v1/core/AbstractQuery;
+	protected final fun withCommonTableExpressionsDetached (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	protected final fun withCommonTableExpressionsDetachedSuspending (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun withCtes ([Lorg/jetbrains/exposed/v1/core/CommonTableExpression;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public fun withDistinct (Z)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public static synthetic fun withDistinct$default (Lorg/jetbrains/exposed/v1/core/AbstractQuery;ZILjava/lang/Object;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public final fun withDistinctOn ([Lorg/jetbrains/exposed/v1/core/Column;)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
@@ -487,6 +496,28 @@ public class org/jetbrains/exposed/v1/core/ColumnWithTransform : org/jetbrains/e
 	public fun unwrapRecursive (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueFromDB (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun valueToDB (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/exposed/v1/core/CommonTableExpression : org/jetbrains/exposed/v1/core/ColumnSet {
+	public fun crossJoin (Lorg/jetbrains/exposed/v1/core/ColumnSet;)Lorg/jetbrains/exposed/v1/core/Join;
+	public fun describe (Lorg/jetbrains/exposed/v1/core/Transaction;Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
+	public fun fullJoin (Lorg/jetbrains/exposed/v1/core/ColumnSet;)Lorg/jetbrains/exposed/v1/core/Join;
+	public final fun get (Lorg/jetbrains/exposed/v1/core/Column;)Lorg/jetbrains/exposed/v1/core/Column;
+	public final fun get (Lorg/jetbrains/exposed/v1/core/Expression;)Lorg/jetbrains/exposed/v1/core/Expression;
+	public final fun get (Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;)Lorg/jetbrains/exposed/v1/core/ExpressionWithColumnType;
+	public fun getColumns ()Ljava/util/List;
+	public fun getFields ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getRecursive ()Z
+	public fun innerJoin (Lorg/jetbrains/exposed/v1/core/ColumnSet;)Lorg/jetbrains/exposed/v1/core/Join;
+	public fun join (Lorg/jetbrains/exposed/v1/core/ColumnSet;Lorg/jetbrains/exposed/v1/core/JoinType;Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/Expression;ZLkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/v1/core/Join;
+	public fun leftJoin (Lorg/jetbrains/exposed/v1/core/ColumnSet;)Lorg/jetbrains/exposed/v1/core/Join;
+	public fun rightJoin (Lorg/jetbrains/exposed/v1/core/ColumnSet;)Lorg/jetbrains/exposed/v1/core/Join;
+}
+
+public final class org/jetbrains/exposed/v1/core/CommonTableExpressionKt {
+	public static final fun asCte (Lorg/jetbrains/exposed/v1/core/AbstractQuery;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/CommonTableExpression;
+	public static final fun recursiveCte (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/exposed/v1/core/CommonTableExpression;
 }
 
 public abstract class org/jetbrains/exposed/v1/core/ComparisonOp : org/jetbrains/exposed/v1/core/Op, org/jetbrains/exposed/v1/core/ComplexExpression, org/jetbrains/exposed/v1/core/Op$OpBoolean {
@@ -4079,11 +4110,13 @@ public abstract interface class org/jetbrains/exposed/v1/core/vendors/DatabaseDi
 	public abstract fun getName ()Ljava/lang/String;
 	public fun getNeedsQuotesWhenSymbolsInNames ()Z
 	public fun getNeedsSequenceToAutoInc ()Z
+	public fun getRecursiveCteSyntax ()Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
 	public fun getSequenceMaxValue ()J
 	public fun getSupportsAlterCheckConstraint ()Z
 	public fun getSupportsCheckConstraints ()Z
 	public fun getSupportsColumnTypeChange ()Z
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsCreateSchema ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsDualTableConcept ()Z
@@ -4094,6 +4127,7 @@ public abstract interface class org/jetbrains/exposed/v1/core/vendors/DatabaseDi
 	public fun getSupportsOnUpdate ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsRestrictReferenceOption ()Z
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
@@ -4122,11 +4156,13 @@ public final class org/jetbrains/exposed/v1/core/vendors/DatabaseDialect$Default
 	public static fun getLikePatternSpecialChars (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Ljava/util/Map;
 	public static fun getNeedsQuotesWhenSymbolsInNames (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getNeedsSequenceToAutoInc (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
+	public static fun getRecursiveCteSyntax (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
 	public static fun getRequiresAutoCommitOnCreateDrop (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSequenceMaxValue (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)J
 	public static fun getSupportsAlterCheckConstraint (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsCheckConstraints (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsColumnTypeChange (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
+	public static fun getSupportsCommonTableExpressions (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsCreateSchema (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsCreateSequence (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsDualTableConcept (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
@@ -4136,6 +4172,7 @@ public final class org/jetbrains/exposed/v1/core/vendors/DatabaseDialect$Default
 	public static fun getSupportsOnUpdate (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsOnlyIdentifiersInGeneratedKeys (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsOrderByNullsFirstLast (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
+	public static fun getSupportsRecursiveCommonTableExpressions (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsRestrictReferenceOption (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsSelectForUpdate (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
 	public static fun getSupportsSequenceAsGeneratedKeys (Lorg/jetbrains/exposed/v1/core/vendors/DatabaseDialect;)Z
@@ -4374,6 +4411,7 @@ public class org/jetbrains/exposed/v1/core/vendors/H2Dialect : org/jetbrains/exp
 	public final fun getOriginalDataTypeProvider ()Lorg/jetbrains/exposed/v1/core/vendors/DataTypeProvider;
 	public final fun getOriginalFunctionProvider ()Lorg/jetbrains/exposed/v1/core/vendors/FunctionProvider;
 	public fun getSupportsColumnTypeChange ()Z
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsCreateSchema ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsDualTableConcept ()Z
@@ -4381,6 +4419,7 @@ public class org/jetbrains/exposed/v1/core/vendors/H2Dialect : org/jetbrains/exp
 	public fun getSupportsMultipleGeneratedKeys ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
 	public fun getSupportsSubqueryUnions ()Z
@@ -4432,8 +4471,10 @@ public class org/jetbrains/exposed/v1/core/vendors/MariaDBDialect : org/jetbrain
 	public fun getFunctionProvider ()Lorg/jetbrains/exposed/v1/core/vendors/FunctionProvider;
 	public fun getName ()Ljava/lang/String;
 	public fun getSequenceMaxValue ()J
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/v1/core/Expression;)Z
@@ -4453,8 +4494,10 @@ public class org/jetbrains/exposed/v1/core/vendors/MysqlDialect : org/jetbrains/
 	public fun dropSchema (Lorg/jetbrains/exposed/v1/core/Schema;Z)Ljava/lang/String;
 	protected final fun getNotAcceptableDefaults ()Ljava/util/List;
 	public fun getSupportsAlterCheckConstraint ()Z
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
 	public fun getSupportsSubqueryUnions ()Z
@@ -4480,12 +4523,15 @@ public class org/jetbrains/exposed/v1/core/vendors/OracleDialect : org/jetbrains
 	public fun getDefaultReferenceOption ()Lorg/jetbrains/exposed/v1/core/ReferenceOption;
 	public fun getNeedsQuotesWhenSymbolsInNames ()Z
 	public fun getNeedsSequenceToAutoInc ()Z
+	public fun getRecursiveCteSyntax ()Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsDualTableConcept ()Z
 	public fun getSupportsIfNotExists ()Z
 	public fun getSupportsMultipleGeneratedKeys ()Z
 	public fun getSupportsOnUpdate ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsRestrictReferenceOption ()Z
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
@@ -4510,7 +4556,9 @@ public class org/jetbrains/exposed/v1/core/vendors/PostgreSQLDialect : org/jetbr
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getSupportsSubqueryUnions ()Z
 	public fun getSupportsWindowFrameGroupsMode ()Z
@@ -4546,6 +4594,14 @@ public final class org/jetbrains/exposed/v1/core/vendors/PrimaryKeyMetadata {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax : java/lang/Enum {
+	public static final field NO_RECURSIVE_KEYWORD Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
+	public static final field RECURSIVE_KEYWORD Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
+	public static fun values ()[Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
+}
+
 public class org/jetbrains/exposed/v1/core/vendors/RedshiftDialect : org/jetbrains/exposed/v1/core/vendors/VendorDialect {
 	public static final field Companion Lorg/jetbrains/exposed/v1/core/vendors/RedshiftDialect$Companion;
 	public fun <init> ()V
@@ -4557,6 +4613,7 @@ public class org/jetbrains/exposed/v1/core/vendors/RedshiftDialect : org/jetbrai
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
 	public fun getSupportsAlterCheckConstraint ()Z
 	public fun getSupportsCheckConstraints ()Z
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsGeneratedKeysRetrieval ()Z
 	public fun getSupportsMultipleGeneratedKeys ()Z
@@ -4564,6 +4621,7 @@ public class org/jetbrains/exposed/v1/core/vendors/RedshiftDialect : org/jetbrai
 	public fun getSupportsOnUpdate ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsRestrictReferenceOption ()Z
 	public fun getSupportsSetDefaultReferenceOption ()Z
 	public fun getSupportsSubqueryUnions ()Z
@@ -4589,8 +4647,11 @@ public class org/jetbrains/exposed/v1/core/vendors/SQLServerDialect : org/jetbra
 	public fun getDefaultReferenceOption ()Lorg/jetbrains/exposed/v1/core/ReferenceOption;
 	public fun getLikePatternSpecialChars ()Ljava/util/Map;
 	public fun getNeedsQuotesWhenSymbolsInNames ()Z
+	public fun getRecursiveCteSyntax ()Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsIfNotExists ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsRestrictReferenceOption ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/v1/core/Expression;)Z
@@ -4611,9 +4672,11 @@ public class org/jetbrains/exposed/v1/core/vendors/SQLiteDialect : org/jetbrains
 	public fun dropDatabase (Ljava/lang/String;)Ljava/lang/String;
 	public fun dropIndex (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
 	public fun getSupportsAlterCheckConstraint ()Z
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsCreateSchema ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsMultipleGeneratedKeys ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsWindowFrameGroupsMode ()Z
 	public fun isAllowedAsColumnDefault (Lorg/jetbrains/exposed/v1/core/Expression;)Z
 	public fun listDatabases ()Ljava/lang/String;
@@ -4657,11 +4720,13 @@ public abstract class org/jetbrains/exposed/v1/core/vendors/VendorDialect : org/
 	public fun getName ()Ljava/lang/String;
 	public fun getNeedsQuotesWhenSymbolsInNames ()Z
 	public fun getNeedsSequenceToAutoInc ()Z
+	public fun getRecursiveCteSyntax ()Lorg/jetbrains/exposed/v1/core/vendors/RecursiveCteSyntax;
 	public fun getRequiresAutoCommitOnCreateDrop ()Z
 	public fun getSequenceMaxValue ()J
 	public fun getSupportsAlterCheckConstraint ()Z
 	public fun getSupportsCheckConstraints ()Z
 	public fun getSupportsColumnTypeChange ()Z
+	public fun getSupportsCommonTableExpressions ()Z
 	public fun getSupportsCreateSchema ()Z
 	public fun getSupportsCreateSequence ()Z
 	public fun getSupportsDualTableConcept ()Z
@@ -4672,6 +4737,7 @@ public abstract class org/jetbrains/exposed/v1/core/vendors/VendorDialect : org/
 	public fun getSupportsOnUpdate ()Z
 	public fun getSupportsOnlyIdentifiersInGeneratedKeys ()Z
 	public fun getSupportsOrderByNullsFirstLast ()Z
+	public fun getSupportsRecursiveCommonTableExpressions ()Z
 	public fun getSupportsRestrictReferenceOption ()Z
 	public fun getSupportsSelectForUpdate ()Z
 	public fun getSupportsSequenceAsGeneratedKeys ()Z

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/AbstractQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/AbstractQuery.kt
@@ -5,7 +5,11 @@ import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.core.statements.api.ResultApi
 import org.jetbrains.exposed.v1.core.transactions.currentTransaction
 import org.jetbrains.exposed.v1.core.vendors.ForUpdateOption
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
+import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
+import org.jetbrains.exposed.v1.core.vendors.RecursiveCteSyntax
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 
 @Suppress("ForbiddenComment")
 // TODO: consider naming this as QueryState (or something related to state of the query) and check that it has only single responsibility
@@ -59,6 +63,8 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
     var comments: Map<CommentPosition, String> = mutableMapOf()
         private set
 
+    private var commonTableExpressions: List<CommonTableExpression> = emptyList()
+
     /**
      * Copies all stored properties of this `SELECT` query into the properties of [other].
      *
@@ -75,6 +81,82 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
         other.having = having
         other.forUpdate = forUpdate
         other.comments = comments.toMutableMap()
+        other.commonTableExpressions = commonTableExpressions.toList()
+    }
+
+    /** Attaches [ctes] to this outermost query in declaration order. */
+    fun withCtes(vararg ctes: CommonTableExpression): T = apply {
+        require(ctes.isNotEmpty()) { "At least one CTE must be provided" }
+        require(ctes.distinct().size == ctes.size) { "The same CTE cannot be attached more than once" }
+        require(commonTableExpressions.none { it in ctes }) { "The same CTE cannot be attached more than once" }
+        commonTableExpressions = commonTableExpressions + ctes
+    } as T
+
+    /** Creates an immutable snapshot suitable for use as a CTE definition. */
+    @InternalApi
+    open fun snapshotForCte(): AbstractQuery<*> = error(
+        "${this::class.simpleName} must override snapshotForCte() before it can be used as a CTE definition"
+    )
+
+    /** Returns whether this query owns an attached `WITH` clause. */
+    @InternalApi
+    protected fun hasCommonTableExpressions(): Boolean = commonTableExpressions.isNotEmpty()
+
+    /** Returns whether the field at [index] has a framework-generated alias. */
+    @InternalApi
+    open fun isGeneratedCteField(index: Int): Boolean = false
+
+    /** Runs [body] while this query's attached CTEs are temporarily detached. */
+    @InternalApi
+    protected fun <R> withCommonTableExpressionsDetached(body: (List<CommonTableExpression>) -> R): R {
+        val originalCtes = commonTableExpressions
+        commonTableExpressions = emptyList()
+        return try {
+            body(originalCtes)
+        } finally {
+            commonTableExpressions = originalCtes
+        }
+    }
+
+    /** Runs suspending [body] while this query's attached CTEs are temporarily detached. */
+    @InternalApi
+    protected suspend fun <R> withCommonTableExpressionsDetachedSuspending(
+        body: suspend (List<CommonTableExpression>) -> R
+    ): R {
+        val originalCtes = commonTableExpressions
+        commonTableExpressions = emptyList()
+        return try {
+            body(originalCtes)
+        } finally {
+            commonTableExpressions = originalCtes
+        }
+    }
+
+    /** Verifies that this query may be rendered as a nested query. */
+    internal fun validateAsSubquery() {
+        require(commonTableExpressions.isEmpty()) {
+            "A query owning a WITH clause cannot be used as a subquery; attach its CTEs to the outermost query instead"
+        }
+    }
+
+    /** Verifies that this query may be stored as a CTE definition. */
+    internal fun validateAsCteDefinition(name: String) {
+        require(commonTableExpressions.isEmpty()) {
+            "CTE '$name' definition already owns a WITH clause; attach all CTEs to the outermost query instead"
+        }
+    }
+
+    /** Renders this query as a nested query after enforcing CTE ownership rules. */
+    @InternalApi
+    fun prepareAsSubquerySQL(builder: QueryBuilder): String {
+        validateAsSubquery()
+        return prepareSQL(builder)
+    }
+
+    /** Renders this query as a nested query after enforcing CTE ownership rules. */
+    internal fun prepareAsSubquerySQL(transaction: Transaction, prepared: Boolean): String {
+        validateAsSubquery()
+        return prepareSQL(transaction, prepared)
     }
 
     override fun arguments() = QueryBuilder(true).let {
@@ -207,9 +289,7 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
         require(set.fields.isNotEmpty()) { "Can't prepare SELECT statement without columns or expressions to retrieve" }
 
         builder {
-            comments[CommentPosition.FRONT]?.let { comment ->
-                append("/*$comment*/ ")
-            }
+            appendStatementPreamble(this)
 
             append("SELECT ")
 
@@ -278,6 +358,63 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
             }
         }
         return builder.toString()
+    }
+
+    /** Appends the front comment and attached CTE definitions. */
+    protected fun appendStatementPreamble(builder: QueryBuilder) {
+        builder {
+            comments[CommentPosition.FRONT]?.let { comment -> append("/*$comment*/ ") }
+            appendCommonTableExpressions(this)
+        }
+    }
+
+    /** Appends attached CTE definitions without emitting comments. */
+    @OptIn(InternalApi::class)
+    protected fun appendCommonTableExpressions(builder: QueryBuilder) {
+        if (commonTableExpressions.isEmpty()) return
+
+        val dialect = currentDialect
+        if (!dialect.supportsCommonTableExpressions) {
+            val message = when (dialect) {
+                is MariaDBDialect -> "MariaDB 10.2 or newer is required for common table expressions"
+                is MysqlDialect -> "MySQL 8.0 or newer is required for common table expressions"
+                else -> "Common table expressions are unsupported"
+            }
+            throw UnsupportedByDialectException(message, dialect)
+        }
+        if (commonTableExpressions.any { it.recursive } && !dialect.supportsRecursiveCommonTableExpressions) {
+            throw UnsupportedByDialectException("Recursive common table expressions are unsupported", dialect)
+        }
+
+        val identifierManager = currentTransaction().db.identifierManager
+        val normalizedCteNames = commonTableExpressions.map { identifierManager.inProperCase(it.name) }
+        require(normalizedCteNames.distinct().size == normalizedCteNames.size) {
+            "A query cannot attach CTEs with duplicate names"
+        }
+        builder.registerCommonTableExpressions(commonTableExpressions)
+
+        builder {
+            append("WITH")
+            if (commonTableExpressions.any { it.recursive } && dialect.recursiveCteSyntax == RecursiveCteSyntax.RECURSIVE_KEYWORD) {
+                append(" RECURSIVE")
+            }
+            append(' ')
+            commonTableExpressions.appendTo { cte ->
+                cte.validatePhysicalSchema()
+                val normalizedOutputNames = cte.outputNames.map { identifierManager.inProperCase(it) }
+                require(normalizedOutputNames.distinct().size == normalizedOutputNames.size) {
+                    "CTE '${cte.name}' contains duplicate output names"
+                }
+                append(identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(cte.name))
+                cte.outputNames.appendTo(prefix = " (", postfix = ")") { outputName ->
+                    append(identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(outputName))
+                }
+                append(" AS (")
+                cte.definition.prepareAsSubquerySQL(this)
+                append(')')
+            }
+            append(' ')
+        }
     }
 
     /** Represents the position at which an SQL comment will be added in a `SELECT` query. */

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
@@ -165,9 +165,10 @@ class ExpressionWithColumnTypeAlias<T>(
 
 /** Represents a temporary SQL identifier, [alias], for a [query]. */
 class QueryAlias(val query: AbstractQuery<*>, val alias: String) : ColumnSet() {
+    @OptIn(InternalApi::class)
     override fun describe(s: Transaction, queryBuilder: QueryBuilder) = queryBuilder {
         append("(")
-        query.prepareSQL(queryBuilder)
+        query.prepareAsSubquerySQL(queryBuilder)
         append(") ", alias)
     }
 
@@ -321,9 +322,10 @@ val Join.lastQueryAlias: QueryAlias?
  * @sample org.jetbrains.exposed.v1.tests.shared.dml.InsertTests.testInsertWithColumnExpression
  */
 fun <T : Any> wrapAsExpression(query: AbstractQuery<*>) = object : Expression<T?>() {
+    @OptIn(InternalApi::class)
     override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
         append("(")
-        query.prepareSQL(this)
+        query.prepareAsSubquerySQL(this)
         append(")")
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/CommonTableExpression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/CommonTableExpression.kt
@@ -1,0 +1,256 @@
+package org.jetbrains.exposed.v1.core
+
+import org.jetbrains.exposed.v1.core.transactions.currentTransaction
+
+/** A named query result that can be referenced as a [ColumnSet] in another query. */
+class CommonTableExpression internal constructor(
+    /** The SQL identifier used to reference this common table expression. */
+    val name: String,
+    outputFields: List<Expression<*>>,
+    /** Whether this common table expression is recursive. */
+    val recursive: Boolean,
+) : ColumnSet() {
+    private val referenceTable = CommonTableExpressionReference(name)
+    private val outputMappings = outputFields.mapIndexed { index, expression ->
+        expression.toCteOutputMapping(index)
+    }
+    private var physicalTargets: List<Table> = emptyList()
+    private var storedDefinition: AbstractQuery<*>? = null
+
+    /** The snapshotted query that defines this common table expression. */
+    internal val definition: AbstractQuery<*>
+        get() = checkNotNull(storedDefinition) { "CTE '$name' definition has not been initialized" }
+
+    internal val outputNames: List<String> = outputMappings.map { it.name }
+
+    override val fields: List<Expression<*>> = outputMappings.map { it.output }
+
+    override val columns: List<Column<*>> = fields.filterIsInstance<Column<*>>()
+
+    init {
+        require(name.isNotBlank()) { "CTE name must not be blank" }
+        require(outputFields.isNotEmpty()) { "CTE '$name' must declare at least one output field" }
+    }
+
+    override fun describe(s: Transaction, queryBuilder: QueryBuilder) {
+        queryBuilder.requireCommonTableExpressionAttached(this)
+        queryBuilder.append(s.db.identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(name))
+    }
+
+    override fun join(
+        otherTable: ColumnSet,
+        joinType: JoinType,
+        onColumn: Expression<*>?,
+        otherColumn: Expression<*>?,
+        lateral: Boolean,
+        additionalConstraint: (() -> Op<Boolean>)?,
+    ): Join = Join(this, otherTable, joinType, onColumn, otherColumn, lateral, additionalConstraint)
+
+    override fun innerJoin(otherTable: ColumnSet): Join = Join(this, otherTable, JoinType.INNER)
+
+    override fun leftJoin(otherTable: ColumnSet): Join = Join(this, otherTable, JoinType.LEFT)
+
+    override fun rightJoin(otherTable: ColumnSet): Join = Join(this, otherTable, JoinType.RIGHT)
+
+    override fun fullJoin(otherTable: ColumnSet): Join = Join(this, otherTable, JoinType.FULL)
+
+    override fun crossJoin(otherTable: ColumnSet): Join = Join(this, otherTable, JoinType.CROSS)
+
+    /** Returns the CTE field corresponding to [original]. */
+    operator fun <T> get(original: Column<T>): Column<T> = get(original as Expression<T>) as? Column<T>
+        ?: error("CTE '$name' field for $original is not a column")
+
+    /** Returns the CTE field corresponding to [original]. */
+    operator fun <T> get(original: Expression<T>): Expression<T> {
+        val matches = outputMappings.filter { original in it.sources }
+        check(matches.size <= 1) {
+            "Field $original is represented more than once in CTE '$name'; use an explicitly aliased output field"
+        }
+        if (matches.isEmpty() && original is CompositeColumn<*>) {
+            error("Composite field $original is expanded in CTE '$name'; use its component columns instead")
+        }
+        @Suppress("UNCHECKED_CAST")
+        return matches.singleOrNull()?.output as? Expression<T>
+            ?: error("Field $original is not part of CTE '$name' output")
+    }
+
+    /** Returns the typed CTE field corresponding to [original]. */
+    operator fun <T> get(original: ExpressionWithColumnType<T>): ExpressionWithColumnType<T> =
+        get(original as Expression<T>) as? ExpressionWithColumnType<T>
+            ?: error("CTE '$name' field for $original has no column type")
+
+    @OptIn(InternalApi::class)
+    internal fun initialize(definition: AbstractQuery<*>, snapshotDefinition: Boolean = true) {
+        check(storedDefinition == null) { "CTE '$name' definition is already initialized" }
+        val snapshot = if (snapshotDefinition) definition.snapshotForCte() else definition
+        snapshot.validateAsCteDefinition(name)
+        require(snapshot.set.realFields.size == outputMappings.size) {
+            "CTE '$name' declares ${outputMappings.size} fields but its definition returns ${snapshot.set.realFields.size} fields"
+        }
+        validateTypeCompatibility(snapshot.set.realFields)
+        storedDefinition = snapshot
+        physicalTargets = snapshot.targets
+    }
+
+    internal fun targetTables(): List<Table> = physicalTargets
+
+    internal fun validatePhysicalSchema() {
+        val physicalFields = definition.set.realFields
+        require(physicalFields.size == outputMappings.size) {
+            "CTE '$name' declares ${outputMappings.size} fields but its definition renders ${physicalFields.size} fields"
+        }
+        validateTypeCompatibility(physicalFields)
+    }
+
+    private fun validateTypeCompatibility(physicalFields: List<Expression<*>>) {
+        outputMappings.zip(physicalFields).forEachIndexed { index, (mapping, physicalField) ->
+            val declaredType = (mapping.output as? ExpressionWithColumnType<*>)?.columnType ?: return@forEachIndexed
+            val actualType = (physicalField as? ExpressionWithColumnType<*>)?.columnType ?: return@forEachIndexed
+            val declaredFamily = declaredType.cteTypeFamily()
+            val actualFamily = actualType.cteTypeFamily()
+            require(declaredFamily == CteTypeFamily.UNKNOWN || actualFamily == CteTypeFamily.UNKNOWN || declaredFamily == actualFamily) {
+                "CTE '$name' field ${index + 1} declares ${declaredType::class.simpleName} " +
+                    "but its definition returns ${actualType::class.simpleName}"
+            }
+        }
+    }
+
+    private fun Expression<*>.toCteOutputMapping(index: Int): OutputMapping {
+        val outputName = stableCteOutputName()
+            ?: error("CTE '$name' field ${index + 1} has no stable name; alias the expression before creating the CTE")
+
+        val sources = buildList {
+            add(this@toCteOutputMapping)
+            if (this@toCteOutputMapping is IExpressionAlias<*>) add(delegate)
+            if (this@toCteOutputMapping is CastToJson<*>) add(expression)
+        }
+        val sourceColumn = sources.filterIsInstance<Column<*>>().firstOrNull()
+        val output = when {
+            sourceColumn != null -> sourceColumn.toCteColumn(outputName)
+            this is ExpressionWithColumnType<*> -> toCteTypedExpression(outputName)
+            else -> CteOutputExpression<Any?>(name, outputName)
+        }
+        return OutputMapping(outputName, sources, output)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Column<*>.toCteColumn(outputName: String): Column<*> =
+        Column<Any?>(referenceTable, outputName, columnType as IColumnType<Any>)
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ExpressionWithColumnType<*>.toCteTypedExpression(outputName: String): ExpressionWithColumnType<*> =
+        CteOutputExpressionWithColumnType<Any?>(name, outputName, columnType as IColumnType<Any>)
+
+    private data class OutputMapping(
+        val name: String,
+        val sources: List<Expression<*>>,
+        val output: Expression<*>,
+    )
+}
+
+internal class CommonTableExpressionReference(private val cteName: String) : Table() {
+    override val tableName: String
+        get() = cteName
+
+    override fun equals(other: Any?): Boolean = this === other
+
+    override fun hashCode(): Int = System.identityHashCode(this)
+}
+
+/** Creates an ordinary common table expression from this query. */
+@OptIn(InternalApi::class)
+fun AbstractQuery<*>.asCte(name: String): CommonTableExpression {
+    val snapshot = snapshotForCte()
+    snapshot.validateAsCteDefinition(name)
+    val fields = snapshot.set.realFields
+    fields.forEachIndexed { index, _ ->
+        require(!snapshot.isGeneratedCteField(index)) {
+            "CTE '$name' field ${index + 1} uses a generated alias; alias the expression explicitly before creating the CTE"
+        }
+    }
+    return CommonTableExpression(name, fields, recursive = false).also { it.initialize(snapshot, snapshotDefinition = false) }
+}
+
+/** Creates a recursive common table expression with an explicit output schema. */
+fun recursiveCte(
+    name: String,
+    outputFields: List<Expression<*>>,
+    definition: (self: CommonTableExpression) -> AbstractQuery<*>,
+): CommonTableExpression {
+    val cte = CommonTableExpression(name, outputFields, recursive = true)
+    cte.initialize(definition(cte))
+    return cte
+}
+
+private interface CteNamedExpression {
+    val cteOutputName: String
+}
+
+private class CteOutputExpression<T>(
+    private val cteName: String,
+    override val cteOutputName: String,
+) : Expression<T>(), CteNamedExpression {
+    @OptIn(InternalApi::class)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        val identifierManager = currentTransaction().db.identifierManager
+        append(identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(cteName))
+        append('.')
+        append(identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(cteOutputName))
+    }
+}
+
+private class CteOutputExpressionWithColumnType<T>(
+    private val cteName: String,
+    override val cteOutputName: String,
+    override val columnType: IColumnType<T & Any>,
+) : ExpressionWithColumnType<T>(), CteNamedExpression {
+    @OptIn(InternalApi::class)
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        val identifierManager = currentTransaction().db.identifierManager
+        append(identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(cteName))
+        append('.')
+        append(identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(cteOutputName))
+    }
+}
+
+private fun Expression<*>.stableCteOutputName(): String? = when (this) {
+    is Column<*> -> name
+    is IExpressionAlias<*> -> alias
+    is CastToJson<*> -> (expression as? Column<*>)?.name
+    is CteNamedExpression -> cteOutputName
+    else -> null
+}
+
+private enum class CteTypeFamily {
+    BOOLEAN,
+    NUMERIC,
+    STRING,
+    BINARY,
+    UUID,
+    DATE_TIME,
+    UNKNOWN,
+}
+
+private fun IColumnType<*>.cteTypeFamily(): CteTypeFamily = when (this) {
+    is AutoIncColumnType<*> -> delegate.cteTypeFamily()
+    is EntityIDColumnType<*> -> idColumn.columnType.cteTypeFamily()
+    is BooleanColumnType -> CteTypeFamily.BOOLEAN
+    is ByteColumnType,
+    is UByteColumnType,
+    is ShortColumnType,
+    is UShortColumnType,
+    is IntegerColumnType,
+    is UIntegerColumnType,
+    is LongColumnType,
+    is ULongColumnType,
+    is FloatColumnType,
+    is DoubleColumnType,
+    is DecimalColumnType -> CteTypeFamily.NUMERIC
+    is CharacterColumnType,
+    is StringColumnType -> CteTypeFamily.STRING
+    is BasicBinaryColumnType,
+    is BlobColumnType -> CteTypeFamily.BINARY
+    is BasicUuidColumnType<*> -> CteTypeFamily.UUID
+    is IDateColumnType -> CteTypeFamily.DATE_TIME
+    else -> CteTypeFamily.UNKNOWN
+}

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Expression.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Expression.kt
@@ -12,9 +12,20 @@ class QueryBuilder(
 ) {
     private val internalBuilder = StringBuilder()
     private val _args = mutableListOf<Pair<IColumnType<*>, Any?>>()
+    private val attachedCommonTableExpressions = mutableSetOf<CommonTableExpression>()
 
     /** Returns the list of arguments used in this query. */
     val args: List<Pair<IColumnType<*>, Any?>> get() = _args
+
+    internal fun registerCommonTableExpressions(ctes: Iterable<CommonTableExpression>) {
+        attachedCommonTableExpressions.addAll(ctes)
+    }
+
+    internal fun requireCommonTableExpressionAttached(cte: CommonTableExpression) {
+        require(cte in attachedCommonTableExpressions) {
+            "CTE '${cte.name}' is referenced but not attached to the outermost query; call withCtes() on that query"
+        }
+    }
 
     operator fun invoke(body: QueryBuilder.() -> Unit): Unit = body()
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Op.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Op.kt
@@ -486,9 +486,10 @@ class Exists(
     /** Returns the query being checked. */
     val query: AbstractQuery<*>
 ) : Op<Boolean>(), Op.OpBoolean {
+    @OptIn(InternalApi::class)
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("EXISTS (")
-        query.prepareSQL(this)
+        query.prepareAsSubquerySQL(this)
         append(")")
     }
 }
@@ -500,9 +501,10 @@ class NotExists(
     /** Returns the query being checked. */
     val query: AbstractQuery<*>
 ) : Op<Boolean>(), Op.OpBoolean {
+    @OptIn(InternalApi::class)
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         append("NOT EXISTS (")
-        query.prepareSQL(this)
+        query.prepareAsSubquerySQL(this)
         append(")")
     }
 }
@@ -516,9 +518,10 @@ sealed class SubQueryOp<T>(
     /** Returns the query to check against. */
     val query: AbstractQuery<*>
 ) : Op<Boolean>(), ComplexExpression, Op.OpBoolean {
+    @OptIn(InternalApi::class)
     override fun toQueryBuilder(queryBuilder: QueryBuilder): Unit = queryBuilder {
         append(expr, " $operator (")
-        query.prepareSQL(this)
+        query.prepareAsSubquerySQL(this)
         +")"
     }
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Table.kt
@@ -1991,6 +1991,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is Table) return false
+        if (this is CommonTableExpressionReference || other is CommonTableExpressionReference) return false
 
         if (tableName != other.tableName) return false
 
@@ -2226,6 +2227,7 @@ open class Table(name: String = "") : ColumnSet(), DdlAware {
 /** Returns the list of tables to which the columns in this column set belong. */
 fun ColumnSet.targetTables(): List<Table> = when (this) {
     is Alias<*> -> listOf(this.delegate)
+    is CommonTableExpression -> targetTables()
     is QueryAlias -> this.query.set.source.targetTables()
     is Table -> listOf(this)
     is Join -> this.table.targetTables() + this.joinParts.flatMap { it.joinPart.targetTables() }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Transaction.kt
@@ -96,10 +96,10 @@ abstract class Transaction : UserDataHolder(), TransactionInterface {
 
     @OptIn(InternalApi::class)
     internal fun fullIdentity(column: Column<*>, queryBuilder: QueryBuilder) = queryBuilder {
-        if (column.table is Alias<*>) {
-            append(db.identifierManager.quoteIfNecessary(column.table.alias))
-        } else {
-            append(db.identifierManager.quoteIfNecessary(column.table.tableName.inProperCase()))
+        when (val table = column.table) {
+            is CommonTableExpressionReference -> append(db.identifierManager.quoteIdentifierWhenWrongCaseOrNecessary(table.tableName))
+            is Alias<*> -> append(db.identifierManager.quoteIfNecessary(table.alias))
+            else -> append(db.identifierManager.quoteIfNecessary(table.tableName.inProperCase()))
         }
         append('.')
         append(identity(column))

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ops/AllAnyOps.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ops/AllAnyOps.kt
@@ -31,8 +31,9 @@ class AllAnyFromSubQueryOp<T>(
     isAny: Boolean,
     subQuery: AbstractQuery<*>
 ) : AllAnyFromBaseOp<T, AbstractQuery<*>>(isAny, subQuery) {
+    @OptIn(InternalApi::class)
     override fun QueryBuilder.registerSubSearchArgument(subSearch: AbstractQuery<*>) {
-        subSearch.prepareSQL(this)
+        subSearch.prepareAsSubquerySQL(this)
     }
 }
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/DeleteStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/DeleteStatement.kt
@@ -41,10 +41,11 @@ open class DeleteStatement(
         }
     }
 
+    @OptIn(InternalApi::class)
     override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = QueryBuilder(true).run {
         if (targetsSet is Join) {
             targetsSet.joinParts.forEach {
-                (it.joinPart as? QueryAlias)?.query?.prepareSQL(this)
+                (it.joinPart as? QueryAlias)?.query?.prepareAsSubquerySQL(this)
                 it.additionalConstraint?.invoke()?.toQueryBuilder(this)
             }
         }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/InsertSelectStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/InsertSelectStatement.kt
@@ -26,8 +26,17 @@ open class InsertSelectStatement(
         if (columns.size != selectQuery.set.fields.size) error("Columns count doesn't equal to query columns count")
     }
 
-    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> = selectQuery.arguments()
+    override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> {
+        selectQuery.validateAsSubquery()
+        return selectQuery.arguments()
+    }
 
     override fun prepareSQL(transaction: Transaction, prepared: Boolean): String =
-        transaction.db.dialect.functionProvider.insert(isIgnore, targets.single(), columns, selectQuery.prepareSQL(transaction, prepared), transaction)
+        transaction.db.dialect.functionProvider.insert(
+            isIgnore,
+            targets.single(),
+            columns,
+            selectQuery.prepareAsSubquerySQL(transaction, prepared),
+            transaction
+        )
 }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MergeStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/MergeStatement.kt
@@ -149,6 +149,7 @@ open class MergeSelectStatement(
     val on: Op<Boolean>
 ) : MergeStatement(dest) {
     override fun arguments(): Iterable<Iterable<Pair<IColumnType<*>, Any?>>> {
+        selectQuery.query.validateAsSubquery()
         val queryArguments = selectQuery.query.arguments().firstOrNull() ?: emptyList()
         val mergeStatementArguments = super.arguments().firstOrNull() ?: emptyList()
         return listOf(

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/ReplaceStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/ReplaceStatement.kt
@@ -39,7 +39,7 @@ open class ReplaceSelectStatement(
     selectQuery: AbstractQuery<*>
 ) : InsertSelectStatement(columns, selectQuery) {
     override fun prepareSQL(transaction: Transaction, prepared: Boolean): String {
-        val querySql = selectQuery.prepareSQL(transaction, prepared)
+        val querySql = selectQuery.prepareAsSubquerySQL(transaction, prepared)
         val dialect = transaction.db.dialect
         val functionProvider = when (dialect.h2Mode) {
             H2Dialect.H2CompatibilityMode.MySQL, H2Dialect.H2CompatibilityMode.MariaDB -> MysqlFunctionProvider.INSTANCE

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/UpdateStatement.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/statements/UpdateStatement.kt
@@ -79,9 +79,10 @@ open class UpdateStatement(val targetsSet: ColumnSet, val limit: Int?, val where
         values.forEach { registerArgument(it.key, it.value) }
     }
 
+    @OptIn(InternalApi::class)
     private fun QueryBuilder.registerAdditionalArgs(join: Join) {
         join.joinParts.forEach {
-            (it.joinPart as? QueryAlias)?.query?.prepareSQL(this)
+            (it.joinPart as? QueryAlias)?.query?.prepareAsSubquerySQL(this)
             it.additionalConstraint?.invoke()?.toQueryBuilder(this)
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/DatabaseDialect.kt
@@ -4,6 +4,15 @@ import org.jetbrains.exposed.v1.core.*
 import org.jetbrains.exposed.v1.core.transactions.currentTransaction
 import org.jetbrains.exposed.v1.core.transactions.currentTransactionOrNull
 
+/** Syntax used by a dialect to declare recursive common table expressions. */
+enum class RecursiveCteSyntax {
+    /** The dialect requires `WITH RECURSIVE`. */
+    RECURSIVE_KEYWORD,
+
+    /** The dialect uses `WITH` without a `RECURSIVE` keyword. */
+    NO_RECURSIVE_KEYWORD,
+}
+
 /**
  * Common interface for all database dialects.
  */
@@ -53,6 +62,15 @@ interface DatabaseDialect {
 
     /** Returns `true` if the dialect supports subqueries within a UNION/EXCEPT/INTERSECT statement. */
     val supportsSubqueryUnions: Boolean get() = false
+
+    /** Returns `true` if the dialect supports common table expressions. */
+    val supportsCommonTableExpressions: Boolean get() = false
+
+    /** Returns `true` if the dialect supports recursive common table expressions. */
+    val supportsRecursiveCommonTableExpressions: Boolean get() = false
+
+    /** Returns the syntax used to declare recursive common table expressions. */
+    val recursiveCteSyntax: RecursiveCteSyntax get() = RecursiveCteSyntax.RECURSIVE_KEYWORD
 
     /** Returns `true` if the dialect provides a special dummy DUAL table, accessible by all users. */
     val supportsDualTableConcept: Boolean get() = false

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/FunctionProvider.kt
@@ -585,7 +585,7 @@ abstract class FunctionProvider {
     ): String {
         validateMergeStatement(transaction, clauses)
 
-        val using = source.query.prepareSQL(transaction, prepared)
+        val using = source.query.prepareAsSubquerySQL(transaction, prepared)
 
         val onRaw = if (currentDialect is OracleDialect) "($on)" else "$on"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/H2.kt
@@ -213,6 +213,8 @@ internal object H2FunctionProvider : FunctionProvider() {
  * H2 dialect implementation.
  */
 open class H2Dialect : VendorDialect(dialectName, H2DataTypeProvider, H2FunctionProvider) {
+    override val supportsCommonTableExpressions: Boolean = true
+    override val supportsRecursiveCommonTableExpressions: Boolean = true
 
     override fun toString(): String = "H2Dialect[$dialectName, $h2Mode]"
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MariaDBDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MariaDBDialect.kt
@@ -106,6 +106,11 @@ internal object MariaDBFunctionProvider : MysqlFunctionProvider() {
  * MariaDB dialect implementation.
  */
 open class MariaDBDialect : MysqlDialect() {
+    @OptIn(InternalApi::class)
+    override val supportsCommonTableExpressions: Boolean
+        get() = currentTransaction().db.version.covers(CTE_MIN_MAJOR_VERSION, CTE_MIN_MINOR_VERSION)
+    override val supportsRecursiveCommonTableExpressions: Boolean
+        get() = supportsCommonTableExpressions
     override val name: String = dialectName
     override val dataTypeProvider: DataTypeProvider = MariaDBDataTypeProvider
     override val functionProvider: FunctionProvider = MariaDBFunctionProvider
@@ -161,6 +166,8 @@ open class MariaDBDialect : MysqlDialect() {
     }
 
     companion object : DialectNameProvider("MariaDB") {
+        private const val CTE_MIN_MAJOR_VERSION = 10
+        private const val CTE_MIN_MINOR_VERSION = 2
         private const val SEQUENCE_MIN_MAJOR_VERSION = 10
         private const val SEQUENCE_MIN_MINOR_VERSION = 3
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MysqlDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/MysqlDialect.kt
@@ -370,6 +370,10 @@ open class MysqlDialect : VendorDialect(dialectName, MysqlDataTypeProvider.INSTA
     override val supportsTernaryAffectedRowValues: Boolean = true
 
     override val supportsSubqueryUnions: Boolean = true
+    override val supportsCommonTableExpressions: Boolean
+        get() = isMysql8
+    override val supportsRecursiveCommonTableExpressions: Boolean
+        get() = isMysql8
 
     override val supportsOrderByNullsFirstLast: Boolean = false
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/OracleDialect.kt
@@ -465,6 +465,9 @@ private fun validateMergeCommandClauses(transaction: Transaction, clauses: List<
  * Oracle dialect implementation.
  */
 open class OracleDialect : VendorDialect(dialectName, OracleDataTypeProvider, OracleFunctionProvider) {
+    override val supportsCommonTableExpressions: Boolean = true
+    override val supportsRecursiveCommonTableExpressions: Boolean = true
+    override val recursiveCteSyntax: RecursiveCteSyntax = RecursiveCteSyntax.NO_RECURSIVE_KEYWORD
     override val supportsIfNotExists: Boolean = false
     override val needsSequenceToAutoInc: Boolean = true
     override val defaultReferenceOption: ReferenceOption = ReferenceOption.NO_ACTION

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/PostgreSQL.kt
@@ -392,6 +392,8 @@ internal object PostgreSQLFunctionProvider : FunctionProvider() {
  */
 open class PostgreSQLDialect(override val name: String = dialectName) : VendorDialect(dialectName, PostgreSQLDataTypeProvider, PostgreSQLFunctionProvider) {
     override val supportsSubqueryUnions: Boolean = true
+    override val supportsCommonTableExpressions: Boolean = true
+    override val supportsRecursiveCommonTableExpressions: Boolean = true
 
     override val supportsOrderByNullsFirstLast: Boolean = true
 

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/Redshift.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/Redshift.kt
@@ -284,6 +284,8 @@ open class RedshiftDialect : VendorDialect(dialectName, RedshiftDataTypeProvider
     override val supportsGeneratedKeysRetrieval: Boolean = false
     override val supportsOnlyIdentifiersInGeneratedKeys: Boolean = true
     override val supportsSubqueryUnions: Boolean = true
+    override val supportsCommonTableExpressions: Boolean = true
+    override val supportsRecursiveCommonTableExpressions: Boolean = true
     override val supportsOrderByNullsFirstLast: Boolean = true
     override val supportsOnUpdate: Boolean = false
     override val supportsOnDelete: Boolean = false

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLServerDialect.kt
@@ -365,6 +365,9 @@ private fun validateMergeCommandClauses(transaction: Transaction, clauses: List<
  * SQLServer dialect implementation.
  */
 open class SQLServerDialect : VendorDialect(dialectName, SQLServerDataTypeProvider, SQLServerFunctionProvider) {
+    override val supportsCommonTableExpressions: Boolean = true
+    override val supportsRecursiveCommonTableExpressions: Boolean = true
+    override val recursiveCteSyntax: RecursiveCteSyntax = RecursiveCteSyntax.NO_RECURSIVE_KEYWORD
     override val supportsIfNotExists: Boolean = false
     override val defaultReferenceOption: ReferenceOption get() = ReferenceOption.NO_ACTION
     override val needsQuotesWhenSymbolsInNames: Boolean = false

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/vendors/SQLiteDialect.kt
@@ -315,6 +315,8 @@ internal object SQLiteFunctionProvider : FunctionProvider() {
  * SQLite dialect implementation.
  */
 open class SQLiteDialect : VendorDialect(dialectName, SQLiteDataTypeProvider, SQLiteFunctionProvider) {
+    override val supportsCommonTableExpressions: Boolean = true
+    override val supportsRecursiveCommonTableExpressions: Boolean = true
     override val supportsCreateSequence: Boolean = false
 
     override val supportsMultipleGeneratedKeys: Boolean = false

--- a/exposed-jdbc/api/exposed-jdbc.api
+++ b/exposed-jdbc/api/exposed-jdbc.api
@@ -54,7 +54,7 @@ public final class org/jetbrains/exposed/v1/jdbc/EmptySizedIterable : java/util/
 
 public final class org/jetbrains/exposed/v1/jdbc/Except : org/jetbrains/exposed/v1/jdbc/SetOperation {
 	public fun <init> (Lorg/jetbrains/exposed/v1/core/AbstractQuery;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)V
-	public fun copy ()Lorg/jetbrains/exposed/v1/jdbc/Intersect;
+	public fun copy ()Lorg/jetbrains/exposed/v1/jdbc/Except;
 	public synthetic fun copy ()Lorg/jetbrains/exposed/v1/jdbc/SizedIterable;
 	public fun getOperationName ()Ljava/lang/String;
 	public synthetic fun withDistinct (Z)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
@@ -278,6 +278,7 @@ public class org/jetbrains/exposed/v1/jdbc/Query : org/jetbrains/exposed/v1/core
 	public static synthetic fun orderBy$default (Lorg/jetbrains/exposed/v1/jdbc/Query;Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/SortOrder;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/jdbc/Query;
 	public fun prepared (Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/jdbc/statements/api/JdbcPreparedStatementApi;
 	public fun setSet (Lorg/jetbrains/exposed/v1/core/FieldSet;)V
+	public fun snapshotForCte ()Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public final fun where (Lkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/v1/jdbc/Query;
 	public final fun where (Lorg/jetbrains/exposed/v1/core/Op;)Lorg/jetbrains/exposed/v1/jdbc/Query;
 	public final fun withDistinctOn ([Lkotlin/Pair;)Lorg/jetbrains/exposed/v1/jdbc/Query;
@@ -337,6 +338,8 @@ public final class org/jetbrains/exposed/v1/jdbc/SchemaUtils : org/jetbrains/exp
 public abstract class org/jetbrains/exposed/v1/jdbc/SetOperation : org/jetbrains/exposed/v1/core/AbstractQuery, org/jetbrains/exposed/v1/jdbc/SizedIterable, org/jetbrains/exposed/v1/jdbc/statements/BlockingExecutable {
 	public static final field Companion Lorg/jetbrains/exposed/v1/jdbc/SetOperation$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/AbstractQuery;Lorg/jetbrains/exposed/v1/core/AbstractQuery;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun copyTo (Lorg/jetbrains/exposed/v1/core/AbstractQuery;)V
+	public fun copyTo (Lorg/jetbrains/exposed/v1/jdbc/SetOperation;)V
 	public fun count ()J
 	public fun empty ()Z
 	public synthetic fun execute (Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction;)Ljava/lang/Object;
@@ -352,6 +355,7 @@ public abstract class org/jetbrains/exposed/v1/jdbc/SetOperation : org/jetbrains
 	public fun getStatement ()Lorg/jetbrains/exposed/v1/jdbc/SetOperation;
 	protected final fun getTransaction ()Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction;
 	public fun isAlwaysBatch ()Z
+	public fun isGeneratedCteField (I)Z
 	public fun iterator ()Ljava/util/Iterator;
 	public fun limit (I)Lorg/jetbrains/exposed/v1/jdbc/SetOperation;
 	public synthetic fun limit (I)Lorg/jetbrains/exposed/v1/jdbc/SizedIterable;
@@ -365,6 +369,7 @@ public abstract class org/jetbrains/exposed/v1/jdbc/SetOperation : org/jetbrains
 	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)Ljava/lang/String;
 	protected fun prepareStatementSQL (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
 	public fun prepared (Lorg/jetbrains/exposed/v1/jdbc/JdbcTransaction;Ljava/lang/String;)Lorg/jetbrains/exposed/v1/jdbc/statements/api/JdbcPreparedStatementApi;
+	public fun snapshotForCte ()Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 }
 
 public final class org/jetbrains/exposed/v1/jdbc/SetOperation$Companion {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Query.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/Query.kt
@@ -28,9 +28,24 @@ open class Query(
     protected val transaction: JdbcTransaction
         get() = TransactionManager.current()
 
-    /** Creates a new [Query] instance using all stored properties of this `SELECT` query. */
+    /**
+     * Creates a new [Query] instance using all stored properties of this `SELECT` query.
+     *
+     * Subclasses used as common table expression definitions must override this function and return the same runtime
+     * subtype so their behavior is preserved when the query is snapshotted.
+     */
     override fun copy(): Query = Query(set, where).also { copy ->
         copyTo(copy)
+    }
+
+    @InternalApi
+    override fun snapshotForCte(): AbstractQuery<*> {
+        val snapshot = copy()
+        check(snapshot::class == this::class) {
+            "${this::class.simpleName ?: "Query subclass"}.copy() must preserve its subtype before it can be used as a " +
+                "CTE definition"
+        }
+        return snapshot
     }
 
     override fun forUpdate(option: ForUpdateOption): Query {
@@ -223,31 +238,35 @@ open class Query(
      *
      * @sample org.jetbrains.exposed.v1.tests.shared.dml.InsertSelectTests.testInsertSelect02
      */
+    @OptIn(InternalApi::class)
     override fun count(): Long {
         return if (distinct || distinctOn != null || groupedByColumns.isNotEmpty() || limit != null || offset > 0) {
-            @OptIn(InternalApi::class)
             fun Column<*>.makeAlias() =
                 alias(transaction.db.identifierManager.quoteIfNecessary("${table.tableNameWithoutSchemeSanitized}_$name"))
 
-            val originalSet = set
-            try {
-                var expInx = 0
-                adjustSelect {
-                    select(
-                        originalSet.fields.map {
-                            when (it) {
-                                is IExpressionAlias<*> -> it
-                                is Column<*> -> it.makeAlias()
-                                is ExpressionWithColumnType<*> -> it.alias("exp${expInx++}")
-                                else -> it.alias("exp${expInx++}")
+            withCommonTableExpressionsDetached { originalCtes ->
+                val originalSet = set
+                try {
+                    var expInx = 0
+                    adjustSelect {
+                        select(
+                            originalSet.fields.map {
+                                when (it) {
+                                    is IExpressionAlias<*> -> it
+                                    is Column<*> -> it.makeAlias()
+                                    is ExpressionWithColumnType<*> -> it.alias("exp${expInx++}")
+                                    else -> it.alias("exp${expInx++}")
+                                }
                             }
-                        }
-                    )
-                }
+                        )
+                    }
 
-                alias("subquery").selectAll().count()
-            } finally {
-                set = originalSet
+                    alias("subquery").selectAll().also { countQuery ->
+                        originalCtes.forEach { countQuery.withCtes(it) }
+                    }.count()
+                } finally {
+                    set = originalSet
+                }
             }
         } else {
             try {

--- a/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/SetOperations.kt
+++ b/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/SetOperations.kt
@@ -29,6 +29,14 @@ sealed class SetOperation(
     BlockingExecutable<ResultApi, SetOperation>,
     SizedIterable<ResultRow> {
 
+    @OptIn(InternalApi::class)
+    private var generatedCteFieldIndexes: Set<Int> = _firstStatement.set.realFields.mapIndexedNotNull { index, expression ->
+        index.takeIf {
+            _firstStatement.isGeneratedCteField(index) ||
+                expression !is Column<*> && expression !is IExpressionAlias<*> && expression !is CastToJson<*>
+        }
+    }.toSet()
+
     override val statement: SetOperation = this
 
     protected val transaction: JdbcTransaction
@@ -70,6 +78,28 @@ sealed class SetOperation(
     /** The SQL keyword representing the set operation. */
     open val operationName = operationName
 
+    override fun copyTo(other: SetOperation) {
+        super.copyTo(other)
+        other.generatedCteFieldIndexes = generatedCteFieldIndexes.toSet()
+    }
+
+    @InternalApi
+    override fun snapshotForCte(): AbstractQuery<*> {
+        val firstSnapshot = firstStatement.snapshotForCte()
+        val secondSnapshot = secondStatement.snapshotForCte()
+        val snapshot = when (this) {
+            is Union -> Union(firstSnapshot, secondSnapshot)
+            is UnionAll -> UnionAll(firstSnapshot, secondSnapshot)
+            is Intersect -> Intersect(firstSnapshot, secondSnapshot)
+            is Except -> Except(firstSnapshot, secondSnapshot)
+        }
+        copyTo(snapshot)
+        return snapshot
+    }
+
+    @InternalApi
+    override fun isGeneratedCteField(index: Int): Boolean = index in generatedCteFieldIndexes
+
     /** Returns the number of results retrieved after query execution. */
     override fun count(): Long {
         try {
@@ -101,8 +131,10 @@ sealed class SetOperation(
         transaction: JdbcTransaction
     ): JdbcResult = executeQuery()
 
+    @OptIn(InternalApi::class)
     override fun prepareSQL(builder: QueryBuilder): String {
         builder {
+            if (hasCommonTableExpressions()) appendStatementPreamble(this)
             if (count) append("SELECT COUNT(*) FROM (")
 
             prepareStatementSQL(this)
@@ -124,6 +156,7 @@ sealed class SetOperation(
         return builder.toString()
     }
 
+    @OptIn(InternalApi::class)
     protected open fun prepareStatementSQL(builder: QueryBuilder) {
         builder {
             rawStatements.appendTo(separator = " $operationName ") {
@@ -131,10 +164,10 @@ sealed class SetOperation(
                     is Query -> {
                         val isSubQuery = it.orderByExpressions.isNotEmpty() || it.limit != null
                         if (isSubQuery) append("(")
-                        it.prepareSQL(this)
+                        it.prepareAsSubquerySQL(this)
                         if (isSubQuery) append(")")
                     }
-                    is SetOperation -> it.prepareSQL(this)
+                    is SetOperation -> it.prepareAsSubquerySQL(this)
                 }
             }
         }
@@ -223,7 +256,9 @@ class UnionAll(
 
     override fun withDistinct(value: Boolean): SetOperation {
         return if (value) {
-            Union(firstStatement, secondStatement)
+            Union(firstStatement, secondStatement).also {
+                copyTo(it)
+            }
         } else {
             this
         }
@@ -268,7 +303,7 @@ class Except(
             else -> "EXCEPT"
         }
 
-    override fun copy() = Intersect(firstStatement, secondStatement).also {
+    override fun copy() = Except(firstStatement, secondStatement).also {
         copyTo(it)
     }
 

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
@@ -133,6 +133,18 @@ class JsonBColumnTests : DatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testCteWithJsonBCastProjection() {
+        val excluded = binaryJsonNotSupportedDB + TestDB.MYSQL_V5 + TestDB.MARIADB
+        withJsonBTable(exclude = excluded) { tester, _, data1, _ ->
+            val castJson = tester.jsonBColumn.castToJson()
+            val cte = tester.select(castJson).asCte("json_values")
+            val jsonValue = cte[tester.jsonBColumn]
+
+            assertEquals(data1, cte.select(jsonValue).withCtes(cte).single()[jsonValue])
+        }
+    }
+
     @Tag(MISSING_R2DBC_TEST)
     @Test
     fun testDAOFunctionsWithJsonBColumn() {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/json/JsonBColumnTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/json/JsonBColumnTests.kt
@@ -138,6 +138,18 @@ class JsonBColumnTests : R2dbcDatabaseTestsBase() {
     }
 
     @Test
+    fun testCteWithJsonBCastProjection() {
+        val excluded = binaryJsonNotSupportedDB + TestDB.MYSQL_V5 + TestDB.MARIADB
+        withJsonBTable(exclude = excluded) { tester, _, data1, _ ->
+            val castJson = tester.jsonBColumn.castToJson()
+            val cte = tester.select(castJson).asCte("json_values")
+            val jsonValue = cte[tester.jsonBColumn]
+
+            assertEquals(data1, cte.select(jsonValue).withCtes(cte).single()[jsonValue])
+        }
+    }
+
+    @Test
     fun testJsonContains() {
         withJsonBTable(exclude = binaryJsonNotSupportedDB + TestDB.ALL_H2_V2) { tester, user1, data1, testDb ->
             val alphaTeamUser = user1.copy(team = "Alpha")

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/CommonTableExpressionTests.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/dml/CommonTableExpressionTests.kt
@@ -1,0 +1,657 @@
+package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml
+
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.v1.core.AbstractQuery
+import org.jetbrains.exposed.v1.core.BiCompositeColumn
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
+import org.jetbrains.exposed.v1.core.FieldSet
+import org.jetbrains.exposed.v1.core.IntegerColumnType
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.alias
+import org.jetbrains.exposed.v1.core.allFrom
+import org.jetbrains.exposed.v1.core.anyFrom
+import org.jetbrains.exposed.v1.core.asCte
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.exists
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.inSubQuery
+import org.jetbrains.exposed.v1.core.intLiteral
+import org.jetbrains.exposed.v1.core.intParam
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.core.recursiveCte
+import org.jetbrains.exposed.v1.core.statements.buildStatement
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.core.times
+import org.jetbrains.exposed.v1.core.wrapAsExpression
+import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
+import org.jetbrains.exposed.v1.r2dbc.Query
+import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.except
+import org.jetbrains.exposed.v1.r2dbc.explain
+import org.jetbrains.exposed.v1.r2dbc.insert
+import org.jetbrains.exposed.v1.r2dbc.intersect
+import org.jetbrains.exposed.v1.r2dbc.select
+import org.jetbrains.exposed.v1.r2dbc.selectAll
+import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
+import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
+import org.jetbrains.exposed.v1.r2dbc.union
+import org.jetbrains.exposed.v1.r2dbc.unionAll
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class CommonTableExpressionTests : R2dbcDatabaseTestsBase() {
+    private object Items : Table("cte_items") {
+        val id = integer("id")
+        val value = integer("value")
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    private object CompositeItems : Table("cte_composite_items") {
+        val first = Column<Int>(this, "first_value", IntegerColumnType())
+        val second = Column<Int>(this, "second_value", IntegerColumnType())
+        val pair = registerCompositeColumn(
+            object : BiCompositeColumn<Int, Int, Pair<Int, Int>>(
+                first,
+                second,
+                transformFromValue = { it },
+                transformToValue = { firstValue, secondValue -> firstValue as Int to secondValue as Int },
+            ) {}
+        )
+    }
+
+    private class UnsnapshottableQuery(override val set: FieldSet) : AbstractQuery<UnsnapshottableQuery>(emptyList())
+
+    private class FailingExpression : ExpressionWithColumnType<Int>() {
+        override val columnType = IntegerColumnType()
+        var shouldFail = true
+
+        override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+            check(!shouldFail) { "Deliberate CTE rendering failure" }
+            queryBuilder.append("1")
+        }
+    }
+
+    @Test
+    fun testOrdinaryCte() {
+        withItems {
+            val selected = Items.select(Items.id, Items.value).where { Items.value less 30 }
+            val cte = selected.asCte("selected_items")
+            val id = cte[Items.id]
+            val value = cte[Items.value]
+
+            val rows = cte.select(id, value).withCtes(cte).orderBy(id).map { it[id] to it[value] }.toList()
+
+            assertEquals(listOf(1 to 10, 2 to 20), rows)
+        }
+    }
+
+    @Test
+    fun testDependentCtes() {
+        withItems {
+            val first = Items.select(Items.id, Items.value).asCte("all_items")
+            val firstId = first[Items.id]
+            val firstValue = first[Items.value]
+            val second = first.select(firstId, firstValue).where { firstValue less 30 }.asCte("selected_items")
+            val secondId = second[firstId]
+
+            val rows = second.select(secondId).withCtes(first, second).orderBy(secondId).map { it[secondId] }.toList()
+
+            assertEquals(listOf(1, 2), rows)
+            assertFailsWith<IllegalStateException> { second[Items.id] }
+        }
+    }
+
+    @Test
+    fun testCteCanBeJoinedToTable() {
+        withItems {
+            val cte = Items.select(Items.id).where { Items.value greater 10 }.asCte("selected_items")
+            val cteId = cte[Items.id]
+            val join = Items.join(cte, JoinType.INNER, Items.id, cteId)
+
+            val ids = join.select(Items.id).orderBy(Items.id).withCtes(cte).map { it[Items.id] }.toList()
+            assertEquals(listOf(2, 3), ids)
+        }
+    }
+
+    @Test
+    fun testRecursiveCte() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            val number = intLiteral(1).alias("n")
+            val numbers = recursiveCte("numbers", listOf(number)) { self ->
+                val current = self[number]
+                val seed = Table.Dual.select(number)
+                val next = (current + intLiteral(1)).alias("n")
+                val recursive = self.select(next).where { current less 3 }
+                seed.unionAll(recursive)
+            }
+            val result = numbers[number]
+
+            val values = numbers.select(result).withCtes(numbers).orderBy(result).map { it[result] }.toList()
+            assertEquals(listOf(1, 2, 3), values)
+        }
+    }
+
+    @Test
+    fun testRecursiveCteWithDistinctUnion() {
+        withDb(TestDB.ALL_H2_V2) {
+            val number = intLiteral(1).alias("number")
+            val numbers = recursiveCte("numbers", listOf(number)) { self ->
+                val current = self[number]
+                val seed = Table.Dual.select(number)
+                val next = (current + intLiteral(1)).alias("number")
+                val recursive = self.select(next).where { current less 3 }
+                seed.union(recursive)
+            }
+            val result = numbers[number]
+
+            val values = numbers.select(result).withCtes(numbers).orderBy(result).map { it[result] }.toList()
+            assertEquals(listOf(1, 2, 3), values)
+        }
+    }
+
+    @Test
+    fun testRecursiveCteSyntax() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) { testDb ->
+            val number = intLiteral(1).alias("number")
+            val numbers = recursiveCte("numbers", listOf(number)) { Table.Dual.select(number) }
+            val sql = numbers.select(numbers[number]).withCtes(numbers).prepareSQL(this, prepared = false)
+            val expectsRecursiveKeyword = testDb != TestDB.SQLSERVER && testDb != TestDB.ORACLE
+
+            assertEquals(expectsRecursiveKeyword, sql.startsWith("WITH RECURSIVE "))
+        }
+    }
+
+    @Test
+    fun testCountWithCte() {
+        withItems {
+            val cte = Items.select(Items.value).asCte("item_values")
+            val value = cte[Items.value]
+
+            assertEquals(3, cte.selectAll().withCtes(cte).count())
+            assertEquals(3, cte.selectAll().withDistinct().withCtes(cte).count())
+            assertEquals(3, cte.select(value).groupBy(value).withCtes(cte).count())
+            assertEquals(1, cte.select(value).withCtes(cte).limit(1).offset(1).count())
+        }
+    }
+
+    @Test
+    fun testComplexCountRestoresCteStateAfterFailure() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            val failingExpression = FailingExpression()
+            val projected = failingExpression.alias("cte_value")
+            val cte = Table.Dual.select(projected).asCte("failing_cte")
+            val value = cte[projected]
+            val query = cte.select(value).withDistinct().withCtes(cte)
+
+            assertFailsWith<IllegalStateException> { query.count() }
+
+            failingExpression.shouldFail = false
+            assertEquals(1, query.count())
+            assertTrue(query.prepareSQL(this, prepared = false).startsWith("WITH "))
+        }
+    }
+
+    @Test
+    fun testComplexCountUsesCustomQuerySubclass() {
+        withItems {
+            class CustomQuery(source: Query) : Query(source.set, source.where) {
+                override fun prepareSQL(builder: QueryBuilder): String = error("Custom query SQL")
+            }
+
+            val query = CustomQuery(Items.selectAll()).withDistinct()
+
+            assertEquals("Custom query SQL", assertFailsWith<IllegalStateException> { query.count() }.message)
+        }
+    }
+
+    @Test
+    fun testParametersAndComputedAlias() {
+        withItems {
+            val doubled = (Items.value * intLiteral(2)).alias("doubled")
+            val cte = Items.select(Items.id, doubled).where { Items.value greater 10 }.asCte("computed_items")
+            val computed = cte[doubled]
+
+            val rows = cte.select(computed).where { computed less 60 }.withCtes(cte).map { it[computed] }.toList()
+
+            assertEquals(listOf(40), rows)
+        }
+    }
+
+    @Test
+    fun testCteOrderAndParameterOrder() {
+        withItems {
+            val first = Items.select(Items.id).where { Items.value greater intParam(10) }.asCte("first_items")
+            val second = Items.select(Items.id).where { Items.value greater intParam(20) }.asCte("second_items")
+            val secondId = second[Items.id]
+            val query = second.select(secondId).where { secondId less intParam(4) }.withCtes(first, second)
+
+            val sql = query.prepareSQL(this, prepared = true)
+            val normalizedSql = sql.uppercase()
+            assertTrue(normalizedSql.indexOf("FIRST_ITEMS") < normalizedSql.indexOf("SECOND_ITEMS"))
+            assertEquals(listOf(10, 20, 4), query.arguments().single().map { it.second })
+            assertTrue(query.prepareSQL(this, prepared = false).contains("20"))
+        }
+    }
+
+    @Test
+    fun testCompositeOutputIsExpanded() {
+        withTables(excludeSettings = listOf(TestDB.MYSQL_V5), CompositeItems) {
+            CompositeItems.insert { it[pair] = 1 to 2 }
+            val cte = CompositeItems.select(CompositeItems.pair).asCte("composite_items")
+            val first = cte[CompositeItems.first]
+            val second = cte[CompositeItems.second]
+
+            val row = cte.select(first, second).withCtes(cte).map { it[first] to it[second] }.toList().single()
+            assertEquals(1 to 2, row)
+            val failure = assertFailsWith<IllegalStateException> { cte[CompositeItems.pair] }
+            assertTrue(failure.message.orEmpty().contains("component columns"))
+        }
+    }
+
+    @Test
+    fun testReservedWordCteName() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("select")
+            val id = cte[Items.id]
+
+            val values = cte.select(id).withCtes(cte).orderBy(id).map { it[id] }.toList()
+            assertEquals(listOf(1, 2, 3), values)
+        }
+    }
+
+    @Test
+    fun testCteReferenceIsDistinctFromPhysicalTableWithSameName() {
+        withDb(TestDB.H2_V2) {
+            val cte = Items.select(Items.id).asCte(Items.tableName)
+            val cteId = cte[Items.id]
+
+            assertNotEquals(Items.id, cteId)
+            assertNotEquals(cteId, Items.id)
+        }
+    }
+
+    @Test
+    fun testDefinitionIsSnapshotted() {
+        withItems {
+            val source = Items.select(Items.id)
+            val cte = source.asCte("item_ids")
+            source.adjustSelect { select(Items.value) }
+            val id = cte[Items.id]
+
+            assertEquals(listOf(1, 2, 3), cte.select(id).withCtes(cte).orderBy(id).map { it[id] }.toList())
+        }
+    }
+
+    @Test
+    fun testSetOperationsWithCte() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val first = cte.select(id).where { id less 2 }
+            val second = cte.select(id).where { id greater 2 }
+            val union = first.unionAll(second).withCtes(cte)
+
+            assertEquals(listOf(1, 3), union.map { it[id] }.toList().sorted())
+            assertEquals(2, union.count())
+        }
+    }
+
+    @Test
+    fun testWithDistinctRetainsCtesOnUnionAll() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val union = cte.select(id).where { id less 3 }
+                .unionAll(cte.select(id).where { id greater 1 })
+                .withCtes(cte)
+                .withDistinct()
+
+            assertEquals(listOf(1, 2, 3), union.map { it[id] }.toList().sorted())
+        }
+    }
+
+    @Test
+    fun testCteBearingSetOperationOperandIsRejected() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val first = cte.select(id).withCtes(cte)
+            val union = first.unionAll(Items.select(Items.id))
+
+            assertFailsWith<IllegalArgumentException> {
+                union.prepareSQL(this, prepared = false)
+            }
+        }
+    }
+
+    @Test
+    fun testSetOperationAsCteDefinition() {
+        withItems {
+            val itemId = Items.id.alias("item_id")
+            val low = Items.select(itemId).where { Items.id less 2 }
+            val high = Items.select(itemId).where { Items.id greater 2 }
+            val cte = low.unionAll(high).asCte("item_ids")
+            val id = cte[itemId]
+
+            assertEquals(listOf(1, 3), cte.select(id).withCtes(cte).orderBy(id).map { it[id] }.toList())
+        }
+    }
+
+    @Test
+    fun testSetOperationDefinitionIsDeeplySnapshotted() {
+        withItems {
+            val itemId = Items.id.alias("item_id")
+            val low = Items.select(itemId).where { Items.id less 2 }
+            val high = Items.select(itemId).where { Items.id greater 2 }
+            val cte = low.unionAll(high).asCte("item_ids")
+            val id = cte[itemId]
+
+            high.adjustWhere { Items.id less 0 }
+
+            assertEquals(listOf(1, 3), cte.select(id).withCtes(cte).orderBy(id).map { it[id] }.toList())
+        }
+    }
+
+    @Test
+    fun testSetOperationSnapshotsPreserveOperation() {
+        withTables(excludeSettings = TestDB.ALL - TestDB.H2_V2, Items) {
+            Items.insert {
+                it[id] = 1
+                it[value] = 10
+            }
+            Items.insert {
+                it[id] = 2
+                it[value] = 20
+            }
+            val itemId = Items.id.alias("item_id")
+
+            val intersected = Items.select(itemId).where { Items.id less 3 }
+                .intersect(Items.select(itemId).where { Items.id eq 1 })
+                .asCte("intersected")
+            val intersectedValue = intersected[itemId]
+            assertEquals(
+                listOf(1),
+                intersected.select(intersectedValue).withCtes(intersected).map { it[intersectedValue] }.toList()
+            )
+
+            val excepted = Items.select(itemId).where { Items.id less 3 }
+                .except(Items.select(itemId).where { Items.id eq 2 })
+                .asCte("excepted")
+            val exceptedValue = excepted[itemId]
+            assertEquals(
+                listOf(1),
+                excepted.select(exceptedValue).withCtes(excepted).map { it[exceptedValue] }.toList()
+            )
+        }
+    }
+
+    @Test
+    fun testExplicitGeneratedStyleAliasIsAccepted() {
+        withItems {
+            val firstValue = (Items.value + intLiteral(1)).alias("exp0")
+            val secondValue = (Items.value + intLiteral(2)).alias("exp0")
+            val cte = Items.select(firstValue).unionAll(Items.select(secondValue)).asCte("explicit_alias")
+            val value = cte[firstValue]
+
+            assertEquals(6, cte.select(value).withCtes(cte).count())
+        }
+    }
+
+    @Test
+    fun testCopyAndEmptyRetainCtes() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val query = cte.selectAll().withCtes(cte)
+
+            assertEquals(3, query.copy().count())
+            assertEquals(false, query.empty())
+        }
+    }
+
+    @Test
+    fun testFrontCommentPrecedesWithClause() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val query = cte.selectAll().withCtes(cte).comment("cte-query")
+            val sql = query.prepareSQL(this, prepared = false)
+
+            assertTrue(sql.startsWith("/*cte-query*/ WITH "))
+            assertEquals(1, Regex("/\\*cte-query\\*/").findAll(sql).count())
+        }
+    }
+
+    @Test
+    fun testInvalidSchemasAreRejected() {
+        withItems {
+            assertFailsWith<IllegalStateException> {
+                Items.select(Items.value + intLiteral(1)).asCte("unnamed")
+            }
+
+            val generated = Items.select(Items.value + intLiteral(1))
+                .unionAll(Items.select(Items.value + intLiteral(2)))
+            assertFailsWith<IllegalArgumentException> { generated.asCte("generated") }
+
+            val duplicate = Items.select(Items.id.alias("same"), Items.value.alias("same")).asCte("duplicate")
+            assertFailsWith<IllegalArgumentException> {
+                duplicate.selectAll().withCtes(duplicate).prepareSQL(this, prepared = false)
+            }
+        }
+    }
+
+    @Test
+    fun testAmbiguousOriginalFieldLookupIsRejected() {
+        withItems {
+            val first = Items.id.alias("first_id")
+            val second = Items.id.alias("second_id")
+            val cte = Items.select(first, second).asCte("duplicate_ids")
+            val firstId = cte[first]
+            val secondId = cte[second]
+
+            assertFailsWith<IllegalStateException> { cte[Items.id] }
+            val rows = cte.select(firstId, secondId).withCtes(cte).map { it[firstId] to it[secondId] }.toList()
+            assertTrue(rows.all { it.first == it.second })
+        }
+    }
+
+    @Test
+    fun testRecursiveArityMismatchIsRejected() {
+        withDb {
+            val first = intLiteral(1).alias("first")
+            val second = intLiteral(2).alias("second")
+
+            assertFailsWith<IllegalArgumentException> {
+                recursiveCte("invalid_recursive", listOf(first, second)) { Table.Dual.select(first) }
+            }
+        }
+    }
+
+    @Test
+    fun testRecursiveTypeMismatchIsRejected() {
+        withDb {
+            val declared = intLiteral(1).alias("value")
+            val actual = stringLiteral("invalid").alias("value")
+
+            assertFailsWith<IllegalArgumentException> {
+                recursiveCte("invalid_recursive", listOf(declared)) { Table.Dual.select(actual) }
+            }
+        }
+    }
+
+    @Test
+    fun testCustomQueryWithoutSnapshotSupportIsRejected() {
+        withDb {
+            assertFailsWith<IllegalStateException> {
+                UnsnapshottableQuery(Table.Dual.select(intLiteral(1).alias("value")).set).asCte("custom")
+            }
+        }
+    }
+
+    @Test
+    fun testQuerySubclassWithoutSubtypePreservingCopyIsRejected() {
+        withDb {
+            class CustomQuery(source: Query) : Query(source.set, source.where) {
+                override fun prepareSQL(builder: QueryBuilder): String = error("Custom query SQL")
+            }
+
+            val exception = assertFailsWith<IllegalStateException> {
+                CustomQuery(Table.Dual.select(intLiteral(1).alias("value"))).asCte("custom")
+            }
+
+            assertContains(exception.message.orEmpty(), "copy() must preserve its subtype")
+        }
+    }
+
+    @Test
+    fun testQuerySubclassWithSubtypePreservingCopyCanBeUsedAsCte() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            class CustomQuery(source: Query) : Query(source.set, source.where) {
+                override fun copy(): CustomQuery = CustomQuery(this).also { copyTo(it) }
+
+                override fun prepareSQL(builder: QueryBuilder): String {
+                    builder.append("/* custom query */ ")
+                    return super.prepareSQL(builder)
+                }
+            }
+
+            val value = intLiteral(1).alias("value")
+            val cte = CustomQuery(Table.Dual.select(value)).asCte("custom")
+
+            val sql = cte.select(cte[value]).withCtes(cte).prepareSQL(this, prepared = false)
+
+            assertContains(sql, "AS (/* custom query */ SELECT")
+        }
+    }
+
+    @Test
+    fun testReferencedCtesMustBeAttachedToOutermostQuery() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            val value = intLiteral(1).alias("value")
+            val first = Table.Dual.select(value).asCte("first_cte")
+            val firstValue = first[value]
+
+            val directReference = assertFailsWith<IllegalArgumentException> {
+                first.select(firstValue).prepareSQL(this, prepared = false)
+            }
+            assertContains(directReference.message.orEmpty(), "CTE 'first_cte' is referenced but not attached")
+
+            val second = first.select(firstValue).asCte("second_cte")
+            val secondValue = second[firstValue]
+            val missingDependency = assertFailsWith<IllegalArgumentException> {
+                second.select(secondValue).withCtes(second).prepareSQL(this, prepared = false)
+            }
+            assertContains(missingDependency.message.orEmpty(), "CTE 'first_cte' is referenced but not attached")
+        }
+    }
+
+    @Test
+    fun testDuplicateCteNamesAreRejected() {
+        withItems {
+            val first = Items.select(Items.id).asCte("duplicate")
+            val second = Items.select(Items.value).asCte("duplicate")
+
+            assertFailsWith<IllegalArgumentException> {
+                first.selectAll().withCtes(first, second).prepareSQL(this, prepared = false)
+            }
+        }
+    }
+
+    @Test
+    fun testMySql5IsRejectedBeforeExecution() {
+        withDb(TestDB.MYSQL_V5) {
+            val value = intLiteral(1).alias("value")
+            val cte = Table.Dual.select(value).asCte("value_cte")
+
+            assertFailsWith<UnsupportedByDialectException> {
+                cte.select(cte[value]).withCtes(cte).prepareSQL(this, prepared = true)
+            }
+        }
+    }
+
+    @Test
+    fun testCteCannotBeNestedInQueriesOrStatements() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val nestedQuery = cte.select(id).withCtes(cte)
+            val nestedAlias = nestedQuery.alias("nested")
+            val join = Items.join(nestedAlias, JoinType.INNER, Items.id, nestedAlias[id])
+
+            assertFailsWith<IllegalArgumentException> { nestedAlias.selectAll().toList() }
+            assertFailsWith<IllegalArgumentException> {
+                Items.select(wrapAsExpression<Int>(nestedQuery)).prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { exists(nestedQuery) }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { Items.id inSubQuery nestedQuery }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { Items.id eq anyFrom<Int>(nestedQuery) }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { Items.id eq allFrom<Int>(nestedQuery) }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { Items.insert(nestedQuery, columns = listOf(Items.id)) }
+                    .prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { Items.replace(nestedQuery, columns = listOf(Items.id)) }
+                    .prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement {
+                    Items.mergeFrom(nestedAlias, on = { Items.id eq nestedAlias[id] }) {}
+                }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { join.update { it[Items.value] = 0 } }.arguments().toList()
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { join.delete(Items) }.arguments().toList()
+            }
+        }
+    }
+
+    @Test
+    fun testExplainAndTargetTracking() {
+        withItems { testDb ->
+            val cte = Items.select(Items.id).asCte("SelectedItems")
+            val query = cte.selectAll().withCtes(cte)
+
+            assertEquals(listOf(Items), query.targets)
+            if (testDb !in TestDB.ALL_SQLSERVER_LIKE + TestDB.ALL_ORACLE_LIKE) {
+                assertTrue(explain { query }.toList().isNotEmpty())
+            }
+        }
+    }
+
+    private fun withItems(statement: suspend R2dbcTransaction.(TestDB) -> Unit) {
+        withTables(excludeSettings = listOf(TestDB.MYSQL_V5), Items) { testDb ->
+            Items.insert {
+                it[id] = 1
+                it[value] = 10
+            }
+            Items.insert {
+                it[id] = 2
+                it[value] = 20
+            }
+            Items.insert {
+                it[id] = 3
+                it[value] = 30
+            }
+            statement(testDb)
+        }
+    }
+}

--- a/exposed-r2dbc/api/exposed-r2dbc.api
+++ b/exposed-r2dbc/api/exposed-r2dbc.api
@@ -19,7 +19,7 @@ public final class org/jetbrains/exposed/v1/r2dbc/EmptySizedIterable : org/jetbr
 
 public final class org/jetbrains/exposed/v1/r2dbc/Except : org/jetbrains/exposed/v1/r2dbc/SetOperation {
 	public fun <init> (Lorg/jetbrains/exposed/v1/core/AbstractQuery;Lorg/jetbrains/exposed/v1/core/AbstractQuery;)V
-	public fun copy ()Lorg/jetbrains/exposed/v1/r2dbc/Intersect;
+	public fun copy ()Lorg/jetbrains/exposed/v1/r2dbc/Except;
 	public synthetic fun copy ()Lorg/jetbrains/exposed/v1/r2dbc/SizedIterable;
 	public fun getOperationName ()Ljava/lang/String;
 	public synthetic fun withDistinct (Z)Lorg/jetbrains/exposed/v1/core/AbstractQuery;
@@ -197,6 +197,7 @@ public class org/jetbrains/exposed/v1/r2dbc/Query : org/jetbrains/exposed/v1/cor
 	public static synthetic fun orderBy$default (Lorg/jetbrains/exposed/v1/r2dbc/Query;Lorg/jetbrains/exposed/v1/core/Expression;Lorg/jetbrains/exposed/v1/core/SortOrder;ILjava/lang/Object;)Lorg/jetbrains/exposed/v1/r2dbc/Query;
 	public fun prepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun setSet (Lorg/jetbrains/exposed/v1/core/FieldSet;)V
+	public fun snapshotForCte ()Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 	public final fun where (Lkotlin/jvm/functions/Function0;)Lorg/jetbrains/exposed/v1/r2dbc/Query;
 	public final fun where (Lorg/jetbrains/exposed/v1/core/Op;)Lorg/jetbrains/exposed/v1/r2dbc/Query;
 	public final fun withDistinctOn ([Lkotlin/Pair;)Lorg/jetbrains/exposed/v1/r2dbc/Query;
@@ -394,6 +395,8 @@ public abstract class org/jetbrains/exposed/v1/r2dbc/SetOperation : org/jetbrain
 	public static final field Companion Lorg/jetbrains/exposed/v1/r2dbc/SetOperation$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lorg/jetbrains/exposed/v1/core/AbstractQuery;Lorg/jetbrains/exposed/v1/core/AbstractQuery;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun collect (Lkotlinx/coroutines/flow/FlowCollector;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun copyTo (Lorg/jetbrains/exposed/v1/core/AbstractQuery;)V
+	public fun copyTo (Lorg/jetbrains/exposed/v1/r2dbc/SetOperation;)V
 	public fun count (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun empty (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun execute (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -407,6 +410,7 @@ public abstract class org/jetbrains/exposed/v1/r2dbc/SetOperation : org/jetbrain
 	public fun getStatement ()Lorg/jetbrains/exposed/v1/r2dbc/SetOperation;
 	protected final fun getTransaction ()Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;
 	public fun isAlwaysBatch ()Z
+	public fun isGeneratedCteField (I)Z
 	public fun limit (I)Lorg/jetbrains/exposed/v1/r2dbc/SetOperation;
 	public synthetic fun limit (I)Lorg/jetbrains/exposed/v1/r2dbc/SizedIterable;
 	public fun notForUpdate ()Lorg/jetbrains/exposed/v1/r2dbc/SizedIterable;
@@ -419,6 +423,7 @@ public abstract class org/jetbrains/exposed/v1/r2dbc/SetOperation : org/jetbrain
 	public fun prepareSQL (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)Ljava/lang/String;
 	protected fun prepareStatementSQL (Lorg/jetbrains/exposed/v1/core/QueryBuilder;)V
 	public fun prepared (Lorg/jetbrains/exposed/v1/r2dbc/R2dbcTransaction;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun snapshotForCte ()Lorg/jetbrains/exposed/v1/core/AbstractQuery;
 }
 
 public final class org/jetbrains/exposed/v1/r2dbc/SetOperation$Companion {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Query.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/Query.kt
@@ -33,9 +33,24 @@ open class Query(
     protected val transaction: R2dbcTransaction
         get() = TransactionManager.current()
 
-    /** Creates a new [Query] instance using all stored properties of this `SELECT` query. */
+    /**
+     * Creates a new [Query] instance using all stored properties of this `SELECT` query.
+     *
+     * Subclasses used as common table expression definitions must override this function and return the same runtime
+     * subtype so their behavior is preserved when the query is snapshotted.
+     */
     override fun copy(): Query = Query(set, where).also { copy ->
         copyTo(copy)
+    }
+
+    @InternalApi
+    override fun snapshotForCte(): AbstractQuery<*> {
+        val snapshot = copy()
+        check(snapshot::class == this::class) {
+            "${this::class.simpleName ?: "Query subclass"}.copy() must preserve its subtype before it can be used as a " +
+                "CTE definition"
+        }
+        return snapshot
     }
 
     override fun forUpdate(option: ForUpdateOption): Query {
@@ -232,31 +247,35 @@ open class Query(
      *
      * @sample org.jetbrains.exposed.v1.r2dbc.sql.tests.shared.dml.InsertSelectTests.testInsertSelect02
      */
+    @OptIn(InternalApi::class)
     override suspend fun count(): Long {
         return if (distinct || distinctOn != null || groupedByColumns.isNotEmpty() || limit != null || offset > 0) {
-            @OptIn(InternalApi::class)
             fun Column<*>.makeAlias() =
                 alias(transaction.db.identifierManager.quoteIfNecessary("${table.tableNameWithoutSchemeSanitized}_$name"))
 
-            val originalSet = set
-            try {
-                var expInx = 0
-                adjustSelect {
-                    select(
-                        originalSet.fields.map {
-                            when (it) {
-                                is IExpressionAlias<*> -> it
-                                is Column<*> -> it.makeAlias()
-                                is ExpressionWithColumnType<*> -> it.alias("exp${expInx++}")
-                                else -> it.alias("exp${expInx++}")
+            withCommonTableExpressionsDetachedSuspending { originalCtes ->
+                val originalSet = set
+                try {
+                    var expInx = 0
+                    adjustSelect {
+                        select(
+                            originalSet.fields.map {
+                                when (it) {
+                                    is IExpressionAlias<*> -> it
+                                    is Column<*> -> it.makeAlias()
+                                    is ExpressionWithColumnType<*> -> it.alias("exp${expInx++}")
+                                    else -> it.alias("exp${expInx++}")
+                                }
                             }
-                        }
-                    )
-                }
+                        )
+                    }
 
-                alias("subquery").selectAll().count()
-            } finally {
-                set = originalSet
+                    alias("subquery").selectAll().also { countQuery ->
+                        originalCtes.forEach { countQuery.withCtes(it) }
+                    }.count()
+                } finally {
+                    set = originalSet
+                }
             }
         } else {
             try {

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/SetOperations.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/SetOperations.kt
@@ -31,6 +31,14 @@ sealed class SetOperation(
     SuspendExecutable<ResultApi, SetOperation>,
     SizedIterable<ResultRow> {
 
+    @OptIn(InternalApi::class)
+    private var generatedCteFieldIndexes: Set<Int> = _firstStatement.set.realFields.mapIndexedNotNull { index, expression ->
+        index.takeIf {
+            _firstStatement.isGeneratedCteField(index) ||
+                expression !is Column<*> && expression !is IExpressionAlias<*> && expression !is CastToJson<*>
+        }
+    }.toSet()
+
     override val statement: SetOperation = this
 
     protected val transaction: R2dbcTransaction
@@ -72,6 +80,28 @@ sealed class SetOperation(
     /** The SQL keyword representing the set operation. */
     open val operationName = operationName
 
+    override fun copyTo(other: SetOperation) {
+        super.copyTo(other)
+        other.generatedCteFieldIndexes = generatedCteFieldIndexes.toSet()
+    }
+
+    @InternalApi
+    override fun snapshotForCte(): AbstractQuery<*> {
+        val firstSnapshot = firstStatement.snapshotForCte()
+        val secondSnapshot = secondStatement.snapshotForCte()
+        val snapshot = when (this) {
+            is Union -> Union(firstSnapshot, secondSnapshot)
+            is UnionAll -> UnionAll(firstSnapshot, secondSnapshot)
+            is Intersect -> Intersect(firstSnapshot, secondSnapshot)
+            is Except -> Except(firstSnapshot, secondSnapshot)
+        }
+        copyTo(snapshot)
+        return snapshot
+    }
+
+    @InternalApi
+    override fun isGeneratedCteField(index: Int): Boolean = index in generatedCteFieldIndexes
+
     /** Returns the number of results retrieved after query execution. */
     override suspend fun count(): Long {
         return try {
@@ -104,8 +134,10 @@ sealed class SetOperation(
         transaction: R2dbcTransaction
     ): R2dbcResult = executeQuery()
 
+    @OptIn(InternalApi::class)
     override fun prepareSQL(builder: QueryBuilder): String {
         builder {
+            if (hasCommonTableExpressions()) appendStatementPreamble(this)
             if (count) append("SELECT COUNT(*) FROM (")
 
             prepareStatementSQL(this)
@@ -127,6 +159,7 @@ sealed class SetOperation(
         return builder.toString()
     }
 
+    @OptIn(InternalApi::class)
     protected open fun prepareStatementSQL(builder: QueryBuilder) {
         builder {
             rawStatements.appendTo(separator = " $operationName ") {
@@ -134,10 +167,10 @@ sealed class SetOperation(
                     is Query -> {
                         val isSubQuery = it.orderByExpressions.isNotEmpty() || it.limit != null
                         if (isSubQuery) append("(")
-                        it.prepareSQL(this)
+                        it.prepareAsSubquerySQL(this)
                         if (isSubQuery) append(")")
                     }
-                    is SetOperation -> it.prepareSQL(this)
+                    is SetOperation -> it.prepareAsSubquerySQL(this)
                 }
             }
         }
@@ -215,7 +248,9 @@ class UnionAll(
 
     override fun withDistinct(value: Boolean): SetOperation {
         return if (value) {
-            Union(firstStatement, secondStatement)
+            Union(firstStatement, secondStatement).also {
+                copyTo(it)
+            }
         } else {
             this
         }
@@ -260,7 +295,7 @@ class Except(
             else -> "EXCEPT"
         }
 
-    override fun copy() = Intersect(firstStatement, secondStatement).also {
+    override fun copy() = Except(firstStatement, secondStatement).also {
         copyTo(it)
     }
 

--- a/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/CommonTableExpressionTests.kt
+++ b/exposed-tests/src/test/kotlin/org/jetbrains/exposed/v1/tests/shared/dml/CommonTableExpressionTests.kt
@@ -1,0 +1,651 @@
+package org.jetbrains.exposed.v1.tests.shared.dml
+
+import org.jetbrains.exposed.v1.core.AbstractQuery
+import org.jetbrains.exposed.v1.core.BiCompositeColumn
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
+import org.jetbrains.exposed.v1.core.FieldSet
+import org.jetbrains.exposed.v1.core.IntegerColumnType
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.alias
+import org.jetbrains.exposed.v1.core.allFrom
+import org.jetbrains.exposed.v1.core.anyFrom
+import org.jetbrains.exposed.v1.core.asCte
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.exists
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.inSubQuery
+import org.jetbrains.exposed.v1.core.intLiteral
+import org.jetbrains.exposed.v1.core.intParam
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.core.recursiveCte
+import org.jetbrains.exposed.v1.core.statements.buildStatement
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.core.times
+import org.jetbrains.exposed.v1.core.wrapAsExpression
+import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
+import org.jetbrains.exposed.v1.jdbc.Query
+import org.jetbrains.exposed.v1.jdbc.except
+import org.jetbrains.exposed.v1.jdbc.explain
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.intersect
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.union
+import org.jetbrains.exposed.v1.jdbc.unionAll
+import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
+import org.jetbrains.exposed.v1.tests.TestDB
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class CommonTableExpressionTests : DatabaseTestsBase() {
+    private object Items : Table("cte_items") {
+        val id = integer("id")
+        val value = integer("value")
+
+        override val primaryKey = PrimaryKey(id)
+    }
+
+    private object CompositeItems : Table("cte_composite_items") {
+        val first = Column<Int>(this, "first_value", IntegerColumnType())
+        val second = Column<Int>(this, "second_value", IntegerColumnType())
+        val pair = registerCompositeColumn(
+            object : BiCompositeColumn<Int, Int, Pair<Int, Int>>(
+                first,
+                second,
+                transformFromValue = { it },
+                transformToValue = { firstValue, secondValue -> firstValue as Int to secondValue as Int },
+            ) {}
+        )
+    }
+
+    private class UnsnapshottableQuery(override val set: FieldSet) : AbstractQuery<UnsnapshottableQuery>(emptyList())
+
+    private class FailingExpression : ExpressionWithColumnType<Int>() {
+        override val columnType = IntegerColumnType()
+        var shouldFail = true
+
+        override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+            check(!shouldFail) { "Deliberate CTE rendering failure" }
+            queryBuilder.append("1")
+        }
+    }
+
+    @Test
+    fun testOrdinaryCte() {
+        withItems {
+            val selected = Items.select(Items.id, Items.value).where { Items.value less 30 }
+            val cte = selected.asCte("selected_items")
+            val id = cte[Items.id]
+            val value = cte[Items.value]
+
+            val rows = cte.select(id, value).withCtes(cte).orderBy(id).map { it[id] to it[value] }
+
+            assertEquals(listOf(1 to 10, 2 to 20), rows)
+        }
+    }
+
+    @Test
+    fun testDependentCtes() {
+        withItems {
+            val first = Items.select(Items.id, Items.value).asCte("all_items")
+            val firstId = first[Items.id]
+            val firstValue = first[Items.value]
+            val second = first.select(firstId, firstValue).where { firstValue less 30 }.asCte("selected_items")
+            val secondId = second[firstId]
+
+            val rows = second.select(secondId).withCtes(first, second).orderBy(secondId).map { it[secondId] }
+
+            assertEquals(listOf(1, 2), rows)
+            assertFailsWith<IllegalStateException> { second[Items.id] }
+        }
+    }
+
+    @Test
+    fun testCteCanBeJoinedToTable() {
+        withItems {
+            val cte = Items.select(Items.id).where { Items.value greater 10 }.asCte("selected_items")
+            val cteId = cte[Items.id]
+            val join = Items.join(cte, JoinType.INNER, Items.id, cteId)
+
+            assertEquals(listOf(2, 3), join.select(Items.id).orderBy(Items.id).withCtes(cte).map { it[Items.id] })
+        }
+    }
+
+    @Test
+    fun testRecursiveCte() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            val number = intLiteral(1).alias("n")
+            val numbers = recursiveCte("numbers", listOf(number)) { self ->
+                val current = self[number]
+                val seed = Table.Dual.select(number)
+                val next = (current + intLiteral(1)).alias("n")
+                val recursive = self.select(next).where { current less 3 }
+                seed.unionAll(recursive)
+            }
+            val result = numbers[number]
+
+            assertEquals(listOf(1, 2, 3), numbers.select(result).withCtes(numbers).orderBy(result).map { it[result] })
+        }
+    }
+
+    @Test
+    fun testRecursiveCteWithDistinctUnion() {
+        withDb(TestDB.ALL_H2_V2) {
+            val number = intLiteral(1).alias("number")
+            val numbers = recursiveCte("numbers", listOf(number)) { self ->
+                val current = self[number]
+                val seed = Table.Dual.select(number)
+                val next = (current + intLiteral(1)).alias("number")
+                val recursive = self.select(next).where { current less 3 }
+                seed.union(recursive)
+            }
+            val result = numbers[number]
+
+            assertEquals(listOf(1, 2, 3), numbers.select(result).withCtes(numbers).orderBy(result).map { it[result] })
+        }
+    }
+
+    @Test
+    fun testRecursiveCteSyntax() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) { testDb ->
+            val number = intLiteral(1).alias("number")
+            val numbers = recursiveCte("numbers", listOf(number)) { Table.Dual.select(number) }
+            val sql = numbers.select(numbers[number]).withCtes(numbers).prepareSQL(this, prepared = false)
+            val expectsRecursiveKeyword = testDb != TestDB.SQLSERVER && testDb != TestDB.ORACLE
+
+            assertEquals(expectsRecursiveKeyword, sql.startsWith("WITH RECURSIVE "))
+        }
+    }
+
+    @Test
+    fun testCountWithCte() {
+        withItems {
+            val cte = Items.select(Items.value).asCte("item_values")
+            val value = cte[Items.value]
+
+            assertEquals(3, cte.selectAll().withCtes(cte).count())
+            assertEquals(3, cte.selectAll().withDistinct().withCtes(cte).count())
+            assertEquals(3, cte.select(value).groupBy(value).withCtes(cte).count())
+            assertEquals(1, cte.select(value).withCtes(cte).limit(1).offset(1).count())
+        }
+    }
+
+    @Test
+    fun testComplexCountRestoresCteStateAfterFailure() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            val failingExpression = FailingExpression()
+            val projected = failingExpression.alias("cte_value")
+            val cte = Table.Dual.select(projected).asCte("failing_cte")
+            val value = cte[projected]
+            val query = cte.select(value).withDistinct().withCtes(cte)
+
+            assertFailsWith<IllegalStateException> { query.count() }
+
+            failingExpression.shouldFail = false
+            assertEquals(1, query.count())
+            assertTrue(query.prepareSQL(this, prepared = false).startsWith("WITH "))
+        }
+    }
+
+    @Test
+    fun testComplexCountUsesCustomQuerySubclass() {
+        withItems {
+            class CustomQuery(source: Query) : Query(source.set, source.where) {
+                override fun prepareSQL(builder: QueryBuilder): String = error("Custom query SQL")
+            }
+
+            val query = CustomQuery(Items.selectAll()).withDistinct()
+
+            assertEquals("Custom query SQL", assertFailsWith<IllegalStateException> { query.count() }.message)
+        }
+    }
+
+    @Test
+    fun testParametersAndComputedAlias() {
+        withItems {
+            val doubled = (Items.value * intLiteral(2)).alias("doubled")
+            val cte = Items.select(Items.id, doubled).where { Items.value greater 10 }.asCte("computed_items")
+            val computed = cte[doubled]
+
+            val rows = cte.select(computed).where { computed less 60 }.withCtes(cte).map { it[computed] }
+
+            assertEquals(listOf(40), rows)
+        }
+    }
+
+    @Test
+    fun testCteOrderAndParameterOrder() {
+        withItems {
+            val first = Items.select(Items.id).where { Items.value greater intParam(10) }.asCte("first_items")
+            val second = Items.select(Items.id).where { Items.value greater intParam(20) }.asCte("second_items")
+            val secondId = second[Items.id]
+            val query = second.select(secondId).where { secondId less intParam(4) }.withCtes(first, second)
+
+            val sql = query.prepareSQL(this, prepared = true)
+            val normalizedSql = sql.uppercase()
+            assertTrue(normalizedSql.indexOf("FIRST_ITEMS") < normalizedSql.indexOf("SECOND_ITEMS"))
+            assertEquals(listOf(10, 20, 4), query.arguments().single().map { it.second })
+            assertTrue(query.prepareSQL(this, prepared = false).contains("20"))
+        }
+    }
+
+    @Test
+    fun testCompositeOutputIsExpanded() {
+        withTables(excludeSettings = listOf(TestDB.MYSQL_V5), CompositeItems) {
+            CompositeItems.insert { it[pair] = 1 to 2 }
+            val cte = CompositeItems.select(CompositeItems.pair).asCte("composite_items")
+            val first = cte[CompositeItems.first]
+            val second = cte[CompositeItems.second]
+
+            val row = cte.select(first, second).withCtes(cte).single()
+            assertEquals(1, row[first])
+            assertEquals(2, row[second])
+            val failure = assertFailsWith<IllegalStateException> { cte[CompositeItems.pair] }
+            assertTrue(failure.message.orEmpty().contains("component columns"))
+        }
+    }
+
+    @Test
+    fun testReservedWordCteName() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("select")
+            val id = cte[Items.id]
+
+            assertEquals(listOf(1, 2, 3), cte.select(id).withCtes(cte).orderBy(id).map { it[id] })
+        }
+    }
+
+    @Test
+    fun testCteReferenceIsDistinctFromPhysicalTableWithSameName() {
+        withDb(TestDB.H2_V2) {
+            val cte = Items.select(Items.id).asCte(Items.tableName)
+            val cteId = cte[Items.id]
+
+            assertNotEquals(Items.id, cteId)
+            assertNotEquals(cteId, Items.id)
+        }
+    }
+
+    @Test
+    fun testDefinitionIsSnapshotted() {
+        withItems {
+            val source = Items.select(Items.id)
+            val cte = source.asCte("item_ids")
+            source.adjustSelect { select(Items.value) }
+            val id = cte[Items.id]
+
+            assertEquals(listOf(1, 2, 3), cte.select(id).withCtes(cte).orderBy(id).map { it[id] })
+        }
+    }
+
+    @Test
+    fun testSetOperationsWithCte() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val first = cte.select(id).where { id less 2 }
+            val second = cte.select(id).where { id greater 2 }
+            val union = first.unionAll(second).withCtes(cte)
+
+            assertEquals(listOf(1, 3), union.map { it[id] }.sorted())
+            assertEquals(2, union.count())
+        }
+    }
+
+    @Test
+    fun testWithDistinctRetainsCtesOnUnionAll() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val union = cte.select(id).where { id less 3 }
+                .unionAll(cte.select(id).where { id greater 1 })
+                .withCtes(cte)
+                .withDistinct()
+
+            assertEquals(listOf(1, 2, 3), union.map { it[id] }.sorted())
+        }
+    }
+
+    @Test
+    fun testCteBearingSetOperationOperandIsRejected() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val first = cte.select(id).withCtes(cte)
+            val union = first.unionAll(Items.select(Items.id))
+
+            assertFailsWith<IllegalArgumentException> {
+                union.prepareSQL(this, prepared = false)
+            }
+        }
+    }
+
+    @Test
+    fun testSetOperationAsCteDefinition() {
+        withItems {
+            val itemId = Items.id.alias("item_id")
+            val low = Items.select(itemId).where { Items.id less 2 }
+            val high = Items.select(itemId).where { Items.id greater 2 }
+            val cte = low.unionAll(high).asCte("item_ids")
+            val id = cte[itemId]
+
+            assertEquals(listOf(1, 3), cte.select(id).withCtes(cte).orderBy(id).map { it[id] })
+        }
+    }
+
+    @Test
+    fun testSetOperationDefinitionIsDeeplySnapshotted() {
+        withItems {
+            val itemId = Items.id.alias("item_id")
+            val low = Items.select(itemId).where { Items.id less 2 }
+            val high = Items.select(itemId).where { Items.id greater 2 }
+            val cte = low.unionAll(high).asCte("item_ids")
+            val id = cte[itemId]
+
+            high.adjustWhere { Items.id less 0 }
+
+            assertEquals(listOf(1, 3), cte.select(id).withCtes(cte).orderBy(id).map { it[id] })
+        }
+    }
+
+    @Test
+    fun testSetOperationSnapshotsPreserveOperation() {
+        withTables(excludeSettings = TestDB.ALL - TestDB.H2_V2, Items) {
+            Items.insert {
+                it[id] = 1
+                it[value] = 10
+            }
+            Items.insert {
+                it[id] = 2
+                it[value] = 20
+            }
+            val itemId = Items.id.alias("item_id")
+
+            val intersected = Items.select(itemId).where { Items.id less 3 }
+                .intersect(Items.select(itemId).where { Items.id eq 1 })
+                .asCte("intersected")
+            val intersectedValue = intersected[itemId]
+            assertEquals(
+                listOf(1),
+                intersected.select(intersectedValue).withCtes(intersected).map { it[intersectedValue] }
+            )
+
+            val excepted = Items.select(itemId).where { Items.id less 3 }
+                .except(Items.select(itemId).where { Items.id eq 2 })
+                .asCte("excepted")
+            val exceptedValue = excepted[itemId]
+            assertEquals(
+                listOf(1),
+                excepted.select(exceptedValue).withCtes(excepted).map { it[exceptedValue] }
+            )
+        }
+    }
+
+    @Test
+    fun testExplicitGeneratedStyleAliasIsAccepted() {
+        withItems {
+            val firstValue = (Items.value + intLiteral(1)).alias("exp0")
+            val secondValue = (Items.value + intLiteral(2)).alias("exp0")
+            val cte = Items.select(firstValue).unionAll(Items.select(secondValue)).asCte("explicit_alias")
+            val value = cte[firstValue]
+
+            assertEquals(6, cte.select(value).withCtes(cte).count())
+        }
+    }
+
+    @Test
+    fun testCopyAndEmptyRetainCtes() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val query = cte.selectAll().withCtes(cte)
+
+            assertEquals(3, query.copy().count())
+            assertEquals(false, query.empty())
+        }
+    }
+
+    @Test
+    fun testFrontCommentPrecedesWithClause() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val query = cte.selectAll().withCtes(cte).comment("cte-query")
+            val sql = query.prepareSQL(this, prepared = false)
+
+            assertTrue(sql.startsWith("/*cte-query*/ WITH "))
+            assertEquals(1, Regex("/\\*cte-query\\*/").findAll(sql).count())
+        }
+    }
+
+    @Test
+    fun testInvalidSchemasAreRejected() {
+        withItems {
+            assertFailsWith<IllegalStateException> {
+                Items.select(Items.value + intLiteral(1)).asCte("unnamed")
+            }
+
+            val generated = Items.select(Items.value + intLiteral(1))
+                .unionAll(Items.select(Items.value + intLiteral(2)))
+            assertFailsWith<IllegalArgumentException> { generated.asCte("generated") }
+
+            val duplicate = Items.select(Items.id.alias("same"), Items.value.alias("same")).asCte("duplicate")
+            assertFailsWith<IllegalArgumentException> {
+                duplicate.selectAll().withCtes(duplicate).prepareSQL(this, prepared = false)
+            }
+        }
+    }
+
+    @Test
+    fun testAmbiguousOriginalFieldLookupIsRejected() {
+        withItems {
+            val first = Items.id.alias("first_id")
+            val second = Items.id.alias("second_id")
+            val cte = Items.select(first, second).asCte("duplicate_ids")
+            val firstId = cte[first]
+            val secondId = cte[second]
+
+            assertFailsWith<IllegalStateException> { cte[Items.id] }
+            assertTrue(cte.select(firstId, secondId).withCtes(cte).all { it[firstId] == it[secondId] })
+        }
+    }
+
+    @Test
+    fun testRecursiveArityMismatchIsRejected() {
+        withDb {
+            val first = intLiteral(1).alias("first")
+            val second = intLiteral(2).alias("second")
+
+            assertFailsWith<IllegalArgumentException> {
+                recursiveCte("invalid_recursive", listOf(first, second)) { Table.Dual.select(first) }
+            }
+        }
+    }
+
+    @Test
+    fun testRecursiveTypeMismatchIsRejected() {
+        withDb {
+            val declared = intLiteral(1).alias("value")
+            val actual = stringLiteral("invalid").alias("value")
+
+            assertFailsWith<IllegalArgumentException> {
+                recursiveCte("invalid_recursive", listOf(declared)) { Table.Dual.select(actual) }
+            }
+        }
+    }
+
+    @Test
+    fun testCustomQueryWithoutSnapshotSupportIsRejected() {
+        withDb {
+            assertFailsWith<IllegalStateException> {
+                UnsnapshottableQuery(Table.Dual.select(intLiteral(1).alias("value")).set).asCte("custom")
+            }
+        }
+    }
+
+    @Test
+    fun testQuerySubclassWithoutSubtypePreservingCopyIsRejected() {
+        withDb {
+            class CustomQuery(source: Query) : Query(source.set, source.where) {
+                override fun prepareSQL(builder: QueryBuilder): String = error("Custom query SQL")
+            }
+
+            val exception = assertFailsWith<IllegalStateException> {
+                CustomQuery(Table.Dual.select(intLiteral(1).alias("value"))).asCte("custom")
+            }
+
+            assertContains(exception.message.orEmpty(), "copy() must preserve its subtype")
+        }
+    }
+
+    @Test
+    fun testQuerySubclassWithSubtypePreservingCopyCanBeUsedAsCte() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            class CustomQuery(source: Query) : Query(source.set, source.where) {
+                override fun copy(): CustomQuery = CustomQuery(this).also { copyTo(it) }
+
+                override fun prepareSQL(builder: QueryBuilder): String {
+                    builder.append("/* custom query */ ")
+                    return super.prepareSQL(builder)
+                }
+            }
+
+            val value = intLiteral(1).alias("value")
+            val cte = CustomQuery(Table.Dual.select(value)).asCte("custom")
+
+            val sql = cte.select(cte[value]).withCtes(cte).prepareSQL(this, prepared = false)
+
+            assertContains(sql, "AS (/* custom query */ SELECT")
+        }
+    }
+
+    @Test
+    fun testReferencedCtesMustBeAttachedToOutermostQuery() {
+        withDb(excludeSettings = listOf(TestDB.MYSQL_V5)) {
+            val value = intLiteral(1).alias("value")
+            val first = Table.Dual.select(value).asCte("first_cte")
+            val firstValue = first[value]
+
+            val directReference = assertFailsWith<IllegalArgumentException> {
+                first.select(firstValue).prepareSQL(this, prepared = false)
+            }
+            assertContains(directReference.message.orEmpty(), "CTE 'first_cte' is referenced but not attached")
+
+            val second = first.select(firstValue).asCte("second_cte")
+            val secondValue = second[firstValue]
+            val missingDependency = assertFailsWith<IllegalArgumentException> {
+                second.select(secondValue).withCtes(second).prepareSQL(this, prepared = false)
+            }
+            assertContains(missingDependency.message.orEmpty(), "CTE 'first_cte' is referenced but not attached")
+        }
+    }
+
+    @Test
+    fun testDuplicateCteNamesAreRejected() {
+        withItems {
+            val first = Items.select(Items.id).asCte("duplicate")
+            val second = Items.select(Items.value).asCte("duplicate")
+
+            assertFailsWith<IllegalArgumentException> {
+                first.selectAll().withCtes(first, second).prepareSQL(this, prepared = false)
+            }
+        }
+    }
+
+    @Test
+    fun testMySql5IsRejectedBeforeExecution() {
+        withDb(TestDB.MYSQL_V5) {
+            val value = intLiteral(1).alias("value")
+            val cte = Table.Dual.select(value).asCte("value_cte")
+
+            assertFailsWith<UnsupportedByDialectException> {
+                cte.select(cte[value]).withCtes(cte).prepareSQL(this, prepared = true)
+            }
+        }
+    }
+
+    @Test
+    fun testCteCannotBeNestedInQueriesOrStatements() {
+        withItems {
+            val cte = Items.select(Items.id).asCte("item_ids")
+            val id = cte[Items.id]
+            val nestedQuery = cte.select(id).withCtes(cte)
+            val nestedAlias = nestedQuery.alias("nested")
+            val join = Items.join(nestedAlias, JoinType.INNER, Items.id, nestedAlias[id])
+
+            assertFailsWith<IllegalArgumentException> { nestedAlias.selectAll().toList() }
+            assertFailsWith<IllegalArgumentException> {
+                Items.select(wrapAsExpression<Int>(nestedQuery)).prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { exists(nestedQuery) }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { Items.id inSubQuery nestedQuery }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { Items.id eq anyFrom<Int>(nestedQuery) }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                Items.selectAll().where { Items.id eq allFrom<Int>(nestedQuery) }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { Items.insert(nestedQuery, columns = listOf(Items.id)) }
+                    .prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { Items.replace(nestedQuery, columns = listOf(Items.id)) }
+                    .prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement {
+                    Items.mergeFrom(nestedAlias, on = { Items.id eq nestedAlias[id] }) {}
+                }.prepareSQL(this, prepared = false)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { join.update { it[Items.value] = 0 } }.arguments().toList()
+            }
+            assertFailsWith<IllegalArgumentException> {
+                buildStatement { join.delete(Items) }.arguments().toList()
+            }
+        }
+    }
+
+    @Test
+    fun testExplainAndTargetTracking() {
+        withItems { testDb ->
+            val cte = Items.select(Items.id).asCte("SelectedItems")
+            val query = cte.selectAll().withCtes(cte)
+
+            assertEquals(listOf(Items), query.targets)
+            if (testDb !in TestDB.ALL_SQLSERVER_LIKE + TestDB.ALL_ORACLE_LIKE) {
+                assertTrue(explain { query }.toList().isNotEmpty())
+            }
+        }
+    }
+
+    private fun withItems(statement: JdbcTransaction.(TestDB) -> Unit) {
+        withTables(excludeSettings = listOf(TestDB.MYSQL_V5), Items) { testDb ->
+            Items.insert {
+                it[id] = 1
+                it[value] = 10
+            }
+            Items.insert {
+                it[id] = 2
+                it[value] = 20
+            }
+            Items.insert {
+                it[id] = 3
+                it[value] = 30
+            }
+            statement(testDb)
+        }
+    }
+}


### PR DESCRIPTION
#### Description

**Summary of the change**: Adds first-class support for ordinary and recursive Common Table Expressions (CTEs) to the Exposed DSL for both JDBC and R2DBC.

**Detailed description**:

- **Why**: Exposed currently requires raw SQL or custom query implementations to use CTEs. This loses DSL type safety, requires manual parameter and column mapping, and makes CTE relations difficult to reuse in joins, predicates, projections, and `ResultRow` access.
- **What**:
  - Adds `asCte()`, `recursiveCte()`, and `withCtes()` APIs.
  - Supports ordinary, recursive, multiple, and dependent CTEs.
  - Allows CTE relations to be selected from, joined, filtered, grouped, and ordered.
  - Supports CTE definitions backed by regular queries and set operations.
  - Preserves parameter ordering, query copying, counting, comments, and target tracking.
  - Adds dialect-specific validation and recursive CTE syntax.
  - Adds equivalent JDBC and R2DBC integration tests, including composite and JSONB projections.
  - Adds API documentation, user documentation, a design specification, and a changelog entry.
- **How**:
  - Introduces `CommonTableExpression` as a query-backed `ColumnSet` with explicitly mapped output fields.
  - CTE definitions are attached to the outermost `AbstractQuery` and rendered as a single `WITH` clause in caller-supplied dependency order.
  - Query definitions are snapshotted to prevent later query mutation from changing the CTE.
  - Dialect capability flags control ordinary and recursive CTE support and whether recursive queries use `WITH RECURSIVE` or plain `WITH`.
  - Invalid schemas, duplicate names, incompatible recursive members, unsupported database versions, and nested CTE usage fail before execution.
  - MySQL 8.0+ and MariaDB 10.2+ are supported; MySQL 5 remains unsupported and is rejected before execution.
  - The initial scope is CTE-backed `SELECT` queries. Data-modifying CTEs, materialization hints, and nested CTE-bearing subqueries remain out of scope.

---

#### Type of Change

Please mark the relevant options with an "X":

- [ ] Bug fix
- [X] New feature
- [X] Documentation update

Updates/remove existing public API methods:

- [ ] Is breaking change

Affected databases:

- [X] MariaDB
- [] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [X] Redshift
- [X] SqlServer
- [X] H2
- [X] SQLite

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

- [A​dd support for CTE (common table expressions) : EXPOSED-868](https://youtrack.jetbrains.com/issue/EXPOSED-868/Add-support-for-CTE-common-table-expressions)
- [k​otlin - Jetbrains Exposed support for Common Table Expressions - Stack Overflow](https://stackoverflow.com/questions/72275394/jetbrains-exposed-support-for-common-table-expressions)
- #423 