### PR TITLE
fix: Migration generator mistakes different indices for duplicates and drops one

### DIFF
--- a/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
+++ b/exposed-core/src/main/kotlin/org/jetbrains/exposed/v1/core/SchemaUtilityApi.kt
@@ -140,11 +140,18 @@ abstract class SchemaUtilityApi {
     /**
      * Filters all table indices and returns those that are defined on a table with more than one index.
      * If [withLogs] is `true`, DROP statements for these indices will also be logged.
+     *
+     * Only indices whose definition can be fully read back are considered: those with at least one mapped
+     * column and no filter condition. An index whose columns could not be resolved against the table object
+     * (a functional index, or an index on a column that has since been removed from the table object) carries
+     * no reliable description of what it covers, and the filter condition of a partial index is not read back
+     * at all, so neither kind is ever reported as excessive.
      * @suppress
      */
     @InternalApi
     protected fun Map<Table, List<Index>>.filterAndLogExcessIndices(withLogs: Boolean): List<Index> {
         val excessiveIndices = flatMap { (_, indices) -> indices }
+            .filter { index -> index.columns.isNotEmpty() && index.filterCondition == null }
             .groupBy { index ->
                 Triple(index.table, index.unique, index.columns.joinToString { column -> column.name })
             }

--- a/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/IndexConstraintsTests.kt
+++ b/exposed-migration-jdbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/jdbc/IndexConstraintsTests.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.v1.migration.jdbc
 
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.lowerCase
 import org.jetbrains.exposed.v1.jdbc.exists
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.tests.DatabaseTestsBase
@@ -193,6 +194,101 @@ class IndexConstraintsTests : DatabaseTestsBase() {
             assertEquals(2, statements.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" indexOnlyInDbIdx".lowercase()) }.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" columnWithIndexOnlyInDbIdx".lowercase()) }.size)
+        }
+    }
+
+    @Test
+    fun testFunctionalIndicesOnDifferentExpressionsAreNotExcessive() {
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+            val email = varchar("email", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+
+            init {
+                index("test_table_lower_name", false, functions = listOf(name.lowerCase()))
+                index("test_table_lower_email", false, functions = listOf(email.lowerCase()))
+            }
+        }
+
+        val functionsNotSupported = TestDB.ALL_H2_V2 + TestDB.MARIADB + TestDB.SQLSERVER + TestDB.MYSQL_V5
+        withTables(excludeSettings = functionsNotSupported, tester) {
+            assertTrue(tester.exists())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+            // Only the drop matters here. Oracle case-folds the index names and Index.onlyNameDiffer() ignores
+            // functions, which already produces a spurious CREATE for one of them independently of this change.
+            assertEquals(0, statements.count { it.contains("DROP INDEX", ignoreCase = true) })
+        }
+    }
+
+    @Test
+    fun testPartialAndFullIndexOnSameColumnAreNotExcessive() {
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+
+            init {
+                index("test_table_by_name", false, name)
+                index("test_table_by_name_partial", false, name) { name like "A%" }
+            }
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            assertTrue(tester.exists())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+            assertEquals(0, statements.size)
+        }
+    }
+
+    @Test
+    fun testIndicesOfUnmappedColumnsAreNotDroppedTwice() {
+        val dbTable = object : Table("test_table") {
+            val id = integer("id")
+            val first = bool("first").nullable().index("test_table_first")
+            val second = bool("second").nullable().index("test_table_second")
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.ORACLE), dbTable) {
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+
+            assertEquals(statements.distinct().size, statements.size)
+            assertEquals(1, statements.count { it.contains("test_table_first", ignoreCase = true) })
+            assertEquals(1, statements.count { it.contains("test_table_second", ignoreCase = true) })
+        }
+    }
+
+    @Test
+    fun testPartialIndicesWithDifferentConditionsOnSameColumnAreNotExcessive() {
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+
+            init {
+                index("test_table_by_name_a", false, name) { name like "A%" }
+                index("test_table_by_name_b", false, name) { name like "B%" }
+            }
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            assertTrue(tester.exists())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+            assertEquals(0, statements.size)
         }
     }
 }

--- a/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/IndexConstraintsTests.kt
+++ b/exposed-migration-r2dbc/src/test/kotlin/org/jetbrains/exposed/v1/migration/r2dbc/IndexConstraintsTests.kt
@@ -2,6 +2,7 @@ package org.jetbrains.exposed.v1.migration.r2dbc
 
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.lowerCase
 import org.jetbrains.exposed.v1.r2dbc.exists
 import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.tests.R2dbcDatabaseTestsBase
