### PR TITLE
fix: EXPOSED-1075 Keep JSONB column identity out of the SELECT list rewrite

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/AbstractQuery.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/AbstractQuery.kt
@@ -228,7 +228,7 @@ abstract class AbstractQuery<T : AbstractQuery<T>>(
                     ?.let { columns ->
                         columns.appendTo(prefix = "DISTINCT ON (", postfix = ") ") { append(it) }
                     }
-                set.realFields.appendTo { +it }
+                set.realFields.appendTo { appendForJsonBCast(it) }
             }
             @OptIn(InternalApi::class)
             if (set.source != Table.Dual || currentDialect.supportsDualTableConcept) {

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Alias.kt
@@ -125,10 +125,8 @@ interface IExpressionAlias<T> {
             +"(CASE WHEN "
             append(delegate)
             +" THEN 1 ELSE 0 END)"
-        } else if ((delegate as? Column<*>)?.isJsonBColumnForCasting() == true) {
-            append(CastToJson(delegate, (delegate as Column<*>).columnType))
         } else {
-            append(delegate)
+            appendForJsonBCast(delegate)
         }
         append(" $alias")
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ColumnType.kt
@@ -1746,6 +1746,23 @@ internal fun Column<*>.isJsonBColumnForCasting(): Boolean {
 }
 
 /**
+ * Appends [expression] to this builder, wrapping it in [CastToJson] if it is a JSONB column that
+ * has to be cast when read.
+ *
+ * This is a rendering concern only: the unwrapped [expression] stays the identity used to look a
+ * value up in a [ResultRow], so every accessor on that row resolves it without having to
+ * reconstruct the cast.
+ */
+internal fun QueryBuilder.appendForJsonBCast(expression: Expression<*>) {
+    val column = expression as? Column<*>
+    if (column?.isJsonBColumnForCasting() == true) {
+        append(CastToJson(column, column.columnType))
+    } else {
+        append(expression)
+    }
+}
+
+/**
  * Returns the [ColumnType] commonly associated with storing values of type [T], or the [defaultType] if a mapping
  * does not exist for type [T].
  *

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ResultRow.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/ResultRow.kt
@@ -58,13 +58,6 @@ class ResultRow private constructor(
                 }
                 EntityID(resultID, column.table) as T
             }
-            column?.isJsonBColumnForCasting() == true -> try {
-                val castExpression = CastToJson(column, column.columnType)
-                getInternal(castExpression, checkNullability = true) as T
-            } catch (_: IllegalStateException) {
-                // DAO may cache an entity after insert with only its column field values cached
-                getInternal(expression, checkNullability = true)
-            }
             else -> getInternal(expression, checkNullability = true)
         }
     }

--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Table.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/Table.kt
@@ -51,10 +51,6 @@ interface FieldSet {
                     (it as? Column<*>)?.isEntityIdentifier() == true && it.table is CompositeIdTable -> {
                         unrolled.addAll(it.table.idColumns)
                     }
-                    (it as? Column<*>)?.isJsonBColumnForCasting() == true -> {
-                        val castExpression = CastToJson(it, it.columnType)
-                        unrolled.add(castExpression)
-                    }
                     else -> unrolled.add(it)
                 }
             }

--- a/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
+++ b/exposed-json/src/test/kotlin/org/jetbrains/exposed/v1/json/JsonBColumnTests.kt
@@ -57,6 +57,19 @@ class JsonBColumnTests : DatabaseTestsBase() {
     }
 
     @Test
+    fun testAllAccessorsAgreeOnJsonBColumn() {
+        withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, data1, _ ->
+            val row = tester.selectAll().single()
+
+            // A JSONB column needing a cast is wrapped when the SELECT list is rendered, but the
+            // column itself remains the identity in the result row, so no accessor has to know.
+            assertEquals(data1, row[tester.jsonBColumn])
+            assertEquals(data1, row.getOrNull(tester.jsonBColumn))
+            assertTrue(row.hasValue(tester.jsonBColumn))
+        }
+    }
+
+    @Test
     fun testUpdate() {
         withJsonBTable(exclude = binaryJsonNotSupportedDB) { tester, _, data1, _ ->
             assertEquals(data1, tester.selectAll().single()[tester.jsonBColumn])


### PR DESCRIPTION
> **Authored by Claude Opus 5 (Anthropic)**, acting as an agent on behalf of @bbasinsk.
> Everything under **Checklist** and **How to verify** was actually executed locally;
> what was *not* run is listed explicitly so you can weigh it.

#### Description

**Summary of the change**: `FieldSet.realFields` no longer rewrites a cast-requiring JSONB column into `CastToJson(column)`. The cast is applied where the SELECT list is rendered instead, so the unwrapped column stays the identity used to look values up in a `ResultRow`.

**Detailed description**:

- **Why**: `realFields` serves two purposes. It renders the SELECT list in `AbstractQuery.prepareSQL`, and it supplies the `fieldIndex` keys a `ResultRow` uses to find a value (`Query.kt:312`, and the same line in the R2DBC `Query`). Substituting `CastToJson(column)` into it therefore changed the row's identity map as a side effect of changing the SQL. `get()` compensated by rebuilding the cast expression to look itself up; `getOrNull()` and `hasValue()` did not, so on SQLite they reported `null` and `false` for a column holding data, with nothing thrown and nothing logged. See EXPOSED-1075 for the reproduction.

- **What**:
  - `Table.kt` — `FieldSet.realFields` drops the `isJsonBColumnForCasting()` branch, so it only unrolls composites and entity identifiers.
  - `ColumnType.kt` — adds `internal fun QueryBuilder.appendForJsonBCast(expression)`, the single place that knows how to render the cast.
  - `AbstractQuery.kt` — the SELECT list uses that renderer.
  - `Alias.kt` — `IExpressionAlias.queryBuilder` reuses it instead of its own copy of the same branch.
  - `ResultRow.kt` — `get()` drops the compensation branch and its `catch (_: IllegalStateException)`.
  - `JsonBColumnTests.kt` — adds `testAllAccessorsAgreeOnJsonBColumn`, pinning `get`, `getOrNull` and `hasValue` together.

- **How**: `IExpressionAlias.queryBuilder` already cast at render time rather than in the field set, so this applies that existing pattern to the SELECT list. Read behavior is unchanged, because `CastToJson(column, column.columnType)` carried the column's own `columnType` — `ResultRow.create` resolves the same `IColumnType` either way, only now keyed by the column itself.

  Removing the `catch` is part of the fix rather than a cleanup. It was swallowing `getExpressionIndex`'s "not in record set" error whenever the cast expression was absent from the row, which covers `RETURNING` clauses and reads outside a transaction, not only the cached DAO entities its comment named. Once nothing constructs a cast expression to look up, it is unreachable.

#### How to verify

1. `./gradlew :exposed-json:test_sqlite --tests "*JsonBColumnTests*"` on `main` with only the test from this PR applied. `testAllAccessorsAgreeOnJsonBColumn` fails:
   `Failed on SQLITE ==> expected: <DataHolder(user=User(name=Admin, team=null), logins=10, active=true, team=null)> but was: <null>`
2. Apply the rest of the PR and rerun. It passes.
3. `./gradlew :exposed-json:test_sqlite :exposed-json:test_all_h2_v2 :exposed-core:test_sqlite` — green.
4. `./gradlew :exposed-core:apiCheck :exposed-core:detekt :exposed-json:detekt` — green.

#### Out of scope

- `RETURNING` clauses still do not cast JSONB columns, since `returningExpressions` are raw columns. On SQLite that means a `RETURNING` read of a JSONB column returns unparsed binary. That is pre-existing and untouched here.
- `DISTINCT ON` columns are likewise not cast. Also pre-existing.
- No change to `needsBinaryFormatCast` or to when the cast is considered necessary. Only where it is applied.

#### Risk + rollback

Low risk and self-contained: the rendered SQL is unchanged, and the only behavior difference is which key a `ResultRow` is indexed by. Revert the commit to roll back.

---

#### Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

`:exposed-core:apiCheck` passes. `appendForJsonBCast` and `isJsonBColumnForCasting` are `internal`, and `realFields`' signature is unchanged.

Affected databases:
- [ ] MariaDB
- [ ] Mysql5
- [ ] Mysql8
- [ ] Oracle
- [ ] Postgres
- [ ] Redshift
- [ ] SqlServer
- [ ] H2
- [X] SQLite

SQLite is the only database where stock Exposed sets `needsBinaryFormatCast`, so it is the only one whose behavior changes. The edited code is dialect-agnostic, so a custom `JsonColumnMarker` type reporting that flag on any dialect is fixed too — that is how this was originally hit, on PostgreSQL.

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

Scope of "green": `:exposed-json:test_sqlite`, `:exposed-json:test_all_h2_v2`, `:exposed-core:test_sqlite`, `:exposed-core:apiCheck` and Detekt on both modules. The container-backed dialects (MySQL, MariaDB, Oracle, SQL Server, PostgreSQL) and the R2DBC path were **not** run locally — the R2DBC `Query` shares the core change but is unexercised here, so CI should be trusted over this checklist for those.

---

#### Related Issues

https://youtrack.jetbrains.com/issue/EXPOSED-1075
