### PR TITLE
fix: EXPOSED-1038 Avoid redundant MySQL R2DBC transaction isolation settings

### DIFF
--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionIsolationTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionIsolationTest.kt
@@ -3,23 +3,30 @@ package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared
 import io.r2dbc.spi.IsolationLevel
 import io.r2dbc.spi.Option
 import io.r2dbc.spi.TransactionDefinition
+import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.insert
+import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
 import org.jetbrains.exposed.v1.r2dbc.tests.TestDB
 import org.jetbrains.exposed.v1.r2dbc.tests.getInt
 import org.jetbrains.exposed.v1.r2dbc.tests.getString
 import org.jetbrains.exposed.v1.r2dbc.tests.shared.assertEquals
+import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.r2dbc.transactions.inTopLevelSuspendTransaction
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.jetbrains.exposed.v1.r2dbc.update
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 
 class TransactionIsolationTest : R2dbcDatabaseTestsBase() {
-    private val transactionIsolationSupportDb = setOf(TestDB.MARIADB, TestDB.MYSQL_V5, TestDB.POSTGRESQL, TestDB.SQLSERVER)
+    private val transactionIsolationSupportDb = TestDB.ALL_MYSQL_MARIADB + TestDB.POSTGRESQL + TestDB.SQLSERVER
 
     @Test
     fun testWhatTransactionIsolationWasApplied() {
@@ -106,10 +113,87 @@ class TransactionIsolationTest : R2dbcDatabaseTestsBase() {
         }
     }
 
+    @Test
+    fun testMySqlTransactionIsolationDoesNotChangeSessionDefault() {
+        runTest {
+            Assumptions.assumeTrue(dialect in TestDB.ALL_MYSQL_MARIADB)
+
+            val db = dialect.connect { defaultMaxAttempts = 1 }
+            val sql = if (dialect == TestDB.MYSQL_V8) {
+                "SELECT @@session.transaction_isolation"
+            } else {
+                "SELECT @@session.tx_isolation"
+            }
+            try {
+                val sessionDefault = suspendTransaction(db = db) {
+                    connection().setTransactionDefinition(null)
+                    exec(sql) { it.getString(1) }?.singleOrNull()
+                }
+                assertNotNull(sessionDefault)
+                val isolation = if (sessionDefault == "READ-COMMITTED") {
+                    IsolationLevel.REPEATABLE_READ
+                } else {
+                    IsolationLevel.READ_COMMITTED
+                }
+
+                suspendTransaction(db = db, transactionIsolation = isolation) {
+                    assertEquals(isolation, connection().getTransactionIsolation())
+                    assertEquals(sessionDefault, exec(sql) { it.getString(1) }?.singleOrNull())
+                }
+            } finally {
+                TransactionManager.closeAndUnregister(db)
+            }
+        }
+    }
+
+    @Test
+    fun testMySqlTransactionIsolationControlsVisibilityOfCommittedChanges() {
+        runTest {
+            Assumptions.assumeTrue(dialect in TestDB.ALL_MYSQL_MARIADB)
+
+            val tester = object : Table("transaction_isolation_tester") {
+                val amount = integer("amount")
+            }
+            val reader = dialect.connect {
+                defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
+                defaultMaxAttempts = 1
+            }
+            val writer = dialect.connect { defaultMaxAttempts = 1 }
+            try {
+                suspendTransaction(db = writer) {
+                    SchemaUtils.create(tester)
+                    tester.insert { it[amount] = 0 }
+                }
+                // A null override exercises DatabaseConfig; the other cases override it for one transaction.
+                for (isolation in listOf(null, IsolationLevel.REPEATABLE_READ, IsolationLevel.READ_COMMITTED)) {
+                    suspendTransaction(db = writer) { tester.update { it[amount] = 0 } }
+                    suspendTransaction(db = reader, transactionIsolation = isolation) {
+                        assertEquals(0, tester.selectAll().single()[tester.amount])
+                        // A different database gets its own transaction and commits before the second read.
+                        suspendTransaction(db = writer) { tester.update { it[amount] = 1 } }
+                        val expected = if (isolation == IsolationLevel.REPEATABLE_READ) 0 else 1
+                        assertEquals(expected, tester.selectAll().single()[tester.amount])
+                    }
+                }
+            } finally {
+                try {
+                    suspendTransaction(db = writer) { SchemaUtils.drop(tester) }
+                } finally {
+                    TransactionManager.closeAndUnregister(reader)
+                    TransactionManager.closeAndUnregister(writer)
+                }
+            }
+        }
+    }
+
     private suspend fun R2dbcTransaction.assertTransactionIsolationLevel(testDb: TestDB, expected: IsolationLevel) {
+        if (testDb in TestDB.ALL_MYSQL_MARIADB) {
+            // Session variables do not report transaction-specific isolation. The visibility test checks its effect on reads.
+            assertEquals(expected, connection().getTransactionIsolation())
+            return
+        }
         val (sql, repeatable, committed) = when (testDb) {
             TestDB.POSTGRESQL -> Triple("SHOW TRANSACTION ISOLATION LEVEL", "repeatable read", "read committed")
-            in TestDB.ALL_MYSQL_MARIADB -> Triple("SELECT @@tx_isolation", "REPEATABLE-READ", "READ-COMMITTED")
             TestDB.SQLSERVER -> Triple("SELECT transaction_isolation_level FROM sys.dm_exec_sessions WHERE session_id = @@SPID", "3", "2")
             else -> throw UnsupportedOperationException("Cannot query isolation level using ${testDb.name}")
         }

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionIsolationTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionIsolationTest.kt
@@ -1,20 +1,13 @@
 package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared
 
-import io.r2dbc.spi.Connection
-import io.r2dbc.spi.ConnectionFactories
-import io.r2dbc.spi.ConnectionFactory
-import io.r2dbc.spi.ConnectionFactoryMetadata
 import io.r2dbc.spi.IsolationLevel
 import io.r2dbc.spi.Option
 import io.r2dbc.spi.TransactionDefinition
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
-import kotlinx.coroutines.reactive.awaitFirstOrNull
-import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
-import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -30,8 +23,6 @@ import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.r2dbc.update
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
-import org.reactivestreams.Publisher
-import reactor.core.publisher.Mono
 import kotlin.test.assertNotNull
 
 class TransactionIsolationTest : R2dbcDatabaseTestsBase() {
@@ -155,85 +146,39 @@ class TransactionIsolationTest : R2dbcDatabaseTestsBase() {
         }
     }
 
-    @Test
-    fun testMySqlTransactionIsolationOnReusedConnection() {
-        runTest {
-            Assumptions.assumeTrue(dialect in TestDB.ALL_MYSQL_MARIADB)
-
-            val tester = object : Table("transaction_isolation_tester") {
-                val amount = integer("amount")
+    private suspend fun R2dbcTransaction.assertOnTwoConnections(testDb: TestDB, expected: IsolationLevel) {
+        val tester = object : Table("transaction_isolation_tester") {
+            val amount = integer("amount")
+        }
+        val expectedAmount = when (expected) {
+            IsolationLevel.REPEATABLE_READ -> 0
+            IsolationLevel.READ_COMMITTED -> 1
+            else -> throw UnsupportedOperationException("Isolation level $expected not supported by this check")
+        }
+        val writer = testDb.connect { defaultMaxAttempts = 1 }
+        try {
+            inTopLevelSuspendTransaction(db = writer) {
+                SchemaUtils.drop(tester)
+                SchemaUtils.create(tester)
+                tester.insert { it[amount] = 0 }
             }
-            val factory = ConnectionFactories.get(dialect.connection())
-            val physicalConnection = factory.create().awaitSingle()
-            // Keep the physical connection across Exposed transactions and close it explicitly below.
-            val retainedConnection = object : Connection by physicalConnection {
-                override fun close(): Publisher<Void> = Mono.empty()
-            }
-            val reusedFactory = object : ConnectionFactory {
-                override fun create(): Publisher<out Connection> = Mono.just(retainedConnection)
-                override fun getMetadata(): ConnectionFactoryMetadata = factory.metadata
-            }
-            val reader = R2dbcDatabase.connect(
-                reusedFactory,
-                R2dbcDatabaseConfig {
-                    setUrl(dialect.connection())
-                    defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
-                    defaultMaxAttempts = 1
-                }
-            )
-            val writer = dialect.connect { defaultMaxAttempts = 1 }
+            assertEquals(0, tester.selectAll().single()[tester.amount])
+            // The writer commits on a separate connection before this transaction reads again.
+            suspendTransaction(db = writer) { tester.update { it[amount] = 1 } }
+            assertEquals(expectedAmount, tester.selectAll().single()[tester.amount])
+        } finally {
             try {
-                suspendTransaction(db = writer) {
-                    SchemaUtils.create(tester)
-                    tester.insert { it[amount] = 0 }
-                }
-                val connectionId = suspendTransaction(db = reader) {
-                    connection().setTransactionDefinition(null)
-                    exec("SELECT CONNECTION_ID()") { it.getInt(1) }?.single()
-                }
-                assertNotNull(connectionId)
-                for (sessionIsolation in listOf(IsolationLevel.REPEATABLE_READ, IsolationLevel.READ_COMMITTED)) {
-                    physicalConnection.setTransactionIsolationLevel(sessionIsolation).awaitFirstOrNull()
-                    // A null override exercises DatabaseConfig; the other cases override it for one transaction.
-                    for (isolation in listOf(null, IsolationLevel.REPEATABLE_READ, IsolationLevel.READ_COMMITTED)) {
-                        suspendTransaction(db = writer) { tester.update { it[amount] = 0 } }
-                        suspendTransaction(db = reader, transactionIsolation = isolation) {
-                            assertEquals(connectionId, exec("SELECT CONNECTION_ID()") { it.getInt(1) }?.single())
-                            assertEquals(0, tester.selectAll().single()[tester.amount])
-                            // A different database gets its own transaction and commits before the second read.
-                            suspendTransaction(db = writer) { tester.update { it[amount] = 1 } }
-                            val expected = if (isolation == IsolationLevel.REPEATABLE_READ) 0 else 1
-                            assertEquals(expected, tester.selectAll().single()[tester.amount])
-                        }
-                        suspendTransaction(db = reader) {
-                            connection().setTransactionDefinition(null)
-                            assertEquals(connectionId, exec("SELECT CONNECTION_ID()") { it.getInt(1) }?.single())
-                            assertEquals(1, tester.selectAll().single()[tester.amount])
-                            suspendTransaction(db = writer) { tester.update { it[amount] = 2 } }
-                            val expected = if (sessionIsolation == IsolationLevel.REPEATABLE_READ) 1 else 2
-                            assertEquals(expected, tester.selectAll().single()[tester.amount])
-                        }
-                    }
-                }
+                SchemaUtils.drop(tester)
             } finally {
-                try {
-                    physicalConnection.close().awaitFirstOrNull()
-                } finally {
-                    try {
-                        suspendTransaction(db = writer) { SchemaUtils.drop(tester) }
-                    } finally {
-                        TransactionManager.closeAndUnregister(reader)
-                        TransactionManager.closeAndUnregister(writer)
-                    }
-                }
+                TransactionManager.closeAndUnregister(writer)
             }
         }
     }
 
     private suspend fun R2dbcTransaction.assertTransactionIsolationLevel(testDb: TestDB, expected: IsolationLevel) {
         if (testDb in TestDB.ALL_MYSQL_MARIADB) {
-            // Session variables do not report transaction-specific isolation. The visibility test checks its effect on reads.
-            assertEquals(expected, connection().getTransactionIsolation())
+            // Session variables do not report transaction-specific isolation, so check its effect on reads.
+            assertOnTwoConnections(testDb, expected)
             return
         }
         val (sql, repeatable, committed) = when (testDb) {

--- a/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionIsolationTest.kt
+++ b/exposed-r2dbc-tests/src/test/kotlin/org/jetbrains/exposed/v1/r2dbc/sql/tests/shared/TransactionIsolationTest.kt
@@ -1,13 +1,20 @@
 package org.jetbrains.exposed.v1.r2dbc.sql.tests.shared
 
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactories
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryMetadata
 import io.r2dbc.spi.IsolationLevel
 import io.r2dbc.spi.Option
 import io.r2dbc.spi.TransactionDefinition
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import org.jetbrains.exposed.v1.r2dbc.insert
@@ -23,6 +30,8 @@ import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.r2dbc.update
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
 import kotlin.test.assertNotNull
 
 class TransactionIsolationTest : R2dbcDatabaseTestsBase() {
@@ -147,40 +156,75 @@ class TransactionIsolationTest : R2dbcDatabaseTestsBase() {
     }
 
     @Test
-    fun testMySqlTransactionIsolationControlsVisibilityOfCommittedChanges() {
+    fun testMySqlTransactionIsolationOnReusedConnection() {
         runTest {
             Assumptions.assumeTrue(dialect in TestDB.ALL_MYSQL_MARIADB)
 
             val tester = object : Table("transaction_isolation_tester") {
                 val amount = integer("amount")
             }
-            val reader = dialect.connect {
-                defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
-                defaultMaxAttempts = 1
+            val factory = ConnectionFactories.get(dialect.connection())
+            val physicalConnection = factory.create().awaitSingle()
+            // Keep the physical connection across Exposed transactions and close it explicitly below.
+            val retainedConnection = object : Connection by physicalConnection {
+                override fun close(): Publisher<Void> = Mono.empty()
             }
+            val reusedFactory = object : ConnectionFactory {
+                override fun create(): Publisher<out Connection> = Mono.just(retainedConnection)
+                override fun getMetadata(): ConnectionFactoryMetadata = factory.metadata
+            }
+            val reader = R2dbcDatabase.connect(
+                reusedFactory,
+                R2dbcDatabaseConfig {
+                    setUrl(dialect.connection())
+                    defaultR2dbcIsolationLevel = IsolationLevel.READ_COMMITTED
+                    defaultMaxAttempts = 1
+                }
+            )
             val writer = dialect.connect { defaultMaxAttempts = 1 }
             try {
                 suspendTransaction(db = writer) {
                     SchemaUtils.create(tester)
                     tester.insert { it[amount] = 0 }
                 }
-                // A null override exercises DatabaseConfig; the other cases override it for one transaction.
-                for (isolation in listOf(null, IsolationLevel.REPEATABLE_READ, IsolationLevel.READ_COMMITTED)) {
-                    suspendTransaction(db = writer) { tester.update { it[amount] = 0 } }
-                    suspendTransaction(db = reader, transactionIsolation = isolation) {
-                        assertEquals(0, tester.selectAll().single()[tester.amount])
-                        // A different database gets its own transaction and commits before the second read.
-                        suspendTransaction(db = writer) { tester.update { it[amount] = 1 } }
-                        val expected = if (isolation == IsolationLevel.REPEATABLE_READ) 0 else 1
-                        assertEquals(expected, tester.selectAll().single()[tester.amount])
+                val connectionId = suspendTransaction(db = reader) {
+                    connection().setTransactionDefinition(null)
+                    exec("SELECT CONNECTION_ID()") { it.getInt(1) }?.single()
+                }
+                assertNotNull(connectionId)
+                for (sessionIsolation in listOf(IsolationLevel.REPEATABLE_READ, IsolationLevel.READ_COMMITTED)) {
+                    physicalConnection.setTransactionIsolationLevel(sessionIsolation).awaitFirstOrNull()
+                    // A null override exercises DatabaseConfig; the other cases override it for one transaction.
+                    for (isolation in listOf(null, IsolationLevel.REPEATABLE_READ, IsolationLevel.READ_COMMITTED)) {
+                        suspendTransaction(db = writer) { tester.update { it[amount] = 0 } }
+                        suspendTransaction(db = reader, transactionIsolation = isolation) {
+                            assertEquals(connectionId, exec("SELECT CONNECTION_ID()") { it.getInt(1) }?.single())
+                            assertEquals(0, tester.selectAll().single()[tester.amount])
+                            // A different database gets its own transaction and commits before the second read.
+                            suspendTransaction(db = writer) { tester.update { it[amount] = 1 } }
+                            val expected = if (isolation == IsolationLevel.REPEATABLE_READ) 0 else 1
+                            assertEquals(expected, tester.selectAll().single()[tester.amount])
+                        }
+                        suspendTransaction(db = reader) {
+                            connection().setTransactionDefinition(null)
+                            assertEquals(connectionId, exec("SELECT CONNECTION_ID()") { it.getInt(1) }?.single())
+                            assertEquals(1, tester.selectAll().single()[tester.amount])
+                            suspendTransaction(db = writer) { tester.update { it[amount] = 2 } }
+                            val expected = if (sessionIsolation == IsolationLevel.REPEATABLE_READ) 1 else 2
+                            assertEquals(expected, tester.selectAll().single()[tester.amount])
+                        }
                     }
                 }
             } finally {
                 try {
-                    suspendTransaction(db = writer) { SchemaUtils.drop(tester) }
+                    physicalConnection.close().awaitFirstOrNull()
                 } finally {
-                    TransactionManager.closeAndUnregister(reader)
-                    TransactionManager.closeAndUnregister(writer)
+                    try {
+                        suspendTransaction(db = writer) { SchemaUtils.drop(tester) }
+                    } finally {
+                        TransactionManager.closeAndUnregister(reader)
+                        TransactionManager.closeAndUnregister(writer)
+                    }
                 }
             }
         }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/statements/R2dbcConnectionImpl.kt
@@ -36,7 +36,6 @@ import org.jetbrains.exposed.v1.r2dbc.statements.api.getString
 import org.jetbrains.exposed.v1.r2dbc.transactions.R2dbcTransactionDefinition
 import org.jetbrains.exposed.v1.r2dbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.r2dbc.vendors.metadata.MetadataProvider
-import org.jetbrains.exposed.v1.r2dbc.vendors.metadata.MySQLMetadata
 import org.jetbrains.exposed.v1.r2dbc.vendors.metadata.OracleMetadata
 import org.reactivestreams.Publisher
 import java.util.*
@@ -246,11 +245,6 @@ class R2dbcConnectionImpl(
                                     // instead it requires a specific order, with transaction isolation always set first.
                                     cx.beginTransaction(definition.toOracleDefinition()).awaitFirstOrNull()
                                     cx.executeSQL(metadataProvider.setReadOnlyMode(definition.readOnly))
-                                }
-                                is R2dbcTransactionDefinition if metadataProvider is MySQLMetadata && definition.isolationLevel != null -> {
-                                    // MySQL/MariaDB driver would set level only on next-next transaction, not the 1 about to start
-                                    cx.executeSQL(metadataProvider.setCurrentTransactionIsolation(definition.isolationLevel))
-                                    cx.beginTransaction(definition).awaitFirstOrNull()
                                 }
                                 else -> cx.beginTransaction(originalDefinition).awaitFirstOrNull()
                             }

--- a/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/vendors/metadata/MySQLMetadata.kt
+++ b/exposed-r2dbc/src/main/kotlin/org/jetbrains/exposed/v1/r2dbc/vendors/metadata/MySQLMetadata.kt
@@ -90,10 +90,6 @@ internal open class MySQLTypeProvider : SqlTypeProvider() {
 }
 
 internal open class MySQLMetadata : MetadataProvider(MySQLPropertyProvider(), MySQLTypeProvider()) {
-    fun setCurrentTransactionIsolation(isolationLevel: IsolationLevel): String {
-        return "SET SESSION TRANSACTION ISOLATION LEVEL ${isolationLevel.asSql()}"
-    }
-
     override fun getUsername(): String {
         return "SELECT SUBSTRING_INDEX(USER(), '@', 1) AS USER_NAME"
     }


### PR DESCRIPTION
#### Description

When a MySQL R2DBC transaction specifies an isolation level, Exposed sends `SET SESSION TRANSACTION ISOLATION LEVEL` before the driver applies the transaction definition. This duplicates the MySQL driver's isolation statement and changes the session default. A later transaction on the same connection without an isolation override can then inherit the previous override.

Remove the MySQL/MariaDB workaround and let `beginTransaction(definition)` apply the isolation level. This preserves the transaction-start behavior introduced in #2679 and continues to pass custom definitions through unchanged.

The regression tests check that session defaults remain unchanged and verify READ COMMITTED / REPEATABLE READ using committed writes on a separate connection. The read-visibility test retains one physical reader connection, checks its server connection ID in each transaction, and verifies that the next transaction without a definition uses the original session default. It covers both session isolation levels, database-configured isolation, and explicit transaction overrides. The existing MySQL assertions now check transaction isolation rather than `@@tx_isolation`, which reports session state, and also run on MySQL 8. The unused internal metadata helper is removed.

#### Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Is breaking change

Affected databases:

- [X] MariaDB
- [X] Mysql5
- [X] Mysql8

#### Validation

The MySQL 8/MariaDB full suites and both MySQL compatibility checks below were rerun after adding the connection-reuse coverage. The H2 checks were run for the original implementation change.

| Check | Passed | Skipped | Failed |
|---|---:|---:|---:|
| Full `exposed-r2dbc-tests` suite, MySQL 8.4.11 / `r2dbc-mysql:1.4.3` | 742 | 212 | 0 |
| Full `exposed-r2dbc-tests` suite, MariaDB 12.1.2 / `r2dbc-mariadb:1.4.0` | 743 | 211 | 0 |
| Focused isolation/read-only tests, MySQL 5.7.44 | 7 | 0 | 0 |
| Focused isolation/read-only tests, MySQL 8.4.11 / `r2dbc-mysql:1.4.2` | 7 | 0 | 0 |
| Focused H2 isolation and connection-release tests | 4 | 5 | 0 |

The session-default regression failed before the production change on both MySQL and MariaDB (`REPEATABLE-READ` expected, `READ-COMMITTED` observed) and passed afterward. The connection-reuse regression also fails without the fix: the next transaction sees a separately committed change (`2`) when its original REPEATABLE READ session default should retain the first read (`1`). Both failures were reproduced on MySQL 8 and MariaDB.

The MySQL server general log confirms one fewer isolation statement before `START TRANSACTION`. The same-connection current/next transaction checks are now included in the repository test suite. The original standalone diagnostic and SQL logs remain outside the repository diff.

`:exposed-r2dbc:detekt`, `:exposed-r2dbc-tests:detekt`, `:exposed-r2dbc:apiCheck`, and `git diff --check` passed. PostgreSQL, SQL Server, and Oracle integration suites were not run.

Remote CI note for the initial commit: the initial [main build](https://exposed.teamcity.com/buildConfiguration/Exposed_Build/16075) and [sample publishing build](https://exposed.teamcity.com/buildConfiguration/Exposed_Samples_PublishPrExposed/16067) failed while resolving Kotlin Gradle plugin dependencies from Maven Central with HTTP 429 (Too Many Requests). The remaining sample failures are downstream dependency failures. These runs did not reach the changed code's tests. GitHub Actions for that commit required repository approval. Remote checks for the latest commit remain separate from the local results above.

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check), for the modules and databases listed above
- [X] All public methods affected by my PR have up-to-date API docs — no public API changes
- [X] Documentation for my change is up to date — no new API or configuration

#### Related Issues

[EXPOSED-1038 — Isolation Level is always set twice](https://youtrack.jetbrains.com/issue/EXPOSED-1038)