@@ -193,6 +194,101 @@ class IndexConstraintsTests : R2dbcDatabaseTestsBase() {
             assertEquals(2, statements.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" indexOnlyInDbIdx".lowercase()) }.size)
             assertEquals(1, statements.map { it.lowercase() }.filter { it.contains(" columnWithIndexOnlyInDbIdx".lowercase()) }.size)
+        }
+    }
+
+    @Test
+    fun testFunctionalIndicesOnDifferentExpressionsAreNotExcessive() {
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+            val email = varchar("email", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+
+            init {
+                index("test_table_lower_name", false, functions = listOf(name.lowerCase()))
+                index("test_table_lower_email", false, functions = listOf(email.lowerCase()))
+            }
+        }
+
+        val functionsNotSupported = TestDB.ALL_H2_V2 + TestDB.MARIADB + TestDB.SQLSERVER + TestDB.MYSQL_V5
+        withTables(excludeSettings = functionsNotSupported, tester) {
+            assertTrue(tester.exists())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+            // Only the drop matters here. Oracle case-folds the index names and Index.onlyNameDiffer() ignores
+            // functions, which already produces a spurious CREATE for one of them independently of this change.
+            assertEquals(0, statements.count { it.contains("DROP INDEX", ignoreCase = true) })
+        }
+    }
+
+    @Test
+    fun testPartialAndFullIndexOnSameColumnAreNotExcessive() {
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+
+            init {
+                index("test_table_by_name", false, name)
+                index("test_table_by_name_partial", false, name) { name like "A%" }
+            }
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            assertTrue(tester.exists())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+            assertEquals(0, statements.size)
+        }
+    }
+
+    @Test
+    fun testIndicesOfUnmappedColumnsAreNotDroppedTwice() {
+        val dbTable = object : Table("test_table") {
+            val id = integer("id")
+            val first = bool("first").nullable().index("test_table_first")
+            val second = bool("second").nullable().index("test_table_second")
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+
+            override val primaryKey = PrimaryKey(id)
+        }
+
+        withTables(excludeSettings = listOf(TestDB.ORACLE), dbTable) {
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+
+            assertEquals(statements.distinct().size, statements.size)
+            assertEquals(1, statements.count { it.contains("test_table_first", ignoreCase = true) })
+            assertEquals(1, statements.count { it.contains("test_table_second", ignoreCase = true) })
+        }
+    }
+
+    @Test
+    fun testPartialIndicesWithDifferentConditionsOnSameColumnAreNotExcessive() {
+        val tester = object : Table("test_table") {
+            val id = integer("id")
+            val name = varchar("name", length = 42)
+
+            override val primaryKey = PrimaryKey(id)
+
+            init {
+                index("test_table_by_name_a", false, name) { name like "A%" }
+                index("test_table_by_name_b", false, name) { name like "B%" }
+            }
+        }
+
+        withTables(excludeSettings = TestDB.ALL - TestDB.ALL_POSTGRES, tester) {
+            assertTrue(tester.exists())
+
+            val statements = MigrationUtils.statementsRequiredForDatabaseMigration(tester, withLogs = false)
+            assertEquals(0, statements.size)
         }
     }
 }


### PR DESCRIPTION
#### Description

The migration generator drops indices it shouldn't, and in one case drops the same index twice.

`statementsRequiredForDatabaseMigration` drops indices in two passes: unmapped indices (correct), then "redundant" indices, meaning two on one table that cover the same thing. The second pass decides "same thing" with:

```kotlin
Triple(index.table, index.unique, index.columns.joinToString { column -> column.name })
```

`columns` only holds names that resolved to a `Column` in the table object; anything else is stored in `functions` instead ([`existingIndices`](https://github.com/JetBrains/Exposed/blob/2155404863401e0257f89c301509cde59e7becd1/exposed-jdbc/src/main/kotlin/org/jetbrains/exposed/v1/jdbc/statements/jdbc/JdbcDatabaseMetadataImpl.kt#L367-L380)). The identifier never looks at `functions`, and never looks at the filter condition, so four kinds of index pairs collide and one of each pair gets dropped.

**Case 1: two functional indices.** Neither resolves to a column, so both are `(table, false, "")`.

```kotlin
index("idx_lower_name", false, functions = listOf(name.lowerCase()))
index("idx_lower_email", false, functions = listOf(email.lowerCase()))
```
```
DROP INDEX IF EXISTS idx_lower_email
```

Both are declared, both exist, nothing changed, and no CREATE follows.

**Case 2: a partial and a full index on the same column.** The filter condition isn't in the identifier, so both are `(table, false, "name")`.

```kotlin
index("idx_by_name", false, name)
index("idx_by_name_partial", false, name) { name like "A%" }
```
```
DROP INDEX IF EXISTS idx_by_name
```

**Case 3: two indexed columns removed from the table object.** Their names no longer resolve, so both are `(table, false, "")`, same as case 1. Pass 1 already drops both; pass 2 drops one of them again.

```kotlin
val flagOne = bool("flagOne").nullable().index()   // since removed from the table object
val flagTwo = bool("flagTwo").nullable().index()   // since removed from the table object
```
```
ALTER TABLE tester DROP COLUMN "flagOne"
ALTER TABLE tester DROP COLUMN "flagTwo"
DROP INDEX IF EXISTS tester_flagtwo
DROP INDEX IF EXISTS tester_flagone
DROP INDEX IF EXISTS tester_flagone   <- duplicate
```

Harmless because of `IF EXISTS`, but it shouldn't be there.

**Case 4: two partial indices on the same column with different conditions.** The filter condition isn't read back from metadata at all, only whether there is one, so both are `(table, false, "name")`.

```kotlin
index("idx_by_name_a", false, name) { name like "A%" }
index("idx_by_name_b", false, name) { name like "B%" }
```
```
DROP INDEX IF EXISTS idx_by_name_b
```

---

#### Fix

The excess check only makes sense for indices whose definition Exposed can fully read back. So skip any index with no resolved columns, and any partial index, before grouping:

```kotlin
val excessiveIndices = flatMap { (_, indices) -> indices }
    .filter { index -> index.columns.isNotEmpty() && index.filterCondition == null }
    .groupBy { index ->
        Triple(index.table, index.unique, index.columns.joinToString { column -> column.name })
    }
    .filterValues { it.size > 1 }
```

That filter line is the whole change; the grouping key itself is untouched.

| Case | Indices | Before | After |
|---|---|---|---|
| 1 | `idx_lower_name` / `idx_lower_email` | both `""`, one dropped | no resolved columns, never candidates |
| 2 | `idx_by_name` / `idx_by_name_partial` | both `"name"`, one dropped | the partial one is never a candidate; the full one is alone in its group |
| 3 | `tester_flagone` / `tester_flagtwo` | both `""`, one dropped twice | no resolved columns, never candidates |
| 4 | `idx_by_name_a` / `idx_by_name_b` | both `"name"`, one dropped | partial, never candidates |

Two genuinely identical full indices on one column still collide; `testDropExtraIndexOnSameColumn` is unchanged and still passes. `SchemaUtils.checkExcessiveIndices()` shares this function and changes the same way.

The trade-off is that two functional indices on the *same* expression, or two partial indices with the *same* condition, are no longer reported as excessive. Neither was ever reliably detectable: Postgres is the only dialect whose metadata returns the expression (Oracle returns a hidden column name, MySQL and SQLite return nothing), and no dialect returns the filter condition. A check that can't tell "same" from "different" shouldn't be dropping either, so not dropping seemed the safer default for a migration generator. It's a judgement call and easy to revisit.

One pre-existing gap is left alone: on Oracle, `Index.onlyNameDiffer()` also ignores `functions`, and Oracle case-folds index names, so it pairs both existing functional indices with the same mapped one and emits a spurious `CREATE` for the other. Fixing that there would trade one spurious `CREATE` for a drop-and-recreate on every run, so it's a separate change. Case 1's test therefore asserts that no `DROP INDEX` is generated, rather than that nothing is generated.

Tests for all four cases are in `IndexConstraintsTests`, in both `exposed-migration-jdbc` and `exposed-migration-r2dbc`. Case 1 runs on every database that supports functional indices in the test suite; cases 2 and 4 are Postgres-only, like the existing partial-index tests.

---

#### Type of Change

Please mark the relevant options with an "X":
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

Updates/remove existing public API methods:
- [ ] Is breaking change

Affected databases:
- [X] MariaDB
- [ ] Mysql5
- [X] Mysql8
- [X] Oracle
- [X] Postgres
- [ ] Redshift
- [ ] SqlServer
- [X] H2
- [X] SQLite

The fix is in `exposed-core` and not dialect-specific. Tested locally on Postgres, Oracle, MariaDB, MySQL 8, SQLite and H2.

#### Checklist

- [X] Unit tests are in place
- [X] The build is green (including the Detekt check)
- [X] All public methods affected by my PR has up to date API docs
- [X] Documentation for my change is up to date

---

#### Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
